### PR TITLE
Fix the error message for name validation

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnector.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnector.java
@@ -221,7 +221,7 @@ public class SnowflakeSinkConnector extends SinkConnector
     {
       LOGGER.error(Logging.logMessage("{}: {} is empty or invalid. It " +
         "should match Snowflake object identifier syntax. Please see the " +
-        "documentation.", SnowflakeSinkConnectorConfig.TOPICS, connectorName));
+        "documentation.", SnowflakeSinkConnectorConfig.NAME, connectorName));
       configIsValid = false;
     }
 


### PR DESCRIPTION
I was getting an error message along the lines of:
`topics: snowflake-sink is empty or invalid. It should match Snowflake object identifier`

I was confused because my topics property seemed to only have letters with underscores which is a valid identifier according to the documentation.

After checking the code, I found that it isn't validating the topics property, but it is validating the name property.

https://github.com/snowflakedb/snowflake-kafka-connector/blob/87041ff188a33c597d2949b2352b294c07f61f73/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnector.java#L219-L220

Updated the error message to have the right property it is validating.