### PR TITLE
Fix logging format for null values

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/Logging.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/Logging.java
@@ -17,6 +17,8 @@
 
 package com.snowflake.kafka.connector.internal;
 
+import java.util.Objects;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -148,7 +150,7 @@ public class Logging
   {
     for (int i = 0; i < vars.length; i++)
     {
-      format = format.replaceFirst("\\{}", vars[i].toString().replaceAll("\\$","\\\\\\$"));
+      format = format.replaceFirst("\\{}", Objects.toString(vars[i]).replaceAll("\\$","\\\\\\$"));
     }
     return logMessage(format);
   }

--- a/src/test/java/com/snowflake/kafka/connector/internal/LoggingTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/LoggingTest.java
@@ -56,9 +56,11 @@ public class LoggingTest
     assert Logging.logMessage("{} test message\n{} test message\n{} test " +
         "message\n{} test message", 1, 2, 3, 4).equals(expected);
 
+    // nulls
+    expected = "\n" + Logging.SF_LOG_TAG + " null test message";
+    assert Logging.logMessage("{} test message",  (String) null).equals(expected);
 
+    expected = "\n" + Logging.SF_LOG_TAG + " some string test null message null";
+    assert Logging.logMessage("{} test {} message {}", "some string", null, null).equals(expected);
   }
-
-
 }
-


### PR DESCRIPTION
This commit fixes Logging.logMessage failing when some of vars are null.

This issue can be experienced, for example, in
https://github.com/snowflakedb/snowflake-kafka-connector/blob/949b5a168f3798be6f560ff1e2a8812023f8b83c/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnector.java#L359