### PR TITLE
Prevent deadlock on converter classes loading

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/records/SnowflakeAvroConverter.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/SnowflakeAvroConverter.java
@@ -143,7 +143,7 @@ public class SnowflakeAvroConverter extends SnowflakeConverter
       encoder.flush();
       output.flush();
 
-      return MAPPER.readTree(output.toByteArray());
+      return mapper.readTree(output.toByteArray());
     } catch (IOException e)
     {
       throw SnowflakeErrors.ERROR_0010.getException("Failed to parse AVRO " +

--- a/src/main/java/com/snowflake/kafka/connector/records/SnowflakeAvroConverterWithoutSchemaRegistry.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/SnowflakeAvroConverterWithoutSchemaRegistry.java
@@ -62,7 +62,7 @@ public class SnowflakeAvroConverterWithoutSchemaRegistry extends SnowflakeConver
         String jsonString = dataFileReader.next().toString();
         try
         {
-          buffer.add(MAPPER.readTree(jsonString));
+          buffer.add(mapper.readTree(jsonString));
         } catch (IOException e)
         {
           throw SnowflakeErrors.ERROR_0010.getException("Failed to parse JSON" +

--- a/src/main/java/com/snowflake/kafka/connector/records/SnowflakeConverter.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/SnowflakeConverter.java
@@ -36,7 +36,7 @@ public abstract class SnowflakeConverter implements Converter
   protected static final Logger LOGGER =
       LoggerFactory.getLogger(SnowflakeConverter.class.getName());
 
-  static ObjectMapper MAPPER = new ObjectMapper();
+  final ObjectMapper mapper = new ObjectMapper();
 
   /**
    * unused

--- a/src/main/java/com/snowflake/kafka/connector/records/SnowflakeJsonConverter.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/SnowflakeJsonConverter.java
@@ -39,7 +39,7 @@ public class SnowflakeJsonConverter extends SnowflakeConverter
       //always return an array of JsonNode because AVRO record may contains
       // multiple records
       return new SchemaAndValue(new SnowflakeJsonSchema(),
-        new SnowflakeRecordContent(MAPPER.readTree(bytes)));
+        new SnowflakeRecordContent(mapper.readTree(bytes)));
     } catch (Exception ex)
     {
       LOGGER.error(Logging.logMessage("Failed to parse JSON record\n" + ex.toString()));


### PR DESCRIPTION
This PR makes `ObjectMapper` in `SnowflakeConverter` non-static. This
prevents potential deadlock on classloading in Kafka Connect
(most likely, caused by https://issues.apache.org/jira/browse/KAFKA-7421).

See https://github.com/snowflakedb/snowflake-kafka-connector/issues/23