### PR TITLE
Removed compatibility check that Snowflake table has only 2 columns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .idea/
 .settings/
 target/
+*.iml
 *.json
 .project
 .classpath

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
@@ -292,12 +292,6 @@ public class SnowflakeConnectionServiceV1 extends Logging
           "VARIANT", tableName);
         compatible = false;
       }
-      //only two columns
-      else if (result.next())
-      {
-        logDebug("table {} contains more than two columns", tableName);
-        compatible = false;
-      }
       else
       {
         compatible = true;


### PR DESCRIPTION
We wanted to add a cluster key to our Snowflake table. We were able to accomplish this by pre-creating the Snowflake table with an extra "virtual" column that is computed from the contents of the `RECORD_CONTENT` column, and the changes in this PR which remove the constraint that the table must have only the two `RECORD_METADATA` and `RECORD_CONTENT` columns.

Tested this locally and everything still works. Don't see any reason to require the target table to have only 2 columns.