### PR TITLE
Move Bouncy Castle dependencies to compile scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -310,13 +310,11 @@
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-ext-jdk15on</artifactId>
             <version>1.61</version>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15on</artifactId>
             <version>1.61</version>
-            <scope>provided</scope>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.apache.kafka/connect-api -->


### PR DESCRIPTION
I propose to move the Bouncy Castle dependencies to the default `compile` scope unless there's a rationale behind having them in `provided`. Otherwise, it requires additional effort to set up the connector.
