### PR TITLE
Throw ConfigException in parseTopicToTableMap

### DIFF
--- a/src/test/java/com/snowflake/kafka/connector/UtilsTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/UtilsTest.java
@@ -6,6 +6,8 @@ import org.junit.Test;
 
 import java.util.Map;
 
+import org.apache.kafka.common.config.ConfigException;
+
 public class UtilsTest
 {
   @Test
@@ -27,10 +29,20 @@ public class UtilsTest
   public void testParseTopicToTable()
   {
     String input = "adsadas";
-    assert Utils.parseTopicToTableMap(input) == null;
+    try
+    {
+      Utils.parseTopicToTableMap(input);
+      assert false;
+    }
+    catch (ConfigException e) { }
 
     input = "abc:@123,bvd:adsa";
-    assert Utils.parseTopicToTableMap(input) == null;
+    try
+    {
+      Utils.parseTopicToTableMap(input);
+      assert false;
+    }
+    catch (ConfigException e) { }
   }
 
   @Test


### PR DESCRIPTION
`parseTopicToTableMap` currently returns `null` in case of issues with
parsing. This behaviour is non-intuitive and potentially causes bugs
like https://github.com/snowflakedb/snowflake-kafka-connector/issues/54.

`ConfigException` in contrast is special Kafka exception designed for
reporting invalid configuration.