### PR TITLE
fix typo in maven url 

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -66,7 +66,7 @@ public class Utils
 
   //mvn repo
   private static final String MVN_REPO =
-    "http://repo1.maven.org/maven2/com/snowflake/snowflake-kafka-connector/";
+    "https://repo1.maven.org/maven2/com/snowflake/snowflake-kafka-connector/";
 
   private static final Logger LOGGER =
     LoggerFactory.getLogger(Utils.class.getName());
@@ -75,7 +75,7 @@ public class Utils
    * check the connector version from Maven repo, report if any update
    * version is available.
    */
-  static void checkConnectorVersion()
+  static boolean checkConnectorVersion()
   {
     LOGGER.info(Logging.logMessage("Snowflake Kafka Connector Version: {}",
       VERSION));
@@ -122,9 +122,10 @@ public class Utils
     {
       LOGGER.warn(Logging.logMessage("can't verify latest connector version " +
         "from Maven Repo\n{}", e.getMessage()));
+      return false;
     }
 
-
+    return true;
   }
 
   /**

--- a/src/test/java/com/snowflake/kafka/connector/UtilsTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/UtilsTest.java
@@ -45,7 +45,7 @@ public class UtilsTest
   @Test
   public void testVersionChecker()
   {
-    Utils.checkConnectorVersion();
+    assert Utils.checkConnectorVersion();
   }
 
   @Test


### PR DESCRIPTION
checkVersion method doesn't work as for now, becouse of type in url it should comtain htts instead of http. As a result we see such WARNINGS in logs:

[SF_KAFKA_CONNECTOR] Server returned HTTP response code: 501 for URL: http://repo1.maven.org/maven2/com/snowflake/snowflake-kafka-connector/ (com.snowflake.kafka.connector.Utils:123)

