### PR TITLE
SnowflakeSinkServiceV1: iterate on a copy of all files in checkStatus()

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
@@ -498,7 +498,9 @@ class SnowflakeSinkServiceV1 extends Logging implements SnowflakeSinkService
 
       //old files
       List<String> oldFiles = new LinkedList<>();
-      tmpFileNames.forEach(
+
+      // iterate over a copy since failed files get removed from it
+      new LinkedList<>(tmpFileNames).forEach(
         name ->
         {
           long time = FileNameUtils.fileNameToTimeIngested(name);


### PR DESCRIPTION
`.remove()` call in .forEach causes loop to be stuck. #123