### PR TITLE
SNOW-119851 Changed pom.xml to exclude avro converter

### DIFF
--- a/.github/workflows/End2EndTest.yml
+++ b/.github/workflows/End2EndTest.yml
@@ -57,7 +57,7 @@ jobs:
         SHELL: "/bin/bash"
       run: |
         cd test
-        ./build_image.sh 5.3.0 ../../snowflake-kafka-connector
+        ./build_image.sh 5.5.0 ../../snowflake-kafka-connector
 
     - name: End to End Test
       env:

--- a/pom.xml
+++ b/pom.xml
@@ -371,41 +371,28 @@
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
             <version>1.9.0</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-core</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>commons-compress</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
-
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.10.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.10.0</version>
+        </dependency>
         <dependency>
             <groupId>io.confluent</groupId>
-            <artifactId>kafka-connect-avro-converter</artifactId>
+            <artifactId>kafka-schema-registry</artifactId>
             <version>5.3.0</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.zookeeper</groupId>
-                    <artifactId>zookeeper</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-avro-serializer</artifactId>
+            <version>5.3.0</version>
+        </dependency>
+
 
         <!--JDBC driver for building connection with Snowflake-->
         <dependency>
@@ -427,12 +414,6 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>2.20.1</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.10.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Major change:
- modified pom.xml to exclude kafka-connect-avro-converter 
- include kafka-schema-registry and kafka-avro-serializer 
The final jar size is 62MB.
Previous master build jar size is 37 MB