### PR TITLE
Restructured all version test to use only one node for better stability

### DIFF
--- a/.github/workflows/End2EndFullTest.yml
+++ b/.github/workflows/End2EndFullTest.yml
@@ -38,31 +38,36 @@ jobs:
         pip3 install --upgrade snowflake-connector-python
         curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
         sudo apt-get -y install jq
-    - name: Start Kubernetes Cluster
-      env:
-        CHANGE_MINIKUBE_NONE_USER: true
-      run: |
-        sudo apt-get -y install conntrack
-        curl -Lo minikube https://storage.googleapis.com/minikube/releases/v1.9.1/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
-        sudo minikube start --vm-driver=none
-        sudo chown -R $USER $HOME/.kube $HOME/.minikube || true
-        minikube update-context
     
-    - name: Build with Unit and Integration Test on 5.2.0
+    - name: Build with Unit and Integration Test
       env:
         JACOCO_COVERAGE: true
         SNOWFLAKE_CREDENTIAL_FILE: "../profile.json"
         SHELL: "/bin/bash"
       run: |
         cd test
-        ./build_image.sh 5.2.0 ../../snowflake-kafka-connector
+        ./build_apache.sh ../../snowflake-kafka-connector
+    
+    - name: End to End Test of Confluent Platform 5.0.0
+      env:
+        SNOWFLAKE_CREDENTIAL_FILE: "../profile.json"
+      run: |
+        cd test
+        ./run_test_confluent.sh 5.0.0 ./apache_properties
+
+    - name: End to End Test of Apache Plarform 2.0.0
+      env:
+        SNOWFLAKE_CREDENTIAL_FILE: "../profile.json"
+      run: |
+        cd test
+        ./run_test_apache.sh 2.0.0 ./apache_properties
 
     - name: End to End Test of Confluent Platform 5.2.0
       env:
         SNOWFLAKE_CREDENTIAL_FILE: "../profile.json"
       run: |
         cd test
-        ./run_test.sh ./helm_values/snow_values_5.2.yaml
+        ./run_test_confluent.sh 5.2.0 ./apache_properties
 
     - name: End to End Test of Apache Plarform 2.2.0
       env:
@@ -71,21 +76,26 @@ jobs:
         cd test
         ./run_test_apache.sh 2.2.0 ./apache_properties
 
-    - name: Build without test on 5.5.0
+    - name: End to End Test of Confluent Platform 5.4.0
       env:
-        JACOCO_COVERAGE: true
         SNOWFLAKE_CREDENTIAL_FILE: "../profile.json"
-        SHELL: "/bin/bash"
       run: |
         cd test
-        ./build_image.sh 5.5.0 ../../snowflake-kafka-connector none
+        ./run_test_confluent.sh 5.4.0 ./apache_properties
+
+    - name: End to End Test of Apache Plarform 2.4.0
+      env:
+        SNOWFLAKE_CREDENTIAL_FILE: "../profile.json"
+      run: |
+        cd test
+        ./run_test_apache.sh 2.4.0 ./apache_properties
 
     - name: End to End Test of Confluent Platform 5.5.0
       env:
         SNOWFLAKE_CREDENTIAL_FILE: "../profile.json"
       run: |
         cd test
-        ./run_test.sh ./helm_values/snow_values_5.5.yaml
+        ./run_test_confluent.sh 5.5.0 ./apache_properties
 
     - name: End to End Test of Apache Plarform 2.5.0
       env:

--- a/test/apache_properties/schema-registry.properties
+++ b/test/apache_properties/schema-registry.properties
@@ -1,0 +1,43 @@
+#
+# Copyright 2018 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# The address the socket server listens on.
+#   FORMAT:
+#     listeners = listener_name://host_name:port
+#   EXAMPLE:
+#     listeners = PLAINTEXT://your.host.name:9092
+listeners=http://0.0.0.0:8081
+
+# Zookeeper connection string for the Zookeeper cluster used by your Kafka cluster
+# (see zookeeper docs for details).
+# This is a comma separated host:port pairs, each corresponding to a zk
+# server. e.g. "127.0.0.1:3000,127.0.0.1:3001,127.0.0.1:3002".
+kafkastore.connection.url=localhost:2181
+
+# Alternatively, Schema Registry can now operate without Zookeeper, handling all coordination via
+# Kafka brokers. Use this setting to specify the bootstrap servers for your Kafka cluster and it
+# will be used both for selecting the master schema registry instance and for storing the data for
+# registered schemas.
+# (Note that you cannot mix the two modes; use this mode only on new deployments or by shutting down
+# all instances, switching to the new configuration, and then starting the schema registry
+# instances again.)
+#kafkastore.bootstrap.servers=PLAINTEXT://localhost:9092
+
+# The name of the topic to store schemas in
+kafkastore.topic=_schemas
+
+# If true, API requests that fail will include extra debugging information, including stack traces
+debug=false

--- a/test/build_apache.sh
+++ b/test/build_apache.sh
@@ -11,12 +11,11 @@ function error_exit() {
 
 # check argument number is 1 or 2 or 3
 if [ $# -gt 3 ] || [ $# -lt 1 ]; then
-    error_exit "Usage: ./build_image.sh <version> [<path to snowflake repo>] [verify/package/none] .  Aborting."
+    error_exit "Usage: ./build_image.sh [<path to snowflake repo>] [verify/package/none] .  Aborting."
 fi
 
-KAFKA_CONNECT_TAG=$1
-SNOWFLAKE_CONNECTOR_PATH=$2
-BUILD_METHOD=$3
+SNOWFLAKE_CONNECTOR_PATH=$1
+BUILD_METHOD=$2
 
 if [[ -z "${BUILD_METHOD}" ]]; then
     # Default build method verify
@@ -75,7 +74,7 @@ case $BUILD_METHOD in
 		echo -e "\n=== skip building, please make sure built connector exist ==="
 		;;
   *)
-    error_exit "Usage: ./build_image.sh <version> [<path to snowflake repo>] [verify/package/none] . Unknown build method $BUILD_METHOD.  Aborting."
+    error_exit "Usage: ./build_image.sh [<path to snowflake repo>] [verify/package/none] . Unknown build method $BUILD_METHOD.  Aborting."
   esac
 popd
 
@@ -85,6 +84,7 @@ SNOWFLAKE_PLUGIN_NAME=$(ls $SNOWFLAKE_PLUGIN_PATH | grep "$SNOWFLAKE_PLUGIN_NAME
 echo -e "\n=== built connector name: $SNOWFLAKE_PLUGIN_NAME ==="
 
 # copy built connector to plugin path
-mkdir -p $KAFKA_CONNECT_PLUGIN_PATH
+mkdir -m 777 -p $KAFKA_CONNECT_PLUGIN_PATH || \
+sudo mkdir -m 777 -p $KAFKA_CONNECT_PLUGIN_PATH 
 cp $SNOWFLAKE_PLUGIN_PATH/$SNOWFLAKE_PLUGIN_NAME $KAFKA_CONNECT_PLUGIN_PATH || true
 echo -e "\n=== copied connector to $KAFKA_CONNECT_PLUGIN_PATH ==="

--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -178,6 +178,9 @@ python3 test_verify.py $K_IP:$SNOWFLAKE_KAFKA_PORT http://$K_IP:$SC_PORT $TEST_S
 testError=$?
 
 if [ $testError -ne 0 ]; then
+    RED='\033[0;31m'
+    NC='\033[0m' # No Color
+    echo -e "${RED} There is error above this line ${NC}"
     for pod_name in $(kubectl get pod | awk '{print $1}' | grep "connect"); do
         echo -e "\n===================================================="
         echo -e "=== Log of $pod_name ==="


### PR DESCRIPTION
Instead of using k8s we now use confluent platform to test, hopefully this is going to provide more stability over k8s in the full version test.