### PR TITLE
Reduce calls to ingest history

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeIngestionServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeIngestionServiceV1.java
@@ -98,6 +98,11 @@ public class SnowflakeIngestionServiceV1 extends Logging
     Map<String, InternalUtils.IngestedFileStatus> fileStatus =
       initFileStatus(files);
 
+    if (fileStatus.size() == 0)
+    {
+      return fileStatus;
+    }
+
     HistoryResponse response;
     try
     {


### PR DESCRIPTION
No need to call get history if the number of files we wanted to check is zero.