### PR TITLE
Fix potential NPE in JSON conversion for int64 type without schema.

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/records/RecordService.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/RecordService.java
@@ -246,9 +246,9 @@ public class RecordService extends Logging
           }
           return JsonNodeFactory.instance.numberNode((Integer) value);
         case INT64:
-          String schemaName = schema.name();
-          if(Timestamp.LOGICAL_NAME.equals(schemaName)){
-            return JsonNodeFactory.instance.numberNode(Timestamp.fromLogical(schema, (java.util.Date) value));
+          if (schema != null && Timestamp.LOGICAL_NAME.equals(schema.name())) {
+            return JsonNodeFactory.instance.numberNode(
+                Timestamp.fromLogical(schema, (java.util.Date) value));
           }
           return JsonNodeFactory.instance.numberNode((Long) value);
         case FLOAT32:
@@ -261,7 +261,7 @@ public class RecordService extends Logging
           CharSequence charSeq = (CharSequence) value;
           return JsonNodeFactory.instance.textNode(charSeq.toString());
         case BYTES:
-          if (Decimal.LOGICAL_NAME.equals(schema.name())) {
+          if (schema != null && Decimal.LOGICAL_NAME.equals(schema.name())) {
             return JsonNodeFactory.instance.numberNode((BigDecimal) value);
           }
 


### PR DESCRIPTION
With `org.apache.kafka.connect.json.JsonConverter`, integers are of type int64. When converting to JSON in `RecordService`, it will hit an NPE if value has no schema.