### PR TITLE
SNOW-171230 Added a option to converter of whether break on schema registry error

### DIFF
--- a/src/test/java/com/snowflake/kafka/connector/records/ConverterTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/records/ConverterTest.java
@@ -160,4 +160,25 @@ public class ConverterTest
     expected.put("test", Integer.MAX_VALUE);
     assert expected.toString().equals(result.toString());
   }
+
+  @Test
+  public void testAvroConverterConfig() {
+    SnowflakeAvroConverter converter = new SnowflakeAvroConverter();
+
+    Map<String, ?> config = Collections.singletonMap("schema.registry.url", "mock://my-scope-name");
+    converter.readBreakOnSchemaRegistryError(config);
+    assert !converter.getBreakOnSchemaRegistryError();
+
+    config = Collections.singletonMap(SnowflakeAvroConverter.BREAK_ON_SCHEMA_REGISTRY_ERROR, "true");
+    converter.readBreakOnSchemaRegistryError(config);
+    assert converter.getBreakOnSchemaRegistryError();
+
+    config = Collections.singletonMap(SnowflakeAvroConverter.BREAK_ON_SCHEMA_REGISTRY_ERROR, "trueeee");
+    converter.readBreakOnSchemaRegistryError(config);
+    assert !converter.getBreakOnSchemaRegistryError();
+
+    config = Collections.singletonMap(SnowflakeAvroConverter.BREAK_ON_SCHEMA_REGISTRY_ERROR, "True");
+    converter.readBreakOnSchemaRegistryError(config);
+    assert converter.getBreakOnSchemaRegistryError();
+  }
 }


### PR DESCRIPTION
Added a new option to the AVRO converter. By default this option is false so that we don’t have breaking change. 
"value.converter.break.on.schema.registry.error"="true"
This option, if set to true, will break the connector when there is error while fetching schema id from Schema Registry.