### PR TITLE
Force cleaner thread to reset files on error

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
@@ -292,6 +292,7 @@ class SnowflakeSinkServiceV1 extends Logging implements SnowflakeSinkService
 
     //make the initialization lazy
     private boolean hasInitialized = false;
+    private boolean forceCleanerFileReset = false;
 
 
     private ServiceContext(String tableName, String stageName,
@@ -343,6 +344,29 @@ class SnowflakeSinkServiceV1 extends Logging implements SnowflakeSinkService
 
     }
 
+    private boolean resetCleanerFiles() {
+      try {
+        logWarn("Resetting cleaner files", pipeName);
+        // list stage again and try to clean the files leaked on stage
+        // this can throw unchecked, it needs to be wrapped in a try/catch
+        // if it fails again do not reset forceCleanerFileReset
+        List<String> tmpCleanerFileNames = conn.listStage(stageName, prefix);
+        fileListLock.lock();
+        try {
+          cleanerFileNames.addAll(tmpCleanerFileNames);
+          cleanerFileNames = cleanerFileNames.stream().distinct().collect(Collectors.toList());
+        } finally {
+          fileListLock.unlock();
+        }
+        forceCleanerFileReset = false;
+      } catch (Throwable t) {
+        logWarn("Cleaner file reset encountered an error{}:\n", t.getMessage());
+      }
+
+      return forceCleanerFileReset;
+    }
+
+
     private void startCleaner()
     {
       // when cleaner start, scan stage for all files of this pipe
@@ -365,6 +389,11 @@ class SnowflakeSinkServiceV1 extends Logging implements SnowflakeSinkService
             try
             {
               Thread.sleep(CLEAN_TIME);
+
+              if (forceCleanerFileReset && resetCleanerFiles()) {
+                continue;
+              }
+
               checkStatus();
               if (System.currentTimeMillis() - startTime > ONE_HOUR)
               {
@@ -378,17 +407,8 @@ class SnowflakeSinkServiceV1 extends Logging implements SnowflakeSinkService
             {
               logWarn("Cleaner encountered an exception {}:\n{}\n{}",
                 e.getClass(), e.getMessage(), e.getStackTrace());
-              // list stage again and try to clean the files leaked on stage
-              List<String> tmpCleanerFileNames = conn.listStage(stageName, prefix);
-              fileListLock.lock();
-              try
-              {
-                cleanerFileNames.addAll(tmpCleanerFileNames);
-                cleanerFileNames = cleanerFileNames.stream().distinct().collect(Collectors.toList());
-              } finally
-              {
-                fileListLock.unlock();
-              }
+
+              forceCleanerFileReset = true;
 
             }
           }


### PR DESCRIPTION
This PR attempts to manage state around failure scenarios. 

Rather than try to force listStage in the exception handler, which is not safe, set state that indicates we are in a failure scenario. Let the cleaner thread sleep, then inspect the state and attempt to reset cleaner file in an exception safe way.

If resetCleanerFiles is not successful forceCleanerFileReset remains true and the main loop in the thread will continue. The loop will not progress past resetCleanerFiles() until it is successful.