### PR TITLE
Upgrade snowflake-jdbc to 3.12.10 to include SNOW-144823 memory leak fix.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -390,7 +390,7 @@
         <dependency>
             <groupId>net.snowflake</groupId>
             <artifactId>snowflake-jdbc</artifactId>
-            <version>3.11.1</version>
+            <version>3.12.10</version>
         </dependency>
 
         <!--junit for unit test-->

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -448,7 +448,7 @@
         <dependency>
             <groupId>net.snowflake</groupId>
             <artifactId>snowflake-jdbc</artifactId>
-            <version>3.11.1</version>
+            <version>3.12.10</version>
         </dependency>
 
         <!--junit for unit test-->

--- a/test/perf_test/pom.xml
+++ b/test/perf_test/pom.xml
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>net.snowflake</groupId>
       <artifactId>snowflake-jdbc</artifactId>
-      <version>3.12.3</version>
+      <version>3.12.10</version>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>


### PR DESCRIPTION
Snowflake connector uses `snowflake-jdbc:3.11.1`.
There is a memory leak in `TelemetryService`, which has been fixed(https://github.com/snowflakedb/snowflake-jdbc/commit/c181874915bc0040fd6025f78374059250ee9ea5) in a newer version(`v3.12.3`) of Snowflake JDBC driver.

Assuming there are no breaking changes between `v3.12.3` and `3.12.10`, this PR upgrades `snowflake-jdbc` to the latest version `3.12.10`.