### PR TITLE
Tweak Confluent Hub description to be less restrictive in input formats

### DIFF
--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -96,8 +96,9 @@
                             <description>
                                 Snowflake is the data warehouse built for the
                                 cloud. The Snowflake Kafka connector lets you
-                                quickly and easily move JSON and AVRO messages
-                                from Kafka topics into Snowflake tables.
+                                quickly and easily move messages in formats
+                                like Avro, JSON, and Protobuf from Kafka topics
+                                into Snowflake tables.
                             </description>
                             <logo>logo/snowflake.png</logo>
 


### PR DESCRIPTION
We had someone ask about whether this connector supports reading Protobuf data since the Confluent Hub description only mentions Avro and JSON. Since it's a Kafka Connect connector it should play nicely with any format as long as the right converter is provided, so we'd like to tweak the language a little to be more permissive and avoid giving the impression that this connector only works with two different types of input format.