### PR TITLE
Fix a minor bug in telemetry

### DIFF
--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -96,8 +96,9 @@
                             <description>
                                 Snowflake is the data warehouse built for the
                                 cloud. The Snowflake Kafka connector lets you
-                                quickly and easily move JSON and AVRO messages
-                                from Kafka topics into Snowflake tables.
+                                quickly and easily move messages in formats
+                                like Avro, JSON, and Protobuf from Kafka topics
+                                into Snowflake tables.
                             </description>
                             <logo>logo/snowflake.png</logo>
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeTelemetryPipeStatus.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeTelemetryPipeStatus.java
@@ -71,6 +71,10 @@ public class SnowflakeTelemetryPipeStatus extends SnowflakeTelemetryBasicInfo {
   {
     super(tableName, stageName, pipeName);
 
+    // Initial value of processed/flushed/committed/purged offset should be set to -1,
+    // because the offset stands for the last offset of the record that are at the status.
+    // When record with offset 0 is processed, processedOffset will be updated to 0.
+    // Therefore initial value should be set to -1 to indicate that no record have been processed.
     this.processedOffset = new AtomicLong(-1);
     this.flushedOffset = new AtomicLong(-1);
     this.committedOffset = new AtomicLong(-1);
@@ -125,6 +129,7 @@ public class SnowflakeTelemetryPipeStatus extends SnowflakeTelemetryBasicInfo {
 
   boolean empty()
   {
+    // Check that all properties are still at the default value.
     return this.processedOffset.get() == -1 &&
             this.flushedOffset.get() == -1 &&
             this.committedOffset.get() == -1 &&

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeTelemetryPipeStatus.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeTelemetryPipeStatus.java
@@ -125,10 +125,10 @@ public class SnowflakeTelemetryPipeStatus extends SnowflakeTelemetryBasicInfo {
 
   boolean empty()
   {
-    return this.processedOffset.get() == 0 &&
-            this.flushedOffset.get() == 0 &&
-            this.committedOffset.get() == 0 &&
-            this.purgedOffset.get() == 0 &&
+    return this.processedOffset.get() == -1 &&
+            this.flushedOffset.get() == -1 &&
+            this.committedOffset.get() == -1 &&
+            this.purgedOffset.get() == -1 &&
             this.totalNumberOfRecord.get() == 0 &&
             this.totalSizeOfData.get() == 0 &&
             this.fileCountOnStage.get() == 0 &&


### PR DESCRIPTION
Initial value of processed/flushed/committed/purged offset should be set to -1, because the offset stands for the last offset of the record that are at the status. When record with offset 0 is processed, processedOffset will be updated to 0. Therefore initial value should be set to -1 to indicate that no record have been processed.