### PR TITLE
SNOW-210058 improve time based flush

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
@@ -604,6 +604,7 @@ class SnowflakeSinkServiceV1 extends Logging implements SnowflakeSinkService
       // Just checking buffer size, no atomic operation required
       if (buffer.isEmpty())
       {
+        this.previousFlushTimeStamp = System.currentTimeMillis();
         return;
       }
       PartitionBuffer tmpBuff;


### PR DESCRIPTION
Lets look at a scenario:
The connector is configured to flush every 5 mins. It is created on minute 0, and should flush at minute 5 and minute 10. From minute 0-6 there is no record, in minute 7 there is one record, in minute 8 there are 100 records.

We would expect the connector to buffer record from minute 7 and minute 8 and create a file that contains 101 records. Then flush the file at minute 10.

But currently the connector would create one file with one record at minute 7 and flush it. Then it will create another file with 100 records and flush the file at minute 10. 

This is caused by not updating the most recent flush time when buffer is empty. At minute 7, the connector checks the last flush time and see that the most recent flush is at minute 0. And the buffer is not empty, so the connector chose to flush the only record it received. 