### PR TITLE
SNOW-220064 Modified pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -218,7 +218,7 @@
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>
-                        <phase>verify</phase>
+                        <phase>install</phase>
                         <goals>
                             <goal>sign</goal>
                         </goals>

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -278,7 +278,7 @@
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>
-                        <phase>verify</phase>
+                        <phase>package</phase>
                         <goals>
                             <goal>sign</goal>
                         </goals>

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -278,7 +278,7 @@
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>
-                        <phase>package</phase>
+                        <phase>verify</phase>
                         <goals>
                             <goal>sign</goal>
                         </goals>


### PR DESCRIPTION
Currently our test is distributed at the following maven life cycle: 
- `validate` 
- `compile`
- `test` 
- `package` - unit test
- `verify` - integrations test
- `install`
- `deploy`

We only need GPG signing when we push the build to Maven central, which uses command `mvn deploy`. Therefore, moving GPG signing from `verify` stage to `install` stage would remove GPG signing during integration test, but reserve GPG signing during `mvn deploy`. 

This modification is used to remove GPG signing error on Jenkins test. 