### PR TITLE
Split end to end and integration test into different GitHub Action workflow

### DIFF
--- a/.github/workflows/End2EndTestApacheAws.yml
+++ b/.github/workflows/End2EndTestApacheAws.yml
@@ -1,0 +1,53 @@
+name: Kafka Connector Apache End2End Test AWS
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: '**'
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v2
+    - name: "Install Java 8"
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Install Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.6'
+        architecture: 'x64'
+    - name: Decrypt profile.json
+      run: ./.github/scripts/decrypt_secret.sh 'aws'
+      env:
+        SNOWFLAKE_TEST_PROFILE_SECRET: ${{ secrets.SNOWFLAKE_TEST_PROFILE_SECRET }}
+    - name: Install Dependency
+      run: |
+        pip3 install --upgrade setuptools
+        pip3 install requests certifi "confluent-kafka[avro,json,protobuf]>=1.5.0"
+        pip3 install avro-python3 kafka-python
+        pip3 install protobuf
+        pip3 install --upgrade snowflake-connector-python
+        curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
+        sudo apt-get -y install jq
+        sudo apt-get -y install protobuf-compiler
+    
+    - name: Build with Unit Test
+      env:
+        JACOCO_COVERAGE: true
+        SNOWFLAKE_CREDENTIAL_FILE: "../profile.json"
+        SHELL: "/bin/bash"
+      run: |
+        cd test
+        ./build_apache.sh ../../snowflake-kafka-connector package
+
+    - name: End to End Test of Apache Plarform 2.5
+      env:
+        SNOWFLAKE_CREDENTIAL_FILE: "../profile.json"
+      run: |
+        cd test
+        ./run_test_apache.sh 2.5.0 ./apache_properties

--- a/.github/workflows/End2EndTestApacheAzure.yml
+++ b/.github/workflows/End2EndTestApacheAzure.yml
@@ -1,4 +1,4 @@
-name: Kafka Connector End2End Test Azure
+name: Kafka Connector Apache End2End Test Azure
 
 on:
   push:
@@ -35,32 +35,15 @@ jobs:
         curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
         sudo apt-get -y install jq
         sudo apt-get -y install protobuf-compiler
-
-#    - name: Start Kubernetes Cluster
-#      env:
-#        CHANGE_MINIKUBE_NONE_USER: true
-#      run: |
-#        sudo apt-get -y install conntrack
-#        curl -Lo minikube https://storage.googleapis.com/minikube/releases/v1.9.1/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
-#        sudo minikube start --vm-driver=none
-#        sudo chown -R $USER $HOME/.kube $HOME/.minikube || true
-#        minikube update-context
     
-    - name: Build with Unit and Integration Test
+    - name: Build with Unit Test
       env:
         JACOCO_COVERAGE: true
         SNOWFLAKE_CREDENTIAL_FILE: "../profile.json"
         SHELL: "/bin/bash"
       run: |
         cd test
-        ./build_apache.sh ../../snowflake-kafka-connector
-
-    - name: End to End Test of Confluent Platform 5.5
-      env:
-        SNOWFLAKE_CREDENTIAL_FILE: "../profile.json"
-      run: |
-        cd test
-        ./run_test_confluent.sh 5.5.0 ./apache_properties
+        ./build_apache.sh ../../snowflake-kafka-connector package
 
     - name: End to End Test of Apache Plarform 2.5
       env:
@@ -68,9 +51,3 @@ jobs:
       run: |
         cd test
         ./run_test_apache.sh 2.5.0 ./apache_properties
-      
-    - name: Code Coverage
-      uses: codecov/codecov-action@v1
-
-
-

--- a/.github/workflows/End2EndTestConfluentAws.yml
+++ b/.github/workflows/End2EndTestConfluentAws.yml
@@ -1,4 +1,4 @@
-name: Kafka Connector End2End Test AWS
+name: Kafka Connector Confluent End2End Test Aws
 
 on:
   push:
@@ -36,24 +36,14 @@ jobs:
         sudo apt-get -y install jq
         sudo apt-get -y install protobuf-compiler
 
-#    - name: Start Kubernetes Cluster
-#      env:
-#        CHANGE_MINIKUBE_NONE_USER: true
-#      run: |
-#        sudo apt-get -y install conntrack
-#        curl -Lo minikube https://storage.googleapis.com/minikube/releases/v1.9.1/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
-#        sudo minikube start --vm-driver=none
-#        sudo chown -R $USER $HOME/.kube $HOME/.minikube || true
-#        minikube update-context
-    
-    - name: Build with Unit and Integration Test
+    - name: Build with Unit Test
       env:
         JACOCO_COVERAGE: true
         SNOWFLAKE_CREDENTIAL_FILE: "../profile.json"
         SHELL: "/bin/bash"
       run: |
         cd test
-        ./build_apache.sh ../../snowflake-kafka-connector
+        ./build_apache.sh ../../snowflake-kafka-connector package
 
     - name: End to End Test of Confluent Platform 5.5
       env:
@@ -61,16 +51,3 @@ jobs:
       run: |
         cd test
         ./run_test_confluent.sh 5.5.0 ./apache_properties
-
-    - name: End to End Test of Apache Plarform 2.5
-      env:
-        SNOWFLAKE_CREDENTIAL_FILE: "../profile.json"
-      run: |
-        cd test
-        ./run_test_apache.sh 2.5.0 ./apache_properties
-      
-    - name: Code Coverage
-      uses: codecov/codecov-action@v1
-
-
-

--- a/.github/workflows/End2EndTestConfluentAzure.yml
+++ b/.github/workflows/End2EndTestConfluentAzure.yml
@@ -1,0 +1,53 @@
+name: Kafka Connector Confluent End2End Test Azure
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: '**'
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v2
+    - name: "Install Java 8"
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Install Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.6'
+        architecture: 'x64'
+    - name: Decrypt profile.json
+      run: ./.github/scripts/decrypt_secret.sh 'azure'
+      env:
+        SNOWFLAKE_TEST_PROFILE_SECRET: ${{ secrets.SNOWFLAKE_TEST_PROFILE_SECRET }}
+    - name: Install Dependency
+      run: |
+        pip3 install --upgrade setuptools
+        pip3 install requests certifi "confluent-kafka[avro,json,protobuf]>=1.5.0"
+        pip3 install avro-python3 kafka-python
+        pip3 install protobuf
+        pip3 install --upgrade snowflake-connector-python
+        curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
+        sudo apt-get -y install jq
+        sudo apt-get -y install protobuf-compiler
+    
+    - name: Build with Unit Test
+      env:
+        JACOCO_COVERAGE: true
+        SNOWFLAKE_CREDENTIAL_FILE: "../profile.json"
+        SHELL: "/bin/bash"
+      run: |
+        cd test
+        ./build_apache.sh ../../snowflake-kafka-connector package
+
+    - name: End to End Test of Confluent Platform 5.5
+      env:
+        SNOWFLAKE_CREDENTIAL_FILE: "../profile.json"
+      run: |
+        cd test
+        ./run_test_confluent.sh 5.5.0 ./apache_properties

--- a/.github/workflows/IntegrationTestAws.yml
+++ b/.github/workflows/IntegrationTestAws.yml
@@ -1,0 +1,49 @@
+name: Kafka Connector Integration Test AWS
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: '**'
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v2
+    - name: "Install Java 8"
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Install Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.6'
+        architecture: 'x64'
+    - name: Decrypt profile.json
+      run: ./.github/scripts/decrypt_secret.sh 'aws'
+      env:
+        SNOWFLAKE_TEST_PROFILE_SECRET: ${{ secrets.SNOWFLAKE_TEST_PROFILE_SECRET }}
+    - name: Install Dependency
+      run: |
+        pip3 install --upgrade setuptools
+        pip3 install requests certifi "confluent-kafka[avro,json,protobuf]>=1.5.0"
+        pip3 install avro-python3 kafka-python
+        pip3 install protobuf
+        pip3 install --upgrade snowflake-connector-python
+        curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
+        sudo apt-get -y install jq
+        sudo apt-get -y install protobuf-compiler
+    
+    - name: Build with Unit and Integration Test
+      env:
+        JACOCO_COVERAGE: true
+        SNOWFLAKE_CREDENTIAL_FILE: "../profile.json"
+        SHELL: "/bin/bash"
+      run: |
+        cd test
+        ./build_apache.sh ../../snowflake-kafka-connector
+      
+    - name: Code Coverage
+      uses: codecov/codecov-action@v1

--- a/.github/workflows/IntegrationTestAzure.yml
+++ b/.github/workflows/IntegrationTestAzure.yml
@@ -1,0 +1,49 @@
+name: Kafka Connector Integration Test Azure
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: '**'
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+      - name: "Install Java 8"
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Install Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.6'
+          architecture: 'x64'
+      - name: Decrypt profile.json
+        run: ./.github/scripts/decrypt_secret.sh 'azure'
+        env:
+          SNOWFLAKE_TEST_PROFILE_SECRET: ${{ secrets.SNOWFLAKE_TEST_PROFILE_SECRET }}
+      - name: Install Dependency
+        run: |
+          pip3 install --upgrade setuptools
+          pip3 install requests certifi "confluent-kafka[avro,json,protobuf]>=1.5.0"
+          pip3 install avro-python3 kafka-python
+          pip3 install protobuf
+          pip3 install --upgrade snowflake-connector-python
+          curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
+          sudo apt-get -y install jq
+          sudo apt-get -y install protobuf-compiler
+
+      - name: Build with Unit and Integration Test
+        env:
+          JACOCO_COVERAGE: true
+          SNOWFLAKE_CREDENTIAL_FILE: "../profile.json"
+          SHELL: "/bin/bash"
+        run: |
+          cd test
+          ./build_apache.sh ../../snowflake-kafka-connector
+
+      - name: Code Coverage
+        uses: codecov/codecov-action@v1

--- a/README-TEST.md
+++ b/README-TEST.md
@@ -4,9 +4,17 @@
 
 GitHub Action is used for CI/CD test. The workflows can be found in `.github/workflows`. Currently, there are 5 workflows:
 
-`End2EndTest.yml` : Run unit test and integration test. Then run end to end test on Confluent 5.5.0 and Apache 2.5.0. Test against Snowflake with on AWS. Run on all PRs.
+`End2EndTestApacheAws.yml` : Run unit test. Then run end to end test on Apache 2.5.0. Test against Snowflake with on AWS. Run on all PRs.
 
-`End2EndTestAzure.yml` : Same with the previous workflow but test with Snowflake deployed on AZURE.
+`End2EndTestApacheAzure.yml` : Same with the previous workflow but test with Snowflake deployed on AZURE.
+
+`End2EndTestConfluentAws.yml` : Run unit test. Then run end to end test on Confluent 5.5.0. Test against Snowflake with on AWS. Run on all PRs.
+
+`End2EndTestConfluentAzure.yml` : Same with the previous workflow but test with Snowflake deployed on AZURE.
+
+`IntegrationTestAws.yml` : Run unit and integration test. Test against Snowflake with on AWS. Run on all PRs.
+
+`IntegrationTestAzure.yml` : Same with the previous workflow but test with Snowflake deployed on AZURE.
 
 `End2EndTestFull.yml` : Run unit test and integration test. Then run end to end test on Confluent 5.2.0, 5.4.0, and 5.5.0 and Apache 2.2.0, 2.4.0, and 2.5.0. Test with Snowflake deployed on AWS. Executed daily, checkout the most recent master branch.
 


### PR DESCRIPTION
Split end to end and integration test, so that they can run in parallel. This speeds up the checkin process as tests are taking longer to run. 