### PR TITLE
SNOW-223109 read from secret files

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnector.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnector.java
@@ -249,8 +249,8 @@ public class SnowflakeSinkConnector extends SinkConnector
       }
     }
     // If private key or private key passphrase is provided through file, skip validation
-    if (connectorConfigs.get(Utils.SF_PRIVATE_KEY).contains("${file:") ||
-      connectorConfigs.get(Utils.PRIVATE_KEY_PASSPHRASE).contains("${file:"))
+    if (connectorConfigs.getOrDefault(Utils.SF_PRIVATE_KEY, "").contains("${file:") ||
+      connectorConfigs.getOrDefault(Utils.PRIVATE_KEY_PASSPHRASE, "").contains("${file:"))
       return result;
 
     // We don't validate name, since it is not included in the return value

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnector.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnector.java
@@ -16,22 +16,18 @@
  */
 package com.snowflake.kafka.connector;
 
-import com.snowflake.kafka.connector.internal.Logging;
-import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
-import com.snowflake.kafka.connector.internal.SnowflakeConnectionServiceFactory;
-import com.snowflake.kafka.connector.internal.SnowflakeErrors;
-import com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException;
-import com.snowflake.kafka.connector.internal.SnowflakeTelemetryService;
-import com.snowflake.kafka.connector.internal.SnowflakeURL;
+import com.snowflake.kafka.connector.internal.*;
 import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigDef;
-import org.apache.kafka.common.config.ConfigValue;
 import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.sink.SinkConnector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 
 /**
@@ -252,6 +248,10 @@ public class SnowflakeSinkConnector extends SinkConnector
             ": proxy username and password must be provided together");
       }
     }
+    // If private key or private key passphrase is provided through file, skip validation
+    if (connectorConfigs.get(Utils.SF_PRIVATE_KEY).contains("${file:") ||
+      connectorConfigs.get(Utils.PRIVATE_KEY_PASSPHRASE).contains("${file:"))
+      return result;
 
     // We don't validate name, since it is not included in the return value
     // so just put a test connector here

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorIT.java
@@ -211,6 +211,25 @@ public class ConnectorIT
     });
   }
 
+
+  @Test
+  public void testValidateFilePasswordConfig()
+  {
+    Map<String, String> config = getCorrectConfig();
+    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_PRIVATE_KEY, " ${file:/");
+    Map<String, ConfigValue> validateMap = toValidateMap(config);
+    assertPropHasError(validateMap, new String[]{});
+  }
+
+  @Test
+  public void testValidateFilePassphraseConfig()
+  {
+    Map<String, String> config = getCorrectConfig();
+    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_PRIVATE_KEY_PASSPHRASE, " ${file:/");
+    Map<String, ConfigValue> validateMap = toValidateMap(config);
+    assertPropHasError(validateMap, new String[]{});
+  }
+
   @Test
   public void testValidateErrorPassphraseConfig()
   {

--- a/test/apache_properties/connect-distributed.properties
+++ b/test/apache_properties/connect-distributed.properties
@@ -84,3 +84,6 @@ rest.port=8083
 # Examples: 
 # plugin.path=/usr/local/share/java,/usr/local/share/kafka/plugins,/opt/connectors,
 plugin.path=/usr/local/share/kafka/plugins
+
+config.providers=file
+config.providers.file.class=org.apache.kafka.common.config.provider.FileConfigProvider

--- a/test/apache_properties/file-secrets.txt
+++ b/test/apache_properties/file-secrets.txt
@@ -1,0 +1,1 @@
+PASSPHRASE=

--- a/test/rest_request_template/travis_correct_string_json.json
+++ b/test/rest_request_template/travis_correct_string_json.json
@@ -6,6 +6,7 @@
     "snowflake.url.name":"SNOWFLAKE_HOST",
     "snowflake.user.name":"SNOWFLAKE_USER",
     "snowflake.private.key":"SNOWFLAKE_PRIVATE_KEY",
+    "snowflake.private.key.passphrase":"${file:./apache_properties/file-secrets.txt:PASSPHRASE}",
     "snowflake.database.name":"SNOWFLAKE_DATABASE",
     "snowflake.schema.name":"SNOWFLAKE_SCHEMA",
     "key.converter":"org.apache.kafka.connect.storage.StringConverter",


### PR DESCRIPTION
If secrets in the config are read from a ConfigFileProvider, we cannot validate the config. Reading file path and do the validation is too complex and might result in permission error. So the simple solution would be to skip validation when passwords or passphrase is from file.