### PR TITLE
Add integration and E2E test for proxy config with username and password

### DIFF
--- a/.github/scripts/squid.conf
+++ b/.github/scripts/squid.conf
@@ -1,0 +1,34 @@
+acl SSL_ports port 443
+acl Safe_ports port 80          # http
+acl Safe_ports port 21          # ftp
+acl Safe_ports port 443         # https
+acl Safe_ports port 70          # gopher
+acl Safe_ports port 210         # wais
+acl Safe_ports port 1025-65535  # unregistered ports
+acl Safe_ports port 280         # http-mgmt
+acl Safe_ports port 488         # gss-http
+acl Safe_ports port 591         # filemaker
+acl Safe_ports port 777         # multiling http
+acl CONNECT method CONNECT
+
+http_access deny !Safe_ports
+http_access deny CONNECT !SSL_ports
+
+http_port 3128
+coredump_dir /var/spool/squid
+
+refresh_pattern ^ftp:           1440    20%     10080
+refresh_pattern ^gopher:        1440    0%      1440
+refresh_pattern -i (/cgi-bin/|\?) 0     0%      0
+refresh_pattern (Release|Packages(.gz)*)$      0       20%     2880
+refresh_pattern .               0       20%     4320
+
+auth_param basic program /usr/lib/squid/basic_ncsa_auth /etc/squid/passwords
+auth_param basic realm proxy
+acl authenticated proxy_auth REQUIRED
+http_access allow authenticated
+
+http_access allow localhost
+
+ident_lookup_access deny all
+http_access deny all

--- a/.github/workflows/End2EndFullTest.yml
+++ b/.github/workflows/End2EndFullTest.yml
@@ -33,6 +33,20 @@ jobs:
         curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
         sudo apt-get -y install jq
         sudo apt-get -y install protobuf-compiler
+
+    - name: Install Squid as Proxy Server and Apache Utils for Password Authentication
+      run: |
+        sudo apt-get update
+        sudo apt-get -y install squid3
+        sudo apt-get install apache2-utils
+
+    - name: Change squid config and run Proxy Server
+      run: |
+        sudo touch /etc/squid/passwords
+        sudo chmod 777 /etc/squid/passwords
+        sudo htpasswd -db -c /etc/squid/passwords admin test
+        sudo mv .github/scripts/squid.conf /etc/squid/squid.conf
+        sudo service squid start
     
     - name: Build with Unit and Integration Test
       env:

--- a/.github/workflows/End2EndFullTestAzure.yml
+++ b/.github/workflows/End2EndFullTestAzure.yml
@@ -33,6 +33,20 @@ jobs:
         curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
         sudo apt-get -y install jq
         sudo apt-get -y install protobuf-compiler
+
+    - name: Install Squid as Proxy Server and Apache Utils for Password Authentication
+      run: |
+        sudo apt-get update
+        sudo apt-get -y install squid3
+        sudo apt-get install apache2-utils
+
+    - name: Change squid config and run Proxy Server
+      run: |
+        sudo touch /etc/squid/passwords
+        sudo chmod 777 /etc/squid/passwords
+        sudo htpasswd -db -c /etc/squid/passwords admin test
+        sudo mv .github/scripts/squid.conf /etc/squid/squid.conf
+        sudo service squid start
     
     - name: Build with Unit and Integration Test
       env:

--- a/.github/workflows/End2EndTestApacheAws.yml
+++ b/.github/workflows/End2EndTestApacheAws.yml
@@ -33,8 +33,22 @@ jobs:
         pip3 install protobuf
         pip3 install --upgrade snowflake-connector-python
         curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
-        sudo apt-get -y install jq
+        sudo apt-get -y install jq vim
         sudo apt-get -y install protobuf-compiler
+
+    - name: Install Squid as Proxy Server and Apache Utils for Password Authentication
+      run: |
+        sudo apt-get update
+        sudo apt-get -y install squid3
+        sudo apt-get install apache2-utils
+
+    - name: Change squid config and run Proxy Server
+      run: |
+        sudo touch /etc/squid/passwords
+        sudo chmod 777 /etc/squid/passwords
+        sudo htpasswd -db -c /etc/squid/passwords admin test
+        sudo mv .github/scripts/squid.conf /etc/squid/squid.conf
+        sudo service squid start
     
     - name: Build with Unit Test
       env:

--- a/.github/workflows/End2EndTestApacheAzure.yml
+++ b/.github/workflows/End2EndTestApacheAzure.yml
@@ -35,6 +35,20 @@ jobs:
         curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
         sudo apt-get -y install jq
         sudo apt-get -y install protobuf-compiler
+
+    - name: Install Squid as Proxy Server and Apache Utils for Password Authentication
+      run: |
+        sudo apt-get update
+        sudo apt-get -y install squid3
+        sudo apt-get install apache2-utils
+
+    - name: Change squid config and run Proxy Server
+      run: |
+        sudo touch /etc/squid/passwords
+        sudo chmod 777 /etc/squid/passwords
+        sudo htpasswd -db -c /etc/squid/passwords admin test
+        sudo mv .github/scripts/squid.conf /etc/squid/squid.conf
+        sudo service squid start
     
     - name: Build with Unit Test
       env:

--- a/.github/workflows/End2EndTestConfluentAws.yml
+++ b/.github/workflows/End2EndTestConfluentAws.yml
@@ -33,8 +33,22 @@ jobs:
         pip3 install protobuf
         pip3 install --upgrade snowflake-connector-python
         curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
-        sudo apt-get -y install jq
+        sudo apt-get -y install jq vim
         sudo apt-get -y install protobuf-compiler
+
+    - name: Install Squid as Proxy Server and Apache Utils for Password Authentication
+      run: |
+        sudo apt-get update
+        sudo apt-get -y install squid3
+        sudo apt-get install apache2-utils
+
+    - name: Change squid config and run Proxy Server
+      run: |
+        sudo touch /etc/squid/passwords
+        sudo chmod 777 /etc/squid/passwords
+        sudo htpasswd -db -c /etc/squid/passwords admin test
+        sudo mv .github/scripts/squid.conf /etc/squid/squid.conf
+        sudo service squid start
 
     - name: Build with Unit Test
       env:

--- a/.github/workflows/End2EndTestConfluentAzure.yml
+++ b/.github/workflows/End2EndTestConfluentAzure.yml
@@ -33,8 +33,22 @@ jobs:
         pip3 install protobuf
         pip3 install --upgrade snowflake-connector-python
         curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
-        sudo apt-get -y install jq
+        sudo apt-get -y install jq vim
         sudo apt-get -y install protobuf-compiler
+
+    - name: Install Squid as Proxy Server and Apache Utils for Password Authentication
+      run: |
+        sudo apt-get update
+        sudo apt-get -y install squid3
+        sudo apt-get install apache2-utils
+
+    - name: Change squid config and run Proxy Server
+      run: |
+        sudo touch /etc/squid/passwords
+        sudo chmod 777 /etc/squid/passwords
+        sudo htpasswd -db -c /etc/squid/passwords admin test
+        sudo mv .github/scripts/squid.conf /etc/squid/squid.conf
+        sudo service squid start
     
     - name: Build with Unit Test
       env:

--- a/.github/workflows/IntegrationTestAws.yml
+++ b/.github/workflows/IntegrationTestAws.yml
@@ -33,8 +33,22 @@ jobs:
         pip3 install protobuf
         pip3 install --upgrade snowflake-connector-python
         curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
-        sudo apt-get -y install jq
+        sudo apt-get -y install jq vim
         sudo apt-get -y install protobuf-compiler
+
+    - name: Install Squid as Proxy Server and Apache Utils for Password Authentication
+      run: |
+        sudo apt-get update
+        sudo apt-get -y install squid3
+        sudo apt-get install apache2-utils
+
+    - name: Change squid config and run Proxy Server
+      run: |
+        sudo touch /etc/squid/passwords
+        sudo chmod 777 /etc/squid/passwords
+        sudo htpasswd -db -c /etc/squid/passwords admin test
+        sudo mv .github/scripts/squid.conf /etc/squid/squid.conf
+        sudo service squid start
     
     - name: Build with Unit and Integration Test
       env:

--- a/.github/workflows/IntegrationTestAzure.yml
+++ b/.github/workflows/IntegrationTestAzure.yml
@@ -33,8 +33,22 @@ jobs:
           pip3 install protobuf
           pip3 install --upgrade snowflake-connector-python
           curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
-          sudo apt-get -y install jq
+          sudo apt-get -y install jq vim
           sudo apt-get -y install protobuf-compiler
+
+      - name: Install Squid as Proxy Server and Apache Utils for Password Authentication
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install squid3
+          sudo apt-get install apache2-utils
+
+      - name: Change squid config and run Proxy Server
+        run: |
+          sudo touch /etc/squid/passwords
+          sudo chmod 777 /etc/squid/passwords
+          sudo htpasswd -db -c /etc/squid/passwords admin test
+          sudo mv .github/scripts/squid.conf /etc/squid/squid.conf
+          sudo service squid start
 
       - name: Build with Unit and Integration Test
         env:

--- a/.github/workflows/StressTest.yml
+++ b/.github/workflows/StressTest.yml
@@ -33,6 +33,20 @@ jobs:
         curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
         sudo apt-get -y install jq
         sudo apt-get -y install protobuf-compiler
+
+    - name: Install Squid as Proxy Server and Apache Utils for Password Authentication
+      run: |
+        sudo apt-get update
+        sudo apt-get -y install squid3
+        sudo apt-get install apache2-utils
+
+    - name: Change squid config and run Proxy Server
+      run: |
+        sudo touch /etc/squid/passwords
+        sudo chmod 777 /etc/squid/passwords
+        sudo htpasswd -db -c /etc/squid/passwords admin test
+        sudo mv .github/scripts/squid.conf /etc/squid/squid.conf
+        sudo service squid start
     
     - name: Build with Unit and Integration Test
       env:

--- a/pom.xml
+++ b/pom.xml
@@ -251,6 +251,15 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.0.0</version>
+                <configuration>
+                    <mainClass>com.snowflake.kafka.connector.internal.ResetProxyConfigExec</mainClass>
+                    <classpathScope>test</classpathScope>
+                </configuration>
+            </plugin>
         </plugins>
 
         <!-- disable default maven deploy plugin since we are using gpg:sign-and-deploy-file -->

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -24,7 +24,6 @@ import org.apache.kafka.common.config.ConfigException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.Map;
 
 /**
@@ -67,10 +66,10 @@ public class SnowflakeSinkConnectorConfig
 
   // Proxy Info
   private static final String PROXY_INFO = "Proxy Info";
-  static final String JVM_PROXY_HOST = "jvm.proxy.host";
-  static final String JVM_PROXY_PORT = "jvm.proxy.port";
-  static final String JVM_PROXY_USERNAME = "jvm.proxy.username";
-  static final String JVM_PROXY_PASSWORD = "jvm.proxy.password";
+  public static final String JVM_PROXY_HOST = "jvm.proxy.host";
+  public static final String JVM_PROXY_PORT = "jvm.proxy.port";
+  public static final String JVM_PROXY_USERNAME = "jvm.proxy.username";
+  public static final String JVM_PROXY_PASSWORD = "jvm.proxy.password";
 
   // JDBC logging directory Info (environment variable)
   static final String SNOWFLAKE_JDBC_LOG_DIR = "JDBC_LOG_DIR";

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
@@ -79,6 +79,15 @@ public class SnowflakeSinkTask extends SinkTask
     return conn;
   }
 
+  /**
+   * Return an instance of SnowflakeConnection if it was set previously by calling Start().
+   * Else, return an empty
+   * @return Optional of SnowflakeConnectionService
+   */
+  public Optional<SnowflakeConnectionService> getSnowflakeConnection() {
+    return Optional.ofNullable(getConnection());
+  }
+
   private SnowflakeSinkService getSink()
   {
     try

--- a/src/main/java/com/snowflake/kafka/connector/internal/FileNameUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/FileNameUtils.java
@@ -7,7 +7,7 @@ import org.slf4j.LoggerFactory;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-class FileNameUtils
+public class FileNameUtils
 {
   private static final Logger LOGGER =
     LoggerFactory.getLogger(FileNameUtils.class.getName());
@@ -25,7 +25,7 @@ class FileNameUtils
    * @param end       end offset
    * @return file name
    */
-  static String fileName(String appName, String table, int partition,
+  public static String fileName(String appName, String table, int partition,
                                 long start, long end)
   {
     return fileName(filePrefix(appName, table, partition), start, end);

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceFactory.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceFactory.java
@@ -1,5 +1,6 @@
 package com.snowflake.kafka.connector.internal;
 
+import com.fasterxml.jackson.databind.annotation.JsonAppend;
 import com.snowflake.kafka.connector.Utils;
 
 import java.util.Map;
@@ -14,6 +15,7 @@ public class SnowflakeConnectionServiceFactory
   public static class SnowflakeConnectionServiceBuilder extends Logging
   {
     private Properties prop;
+    private Properties proxyProperties;
     private SnowflakeURL url;
     private String connectorName;
     private String taskID = "-1";
@@ -57,6 +59,10 @@ public class SnowflakeConnectionServiceFactory
       }
       this.url = new SnowflakeURL(conf.get(Utils.SF_URL));
       this.prop = InternalUtils.createProperties(conf, this.url.sslEnabled());
+      // TODO: Ideally only one property is required, but because we dont pass it around in JDBC and snowpipe SDK,
+      //  it is better if we have two properties decoupled
+      // Right now, proxy parameters are picked from jvm system properties, in future they need to be decoupled
+      this.proxyProperties = InternalUtils.generateProxyParametersIfRequired(conf);
       this.connectorName = conf.get(Utils.NAME);
       return this;
     }
@@ -66,7 +72,7 @@ public class SnowflakeConnectionServiceFactory
       InternalUtils.assertNotEmpty("properties", prop);
       InternalUtils.assertNotEmpty("url", url);
       InternalUtils.assertNotEmpty("connectorName", connectorName);
-      return new SnowflakeConnectionServiceV1(prop, url, connectorName, taskID);
+      return new SnowflakeConnectionServiceV1(prop, url, connectorName, taskID, proxyProperties);
     }
   }
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
@@ -28,18 +28,22 @@ public class SnowflakeConnectionServiceV1 extends Logging
   private final String connectorName;
   private final String taskID;
   private final Properties prop;
+
+  // Placeholder for all proxy related properties set in the connector configuration
+  private final Properties proxyProperties;
   private final SnowflakeURL url;
   private final SnowflakeInternalStage internalStage;
   private StageInfo.StageType stageType;
 
   SnowflakeConnectionServiceV1(Properties prop, SnowflakeURL url,
-                               String connectorName, String taskID)
+                               String connectorName, String taskID, Properties proxyProperties)
   {
     this.connectorName = connectorName;
     this.taskID = taskID;
     this.url = url;
     this.prop = prop;
     this.stageType = null;
+    this.proxyProperties = proxyProperties;
     try
     {
       this.conn = new SnowflakeDriver().connect(url.getJdbcUrl(), prop);
@@ -48,7 +52,7 @@ public class SnowflakeConnectionServiceV1 extends Logging
       throw SnowflakeErrors.ERROR_1001.getException(e);
     }
     long credentialExpireTime = 30 * 60 * 1000L;
-    this.internalStage = new SnowflakeInternalStage((SnowflakeConnectionV1) this.conn, credentialExpireTime);
+    this.internalStage = new SnowflakeInternalStage((SnowflakeConnectionV1) this.conn, credentialExpireTime, proxyProperties);
     this.telemetry =
       SnowflakeTelemetryServiceFactory.builder(conn)
         .setAppName(this.connectorName)

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeInternalStage.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeInternalStage.java
@@ -10,6 +10,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.locks.Lock;
@@ -34,11 +35,16 @@ public class SnowflakeInternalStage extends Logging {
   public static String dummyPutCommandTemplate = "PUT file:///tmp/dummy_location_kakfa_connector_tmp/ @";
   private final SnowflakeConnectionV1 conn;
   private final long expirationTime;
+  // Proxy parameters that we set while calling the snowflake JDBC.
+  // Also required to pass in the uploadWithoutConnection API in the SnowflakeFileTransferConfig
+  // It may not necessarily just contain proxy parameters, JDBC client filters all other properties.
+  private final Properties proxyProperties;
 
-  public SnowflakeInternalStage(SnowflakeConnectionV1 conn, long expirationTime)
+  public SnowflakeInternalStage(SnowflakeConnectionV1 conn, long expirationTime, Properties proxyProperties)
   {
     this.conn = conn;
     this.expirationTime = expirationTime;
+    this.proxyProperties = proxyProperties;
   }
 
   /**
@@ -115,6 +121,7 @@ public class SnowflakeInternalStage extends Logging {
             .setUploadStream(inStream)
             .setRequireCompress(true)
             .setOcspMode(OCSPMode.FAIL_OPEN)
+            .setProxyProperties(proxyProperties)
             .build());
       } catch (Throwable t)
       {

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorIT.java
@@ -1,7 +1,13 @@
 package com.snowflake.kafka.connector;
 
+import com.snowflake.kafka.connector.internal.TestUtils;
+import net.snowflake.client.core.HttpUtil;
+import net.snowflake.client.core.SFSessionProperty;
+import net.snowflake.client.jdbc.SnowflakeSQLException;
 import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigValue;
+import org.junit.After;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.*;
@@ -107,6 +113,15 @@ public class ConnectorIT
     config.remove(Utils.NAME);
     config.remove(TASK_ID);
     return config;
+  }
+
+  @After
+  public void cleanup() throws SnowflakeSQLException {
+    try {
+      TestUtils.resetProxyParametersInJDBC();
+    } catch (SnowflakeSQLException ex) {
+      Assert.fail("Cannot reset proxy parameters in:" + this.getClass().getName());
+    }
   }
 
   @Test
@@ -332,9 +347,9 @@ public class ConnectorIT
   {
     Map<String, String> config = getCorrectConfig();
     config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_HOST, "localhost");
-    config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_PORT, "8080");
-    config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_USERNAME, "user");
-    config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_PASSWORD, "pass");
+    config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_PORT, "3128");
+    config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_USERNAME, "admin");
+    config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_PASSWORD, "test");
     Map<String, ConfigValue> validateMap = toValidateMap(config);
     assertPropHasError(validateMap, new String[]{
     });

--- a/src/test/java/com/snowflake/kafka/connector/SinkTaskIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/SinkTaskIT.java
@@ -1,9 +1,6 @@
 package com.snowflake.kafka.connector;
 
-import com.snowflake.kafka.connector.internal.FileNameUtils;
 import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
-import com.snowflake.kafka.connector.internal.SnowflakeIngestionService;
-import com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException;
 import com.snowflake.kafka.connector.internal.TestUtils;
 import com.snowflake.kafka.connector.records.SnowflakeJsonSchema;
 import com.snowflake.kafka.connector.records.SnowflakeRecordContent;
@@ -14,7 +11,7 @@ import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.After;
-import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.*;
@@ -23,16 +20,22 @@ import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BUFFER_
 import static com.snowflake.kafka.connector.internal.TestUtils.TEST_CONNECTOR_NAME;
 
 public class SinkTaskIT {
-  private String topicName = TestUtils.randomTableName();
-  private SnowflakeConnectionService conn = TestUtils.getConnectionService();
+  private String topicName;
+  private SnowflakeConnectionService snowflakeConnectionService;
   private static int partition = 0;
 
+  @Before
+  public void setup() {
+    topicName = TestUtils.randomTableName();
+
+    snowflakeConnectionService = TestUtils.getConnectionService();
+  }
+
   @After
-  public void after()
-  {
+  public void after() {
     TestUtils.dropTable(topicName);
-    conn.dropStage(Utils.stageName(TEST_CONNECTOR_NAME, topicName));
-    conn.dropPipe(Utils.pipeName(TEST_CONNECTOR_NAME, topicName, partition));
+    snowflakeConnectionService.dropStage(Utils.stageName(TEST_CONNECTOR_NAME, topicName));
+    snowflakeConnectionService.dropPipe(Utils.pipeName(TEST_CONNECTOR_NAME, topicName, partition));
   }
 
   @Test
@@ -43,47 +46,6 @@ public class SinkTaskIT {
 
     sinkTask.preCommit(offsetMap);
     System.out.println("PreCommit test success");
-  }
-
-  @Test(expected = SnowflakeKafkaConnectorException.class)
-  public void testSinkTaskProxyConfigMock()
-  {
-    Map<String, String> config = TestUtils.getConf();
-    SnowflakeSinkConnectorConfig.setDefaultValues(config);
-
-    config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_HOST, "wronghost");
-    config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_PORT, "wrongport");
-    config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_USERNAME, "user");
-    config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_PASSWORD, "password");
-    SnowflakeSinkTask sinkTask = new SnowflakeSinkTask();
-    try
-    {
-      sinkTask.start(config);
-    } catch (SnowflakeKafkaConnectorException e)
-    {
-      assert System.getProperty(Utils.HTTP_USE_PROXY).equals("true");
-      assert System.getProperty(Utils.HTTP_PROXY_HOST).equals("wronghost");
-      assert System.getProperty(Utils.HTTP_PROXY_PORT).equals("wrongport");
-      assert System.getProperty(Utils.HTTPS_PROXY_HOST).equals("wronghost");
-      assert System.getProperty(Utils.HTTPS_PROXY_PORT).equals("wrongport");
-      assert System.getProperty(Utils.JDK_HTTP_AUTH_TUNNELING).isEmpty();
-      assert System.getProperty(Utils.HTTP_PROXY_USER).equals("user");
-      assert System.getProperty(Utils.HTTP_PROXY_PASSWORD).equals("password");
-      assert System.getProperty(Utils.HTTPS_PROXY_USER).equals("user");
-      assert System.getProperty(Utils.HTTPS_PROXY_PASSWORD).equals("password");
-
-      System.setProperty(Utils.HTTP_USE_PROXY, "");
-      System.setProperty(Utils.HTTP_PROXY_HOST, "");
-      System.setProperty(Utils.HTTP_PROXY_PORT, "");
-      System.setProperty(Utils.HTTPS_PROXY_HOST, "");
-      System.setProperty(Utils.HTTPS_PROXY_PORT, "");
-      System.setProperty(Utils.JDK_HTTP_AUTH_TUNNELING, "");
-      System.setProperty(Utils.HTTP_PROXY_USER, "");
-      System.setProperty(Utils.HTTP_PROXY_PASSWORD, "");
-      System.setProperty(Utils.HTTPS_PROXY_USER, "");
-      System.setProperty(Utils.HTTPS_PROXY_PASSWORD, "");
-      throw e;
-    }
   }
 
   @Test
@@ -178,64 +140,5 @@ public class SinkTaskIT {
     sinkTask.stop();
 
     sinkTask.logWarningForPutAndPrecommit(System.currentTimeMillis() - 400 * 1000, 1, "put");
-  }
-
-  /* Proxy Related tests */
-
-  /**
-   * To run this test, spin up a http/https proxy at 127.0.0.1:3128 and set authentication as required.
-   *
-   * For instructions on how to setup proxy server take a look at .github/workflows/IntegrationTestAws.yml
-   */
-  @Test
-  public void testSinkTaskProxyConfig()
-  {
-    Map<String, String> config = TestUtils.getConf();
-    SnowflakeSinkConnectorConfig.setDefaultValues(config);
-
-    config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_HOST, "127.0.0.1");
-    config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_PORT, "3128");
-    config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_USERNAME, "admin");
-    config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_PASSWORD, "test");
-    SnowflakeSinkTask sinkTask = new SnowflakeSinkTask();
-
-    sinkTask.start(config);
-
-    assert System.getProperty(Utils.HTTP_USE_PROXY).equals("true");
-    assert System.getProperty(Utils.HTTP_PROXY_HOST).equals("127.0.0.1");
-    assert System.getProperty(Utils.HTTP_PROXY_PORT).equals("3128");
-    assert System.getProperty(Utils.HTTPS_PROXY_HOST).equals("127.0.0.1");
-    assert System.getProperty(Utils.HTTPS_PROXY_PORT).equals("3128");
-    assert System.getProperty(Utils.JDK_HTTP_AUTH_TUNNELING).isEmpty();
-    assert System.getProperty(Utils.HTTP_PROXY_USER).equals("admin");
-    assert System.getProperty(Utils.HTTP_PROXY_PASSWORD).equals("test");
-    assert System.getProperty(Utils.HTTPS_PROXY_USER).equals("admin");
-    assert System.getProperty(Utils.HTTPS_PROXY_PASSWORD).equals("test");
-
-    // get the snowflakeconnection service which was made during sinkTask
-
-    Optional<SnowflakeConnectionService> optSfConnectionService = sinkTask.getSnowflakeConnection();
-
-    Assert.assertTrue(optSfConnectionService.isPresent());
-
-    SnowflakeConnectionService connectionService = optSfConnectionService.get();
-
-    String stage = TestUtils.randomStageName();
-    String pipe = TestUtils.randomPipeName();
-    String table = TestUtils.randomTableName();
-
-    connectionService.createStage(stage);
-    connectionService.createTable(table);
-    connectionService.createPipe(table, stage, pipe);
-
-    SnowflakeIngestionService ingestionService = connectionService.buildIngestService(stage, pipe);
-
-    String file = "{\"aa\":123}";
-    String fileName = FileNameUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, 0, 0, 1);
-
-    connectionService.putWithCache(stage, fileName, file);
-    ingestionService.ingestFile(fileName);
-    List<String> names = new ArrayList<>(1);
-    names.add(fileName);
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/SinkTaskProxyIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/SinkTaskProxyIT.java
@@ -1,0 +1,116 @@
+package com.snowflake.kafka.connector;
+
+import com.snowflake.kafka.connector.internal.FileNameUtils;
+import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
+import com.snowflake.kafka.connector.internal.SnowflakeIngestionService;
+import com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException;
+import com.snowflake.kafka.connector.internal.TestUtils;
+import net.snowflake.client.jdbc.SnowflakeSQLException;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.*;
+
+public class SinkTaskProxyIT {
+
+    @After
+    public void testCleanup() {
+        try {
+            TestUtils.resetProxyParametersInJDBC();
+            TestUtils.resetProxyParametersInJVM();
+        } catch (SnowflakeSQLException ex) {
+            Assert.fail("Cannot reset proxy parameters in:" + this.getClass().getName());
+        }
+    }
+
+    @Test(expected = SnowflakeKafkaConnectorException.class)
+    public void testSinkTaskProxyConfigMock()
+    {
+        Map<String, String> config = TestUtils.getConf();
+        SnowflakeSinkConnectorConfig.setDefaultValues(config);
+
+        config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_HOST, "wronghost");
+        config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_PORT, "9093"); // wrongport
+        config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_USERNAME, "user");
+        config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_PASSWORD, "password");
+        SnowflakeSinkTask sinkTask = new SnowflakeSinkTask();
+        try
+        {
+            sinkTask.start(config);
+        } catch (SnowflakeKafkaConnectorException e)
+        {
+            assert System.getProperty(Utils.HTTP_USE_PROXY).equals("true");
+            assert System.getProperty(Utils.HTTP_PROXY_HOST).equals("wronghost");
+            assert System.getProperty(Utils.HTTP_PROXY_PORT).equals("9093");
+            assert System.getProperty(Utils.HTTPS_PROXY_HOST).equals("wronghost");
+            assert System.getProperty(Utils.HTTPS_PROXY_PORT).equals("9093");
+            assert System.getProperty(Utils.JDK_HTTP_AUTH_TUNNELING).isEmpty();
+            assert System.getProperty(Utils.HTTP_PROXY_USER).equals("user");
+            assert System.getProperty(Utils.HTTP_PROXY_PASSWORD).equals("password");
+            assert System.getProperty(Utils.HTTPS_PROXY_USER).equals("user");
+            assert System.getProperty(Utils.HTTPS_PROXY_PASSWORD).equals("password");
+
+            // unset the system parameters please.
+            TestUtils.resetProxyParametersInJVM();
+            throw e;
+        }
+    }
+
+    /**
+     * To run this test, spin up a http/https proxy at 127.0.0.1:3128 and set authentication as required.
+     *
+     * For instructions on how to setup proxy server take a look at .github/workflows/IntegrationTestAws.yml
+     */
+    @Test
+    public void testSinkTaskProxyConfig()
+    {
+        Map<String, String> config = TestUtils.getConf();
+        SnowflakeSinkConnectorConfig.setDefaultValues(config);
+
+        config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_HOST, "localhost");
+        config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_PORT, "3128");
+        config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_USERNAME, "admin");
+        config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_PASSWORD, "test");
+        SnowflakeSinkTask sinkTask = new SnowflakeSinkTask();
+
+        sinkTask.start(config);
+
+        assert System.getProperty(Utils.HTTP_USE_PROXY).equals("true");
+        assert System.getProperty(Utils.HTTP_PROXY_HOST).equals("localhost");
+        assert System.getProperty(Utils.HTTP_PROXY_PORT).equals("3128");
+        assert System.getProperty(Utils.HTTPS_PROXY_HOST).equals("localhost");
+        assert System.getProperty(Utils.HTTPS_PROXY_PORT).equals("3128");
+        assert System.getProperty(Utils.JDK_HTTP_AUTH_TUNNELING).isEmpty();
+        assert System.getProperty(Utils.HTTP_PROXY_USER).equals("admin");
+        assert System.getProperty(Utils.HTTP_PROXY_PASSWORD).equals("test");
+        assert System.getProperty(Utils.HTTPS_PROXY_USER).equals("admin");
+        assert System.getProperty(Utils.HTTPS_PROXY_PASSWORD).equals("test");
+
+        // get the snowflakeconnection service which was made during sinkTask
+
+        Optional<SnowflakeConnectionService> optSfConnectionService = sinkTask.getSnowflakeConnection();
+
+        Assert.assertTrue(optSfConnectionService.isPresent());
+
+        SnowflakeConnectionService connectionService = optSfConnectionService.get();
+
+        String stage = TestUtils.randomStageName();
+        String pipe = TestUtils.randomPipeName();
+        String table = TestUtils.randomTableName();
+
+        connectionService.createStage(stage);
+        connectionService.createTable(table);
+        connectionService.createPipe(table, stage, pipe);
+
+        SnowflakeIngestionService ingestionService = connectionService.buildIngestService(stage, pipe);
+
+        String file = "{\"aa\":123}";
+        String fileName = FileNameUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, 0, 0, 1);
+
+        connectionService.putWithCache(stage, fileName, file);
+        ingestionService.ingestFile(fileName);
+        List<String> names = new ArrayList<>(1);
+        names.add(fileName);
+    }
+}

--- a/src/test/java/com/snowflake/kafka/connector/internal/InternalStageIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/InternalStageIT.java
@@ -1,22 +1,24 @@
 package com.snowflake.kafka.connector.internal;
 
+import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
 import net.snowflake.client.core.OCSPMode;
+import net.snowflake.client.core.SFSessionProperty;
 import net.snowflake.client.core.SFStatement;
 import net.snowflake.client.jdbc.SnowflakeConnectionV1;
 import net.snowflake.client.jdbc.SnowflakeFileTransferAgent;
 import net.snowflake.client.jdbc.SnowflakeFileTransferConfig;
 import net.snowflake.client.jdbc.SnowflakeFileTransferMetadataV1;
-import net.snowflake.client.jdbc.cloud.storage.StageInfo;
+import net.snowflake.client.jdbc.SnowflakeSQLException;
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 
 public class InternalStageIT {
 
@@ -26,6 +28,7 @@ public class InternalStageIT {
   private final String stageName2 = TestUtils.randomStageName();
   private final String stageName3 = TestUtils.randomStageName();
   private final String stageName4 = TestUtils.randomStageName();
+  private final String proxyStage = TestUtils.randomStageName();
   private final String stageNameExpire= "kafka_connector_test_stage_credential_cache_expire";
 
   @After
@@ -46,7 +49,7 @@ public class InternalStageIT {
     service.createStage(stageName3);
 
     SnowflakeInternalStage agent = new SnowflakeInternalStage((SnowflakeConnectionV1) service.getConnection(),
-      30 * 60 * 1000L);
+      30 * 60 * 1000L, null);
 
     // PUT two files to stageName1
     long startTime = System.currentTimeMillis();
@@ -82,6 +85,52 @@ public class InternalStageIT {
 
   }
 
+  /**
+   * Tests internal put with cache API with proxy parameters set.
+   * Please take a look at workflow file for configuration of proxy.
+   */
+  @Test
+  public void testInternalStageWithProxy() throws SnowflakeSQLException {
+    // create properties for proxy
+    Properties proxyProperties = new Properties();
+
+    proxyProperties.put(SFSessionProperty.USE_PROXY.getPropertyKey(), "true");
+    proxyProperties.put(SFSessionProperty.PROXY_HOST.getPropertyKey(), "localhost");
+    proxyProperties.put(SFSessionProperty.PROXY_PORT.getPropertyKey(), "3128");
+    proxyProperties.put(SFSessionProperty.PROXY_USER.getPropertyKey(), "admin");
+    proxyProperties.put(SFSessionProperty.PROXY_PASSWORD.getPropertyKey(), "test");
+
+    // Create new snowflake connection service
+    Map<String, String> config = TestUtils.getConf();
+
+    config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_HOST, "localhost");
+    config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_PORT, "3128");
+    config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_USERNAME, "admin");
+    config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_PASSWORD, "test");
+
+    SnowflakeConnectionService proxyConnectionService = TestUtils.getConnectionService(config);
+    // create stage
+    proxyConnectionService.createStage(proxyStage);
+
+    SnowflakeInternalStage agent = new SnowflakeInternalStage(
+            (SnowflakeConnectionV1) proxyConnectionService.getConnection(),
+            30 * 60 * 1000L, // cache expiration time
+            proxyProperties); // proxy parameters used in JDBC
+
+    // PUT two files to proxyStage
+    long startTime = System.currentTimeMillis();
+    agent.putWithCache(proxyStage, "testInternalStageWithProxy1", "Any cache");
+    agent.putWithCache(proxyStage, "testInternalStageWithProxy2", "Any cache");
+    List<String> files1 = proxyConnectionService.listStage(proxyStage, "testInternalStage");
+    assert files1.size() == 2;
+    System.out.println(Logging.logMessage("Time: {} ms",
+            (System.currentTimeMillis() - startTime)));
+    proxyConnectionService.dropStage(proxyStage);
+
+    // Reset proxy configuration
+    TestUtils.resetProxyParametersInJDBC();
+  }
+
   @Test
   public void testCredentialRefresh() throws Exception
   {
@@ -91,7 +140,7 @@ public class InternalStageIT {
 
     // credential expires in 30 seconds
     SnowflakeInternalStage agent = new SnowflakeInternalStage((SnowflakeConnectionV1) service.getConnection(),
-      30 * 1000L);
+      30 * 1000L, null);
 
     // PUT two files to stageName1
     agent.putWithCache(stageName4, "testCacheFileName1", "Any cache");

--- a/src/test/java/com/snowflake/kafka/connector/internal/ResetProxyConfigExec.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/ResetProxyConfigExec.java
@@ -1,0 +1,12 @@
+package com.snowflake.kafka.connector.internal;
+
+import net.snowflake.client.jdbc.SnowflakeSQLException;
+
+public class ResetProxyConfigExec extends Logging {
+    public static void main(String[] args) throws SnowflakeSQLException {
+        System.out.println("ResetProxyConfigExec::Start wiping Proxy config");
+        TestUtils.resetProxyParametersInJDBC();
+        TestUtils.resetProxyParametersInJVM();
+        System.out.println("ResetProxyConfigExec::Proxy Parameters reset in JVM in JDBC");
+    }
+}

--- a/test/rest_request_template/travis_correct_string_proxy.json
+++ b/test/rest_request_template/travis_correct_string_proxy.json
@@ -1,0 +1,19 @@
+{
+  "name":"SNOWFLAKE_CONNECTOR_NAME",
+  "config":{
+    "connector.class":"com.snowflake.kafka.connector.SnowflakeSinkConnector",
+    "topics":"SNOWFLAKE_TEST_TOPIC",
+    "snowflake.url.name":"SNOWFLAKE_HOST",
+    "snowflake.user.name":"SNOWFLAKE_USER",
+    "snowflake.private.key":"SNOWFLAKE_PRIVATE_KEY",
+    "snowflake.private.key.passphrase":"${file:./apache_properties/file-secrets.txt:PASSPHRASE}",
+    "snowflake.database.name":"SNOWFLAKE_DATABASE",
+    "snowflake.schema.name":"SNOWFLAKE_SCHEMA",
+    "key.converter":"org.apache.kafka.connect.storage.StringConverter",
+    "value.converter":"com.snowflake.kafka.connector.records.SnowflakeJsonConverter",
+    "jvm.proxy.host": "localhost",
+    "jvm.proxy.port": "3128",
+    "jvm.proxy.username": "admin",
+    "jvm.proxy.password": "test"
+  }
+}

--- a/test/test_suit/test_string_json_proxy.py
+++ b/test/test_suit/test_string_json_proxy.py
@@ -42,3 +42,11 @@ class TestStringJsonProxy:
 
     def clean(self):
         self.driver.cleanTableStagePipe(self.topic)
+        # unset the JVM parameters
+        print("Unset JVM Parameters")
+        mvnExecMain = "mvn exec:java -Dexec.mainClass=\"com.snowflake.kafka.connector.internal.ResetProxyConfigExec\""
+        print(self.run_cmd(mvnExecMain).split())
+
+    def run_cmd(self, command):
+        import subprocess
+        return subprocess.Popen(command, shell=True, stdout=subprocess.PIPE).stdout.read()

--- a/test/test_suit/test_string_json_proxy.py
+++ b/test/test_suit/test_string_json_proxy.py
@@ -1,0 +1,44 @@
+from test_suit.test_utils import RetryableError, NonRetryableError
+import json
+
+
+class TestStringJsonProxy:
+    def __init__(self, driver, nameSalt):
+        self.driver = driver
+        self.fileName = "travis_correct_string_proxy"
+        self.topic = self.fileName + nameSalt
+
+    def getConfigFileName(self):
+        return self.fileName + ".json"
+
+    def send(self):
+        value = []
+        for e in range(100):
+            value.append(json.dumps({'number': str(e)}).encode('utf-8'))
+        header = [('header1', 'value1'), ('header2', '{}')]
+        self.driver.sendBytesData(self.topic, value, [], 0, header)
+
+    def verify(self, round):
+        res = self.driver.snowflake_conn.cursor().execute(
+            "SELECT count(*) FROM {}".format(self.topic)).fetchone()[0]
+        if res == 0:
+            raise RetryableError()
+        elif res != 100:
+            raise NonRetryableError("Number of record in table is different from number of record sent")
+
+        # validate content of line 1
+        oldVersions = ["5.4.0", "5.3.0", "5.2.0", "2.4.0", "2.3.0", "2.2.0"]
+        if self.driver.testVersion in oldVersions:
+            goldMeta = r'{"CreateTime":\d*,"headers":{"header1":"value1","header2":{}},"offset":0,"partition":0,"topic":"travis_correct_string_proxy....."}'
+        else:
+            goldMeta = r'{"CreateTime":\d*,"headers":{"header1":"value1","header2":[]},"offset":0,"partition":0,"topic":"travis_correct_string_proxy....."}'
+
+        res = self.driver.snowflake_conn.cursor().execute(
+            "Select * from {} limit 1".format(self.topic)).fetchone()
+        goldContent = r'{"number":"0"}'
+        self.driver.regexMatchOneLine(res, goldMeta, goldContent)
+
+        self.driver.verifyStageIsCleaned(self.topic)
+
+    def clean(self):
+        self.driver.cleanTableStagePipe(self.topic)

--- a/test/test_verify.py
+++ b/test/test_verify.py
@@ -289,6 +289,7 @@ class KafkaTest:
 
 def runTestSet(driver, testSet, nameSalt, pressure):
     from test_suit.test_string_json import TestStringJson
+    from test_suit.test_string_json_proxy import TestStringJsonProxy
     from test_suit.test_json_json import TestJsonJson
     from test_suit.test_string_avro import TestStringAvro
     from test_suit.test_avro_avro import TestAvroAvro
@@ -320,18 +321,21 @@ def runTestSet(driver, testSet, nameSalt, pressure):
     testNativeStringProtobuf = TestNativeStringProtobuf(driver, nameSalt)
     testConfluentProtobufProtobuf = TestConfluentProtobufProtobuf(driver, nameSalt)
 
+    testStringJsonProxy = TestStringJsonProxy(driver, nameSalt)
+
     ############################ round 1 ############################
     print(datetime.now().strftime("\n%H:%M:%S "), "=== Round 1 ===")
     testSuitList1 = [testStringJson, testJsonJson, testStringAvro, testAvroAvro, testStringAvrosr,
                      testAvrosrAvrosr, testNativeStringAvrosr, testNativeStringJsonWithoutSchema,
-                     testNativeComplexSmt, testNativeStringProtobuf, testConfluentProtobufProtobuf]
+                     testNativeComplexSmt, testNativeStringProtobuf, testConfluentProtobufProtobuf, testStringJsonProxy]
 
-    testCleanEnableList1 = [True, True, True, True, True, True, True, True, True, True, True]
+    # Adding StringJsonProxy test at the end
+    testCleanEnableList1 = [True, True, True, True, True, True, True, True, True, True, True, True]
     testSuitEnableList1 = []
     if testSet == "confluent":
-        testSuitEnableList1 = [True, True, True, True, True, True, True, True, True, True, False]
+        testSuitEnableList1 = [True, True, True, True, True, True, True, True, True, True, False, True]
     elif testSet == "apache":
-        testSuitEnableList1 = [True, True, True, True, False, False, False, True, True, True, False]
+        testSuitEnableList1 = [True, True, True, True, False, False, False, True, True, True, False, True]
     elif testSet != "clean":
         errorExit("Unknown testSet option {}, please input confluent, apache or clean".format(testSet))
 

--- a/test/test_verify.py
+++ b/test/test_verify.py
@@ -327,15 +327,15 @@ def runTestSet(driver, testSet, nameSalt, pressure):
     print(datetime.now().strftime("\n%H:%M:%S "), "=== Round 1 ===")
     testSuitList1 = [testStringJson, testJsonJson, testStringAvro, testAvroAvro, testStringAvrosr,
                      testAvrosrAvrosr, testNativeStringAvrosr, testNativeStringJsonWithoutSchema,
-                     testNativeComplexSmt, testNativeStringProtobuf, testConfluentProtobufProtobuf, testStringJsonProxy]
+                     testNativeComplexSmt, testNativeStringProtobuf, testConfluentProtobufProtobuf]
 
     # Adding StringJsonProxy test at the end
-    testCleanEnableList1 = [True, True, True, True, True, True, True, True, True, True, True, True]
+    testCleanEnableList1 = [True, True, True, True, True, True, True, True, True, True, True]
     testSuitEnableList1 = []
     if testSet == "confluent":
-        testSuitEnableList1 = [True, True, True, True, True, True, True, True, True, True, False, True]
+        testSuitEnableList1 = [True, True, True, True, True, True, True, True, True, True, False]
     elif testSet == "apache":
-        testSuitEnableList1 = [True, True, True, True, False, False, False, True, True, True, False, True]
+        testSuitEnableList1 = [True, True, True, True, False, False, False, True, True, True, False]
     elif testSet != "clean":
         errorExit("Unknown testSet option {}, please input confluent, apache or clean".format(testSet))
 
@@ -373,6 +373,26 @@ def runTestSet(driver, testSet, nameSalt, pressure):
 
     execution(testSet, testSuitList3, testCleanEnableList3, testSuitEnableList3, driver, nameSalt, 4)
     ############################ round 3 ############################
+
+    ############################ round 4: Proxy End To End Test ############################
+    print(datetime.now().strftime("\n%H:%M:%S "), "=== Round 4: Proxy E2E Test ===")
+    print("Proxy Test should be the last test, since it modifies the JVM values")
+    testSuitList4 = [testStringJsonProxy]
+
+    # Should we invoke clean before and after the test
+    testCleanEnableList4 = [True]
+
+    # should we enable this? Set to false to disable
+    testSuitEnableList4 = []
+    if testSet == "confluent":
+        testSuitEnableList4 = [True]
+    elif testSet == "apache":
+        testSuitEnableList4 = [True]
+    elif testSet != "clean":
+        errorExit("Unknown testSet option {}, please input confluent, apache or clean".format(testSet))
+
+    execution(testSet, testSuitList4, testCleanEnableList4, testSuitEnableList4, driver, nameSalt)
+    ############################ round 4 ############################
 
 
 def execution(testSet, testSuitList, testCleanEnableList, testSuitEnableList, driver, nameSalt, round = 1):


### PR DESCRIPTION
This includes following:
### Commit 1:
- Setup proxy server
- Run integration test and end to end test with proxy setup.
- Proxy username passwords are always admin and test.
- Integration test which is currently disabled but requires a proxy on local machine

### Commit 2
Which was approved here: https://github.com/snowflakedb/snowflake-kafka-connector/pull/273

## Testing:
- Tested locally with newer version of snowpipe SDK jar. 
- Tested with github actions act: https://github.com/nektos/act
- It is able to create connector and also able to ingest a file in snowflake. 

## Prerequisite:
- Waiting for tests to pass in workflow. 
