### PR TITLE
Release Connector 1.5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.snowflake</groupId>
     <artifactId>snowflake-kafka-connector</artifactId>
-    <version>1.5.1</version>
+    <version>1.5.2</version>
     <packaging>jar</packaging>
     <name>Snowflake Kafka Connector</name>
     <description>Snowflake Kafka Connect Sink Connector</description>

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -13,7 +13,7 @@
 
     <groupId>com.snowflake</groupId>
     <artifactId>snowflake-kafka-connector</artifactId>
-    <version>1.5.1</version>
+    <version>1.5.2</version>
     <packaging>jar</packaging>
     <name>Snowflake Kafka Connector</name>
     <description>Snowflake Kafka Connect Sink Connector</description>

--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -44,7 +44,7 @@ public class Utils
 {
 
   //Connector version, change every release
-  public static final String VERSION = "1.5.1";
+  public static final String VERSION = "1.5.2";
 
   //connector parameter list
   public static final String NAME = "name";


### PR DESCRIPTION
New release 1.5.2

Release Notes:
- Fixes bug for proxy configured kafka connector
- Newer version of Snowpipe SDK which support proxy configuration. 

