### PR TITLE
Fix handling of schemaless Date objects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -287,7 +287,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-api</artifactId>
-            <version>2.3.0</version>
+            <version>2.7.0</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/src/main/java/com/snowflake/kafka/connector/records/RecordService.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/RecordService.java
@@ -235,11 +235,18 @@ public class RecordService extends Logging
     try
     {
       final Schema.Type schemaType;
-      if (schema == null)
-      {
-        schemaType = ConnectSchema.schemaType(value.getClass());
-        if (schemaType == null)
-          throw SnowflakeErrors.ERROR_5015.getException("Java class " + value.getClass() + " does not have corresponding schema type.");
+      if (schema == null) {
+        Schema.Type primitiveType = ConnectSchema.schemaType(value.getClass());
+        if (primitiveType != null) {
+          schemaType = primitiveType;
+        } else {
+          if (value instanceof java.util.Date) {
+            schema = Timestamp.SCHEMA;
+            schemaType = Schema.Type.INT64;
+          } else {
+            throw SnowflakeErrors.ERROR_5015.getException("Java class " + value.getClass() + " does not have corresponding schema type.");
+          }
+        }
       } else {
         schemaType = schema.type();
       }

--- a/src/test/java/com/snowflake/kafka/connector/records/ConverterTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/records/ConverterTest.java
@@ -42,6 +42,7 @@ import org.apache.kafka.connect.data.SchemaAndValue;
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.ObjectMapper;
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.kafka.connect.json.JsonConverter;
+import org.apache.kafka.connect.storage.SimpleHeaderConverter;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -256,6 +257,19 @@ public class ConverterTest
     expected.put("test", new BigDecimal("999999999999999999999999999999999999999"));
     //TODO: uncomment it once KAFKA-10457 is merged
     //assert expected.toString().equals(result.toString());
+  }
+
+  @Test
+  public void testConnectSimpleHeaderConverter_MapDateAndOtherTypes() throws JsonProcessingException {
+    SimpleHeaderConverter headerConverter = new SimpleHeaderConverter();
+    String rawHeader = "{\"f1\": \"1970-03-22\", \"f2\": true}";
+    SchemaAndValue schemaAndValue = headerConverter.toConnectHeader("test", "h1", rawHeader.getBytes(StandardCharsets.US_ASCII));
+    JsonNode result = RecordService.convertToJson(schemaAndValue.schema(), schemaAndValue.value());
+
+    ObjectNode expected = mapper.createObjectNode();
+    expected.put("f1", 6930000000L);
+    expected.put("f2", true);
+    assert expected.toString().equals(result.toString());
   }
 
   @Test

--- a/src/test/java/com/snowflake/kafka/connector/records/ConverterTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/records/ConverterTest.java
@@ -262,7 +262,7 @@ public class ConverterTest
   @Test
   public void testConnectSimpleHeaderConverter_MapDateAndOtherTypes() throws JsonProcessingException {
     SimpleHeaderConverter headerConverter = new SimpleHeaderConverter();
-    String rawHeader = "{\"f1\": \"1970-03-22\", \"f2\": true}";
+    String rawHeader = "{\"f1\": \"1970-03-22T00:00:00.000Z\", \"f2\": true}";
     SchemaAndValue schemaAndValue = headerConverter.toConnectHeader("test", "h1", rawHeader.getBytes(StandardCharsets.US_ASCII));
     JsonNode result = RecordService.convertToJson(schemaAndValue.schema(), schemaAndValue.value());
 

--- a/src/test/java/com/snowflake/kafka/connector/records/ConverterTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/records/ConverterTest.java
@@ -22,6 +22,8 @@ import com.snowflake.kafka.connector.mock.MockSchemaRegistryClient;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.*;
 
 import io.confluent.connect.avro.AvroConverter;
@@ -260,14 +262,16 @@ public class ConverterTest
   }
 
   @Test
-  public void testConnectSimpleHeaderConverter_MapDateAndOtherTypes() throws JsonProcessingException {
+  public void testConnectSimpleHeaderConverter_MapDateAndOtherTypes() throws JsonProcessingException, ParseException {
     SimpleHeaderConverter headerConverter = new SimpleHeaderConverter();
-    String rawHeader = "{\"f1\": \"1970-03-22T00:00:00.000Z\", \"f2\": true}";
+    String timestamp = "1970-03-22T00:00:00.000Z";
+    String rawHeader = "{\"f1\": \"" + timestamp + "\", \"f2\": true}";
     SchemaAndValue schemaAndValue = headerConverter.toConnectHeader("test", "h1", rawHeader.getBytes(StandardCharsets.US_ASCII));
     JsonNode result = RecordService.convertToJson(schemaAndValue.schema(), schemaAndValue.value());
 
     ObjectNode expected = mapper.createObjectNode();
-    expected.put("f1", 6930000000L);
+    long expectedTimestampValue = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").parse("1970-03-22T00:00:00.000Z").getTime();
+    expected.put("f1", expectedTimestampValue);
     expected.put("f2", true);
     assert expected.toString().equals(result.toString());
   }


### PR DESCRIPTION
The default header converter for Connect is the `SimpleHeaderConverter`, which tries to parse byte array headers into structured data and, when possible, provide a schema for that data.

When parsing maps, it will sometimes be unable to provide a schema for their keys or values if disjoint types are detected. For example, if a map contains the values `34` and `true`, there is no one Connect schema that can cover both of those types (int and boolean). When this happens, it still parses the map and all of its keys and values, but will leave out schema information for the key and/or value type.

If one of those map keys or values gets parsed as a temporal type (date, time, timestamp), this ends up causing issues when the Snowflake connector tries to convert these headers to JSON, since it encounters a value with no schema and for which the `ConnectSchema::schemaType` method returns `null`. See https://github.com/snowflakedb/snowflake-kafka-connector/blob/52bfb720d3e43eeed944e92fbb302752a5c4ae0f/src/main/java/com/snowflake/kafka/connector/records/RecordService.java#L238-L242

This change adds some logic to handle those schemaless `Date` objects as timestamps, and includes a unit test that leverages the `SimpleHeaderConverter` to provide a minimal case where the issue arises.

The `connect-api` dependency is bumped to 2.7.0 in order to leverage improvements in the `SimpleHeaderConverter`'s parsing logic that, unfortunately, make this issue possible in the Snowflake connector.