### PR TITLE
GCS Put API Improvements + Refactoring

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionService.java
@@ -188,13 +188,16 @@ public interface SnowflakeConnectionService {
    * @param content file content
    * @param stageName stage name
    */
+  @Deprecated
   void put(String stageName, String fileName, String content);
 
   /**
-   * put a file to stage. Cache credential for AWS and Azure storage. Don't cache for GCS.
+   * put a file to stage. Cache credential for AWS, Azure and GCS storage.
    *
-   * @param fileName file name
-   * @param content file content
+   * @param fileName  file name which is of format (stageName/connectorName/tableName/partition/offsetStart_offsetEnd_timestamp)
+   *                  Check {@link FileNameUtils to find out fileName is determined}
+   *
+   * @param content   file content
    * @param stageName stage name
    */
   void putWithCache(final String stageName, final String fileName, final String content);

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionService.java
@@ -194,10 +194,10 @@ public interface SnowflakeConnectionService {
   /**
    * put a file to stage. Cache credential for AWS, Azure and GCS storage.
    *
-   * @param fileName  file name which is of format (stageName/connectorName/tableName/partition/offsetStart_offsetEnd_timestamp)
-   *                  Check {@link FileNameUtils to find out fileName is determined}
-   *
-   * @param content   file content
+   * @param fileName file name which is of format
+   *     (stageName/connectorName/tableName/partition/offsetStart_offsetEnd_timestamp)
+   *     <p>Check {@link FileNameUtils to find out how fileName is determined}
+   * @param content file content
    * @param stageName stage name
    */
   void putWithCache(final String stageName, final String fileName, final String content);

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
@@ -11,6 +11,7 @@ import java.sql.SQLException;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 import net.snowflake.client.jdbc.SnowflakeConnectionV1;
 import net.snowflake.client.jdbc.SnowflakeDriver;
 import net.snowflake.client.jdbc.cloud.storage.StageInfo;
@@ -32,6 +33,8 @@ public class SnowflakeConnectionServiceV1 extends Logging implements SnowflakeCo
   private final SnowflakeInternalStage internalStage;
   private StageInfo.StageType stageType;
 
+  private static final long CREDENTIAL_EXPIRY_TIMEOUT_MILLIS = TimeUnit.MINUTES.toMillis(30);
+
   SnowflakeConnectionServiceV1(
       Properties prop,
       SnowflakeURL url,
@@ -49,7 +52,7 @@ public class SnowflakeConnectionServiceV1 extends Logging implements SnowflakeCo
     } catch (SQLException e) {
       throw SnowflakeErrors.ERROR_1001.getException(e);
     }
-    long credentialExpireTimeMillis = 30 * 60 * 1000L;
+    long credentialExpireTimeMillis = CREDENTIAL_EXPIRY_TIMEOUT_MILLIS;
     this.internalStage =
         new SnowflakeInternalStage(
             (SnowflakeConnectionV1) this.conn, credentialExpireTimeMillis, proxyProperties);

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeErrors.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeErrors.java
@@ -228,11 +228,21 @@ public enum SnowflakeErrors {
       "Invalid SinkRecord received",
       "SinkRecord.value and SinkRecord.valueSchema cannot be null"),
   ERROR_5017(
-      "5017",
-      "Invalid api call to cached put",
-      "Cached put only support AWS and Azure. However GCP was found as storage"),
-  ERROR_5018("5018", "Failed to execute cached put", "Error in cached put command"),
-  ERROR_5019("5019", "Failed to get stage storage type", "Error in get storage type");
+    "5017",
+    "Invalid api call to cached put",
+    "Cached put only support AWS, Azure and GCS."
+  ),
+  ERROR_5018(
+    "5018",
+    "Failed to execute cached put",
+    "Error in cached put command"
+  ),
+  ERROR_5019(
+    "5019",
+    "Failed to get stage storage type",
+    "Error in get storage type"
+  )
+  ;
 
   // properties
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeErrors.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeErrors.java
@@ -228,21 +228,9 @@ public enum SnowflakeErrors {
       "Invalid SinkRecord received",
       "SinkRecord.value and SinkRecord.valueSchema cannot be null"),
   ERROR_5017(
-    "5017",
-    "Invalid api call to cached put",
-    "Cached put only support AWS, Azure and GCS."
-  ),
-  ERROR_5018(
-    "5018",
-    "Failed to execute cached put",
-    "Error in cached put command"
-  ),
-  ERROR_5019(
-    "5019",
-    "Failed to get stage storage type",
-    "Error in get storage type"
-  )
-  ;
+      "5017", "Invalid api call to cached put", "Cached put only support AWS, Azure and GCS."),
+  ERROR_5018("5018", "Failed to execute cached put", "Error in cached put command"),
+  ERROR_5019("5019", "Failed to get stage storage type", "Error in get storage type");
 
   // properties
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeInternalOperations.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeInternalOperations.java
@@ -8,7 +8,10 @@ public enum SnowflakeInternalOperations {
   /* Put api (uploadStream) for GCS */
   UPLOAD_FILE_TO_INTERNAL_STAGE,
 
-  /* Put API for AWS and Azure which caches the crdentials. */
+  /* Put without connections API for AWS, Azure and GCS.
+   * In GCS, we will not reuse the credentials since we require presigned URL for every file.
+   * In AWS and Azure, we will cache the credential.
+   */
   UPLOAD_FILE_TO_INTERNAL_STAGE_NO_CONNECTION,
 
   /* Broken records or (Failed ingestion files) or (files in internal stage for > 1 hour ) */

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeInternalStage.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeInternalStage.java
@@ -1,30 +1,54 @@
 package com.snowflake.kafka.connector.internal;
 
+import com.google.common.annotations.VisibleForTesting;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import net.snowflake.client.core.OCSPMode;
 import net.snowflake.client.core.SFStatement;
 import net.snowflake.client.jdbc.SnowflakeConnectionV1;
 import net.snowflake.client.jdbc.SnowflakeFileTransferAgent;
 import net.snowflake.client.jdbc.SnowflakeFileTransferConfig;
 import net.snowflake.client.jdbc.SnowflakeFileTransferMetadataV1;
+import net.snowflake.client.jdbc.SnowflakeSQLException;
 import net.snowflake.client.jdbc.cloud.storage.StageInfo;
+import net.snowflake.client.jdbc.internal.apache.commons.io.FilenameUtils;
 
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
-import java.util.Properties;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-
+/**
+ * Implementation of put API through JDBC's API uploadWithoutConnection.
+ *
+ * <p>We fetch the credentials and cache it for AWS and Azure. We will refresh if cache hits 30 mins
+ * (Cache Eviction)
+ *
+ * <p>For GCS, we dont have any cache, we will make a call to GS for every put API since we require
+ * presignedURL
+ */
 public class SnowflakeInternalStage extends Logging {
 
   private static class SnowflakeMetadataWithExpiration {
-    SnowflakeFileTransferMetadataV1 fileTransferMetadata;
-    long timestamp;
+
+    /* File transfer metadata when fetched from GS call */
+    private final SnowflakeFileTransferMetadataV1 fileTransferMetadata;
+
+    /* Timestamp when GS call happened */
+    private final long timestampLastCredentialFetchMillis;
+
+    /* StageType, can be fetched from fileTransferMetadata */
+    private final StageInfo.StageType stageType;
 
     SnowflakeMetadataWithExpiration(
         SnowflakeFileTransferMetadataV1 fileTransferMetadata, long timestamp) {
       this.fileTransferMetadata = fileTransferMetadata;
-      this.timestamp = timestamp;
+      this.timestampLastCredentialFetchMillis = timestamp;
+      this.stageType = this.fileTransferMetadata.getStageInfo().getStageType();
+    }
+
+    public StageInfo.StageType getStageType() {
+      return this.stageType;
     }
   }
 
@@ -32,33 +56,47 @@ public class SnowflakeInternalStage extends Logging {
   private final ConcurrentMap<String, SnowflakeMetadataWithExpiration> storageInfoCache =
       new ConcurrentHashMap<>();
 
-  // GCS Put version requires the dummy command to have filename
-  public static String dummyPutCommandTemplate = "PUT file:///%s @%s";
-  private static final String PUT_COMMAND_DUMMY_FILENAME = "dummyFileName";
+  // GCS Put version requires the dummy command to have filename and entire filePath including
+  // stageName after "@"
+  // For example: PUT file:///fileName @stageName/app/table/partition
+  public static String dummyPutCommandTemplateGCS = "PUT file:///%s @%s/%s";
+
+  // Aws and Azure Put version requires fullFilePath to be set as presignedURL
+  public static String dummyPutCommandTemplateAWSAndAzure = "PUT file:///tmp/ @%s";
+
+  // This will work on all three clouds since we only care about fetching stageType
+  public static String dummyPutCommandToGetStageType = "PUT file:///tmp/dummyFileName @%s";
 
   private final SnowflakeConnectionV1 conn;
-  private final long expirationTime;
+  private final long expirationTimeMillis;
   // Proxy parameters that we set while calling the snowflake JDBC.
   // Also required to pass in the uploadWithoutConnection API in the SnowflakeFileTransferConfig
   // It may not necessarily just contain proxy parameters, JDBC client filters all other properties.
   private final Properties proxyProperties;
 
   public SnowflakeInternalStage(
-      SnowflakeConnectionV1 conn, long expirationTime, Properties proxyProperties) {
+      SnowflakeConnectionV1 conn, long expirationTimeMillis, Properties proxyProperties) {
     this.conn = conn;
-    this.expirationTime = expirationTime;
+    this.expirationTimeMillis = expirationTimeMillis;
     this.proxyProperties = proxyProperties;
   }
 
   /**
-   * Get the backend stage type, S3, Azure or GCS. Involves one GS call.
+   * Get the backend stage type, S3, Azure or GCS. Involves one GS only when storageInfoCache has
+   * stage name missing.
    *
-   * @param stage name of the stage
+   * @param stageName name of the stage
    * @return stage type
    */
-  public StageInfo.StageType getStageType(String stage) {
+  public StageInfo.StageType getStageType(String stageName) {
+
+    Optional<StageInfo.StageType> existingStageTypeFromCache = getStageTypeFromCache(stageName);
+    if (existingStageTypeFromCache.isPresent()) {
+      return existingStageTypeFromCache.get();
+    }
+    // Lets try to fetch the stageType by making a GS call.
     try {
-      String command = String.format(dummyPutCommandTemplate, PUT_COMMAND_DUMMY_FILENAME, stage);
+      String command = String.format(dummyPutCommandToGetStageType, stageName);
       SnowflakeFileTransferAgent agent =
           new SnowflakeFileTransferAgent(
               command, conn.getSfSession(), new SFStatement(conn.getSfSession()));
@@ -69,76 +107,138 @@ public class SnowflakeInternalStage extends Logging {
   }
 
   /**
+   * Helper function which fetches the stageType from Cache. Cache Hit -> Return StageType Cache
+   * Miss -> Optional.empty
+   *
+   * @param stageName to search inside cache
+   * @return stage if present in cache
+   */
+  private Optional<StageInfo.StageType> getStageTypeFromCache(final String stageName) {
+    if (storageInfoCache.containsKey(stageName)) {
+      return Optional.of(storageInfoCache.get(stageName).getStageType());
+    }
+    return Optional.empty();
+  }
+
+  /**
    * Upload file to internal stage with previously cached credentials. Refresh credential every 30
    * minutes
    *
-   * @param stage Stage name
+   * @param stageName Stage name
    * @param fullFilePath Full file name to be uploaded
    * @param data Data string to be uploaded
+   * @param stageType GCS, Azure or AWS
    */
-  public void putWithCache(String stage, String fullFilePath, String data) {
-    //    String command = String.format(dummyPutCommandTemplate, fullFilePath) + stage;
-    String command =
-        String.format(dummyPutCommandTemplate, FilenameUtils.getName(fullFilePath), stage)
-            + "/"
-            + FilenameUtils.getFullPathNoEndSeparator(fullFilePath);
+  public void putWithCache(
+      String stageName, String fullFilePath, String data, final StageInfo.StageType stageType) {
     try {
-      SnowflakeMetadataWithExpiration credential = storageInfoCache.getOrDefault(stage, null);
-      if (!isCredentialValid(credential)) {
-        logDebug("Query credential for stage " + stage);
-        SnowflakeFileTransferAgent agent =
-            new SnowflakeFileTransferAgent(
-                command, conn.getSfSession(), new SFStatement(conn.getSfSession()));
-        // transfer metadata list must only have one element
-        SnowflakeFileTransferMetadataV1 fileTransferMetadata =
-            (SnowflakeFileTransferMetadataV1) agent.getFileTransferMetadatas().get(0);
-        if (fileTransferMetadata.getStageInfo().getStageType() == StageInfo.StageType.LOCAL_FS) {
-          throw SnowflakeErrors.ERROR_5017.getException();
-        } else {
-          // Overwrite the credential to be used
-          credential =
-              new SnowflakeMetadataWithExpiration(fileTransferMetadata, System.currentTimeMillis());
-          storageInfoCache.put(stage, credential);
-        }
+      SnowflakeMetadataWithExpiration credential = storageInfoCache.getOrDefault(stageName, null);
+
+      if (!isCredentialValid(credential, stageType)) {
+        logDebug(
+            "Query credential(Refreshing Credentials) for stageName:{}, filePath:{}",
+            stageName,
+            fullFilePath);
+        refreshCredentials(stageName, stageType, fullFilePath);
       }
+    } catch (Exception e) {
+      logWarn(
+          "Failed to refresh Credentials for stageName:{}, filePath:{}", stageName, fullFilePath);
+      throw SnowflakeErrors.ERROR_5018.getException(e.getMessage());
+    }
 
-      SnowflakeFileTransferMetadataV1 fileTransferMetadata = credential.fileTransferMetadata;
-      // Set filename to be uploaded
-      //      fileTransferMetadata.setPresignedUrlFileName(fullFilePath);
+    // Lets fetch the file transfer metadata from cache again. (Because we might have refreshed
+    // them)
+    SnowflakeFileTransferMetadataV1 fileTransferMetadata =
+        storageInfoCache.get(stageName).fileTransferMetadata;
+    // Set filename to be uploaded
+    // This set is not useful in GCS since there is a bug in JDBC which doesnt use destFileName.
+    fileTransferMetadata.setPresignedUrlFileName(fullFilePath);
 
-      byte[] dataBytes = data.getBytes(StandardCharsets.UTF_8);
-      InputStream inStream = new ByteArrayInputStream(dataBytes);
+    byte[] dataBytes = data.getBytes(StandardCharsets.UTF_8);
+    InputStream inStream = new ByteArrayInputStream(dataBytes);
 
-      // This uploadWithoutConnection api cannot handle expired credentials very well.
-      // Need to prevent passing expired credential to it.
-      try {
-        SnowflakeFileTransferAgent.uploadWithoutConnection(
-            SnowflakeFileTransferConfig.Builder.newInstance()
-                .setSnowflakeFileTransferMetadata(fileTransferMetadata)
-                .setUploadStream(inStream)
-                .setRequireCompress(true)
-                .setOcspMode(OCSPMode.FAIL_OPEN)
-                .setProxyProperties(proxyProperties)
-                .build());
-      } catch (Exception e) {
-        // If this api encounters error, invalid the cached credentials
-        // Caller will retry this function
-        logWarn(
-            "uploadWithoutConnection encountered an exception:{} for filePath:{} in Storage:{}",
-            e.getMessage(),
-            fullFilePath,
-            credential.fileTransferMetadata.getStageInfo().getStageType());
-        storageInfoCache.remove(stage);
-        throw e;
-      }
-
-    } catch (Throwable t) {
-      throw SnowflakeErrors.ERROR_5018.getException(t.getMessage());
+    // This uploadWithoutConnection api cannot handle expired credentials very well.
+    // Need to prevent passing expired credential to it.
+    try {
+      SnowflakeFileTransferAgent.uploadWithoutConnection(
+          SnowflakeFileTransferConfig.Builder.newInstance()
+              .setSnowflakeFileTransferMetadata(fileTransferMetadata)
+              .setUploadStream(inStream)
+              .setRequireCompress(true)
+              .setOcspMode(OCSPMode.FAIL_OPEN)
+              .setProxyProperties(proxyProperties)
+              .build());
+    } catch (Exception e) {
+      // If this api encounters error, invalidate the cached credentials
+      // Caller will retry this function
+      logWarn(
+          "uploadWithoutConnection encountered an exception:{} for filePath:{} in Storage:{}",
+          e.getMessage(),
+          fullFilePath,
+          stageType);
+      storageInfoCache.remove(stageName);
+      throw SnowflakeErrors.ERROR_5018.getException(e.getMessage());
     }
   }
 
-  private boolean isCredentialValid(SnowflakeMetadataWithExpiration credential) {
-    // Kay is cached and not expired
-    return credential != null && System.currentTimeMillis() - credential.timestamp < expirationTime;
+  /**
+   * Check if credentials are valid before calling uploadWithoutConnection API. Valid if they are
+   * not null and last fetch time was within {@link #expirationTimeMillis} For GCS, this will be
+   * false and we always refresh the credentials.
+   *
+   * @param credential to check the validity for
+   * @param stageType stageType of the stage fetched from JDBC and at least one GS call
+   * @return true if we can reuse the credentials, false in case of GCS
+   */
+  private boolean isCredentialValid(
+      SnowflakeMetadataWithExpiration credential, final StageInfo.StageType stageType) {
+
+    if (stageType == StageInfo.StageType.GCS) {
+      return false;
+    }
+    // Key is cached and not expired
+    return credential != null
+        && System.currentTimeMillis() - credential.timestampLastCredentialFetchMillis
+            < expirationTimeMillis;
+  }
+
+  @VisibleForTesting
+  protected void refreshCredentials(
+      final String stageName, final StageInfo.StageType stageType, final String fullFilePath)
+      throws SnowflakeSQLException {
+    String putCommandToFetchMetadata;
+    if (stageType == StageInfo.StageType.GCS) {
+      putCommandToFetchMetadata =
+          String.format(
+              dummyPutCommandTemplateGCS,
+              FilenameUtils.getName(fullFilePath), // Gets just the fileName
+              stageName,
+              FilenameUtils.getFullPathNoEndSeparator(
+                  fullFilePath)); // Gets everything leading up to the file
+    } else {
+      // AWS and Azure
+      putCommandToFetchMetadata = String.format(dummyPutCommandTemplateAWSAndAzure, stageName);
+    }
+
+    // This should always be executed in GCS
+    SnowflakeFileTransferAgent agent =
+        new SnowflakeFileTransferAgent(
+            putCommandToFetchMetadata, conn.getSfSession(), new SFStatement(conn.getSfSession()));
+    // transfer metadata list must only have one element
+    SnowflakeFileTransferMetadataV1 fileTransferMetadata =
+        (SnowflakeFileTransferMetadataV1) agent.getFileTransferMetadatas().get(0);
+    if (fileTransferMetadata.getStageInfo().getStageType() == StageInfo.StageType.LOCAL_FS) {
+      logError(
+          "StageName:{} is not a valid stageType:{}",
+          stageName,
+          fileTransferMetadata.getStageInfo().getStageType());
+      throw SnowflakeErrors.ERROR_5017.getException();
+    } else {
+      // Overwrite the credential to be used
+      SnowflakeMetadataWithExpiration credential =
+          new SnowflakeMetadataWithExpiration(fileTransferMetadata, System.currentTimeMillis());
+      storageInfoCache.put(stageName, credential);
+    }
   }
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeTelemetryServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeTelemetryServiceV1.java
@@ -116,7 +116,7 @@ public class SnowflakeTelemetryServiceV1 extends Logging implements SnowflakeTel
     msg.put(VERSION, Utils.VERSION); // version number
     try {
       telemetry.addLogToBatch(TelemetryUtil.buildJobData(msg));
-      logDebug("sending telemetry data: {}", data.toString());
+      logDebug("sending telemetry data: {} of type:{}", data.toString(), type.toString());
       telemetry.sendBatchAsync();
     } catch (Exception e) {
       logError("Failed to send telemetry data: {}, Error: {}", data.toString(), e.getMessage());

--- a/src/test/java/com/snowflake/kafka/connector/internal/InternalStageIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/InternalStageIT.java
@@ -1,89 +1,119 @@
 package com.snowflake.kafka.connector.internal;
 
 import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
+import net.snowflake.client.core.OCSPMode;
+import net.snowflake.client.core.SFSessionProperty;
+import net.snowflake.client.core.SFStatement;
+import net.snowflake.client.jdbc.*;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import net.snowflake.client.core.OCSPMode;
-import net.snowflake.client.core.SFSessionProperty;
-import net.snowflake.client.core.SFStatement;
-import net.snowflake.client.jdbc.*;
-import net.snowflake.client.jdbc.cloud.storage.StageInfo;
-import org.junit.After;
-import org.junit.Ignore;
-import org.junit.Test;
 
 public class InternalStageIT {
 
-  private final SnowflakeConnectionService service = TestUtils.getConnectionService();
+  private static SnowflakeConnectionService service;
+  private static final String stageName1 = TestUtils.randomStageName();
+  private static final String stageName2 = TestUtils.randomStageName();
+  private static final String stageNameGCSPut = TestUtils.randomStageName();
+  private static final String stageNameGCSPutWithCache =
+      "kafka_connector_test_stage_8521123643496264815";
+  private static final String stageName4 = TestUtils.randomStageName();
+  private static final String proxyStage = TestUtils.randomStageName();
+  private static final String stageNameExpire =
+      "kafka_connector_test_stage_credential_cache_expire";
 
-  private final String stageName1 = TestUtils.randomStageName();
-  private final String stageName2 = TestUtils.randomStageName();
-  private final String stageName3 = TestUtils.randomStageName();
-  private final String stageName4 = TestUtils.randomStageName();
-  private final String proxyStage = TestUtils.randomStageName();
-  private final String stageNameExpire = "kafka_connector_test_stage_credential_cache_expire";
+  @BeforeClass
+  public static void beforeAllClasses() {
+    service = TestUtils.getConnectionService();
+    service.createStage(stageName1);
+    service.createStage(stageName2);
+    service.createStage(stageNameGCSPut);
+    service.createStage(stageNameGCSPutWithCache);
+    service.createStage(stageName4);
+    service.createStage(proxyStage);
+    service.createStage(stageNameExpire);
+  }
 
-  @After
-  public void afterAll() {
+  @AfterClass
+  public static void afterAllClasses() {
     service.dropStage(stageName1);
     service.dropStage(stageName2);
-    service.dropStage(stageName3);
+    service.dropStage(stageNameGCSPut);
+    //    service.dropStage(stageNameGCSPutWithCache);
     service.dropStage(stageName4);
+    service.dropStage(proxyStage);
+    service.dropStage(stageNameExpire);
   }
 
   @Test
   public void testInternalStage() throws Exception {
     // create stage
-    service.createStage(stageName1);
-    service.createStage(stageName2);
-    service.createStage(stageName3);
     long startTime, fileNumber = 50;
     SnowflakeInternalStage agent =
         new SnowflakeInternalStage(
             (SnowflakeConnectionV1) service.getConnection(), 30 * 60 * 1000L, null);
 
-    // we are using putwithcache API in s3 and azure.
-    // TODO:: Once we move GCS to putWithCache, we can remove this check.
-    if (usePutWithCacheApi(agent, stageName1)) {
-      // PUT two files to stageName1
-      startTime = System.currentTimeMillis();
-      agent.putWithCache(stageName1, "testCacheFileName1", "Any cache");
-      agent.putWithCache(stageName1, "testCacheFileName2", "Any cache");
-      List<String> files1 = service.listStage(stageName1, "testCache");
-      assert files1.size() == 2;
-      System.out.println(
-          Logging.logMessage("Time: {} ms", (System.currentTimeMillis() - startTime)));
+    // PUT two files to stageName1
+    startTime = System.currentTimeMillis();
+    agent.putWithCache(stageName1, "testCacheFileName1", "Any cache");
+    agent.putWithCache(stageName1, "testCacheFileName2", "Any cache");
+    List<String> files1 = service.listStage(stageName1, "testCache");
+    assert files1.size() == 2;
+    System.out.println(Logging.logMessage("Time: {} ms", (System.currentTimeMillis() - startTime)));
 
-      // PUT 50 files to stageName2
-      startTime = System.currentTimeMillis();
-      fileNumber = 50;
-      for (int i = 0; i < fileNumber; i++) {
-        agent.putWithCache(
-            stageName2, "appName/tableName/partition/testCacheFileName" + i, "Any cache");
-      }
-      List<String> files2 = service.listStage(stageName2, "appName/tableName/partition/testCache");
-      assert files2.size() == fileNumber;
-      System.out.println(
-          Logging.logMessage("Time: {} ms", (System.currentTimeMillis() - startTime)));
+    // PUT 50 files to stageName2
+    startTime = System.currentTimeMillis();
+    for (int i = 0; i < fileNumber; i++) {
+      agent.putWithCache(
+          stageName2, "appName/tableName/partition/testCacheFileName" + i, "Any cache");
     }
+    List<String> files2 = service.listStage(stageName2, "appName/tableName/partition/testCache");
+    assert files2.size() == fileNumber;
+    System.out.println(Logging.logMessage("Time: {} ms", (System.currentTimeMillis() - startTime)));
+  }
 
-    // When stage is GCS
-    if (!usePutWithCacheApi(agent, stageName1)) {
-      // PUT 50 files to stageName3
-      startTime = System.currentTimeMillis();
-      for (int i = 0; i < fileNumber; i++) {
-        service.put(stageName3, "appName/tableName/partition/testNoCacheFileName" + i, "Any cache");
-      }
-      List<String> files3 =
-          service.listStage(stageName3, "appName/tableName/partition/testNoCache");
-      assert files3.size() == fileNumber;
-      System.out.println(
-          Logging.logMessage("Time: {} ms", (System.currentTimeMillis() - startTime)));
+  @Test
+  public void testComparePutAPIVersionsForGCS() {
+    // PUT 500 files to stageName3
+    final int numberOfFiles = 1;
+    long startTime = System.currentTimeMillis();
+    //    for (int i = 0; i < numberOfFiles; i++)
+    //    {
+    //      service.put(stageNameGCSPut, "appName/tableName/partition/testNoCacheFileName" + i, "Any
+    // data");
+    //    }
+    //    System.out.println(Logging.logMessage("Time for putting {} files in GCS is:{} ms",
+    // numberOfFiles,
+    //            (System.currentTimeMillis() - startTime)));
+    //    List<String> files = service.listStage(stageNameGCSPut,
+    // "appName/tableName/partition/testNoCacheFileName");
+    //    assert files.size() == numberOfFiles;
+
+    System.out.println("Same test but with uploadWithoutConnection API");
+    startTime = System.currentTimeMillis();
+    for (int i = 0; i < numberOfFiles; i++) {
+      service.putWithCache(
+          stageNameGCSPutWithCache,
+          "appName/tableName/partition/testCacheFileName" + i,
+          "1|36901|O|173665.47|1996-01-02|5-LOW|Clerk#000000951|0|nstructions sleep furiously among |");
     }
+    System.out.println(
+        Logging.logMessage(
+            "Time for putting {} files in GCS(UploadWithoutConnection) is:{} ms",
+            numberOfFiles,
+            (System.currentTimeMillis() - startTime)));
+    List<String> filesWithCache =
+        service.listStage(
+            stageNameGCSPutWithCache, "appName/tableName/partition/testCacheFileName");
+    assert filesWithCache.size() == numberOfFiles;
   }
 
   /**
@@ -122,13 +152,8 @@ public class InternalStageIT {
 
     // PUT two files to proxyStage
     long startTime = System.currentTimeMillis();
-    if (usePutWithCacheApi(agent, proxyStage)) {
-      agent.putWithCache(proxyStage, "testInternalStageWithProxy1", "Any cache");
-      agent.putWithCache(proxyStage, "testInternalStageWithProxy2", "Any cache");
-    } else {
-      proxyConnectionService.put(proxyStage, "testInternalStageWithProxy1", "Any cache");
-      proxyConnectionService.put(proxyStage, "testInternalStageWithProxy2", "Any cache");
-    }
+    agent.putWithCache(proxyStage, "testInternalStageWithProxy1", "Any cache");
+    agent.putWithCache(proxyStage, "testInternalStageWithProxy2", "Any cache");
 
     List<String> files1 = proxyConnectionService.listStage(proxyStage, "testInternalStage");
     assert files1.size() == 2;
@@ -139,41 +164,32 @@ public class InternalStageIT {
     TestUtils.resetProxyParametersInJDBC();
   }
 
-  // Only runs in AWS and Azure until we move to putwithcache in gcs.
   @Test
-  @Ignore
   public void testCredentialRefresh() throws Exception {
-
-    // create stage
-    service.createStage(stageName4);
-
     // credential expires in 30 seconds
     SnowflakeInternalStage agent =
         new SnowflakeInternalStage(
             (SnowflakeConnectionV1) service.getConnection(), 30 * 1000L, null);
 
-    if (usePutWithCacheApi(agent, stageName4)) {
-      // PUT two files to stageName1
-      agent.putWithCache(stageName4, "testCacheFileName1", "Any cache");
-      agent.putWithCache(stageName4, "testCacheFileName2", "Any cache");
-      List<String> files1 = service.listStage(stageName4, "testCache");
-      assert files1.size() == 2;
+    // PUT two files to stageName1
+    agent.putWithCache(stageName4, "testCacheFileName1", "Any cache");
+    agent.putWithCache(stageName4, "testCacheFileName2", "Any cache");
+    List<String> files1 = service.listStage(stageName4, "testCache");
+    assert files1.size() == 2;
 
-      // wait until the credential expires
-      Thread.sleep(60 * 1000);
+    // wait until the credential expires
+    Thread.sleep(60 * 1000);
 
-      agent.putWithCache(stageName4, "testCacheFileName3", "Any cache");
-      agent.putWithCache(stageName4, "testCacheFileName4", "Any cache");
-      List<String> files2 = service.listStage(stageName4, "testCache");
-      assert files2.size() == 4;
-    }
+    agent.putWithCache(stageName4, "testCacheFileName3", "Any cache");
+    agent.putWithCache(stageName4, "testCacheFileName4", "Any cache");
+    List<String> files2 = service.listStage(stageName4, "testCache");
+    assert files2.size() == 4;
   }
 
   @Ignore
   @Test
   /** This test is manually tested as it takes around 2 hours */
   public void testCredentialExpire() throws Exception {
-    service.createStage(stageNameExpire);
     List<String> filesToDelete = service.listStage(stageNameExpire, "testExpire");
     service.purgeStage(stageNameExpire, filesToDelete);
     SnowflakeConnectionV1 conn = (SnowflakeConnectionV1) service.getConnection();
@@ -209,14 +225,5 @@ public class InternalStageIT {
 
     List<String> filesExpire = service.listStage(stageNameExpire, "testExpire");
     assert filesExpire.size() == 1;
-  }
-
-  private boolean usePutWithCacheApi(final SnowflakeInternalStage agent, final String stageName) {
-    if (agent.getStageType(stageName) == StageInfo.StageType.S3
-        || agent.getStageType(stageName) == StageInfo.StageType.AZURE) {
-      System.out.println("Using Put with cache since stage is in:" + agent.getStageType(stageName));
-      return true;
-    }
-    return false;
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/internal/InternalStageIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/InternalStageIT.java
@@ -84,11 +84,10 @@ public class InternalStageIT {
     System.out.println(Logging.logMessage("Time: {} ms", (System.currentTimeMillis() - startTime)));
   }
 
-  @Ignore
   @Test
   public void testComparePutAPIVersionsForGCS() {
 
-    // PUT 50 files to stageName3
+    // PUT 500 files to stageName3
     final int numberOfFiles = 50;
     long startTime = System.currentTimeMillis();
     for (int i = 0; i < numberOfFiles; i++) {

--- a/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
@@ -16,14 +16,10 @@
  */
 package com.snowflake.kafka.connector.internal;
 
+import static com.snowflake.kafka.connector.Utils.*;
+
 import com.snowflake.client.jdbc.SnowflakeDriver;
 import com.snowflake.kafka.connector.Utils;
-import net.snowflake.client.core.HttpUtil;
-import net.snowflake.client.core.SFSessionProperty;
-import net.snowflake.client.jdbc.SnowflakeSQLException;
-import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.JsonNode;
-import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.ObjectMapper;
-
 import java.io.File;
 import java.io.IOException;
 import java.security.PrivateKey;
@@ -34,8 +30,11 @@ import java.sql.Statement;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import static com.snowflake.kafka.connector.Utils.*;
+import net.snowflake.client.core.HttpUtil;
+import net.snowflake.client.core.SFSessionProperty;
+import net.snowflake.client.jdbc.SnowflakeSQLException;
+import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.JsonNode;
+import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.ObjectMapper;
 
 public class TestUtils {
   // test profile properties
@@ -54,7 +53,7 @@ public class TestUtils {
       Pattern.compile("^[^/]+/[^/]+/(\\d+)/(\\d+)_(key|value)_(\\d+)\\.gz$");
 
   // profile path
-  private static final String PROFILE_PATH = "profile_gcs.json";
+  private static final String PROFILE_PATH = "profile.json";
 
   private static final ObjectMapper mapper = new ObjectMapper();
 

--- a/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
@@ -16,10 +16,14 @@
  */
 package com.snowflake.kafka.connector.internal;
 
-import static com.snowflake.kafka.connector.Utils.*;
-
 import com.snowflake.client.jdbc.SnowflakeDriver;
 import com.snowflake.kafka.connector.Utils;
+import net.snowflake.client.core.HttpUtil;
+import net.snowflake.client.core.SFSessionProperty;
+import net.snowflake.client.jdbc.SnowflakeSQLException;
+import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.JsonNode;
+import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.ObjectMapper;
+
 import java.io.File;
 import java.io.IOException;
 import java.security.PrivateKey;
@@ -30,11 +34,8 @@ import java.sql.Statement;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import net.snowflake.client.core.HttpUtil;
-import net.snowflake.client.core.SFSessionProperty;
-import net.snowflake.client.jdbc.SnowflakeSQLException;
-import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.JsonNode;
-import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.ObjectMapper;
+
+import static com.snowflake.kafka.connector.Utils.*;
 
 public class TestUtils {
   // test profile properties
@@ -53,7 +54,7 @@ public class TestUtils {
       Pattern.compile("^[^/]+/[^/]+/(\\d+)/(\\d+)_(key|value)_(\\d+)\\.gz$");
 
   // profile path
-  private static final String PROFILE_PATH = "profile.json";
+  private static final String PROFILE_PATH = "profile_gcs.json";
 
   private static final ObjectMapper mapper = new ObjectMapper();
 


### PR DESCRIPTION
- Added Java doc wherever I could to make code more readable.
- Added few log statements which will help for debugging.
- Refactoring a bit of code. (Sorry for mixing two, but it was too late when I decided I should have decoupled them)
- To make it easy, here are the changes:
  - SnowflakeMetadataWithExpiration - Added `stageType` and made all fields `private final`. 
  - `getStageType` - Make use of cache since cache has that information
  - putWithCache API had a nested `try catch` -> Decoupled the mono-function to sub-functions based on the jobs and also added more logs which will help debug. `isValidCredential`, `refreshCredential`. 
  - Removed `catch throwable` + `throw t`  which eventually `caught exception`. -> reduced it to just caught exception because Errors would have still be uncaught before. -> No change in behavior 
- Using uploadWithoutConnection API for GCS
  - This will return error if API throws error. 
  - Even if we are calling GS for every file, new uploadWithoutConnection is faster
  - Test 1
    - `[SF_KAFKA_CONNECTOR] Time for putting 50 files in GCS is:16719 ms`
    - `[SF_KAFKA_CONNECTOR] Time for putting 50 files in GCS(UploadWithoutConnection) is:10978 ms`
  - Test 2
    - `[SF_KAFKA_CONNECTOR] Time for putting 50 files in GCS is:16719 ms`
    - `[SF_KAFKA_CONNECTOR] Time for putting 50 files in GCS(UploadWithoutConnection) is:10978 ms`
- Need an ugly way to manipulate put in GCS since there is bug in JDBC:
  - PR in JDBC: https://github.com/snowflakedb/snowflake-jdbc/pull/486/files
- Tested on GCS, AWS, Azure - Especially `InternalStageIT.java`
- I haven't run any End to End test but relying on Github Actions. 

### Reviewers:
Required: @sfc-gh-zli 
Just FYI for @sfc-gh-rramachandran and @sfc-gh-tjones 