### PR TITLE
Upgrade kafka to new version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.snowflake</groupId>
     <artifactId>snowflake-kafka-connector</artifactId>
-    <version>1.5.2</version>
+    <version>1.5.3</version>
     <packaging>jar</packaging>
     <name>Snowflake Kafka Connector</name>
     <description>Snowflake Kafka Connect Sink Connector</description>

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -13,7 +13,7 @@
 
     <groupId>com.snowflake</groupId>
     <artifactId>snowflake-kafka-connector</artifactId>
-    <version>1.5.2</version>
+    <version>1.5.3</version>
     <packaging>jar</packaging>
     <name>Snowflake Kafka Connector</name>
     <description>Snowflake Kafka Connect Sink Connector</description>

--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
 public class Utils {
 
   // Connector version, change every release
-  public static final String VERSION = "1.5.2";
+  public static final String VERSION = "1.5.3";
 
   // connector parameter list
   public static final String NAME = "name";


### PR DESCRIPTION
Release Notes: 
- BUG_FIX
  - Added timeout while fetching latest kafka connector version from Maven. [SNOW-330782]
  - Added thread safety around SimpleDataFormat while parsing dates and times. #302 [SNOW-295783]
  - Fix handling of schemaless date objects. (#288) no-snow
- New Improvements
  - More logs around retry and putting file into internal stage
  - GCS Put API uses uploadWithoutConnection API - Should improve the latency. 

[SNOW-330782]: https://snowflakecomputing.atlassian.net/browse/SNOW-330782
[SNOW-295783]: https://snowflakecomputing.atlassian.net/browse/SNOW-295783