### PR TITLE
Release SF KC version 1.5.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.snowflake</groupId>
     <artifactId>snowflake-kafka-connector</artifactId>
-    <version>1.5.3</version>
+    <version>1.5.4</version>
     <packaging>jar</packaging>
     <name>Snowflake Kafka Connector</name>
     <description>Snowflake Kafka Connect Sink Connector</description>
@@ -242,6 +242,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>2.9.1</version>
+                <configuration>
+                    <detectJavaApiLink>false</detectJavaApiLink>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -242,9 +242,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>2.9.1</version>
-                <configuration>
-                    <detectJavaApiLink>false</detectJavaApiLink>
-                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -13,7 +13,7 @@
 
     <groupId>com.snowflake</groupId>
     <artifactId>snowflake-kafka-connector</artifactId>
-    <version>1.5.3</version>
+    <version>1.5.4</version>
     <packaging>jar</packaging>
     <name>Snowflake Kafka Connector</name>
     <description>Snowflake Kafka Connect Sink Connector</description>

--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
 public class Utils {
 
   // Connector version, change every release
-  public static final String VERSION = "1.5.3";
+  public static final String VERSION = "1.5.4";
 
   // connector parameter list
   public static final String NAME = "name";


### PR DESCRIPTION
Release Notes:
- Bumped up dependency (SF JDBC to latest version 3.13.3) 
- Mainly solves the problem around failures in putWithconnection API (Returns a failure if internal implementation around rest API throws a non 200 response)