### PR TITLE
Avro converter supports a fixed reader schema

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeErrors.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeErrors.java
@@ -97,6 +97,10 @@ public enum SnowflakeErrors {
       "0023",
       "Invalid proxy username or password",
       "Both username and password need to be provided if one of them is provided"),
+  ERROR_0024(
+          "0024",
+          "Reader schema invalid",
+          "A reader schema is provided but can not be parsed as an Avro schema" ),
   // Snowflake connection issues 1---
   ERROR_1001(
       "1001",


### PR DESCRIPTION
This pull requests addresses #290. The issue addresses the problem that schema evolution in a Kafka topic leads to `RECORD_CONTENT` elements in the staging table with different schemas. 

While in many cases  this might be desirable (e.g., in a data lake of semi-structured data), it makes downstream processing of the staging table difficult, e.g., when populating another table from it using Snowflake streams and tasks. 

For such cases, it would be great to have an option to interpret all messages in the Kafka topic as having the same schema, so that the `RECORD_CONTENT` elements in the staging table have the same structure. 

The Avro deserializer provided by the Avro project, which is also used in the `SnowflakeAvroConverter` internally, supports a writer schema (the schema in which a message got serialized), and a reader schema (a schema that has to be compatible to the writer schema according to [certain rules](https://avro.apache.org/docs/1.10.2/spec.html#Schema+Resolution), which does exactly this. Until now, the Snowflake Kafka connector does not allow to set a reader schema.

The PR adds a configuration property `reader.schema` to the `SnowflakeAvroConverter.` Using this reader schema, all messages in a Kafka topic, independent of their individual writer schema, can be interpreted as having the same schema (provided the reader schema is compatible to the writer schemas). 

If the property is not set, the `SnowflakeAvroConverter` works as usual, i.e., by deserializing each consumed message (value or key) with the writer schema that is referenced in the message. 

If the property is set and can be parsed as an Avro schema, the message is deserialized into the provided reader schema. If the reader schema is not compatible to the writer schema, an error is raised on deserialization.

If the property is set but can not be parsed as an Avro schema, an error is signalled on startup of the connector.

