### PR TITLE
Added provider config which is fed into userAgentSuffix for snowpipe for monitoring purpose

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -317,7 +317,7 @@
         <dependency>
             <groupId>net.snowflake</groupId>
             <artifactId>snowflake-ingest-sdk</artifactId>
-            <version>0.10.1</version>
+            <version>0.10.3</version>
         </dependency>
 
         <dependency>

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -367,7 +367,7 @@
         <dependency>
             <groupId>net.snowflake</groupId>
             <artifactId>snowflake-ingest-sdk</artifactId>
-            <version>0.10.1</version>
+            <version>0.10.3</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -359,6 +359,7 @@ public class SnowflakeSinkConnectorConfig {
 
     // This API is called by framework to ensure the validity when connector is started or when a
     // validate REST API is called
+    @Override
     public void ensureValid(String name, Object value) {
       assert value instanceof String;
       final String strValue = (String) value;

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -327,7 +327,7 @@ public class SnowflakeSinkConnectorConfig {
         .define(
             PROVIDER_CONFIG,
             Type.STRING,
-            KafkaProvider.NONE.name(),
+            KafkaProvider.UNKNOWN.name(),
             KAFKA_PROVIDER_VALIDATOR,
             Importance.LOW,
             "Whether kafka is running on Confluent code, self hosted or other managed service");
@@ -357,6 +357,8 @@ public class SnowflakeSinkConnectorConfig {
   public static class KafkaProviderValidator implements ConfigDef.Validator {
     public KafkaProviderValidator() {}
 
+    // This API is called by framework to ensure the validity when connector is started or when a
+    // validate REST API is called
     public void ensureValid(String name, Object value) {
       assert value instanceof String;
       final String strValue = (String) value;
@@ -379,7 +381,7 @@ public class SnowflakeSinkConnectorConfig {
   /* Enum which represents allowed values of kafka provider. (Hosted Platform) */
   public enum KafkaProvider {
     // Default value, when nothing is provided. (More like Not Applicable)
-    NONE,
+    UNKNOWN,
 
     // Kafka/KC is on self hosted node
     SELF_HOSTED,
@@ -388,6 +390,7 @@ public class SnowflakeSinkConnectorConfig {
     CONFLUENT,
     ;
 
+    // All valid enum values
     public static final List<String> PROVIDER_NAMES =
         Arrays.stream(KafkaProvider.values())
             .map(kafkaProvider -> kafkaProvider.name().toLowerCase())
@@ -398,7 +401,7 @@ public class SnowflakeSinkConnectorConfig {
     public static KafkaProvider of(final String kafkaProviderStr) {
 
       if (Strings.isNullOrEmpty(kafkaProviderStr)) {
-        return KafkaProvider.NONE;
+        return KafkaProvider.UNKNOWN;
       }
 
       for (final KafkaProvider b : KafkaProvider.values()) {

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -16,8 +16,12 @@
  */
 package com.snowflake.kafka.connector;
 
+import com.google.common.base.Strings;
 import com.snowflake.kafka.connector.internal.Logging;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
@@ -81,11 +85,16 @@ public class SnowflakeSinkConnectorConfig {
   public static final String SNOWFLAKE_METADATA_ALL = "snowflake.metadata.all";
   public static final String SNOWFLAKE_METADATA_DEFAULT = "true";
 
+  // Where is Kafka hosted? self, confluent or any other in future.
+  // By default it will be None since this is not enforced and only used for monitoring
+  public static final String PROVIDER_CONFIG = "provider";
+
   private static final Logger LOGGER =
       LoggerFactory.getLogger(SnowflakeSinkConnectorConfig.class.getName());
 
   private static final ConfigDef.Validator nonEmptyStringValidator = new ConfigDef.NonEmptyString();
   private static final ConfigDef.Validator topicToTableValidator = new TopicToTableValidator();
+  private static final ConfigDef.Validator KAFKA_PROVIDER_VALIDATOR = new KafkaProviderValidator();
 
   static void setDefaultValues(Map<String, String> config) {
     setFieldToDefaultValues(config, BUFFER_COUNT_RECORDS, BUFFER_COUNT_RECORDS_DEFAULT);
@@ -314,7 +323,14 @@ public class SnowflakeSinkConnectorConfig {
             SNOWFLAKE_METADATA_FLAGS,
             3,
             ConfigDef.Width.NONE,
-            SNOWFLAKE_METADATA_OFFSET_AND_PARTITION);
+            SNOWFLAKE_METADATA_OFFSET_AND_PARTITION)
+        .define(
+            PROVIDER_CONFIG,
+            Type.STRING,
+            KafkaProvider.NONE.name(),
+            KAFKA_PROVIDER_VALIDATOR,
+            Importance.LOW,
+            "Whether kafka is running on Confluent code, self hosted or other managed service");
   }
 
   public static class TopicToTableValidator implements ConfigDef.Validator {
@@ -334,6 +350,66 @@ public class SnowflakeSinkConnectorConfig {
     public String toString() {
       return "Topic to table map format : comma-seperated tuples, e.g."
           + " <topic-1>:<table-1>,<topic-2>:<table-2>,... ";
+    }
+  }
+
+  /* Validator to validate Kafka Provider values which says where kafka is hosted */
+  public static class KafkaProviderValidator implements ConfigDef.Validator {
+    public KafkaProviderValidator() {}
+
+    public void ensureValid(String name, Object value) {
+      assert value instanceof String;
+      final String strValue = (String) value;
+      // The value can be null or empty.
+      try {
+        KafkaProvider kafkaProvider = KafkaProvider.of(strValue);
+        LOGGER.debug("KafkaProvider value is:{}", kafkaProvider.name());
+      } catch (final IllegalArgumentException e) {
+        throw new ConfigException(PROVIDER_CONFIG, value, e.getMessage());
+      }
+    }
+
+    public String toString() {
+      return "Whether kafka is running on Confluent code, self hosted or other managed service."
+          + " Allowed values are:"
+          + String.join(",", KafkaProvider.PROVIDER_NAMES);
+    }
+  }
+
+  /* Enum which represents allowed values of kafka provider. (Hosted Platform) */
+  public enum KafkaProvider {
+    // Default value, when nothing is provided. (More like Not Applicable)
+    NONE,
+
+    // Kafka/KC is on self hosted node
+    SELF_HOSTED,
+
+    // Hosted/managed by Confluent
+    CONFLUENT,
+    ;
+
+    public static final List<String> PROVIDER_NAMES =
+        Arrays.stream(KafkaProvider.values())
+            .map(kafkaProvider -> kafkaProvider.name().toLowerCase())
+            .collect(Collectors.toList());
+
+    // Returns the KafkaProvider object from string. It does convert an empty or null value to an
+    // Enum.
+    public static KafkaProvider of(final String kafkaProviderStr) {
+
+      if (Strings.isNullOrEmpty(kafkaProviderStr)) {
+        return KafkaProvider.NONE;
+      }
+
+      for (final KafkaProvider b : KafkaProvider.values()) {
+        if (b.name().equalsIgnoreCase(kafkaProviderStr)) {
+          return b;
+        }
+      }
+      throw new IllegalArgumentException(
+          String.format(
+              "Unsupported provider name: %s. Supported are: %s",
+              kafkaProviderStr, String.join(",", PROVIDER_NAMES)));
     }
   }
 }

--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -460,6 +460,17 @@ public class Utils {
     // set jdbc logging directory
     Utils.setJDBCLoggingDirectory();
 
+    // validate whether kafka provider config is a valid value
+    if (config.containsKey(SnowflakeSinkConnectorConfig.PROVIDER_CONFIG)) {
+      try {
+        SnowflakeSinkConnectorConfig.KafkaProvider.of(
+            config.get(SnowflakeSinkConnectorConfig.PROVIDER_CONFIG));
+      } catch (IllegalArgumentException exception) {
+        LOGGER.error(Logging.logMessage("Kafka provider config error:{}", exception.getMessage()));
+        configIsValid = false;
+      }
+    }
+
     if (!configIsValid) {
       throw SnowflakeErrors.ERROR_0001.getException();
     }

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeIngestionServiceFactory.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeIngestionServiceFactory.java
@@ -13,9 +13,18 @@ public class SnowflakeIngestionServiceFactory {
       String connectionScheme,
       String stageName,
       String pipeName,
-      PrivateKey privateKey) {
+      PrivateKey privateKey,
+      String userAgentSuffix) {
     return new SnowflakeIngestionServiceBuilder(
-        accountName, userName, host, port, connectionScheme, stageName, pipeName, privateKey);
+        accountName,
+        userName,
+        host,
+        port,
+        connectionScheme,
+        stageName,
+        pipeName,
+        privateKey,
+        userAgentSuffix);
   }
 
   /** Builder class to create instance of {@link SnowflakeIngestionService} */
@@ -30,10 +39,19 @@ public class SnowflakeIngestionServiceFactory {
         String connectionScheme,
         String stageName,
         String pipeName,
-        PrivateKey privateKey) {
+        PrivateKey privateKey,
+        String userAgentSuffix) {
       this.service =
           new SnowflakeIngestionServiceV1(
-              accountName, userName, host, port, connectionScheme, stageName, pipeName, privateKey);
+              accountName,
+              userName,
+              host,
+              port,
+              connectionScheme,
+              stageName,
+              pipeName,
+              privateKey,
+              userAgentSuffix);
     }
 
     SnowflakeIngestionServiceBuilder setTelemetry(SnowflakeTelemetryService telemetry) {

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeIngestionServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeIngestionServiceV1.java
@@ -39,12 +39,20 @@ public class SnowflakeIngestionServiceV1 extends Logging implements SnowflakeIng
       String connectionScheme,
       String stageName,
       String pipeName,
-      PrivateKey privateKey) {
+      PrivateKey privateKey,
+      String userAgentSuffix) {
     this.stageName = stageName;
     try {
       this.ingestManager =
           new SimpleIngestManager(
-              accountName, userName, pipeName, privateKey, connectionScheme, host, port);
+              accountName,
+              userName,
+              pipeName,
+              privateKey,
+              connectionScheme,
+              host,
+              port,
+              userAgentSuffix);
     } catch (Exception e) {
       throw SnowflakeErrors.ERROR_0002.getException(e);
     }
@@ -240,5 +248,10 @@ public class SnowflakeIngestionServiceV1 extends Logging implements SnowflakeIng
     }
 
     return result;
+  }
+
+  /* Only used for testing */
+  public SimpleIngestManager getIngestManager() {
+    return this.ingestManager;
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
@@ -224,7 +224,7 @@ public class ConnectorConfigTest {
     config.put(SnowflakeSinkConnectorConfig.PROVIDER_CONFIG, "CONFLUENT");
     Utils.validateConfig(config);
 
-    config.put(SnowflakeSinkConnectorConfig.PROVIDER_CONFIG, "NONE");
+    config.put(SnowflakeSinkConnectorConfig.PROVIDER_CONFIG, "UNKNOWN");
     Utils.validateConfig(config);
   }
 

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
@@ -200,4 +200,38 @@ public class ConnectorConfigTest {
     config.put(SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS, "adssadsa");
     Utils.validateConfig(config);
   }
+
+  @Test
+  public void testKafkaProviderConfigValue_valid_null() {
+    Map<String, String> config = getConfig();
+    config.put(SnowflakeSinkConnectorConfig.PROVIDER_CONFIG, null);
+    Utils.validateConfig(config);
+  }
+
+  @Test
+  public void testKafkaProviderConfigValue_valid_empty() {
+    Map<String, String> config = getConfig();
+    config.put(SnowflakeSinkConnectorConfig.PROVIDER_CONFIG, "");
+    Utils.validateConfig(config);
+  }
+
+  @Test
+  public void testKafkaProviderConfigValue_valid_provider() {
+    Map<String, String> config = getConfig();
+    config.put(SnowflakeSinkConnectorConfig.PROVIDER_CONFIG, "self_hosted");
+    Utils.validateConfig(config);
+
+    config.put(SnowflakeSinkConnectorConfig.PROVIDER_CONFIG, "CONFLUENT");
+    Utils.validateConfig(config);
+
+    config.put(SnowflakeSinkConnectorConfig.PROVIDER_CONFIG, "NONE");
+    Utils.validateConfig(config);
+  }
+
+  @Test(expected = SnowflakeKafkaConnectorException.class)
+  public void testKafkaProviderConfigValue_invalid_value() {
+    Map<String, String> config = getConfig();
+    config.put(SnowflakeSinkConnectorConfig.PROVIDER_CONFIG, "Something_which_is_not_supported");
+    Utils.validateConfig(config);
+  }
 }


### PR DESCRIPTION
Testing:
- I have locally tested this by overriding the snowpipe sdk jar. (Which is not yet released) Reason being I want to get an approval on this one so that I can release the SDK. 
- Here is what the userAgent looks like: 
  - `SnowpipeJavaSDK/0.10.3 (Mac OS X 10.16 x86_64) JAVA/13 SFKafkaConnector/1.5.4 provider/SELF_HOSTED`
- I have added comments in the code which are self explanatory. 
- There are three allowed values to this configuration - `null/empty(equivalent to not provided)= UNKNOWN, SELF_HOSTED, CONFLUENT

PS:
- The test will fail now since I have not added the pom xml file. 
- Plan of action: Release snowpipe sdk, and push this with new version of sdk and see if the test passes. 

Here is how I have tested the local jar"
```
<repository>
            <id>local-maven-repo</id>
            <url>file:///Users/japatel/Desktop/Kafka-Connector/snowflake-kafka-connector/local-maven-repo</url>
</repository>

-- snowpipe sdk
<version>0.10.3</version>

-- maven command to install a local jar
mvn deploy:deploy-file -DgroupId=net.snowflake -DartifactId=snowflake-ingest-sdk -Dversion=0.10.3 -Durl=file:./local-maven-repo/ -DrepositoryId=local-maven-repo -DupdateReleaseInfo=true -Dfile=local-maven-repo/snowflake-ingest-sdk.jar