### PR TITLE
Add config for tombstone record with a default behavior of ingesting …

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -20,6 +20,7 @@ import com.google.common.base.Strings;
 import com.snowflake.kafka.connector.internal.Logging;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.kafka.common.config.ConfigDef;
@@ -48,6 +49,9 @@ public class SnowflakeSinkConnectorConfig {
   public static final long BUFFER_SIZE_BYTES_DEFAULT = 5000000;
   public static final long BUFFER_SIZE_BYTES_MIN = 1;
   static final String TOPICS_TABLES_MAP = "snowflake.topic2table.map";
+
+  // For tombstone records
+  public static final String BEHAVIOR_ON_NULL_VALUES_CONFIG = "behavior.on.null.values";
 
   // Time in seconds
   public static final long BUFFER_FLUSH_TIME_SEC_MIN = 10;
@@ -330,7 +334,19 @@ public class SnowflakeSinkConnectorConfig {
             KafkaProvider.UNKNOWN.name(),
             KAFKA_PROVIDER_VALIDATOR,
             Importance.LOW,
-            "Whether kafka is running on Confluent code, self hosted or other managed service");
+            "Whether kafka is running on Confluent code, self hosted or other managed service")
+        .define(
+            BEHAVIOR_ON_NULL_VALUES_CONFIG,
+            Type.STRING,
+            BehaviorOnNullValues.DEFAULT.toString(),
+            BehaviorOnNullValues.VALIDATOR,
+            Importance.LOW,
+            "How to handle records with a null value (i.e. Kafka tombstone records)."
+                + " Valid options are 'DEFAULT' and 'IGNORE'.",
+            CONNECTOR_CONFIG,
+            4,
+            ConfigDef.Width.NONE,
+            BEHAVIOR_ON_NULL_VALUES_CONFIG);
   }
 
   public static class TopicToTableValidator implements ConfigDef.Validator {
@@ -414,6 +430,55 @@ public class SnowflakeSinkConnectorConfig {
           String.format(
               "Unsupported provider name: %s. Supported are: %s",
               kafkaProviderStr, String.join(",", PROVIDER_NAMES)));
+    }
+  }
+
+  /* The allowed values for tombstone records. */
+  public enum BehaviorOnNullValues {
+    // Ignore would filter out records which has null value, but a valid key.
+    IGNORE,
+
+    // Default as the name suggests, would be a default behavior which will not filter null values.
+    // This will put an empty JSON string in corresponding snowflake table.
+    // Using this means we will fall back to old behavior before introducing this config.
+    DEFAULT,
+    ;
+
+    /* Validator to validate behavior.on.null.values which says whether kafka should keep null value records or ignore them while ingesting into snowflake table. */
+    public static final ConfigDef.Validator VALIDATOR =
+        new ConfigDef.Validator() {
+          private final ConfigDef.ValidString validator = ConfigDef.ValidString.in(names());
+
+          @Override
+          public void ensureValid(String name, Object value) {
+            if (value instanceof String) {
+              value = ((String) value).toLowerCase(Locale.ROOT);
+            }
+            validator.ensureValid(name, value);
+          }
+
+          // Overridden here so that ConfigDef.toEnrichedRst shows possible values correctly
+          @Override
+          public String toString() {
+            return validator.toString();
+          }
+        };
+
+    // All valid enum values
+    public static String[] names() {
+      BehaviorOnNullValues[] behaviors = values();
+      String[] result = new String[behaviors.length];
+
+      for (int i = 0; i < behaviors.length; i++) {
+        result[i] = behaviors[i].toString();
+      }
+
+      return result;
+    }
+
+    @Override
+    public String toString() {
+      return name().toLowerCase(Locale.ROOT);
     }
   }
 }

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -435,13 +435,13 @@ public class SnowflakeSinkConnectorConfig {
 
   /* The allowed values for tombstone records. */
   public enum BehaviorOnNullValues {
-    // Ignore would filter out records which has null value, but a valid key.
-    IGNORE,
-
     // Default as the name suggests, would be a default behavior which will not filter null values.
     // This will put an empty JSON string in corresponding snowflake table.
     // Using this means we will fall back to old behavior before introducing this config.
     DEFAULT,
+
+    // Ignore would filter out records which has null value, but a valid key.
+    IGNORE,
     ;
 
     /* Validator to validate behavior.on.null.values which says whether kafka should keep null value records or ignore them while ingesting into snowflake table. */

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
@@ -120,6 +120,18 @@ public class SnowflakeSinkTask extends SinkTask {
     final long bufferFlushTime =
         Long.parseLong(parsedConfig.get(SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC));
 
+    // Falling back to default behavior which is to ingest an empty json string if we get null
+    // value. (Tombstone record)
+    SnowflakeSinkConnectorConfig.BehaviorOnNullValues behavior =
+        SnowflakeSinkConnectorConfig.BehaviorOnNullValues.DEFAULT;
+    if (parsedConfig.containsKey(SnowflakeSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG)) {
+      // we can always assume here that value passed in would be an allowed value, otherwise the
+      // connector would never start or reach the sink task stage
+      behavior =
+          SnowflakeSinkConnectorConfig.BehaviorOnNullValues.valueOf(
+              parsedConfig.get(SnowflakeSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG));
+    }
+
     conn =
         SnowflakeConnectionServiceFactory.builder()
             .setProperties(parsedConfig)
@@ -136,6 +148,7 @@ public class SnowflakeSinkTask extends SinkTask {
             .setFlushTime(bufferFlushTime)
             .setTopic2TableMap(topic2table)
             .setMetadataConfig(metadataConfig)
+            .setBehaviorOnNullValuesConfig(behavior)
             .build();
 
     LOGGER.info(

--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -16,6 +16,9 @@
  */
 package com.snowflake.kafka.connector;
 
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BehaviorOnNullValues.VALIDATOR;
+
 import com.snowflake.kafka.connector.internal.Logging;
 import com.snowflake.kafka.connector.internal.SnowflakeErrors;
 import com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException;
@@ -33,6 +36,7 @@ import java.util.Random;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.kafka.common.config.Config;
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.ConfigValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -467,6 +471,21 @@ public class Utils {
             config.get(SnowflakeSinkConnectorConfig.PROVIDER_CONFIG));
       } catch (IllegalArgumentException exception) {
         LOGGER.error(Logging.logMessage("Kafka provider config error:{}", exception.getMessage()));
+        configIsValid = false;
+      }
+    }
+
+    if (config.containsKey(BEHAVIOR_ON_NULL_VALUES_CONFIG)) {
+      try {
+        // This throws an exception if config value is invalid.
+        VALIDATOR.ensureValid(
+            BEHAVIOR_ON_NULL_VALUES_CONFIG, config.get(BEHAVIOR_ON_NULL_VALUES_CONFIG));
+      } catch (ConfigException exception) {
+        LOGGER.error(
+            Logging.logMessage(
+                "Kafka config:{} error:{}",
+                BEHAVIOR_ON_NULL_VALUES_CONFIG,
+                exception.getMessage()));
         configIsValid = false;
       }
     }

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkService.java
@@ -1,5 +1,6 @@
 package com.snowflake.kafka.connector.internal;
 
+import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
 import com.snowflake.kafka.connector.records.SnowflakeMetadataConfig;
 import java.util.Collection;
 import java.util.Map;
@@ -115,4 +116,10 @@ public interface SnowflakeSinkService {
 
   /** @return current file size limitation */
   long getFileSize();
+
+  /* Set the behavior on what action to perform when this( @see com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig#BEHAVIOR_ON_NULL_VALUES_CONFIG ) config is set. */
+  void setBehaviorOnNullValuesConfig(SnowflakeSinkConnectorConfig.BehaviorOnNullValues behavior);
+
+  /* Only used in testing and verifying what was the passed value of this behavior from config to sink service*/
+  SnowflakeSinkConnectorConfig.BehaviorOnNullValues getBehaviorOnNullValuesConfig();
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceFactory.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceFactory.java
@@ -1,5 +1,6 @@
 package com.snowflake.kafka.connector.internal;
 
+import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
 import com.snowflake.kafka.connector.records.SnowflakeMetadataConfig;
 import java.util.Map;
 
@@ -66,6 +67,13 @@ public class SnowflakeSinkServiceFactory {
     public SnowflakeSinkServiceBuilder setMetadataConfig(SnowflakeMetadataConfig configMap) {
       this.service.setMetadataConfig(configMap);
       logInfo("metadata config map is {}", configMap.toString());
+      return this;
+    }
+
+    public SnowflakeSinkServiceBuilder setBehaviorOnNullValuesConfig(
+        SnowflakeSinkConnectorConfig.BehaviorOnNullValues behavior) {
+      this.service.setBehaviorOnNullValuesConfig(behavior);
+      logInfo("Config Behavior on null value is {}", behavior.toString());
       return this;
     }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
@@ -1018,8 +1018,8 @@ class SnowflakeSinkServiceV1 extends Logging implements SnowflakeSinkService {
   }
 
   /**
-   * Only used for testing
-   * Given a pipename, find out if buffer for this pipe has any data inserted.
+   * Only used for testing Given a pipename, find out if buffer for this pipe has any data inserted.
+   *
    * @param pipeName
    * @return
    */

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
@@ -84,7 +84,7 @@ class SnowflakeSinkServiceV1 extends Logging implements SnowflakeSinkService {
     // note that records can be empty
     for (SinkRecord record : records) {
       // check if need to handle null value records
-      if (maybeSkipOnNullValue(record)) {
+      if (shouldSkipNullValue(record)) {
         continue;
       }
       // Might happen a count of record based flushing
@@ -115,7 +115,7 @@ class SnowflakeSinkServiceV1 extends Logging implements SnowflakeSinkService {
    * @return true if we would skip adding it to buffer -> skip to internal stage and hence skipped
    *     inside SF Table
    */
-  private boolean maybeSkipOnNullValue(SinkRecord record) {
+  private boolean shouldSkipNullValue(SinkRecord record) {
     boolean isRecordValueNull = false;
     // get valueSchema
     Schema valueSchema = record.valueSchema();
@@ -150,9 +150,7 @@ class SnowflakeSinkServiceV1 extends Logging implements SnowflakeSinkService {
     }
 
     if (isRecordValueNull) {
-      if (behaviorOnNullValues
-          .toString()
-          .equalsIgnoreCase(SnowflakeSinkConnectorConfig.BehaviorOnNullValues.IGNORE.toString())) {
+      if (behaviorOnNullValues == SnowflakeSinkConnectorConfig.BehaviorOnNullValues.IGNORE) {
         logDebug(
             "Null valued record from topic '{}', partition {} and offset {} was skipped.",
             record.topic(),

--- a/src/main/java/com/snowflake/kafka/connector/records/SnowflakeRecordContent.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/SnowflakeRecordContent.java
@@ -26,8 +26,7 @@ public class SnowflakeRecordContent {
    * <p>If we change this logic in future, we need to carefully modify how we handle tombstone
    * records.
    *
-   * <p>@see
-   * com.snowflake.kafka.connector.internal.SnowflakeSinkServiceV1#maybeSkipOnNullValue(SinkRecord)
+   * <p>@see SnowflakeSinkServiceV1#shouldSkipNullValue(SinkRecord)
    */
   public SnowflakeRecordContent() {
     content = new JsonNode[1];

--- a/src/main/java/com/snowflake/kafka/connector/records/SnowflakeRecordContent.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/SnowflakeRecordContent.java
@@ -126,11 +126,13 @@ public class SnowflakeRecordContent {
     return content.clone();
   }
 
-
   /**
-   * Check if primary reason for this record content's value to be an empty json String, a null value?
+   * Check if primary reason for this record content's value to be an empty json String, a null
+   * value?
    *
-   * <p> i.e if value passed in by record is empty json node (`{}`), we don't interpret this as null value.
+   * <p>i.e if value passed in by record is empty json node (`{}`), we don't interpret this as null
+   * value.
+   *
    * @return true if content value is empty json node as well as isNullValueRecord is set to true.
    */
   public boolean isRecordContentValueNull() {

--- a/src/main/java/com/snowflake/kafka/connector/records/SnowflakeRecordContent.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/SnowflakeRecordContent.java
@@ -4,7 +4,6 @@ import com.snowflake.kafka.connector.internal.SnowflakeErrors;
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.JsonNode;
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.sink.SinkRecord;
 
 public class SnowflakeRecordContent {
 
@@ -27,8 +26,8 @@ public class SnowflakeRecordContent {
    * <p>If we change this logic in future, we need to carefully modify how we handle tombstone
    * records.
    *
-   * <p>@see {@link
-   * com.snowflake.kafka.connector.internal.SnowflakeSinkServiceV1#maybeSkipOnNullValue(SinkRecord)}
+   * <p>@see
+   * com.snowflake.kafka.connector.internal.SnowflakeSinkServiceV1#maybeSkipOnNullValue(SinkRecord)
    */
   public SnowflakeRecordContent() {
     content = new JsonNode[1];

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
@@ -234,4 +234,21 @@ public class ConnectorConfigTest {
     config.put(SnowflakeSinkConnectorConfig.PROVIDER_CONFIG, "Something_which_is_not_supported");
     Utils.validateConfig(config);
   }
+
+  @Test
+  public void testBehaviorOnNullValuesConfig_valid_value() {
+    Map<String, String> config = getConfig();
+    config.put(SnowflakeSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG, "IGNORE");
+    Utils.validateConfig(config);
+
+    config.put(SnowflakeSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG, "DEFAULT");
+    Utils.validateConfig(config);
+  }
+
+  @Test(expected = SnowflakeKafkaConnectorException.class)
+  public void testBehaviorOnNullValuesConfig_invalid_value() {
+    Map<String, String> config = getConfig();
+    config.put(SnowflakeSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG, "INVALID");
+    Utils.validateConfig(config);
+  }
 }

--- a/src/test/java/com/snowflake/kafka/connector/internal/SinkServiceIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/SinkServiceIT.java
@@ -17,7 +17,6 @@ import java.sql.ResultSet;
 import java.util.*;
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.ObjectMapper;
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.node.ObjectNode;
-import org.apache.avro.data.Json;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
@@ -266,7 +265,9 @@ public class SinkServiceIT {
         new SinkRecord(
             topic, partition, Schema.STRING_SCHEMA, "test", input.schema(), input.value(), offset);
     service.insert(Collections.singletonList(record1));
-    Assert.assertTrue(((SnowflakeSinkServiceV1)service).isPartitionBufferEmpty(SnowflakeSinkServiceV1.getNameIndex(topic, partition)));
+    Assert.assertTrue(
+        ((SnowflakeSinkServiceV1) service)
+            .isPartitionBufferEmpty(SnowflakeSinkServiceV1.getNameIndex(topic, partition)));
     TestUtils.assertWithRetry(
         () ->
             conn.listStage(
@@ -288,22 +289,23 @@ public class SinkServiceIT {
   }
 
   @Test
-  public void testTombstoneRecords_IGNORE_behavior_ingestion_CommunityJsonConverter() throws Exception {
+  public void testTombstoneRecords_IGNORE_behavior_ingestion_CommunityJsonConverter()
+      throws Exception {
     conn.createTable(table);
     conn.createStage(stage);
     SnowflakeSinkService service =
-            SnowflakeSinkServiceFactory.builder(conn)
-                    .setRecordNumber(1)
-                    .addTask(table, topic, partition)
-                    .setBehaviorOnNullValuesConfig(SnowflakeSinkConnectorConfig.BehaviorOnNullValues.IGNORE)
-                    .build();
+        SnowflakeSinkServiceFactory.builder(conn)
+            .setRecordNumber(1)
+            .addTask(table, topic, partition)
+            .setBehaviorOnNullValuesConfig(SnowflakeSinkConnectorConfig.BehaviorOnNullValues.IGNORE)
+            .build();
 
     // Verifying it here to see if it fallbacks to default behavior - which is to ingest empty json
     // string
     Assert.assertTrue(
-            service
-                    .getBehaviorOnNullValuesConfig()
-                    .equals(SnowflakeSinkConnectorConfig.BehaviorOnNullValues.IGNORE));
+        service
+            .getBehaviorOnNullValuesConfig()
+            .equals(SnowflakeSinkConnectorConfig.BehaviorOnNullValues.IGNORE));
     JsonConverter converter = new JsonConverter();
     HashMap<String, String> converterConfig = new HashMap<String, String>();
     converterConfig.put("schemas.enable", "false");
@@ -312,19 +314,21 @@ public class SinkServiceIT {
     long offset = 0;
 
     SinkRecord record1 =
-            new SinkRecord(
-                    topic, partition, Schema.STRING_SCHEMA, "test", input.schema(), input.value(), offset);
+        new SinkRecord(
+            topic, partition, Schema.STRING_SCHEMA, "test", input.schema(), input.value(), offset);
     service.insert(Collections.singletonList(record1));
-    Assert.assertTrue(((SnowflakeSinkServiceV1)service).isPartitionBufferEmpty(SnowflakeSinkServiceV1.getNameIndex(topic, partition)));
+    Assert.assertTrue(
+        ((SnowflakeSinkServiceV1) service)
+            .isPartitionBufferEmpty(SnowflakeSinkServiceV1.getNameIndex(topic, partition)));
     TestUtils.assertWithRetry(
-            () ->
-                    conn.listStage(
-                            stage,
-                            FileNameUtils.filePrefix(TestUtils.TEST_CONNECTOR_NAME, table, partition))
-                            .size()
-                            == 0,
-            5,
-            4);
+        () ->
+            conn.listStage(
+                        stage,
+                        FileNameUtils.filePrefix(TestUtils.TEST_CONNECTOR_NAME, table, partition))
+                    .size()
+                == 0,
+        5,
+        4);
 
     // wait for ingest
     TestUtils.assertWithRetry(() -> TestUtils.tableSize(table) == 0, 30, 20);

--- a/src/test/java/com/snowflake/kafka/connector/internal/SinkServiceIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/SinkServiceIT.java
@@ -17,6 +17,7 @@ import java.sql.ResultSet;
 import java.util.*;
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.ObjectMapper;
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.avro.data.Json;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
@@ -25,6 +26,7 @@ import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -173,7 +175,7 @@ public class SinkServiceIT {
   }
 
   @Test
-  public void testTombstoneRecords_ingestion() throws Exception {
+  public void testTombstoneRecords_DEFAULT_behavior_ingestion_SFJsonConverter() throws Exception {
     conn.createTable(table);
     conn.createStage(stage);
     SnowflakeSinkService service =
@@ -182,6 +184,12 @@ public class SinkServiceIT {
             .addTask(table, topic, partition)
             .build();
 
+    // Verifying it here to see if it fallbacks to default behavior - which is to ingest empty json
+    // string
+    Assert.assertTrue(
+        service
+            .getBehaviorOnNullValuesConfig()
+            .equals(SnowflakeSinkConnectorConfig.BehaviorOnNullValues.DEFAULT));
     SnowflakeConverter converter = new SnowflakeJsonConverter();
     SchemaAndValue input = converter.toConnectData(topic, null);
     long offset = 0;
@@ -189,8 +197,7 @@ public class SinkServiceIT {
     SinkRecord record1 =
         new SinkRecord(
             topic, partition, Schema.STRING_SCHEMA, "test", input.schema(), input.value(), offset);
-
-    service.insert(record1);
+    service.insert(Collections.singletonList(record1));
     TestUtils.assertWithRetry(
         () ->
             conn.listStage(
@@ -230,6 +237,101 @@ public class SinkServiceIT {
     TestUtils.assertWithRetry(() -> getStageSize(stage, table, partition) == 0, 30, 20);
 
     assert service.getOffset(new TopicPartition(topic, partition)) == offset + 1;
+
+    service.closeAll();
+  }
+
+  @Test
+  public void testTombstoneRecords_IGNORE_behavior_ingestion_SFJsonConverter() throws Exception {
+    conn.createTable(table);
+    conn.createStage(stage);
+    SnowflakeSinkService service =
+        SnowflakeSinkServiceFactory.builder(conn)
+            .setRecordNumber(1)
+            .addTask(table, topic, partition)
+            .setBehaviorOnNullValuesConfig(SnowflakeSinkConnectorConfig.BehaviorOnNullValues.IGNORE)
+            .build();
+
+    // Verifying it here to see if it fallbacks to default behavior - which is to ingest empty json
+    // string
+    Assert.assertTrue(
+        service
+            .getBehaviorOnNullValuesConfig()
+            .equals(SnowflakeSinkConnectorConfig.BehaviorOnNullValues.IGNORE));
+    SnowflakeConverter converter = new SnowflakeJsonConverter();
+    SchemaAndValue input = converter.toConnectData(topic, null);
+    long offset = 0;
+
+    SinkRecord record1 =
+        new SinkRecord(
+            topic, partition, Schema.STRING_SCHEMA, "test", input.schema(), input.value(), offset);
+    service.insert(Collections.singletonList(record1));
+    Assert.assertTrue(((SnowflakeSinkServiceV1)service).isPartitionBufferEmpty(SnowflakeSinkServiceV1.getNameIndex(topic, partition)));
+    TestUtils.assertWithRetry(
+        () ->
+            conn.listStage(
+                        stage,
+                        FileNameUtils.filePrefix(TestUtils.TEST_CONNECTOR_NAME, table, partition))
+                    .size()
+                == 0,
+        5,
+        4);
+
+    // wait for ingest
+    TestUtils.assertWithRetry(() -> TestUtils.tableSize(table) == 0, 30, 20);
+
+    ResultSet resultSet = TestUtils.showTable(table);
+    Assert.assertTrue(resultSet.getFetchSize() == 0);
+    resultSet.close();
+
+    service.closeAll();
+  }
+
+  @Test
+  public void testTombstoneRecords_IGNORE_behavior_ingestion_CommunityJsonConverter() throws Exception {
+    conn.createTable(table);
+    conn.createStage(stage);
+    SnowflakeSinkService service =
+            SnowflakeSinkServiceFactory.builder(conn)
+                    .setRecordNumber(1)
+                    .addTask(table, topic, partition)
+                    .setBehaviorOnNullValuesConfig(SnowflakeSinkConnectorConfig.BehaviorOnNullValues.IGNORE)
+                    .build();
+
+    // Verifying it here to see if it fallbacks to default behavior - which is to ingest empty json
+    // string
+    Assert.assertTrue(
+            service
+                    .getBehaviorOnNullValuesConfig()
+                    .equals(SnowflakeSinkConnectorConfig.BehaviorOnNullValues.IGNORE));
+    JsonConverter converter = new JsonConverter();
+    HashMap<String, String> converterConfig = new HashMap<String, String>();
+    converterConfig.put("schemas.enable", "false");
+    converter.configure(converterConfig, false);
+    SchemaAndValue input = converter.toConnectData(topic, null);
+    long offset = 0;
+
+    SinkRecord record1 =
+            new SinkRecord(
+                    topic, partition, Schema.STRING_SCHEMA, "test", input.schema(), input.value(), offset);
+    service.insert(Collections.singletonList(record1));
+    Assert.assertTrue(((SnowflakeSinkServiceV1)service).isPartitionBufferEmpty(SnowflakeSinkServiceV1.getNameIndex(topic, partition)));
+    TestUtils.assertWithRetry(
+            () ->
+                    conn.listStage(
+                            stage,
+                            FileNameUtils.filePrefix(TestUtils.TEST_CONNECTOR_NAME, table, partition))
+                            .size()
+                            == 0,
+            5,
+            4);
+
+    // wait for ingest
+    TestUtils.assertWithRetry(() -> TestUtils.tableSize(table) == 0, 30, 20);
+
+    ResultSet resultSet = TestUtils.showTable(table);
+    Assert.assertTrue(resultSet.getFetchSize() == 0);
+    resultSet.close();
 
     service.closeAll();
   }


### PR DESCRIPTION
…empty json

https://snowflakecomputing.atlassian.net/browse/SNOW-298877

Background:
- Tombstone records: Records with null value. 
- Clients can use community converters with Tombstone Handler SMT (Single Message Transformation) - https://docs.confluent.io/platform/current/connect/transforms/tombstonehandler.html
- But, if they use converters defined by our KC, SMT is not supported. 
- Current behavior of TS records are that they are representing an empty json string in Snowflake Table. 
- To avoid doing this and prevent us from doing a breaking change, we can fallback to default behavior and introduce another behavior which would ignore those null values. 
- Remember, Snowflake is meant to be append only and this tombstone records are not used for removing corresponding keys from Snowflake Table. (Original idea of TS record is to be able to remove those keys from destination table if values are null)
- Custom converters create an empty Json String(Check default ctor for SnowflakeRecordContent). So, I introduced a flag(`isNullValueRecord`) for Sink service to identify if converter received an null value which still resulted into a non null content (representing an empty json string)

### Testing
- I had long ago added a test to verify that tombstone records are resulting into an empty string. 
- The above test had default behavior of "DEFAULT" which gave the same result. 
- Added one more test with different config "IGNORE" which proved the buffer to be empty and nothing on stage as well. 
- Here is the connector config: https://jsonblob.com/1c34495a-c88b-11eb-ba15-1ba7dd08f3a3
  - If debug logs are enabled, here is what it looks like: 
  - ``` Null valued record from topic 'SnowflakeSink_JP2', partition 0 and offset 2 was skipped. (com.snowflake.kafka.connector.internal.SnowflakeSinkServiceV1:75)```

Required Reviewers:
@sfc-gh-rramachandran and @sfc-gh-zli (As he would have some more context if I missed an edge case)
