### PR TITLE
Added JMX metrics which will be exported to Mbean Server

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeErrors.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeErrors.java
@@ -230,7 +230,8 @@ public enum SnowflakeErrors {
   ERROR_5017(
       "5017", "Invalid api call to cached put", "Cached put only support AWS, Azure and GCS."),
   ERROR_5018("5018", "Failed to execute cached put", "Error in cached put command"),
-  ERROR_5019("5019", "Failed to get stage storage type", "Error in get storage type");
+  ERROR_5019("5019", "Failed to get stage storage type", "Error in get storage type"),
+  ERROR_5020("5020", "Failed to register MBean in MbeanServer", "Object Name is invalid");
 
   // properties
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeKafkaConnectorException.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeKafkaConnectorException.java
@@ -3,7 +3,7 @@ package com.snowflake.kafka.connector.internal;
 public class SnowflakeKafkaConnectorException extends RuntimeException {
   private final String code;
 
-  SnowflakeKafkaConnectorException(String msg, String code) {
+  public SnowflakeKafkaConnectorException(String msg, String code) {
     super(msg);
     this.code = code;
   }

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeTelemetryBasicInfo.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeTelemetryBasicInfo.java
@@ -1,6 +1,13 @@
 package com.snowflake.kafka.connector.internal;
 
+import java.lang.management.ManagementFactory;
+import javax.management.JMException;
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.node.ObjectNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class SnowflakeTelemetryBasicInfo {
   final String tableName;
@@ -10,12 +17,87 @@ public abstract class SnowflakeTelemetryBasicInfo {
   static final String STAGE_NAME = "stage_name";
   static final String PIPE_NAME = "pipe_name";
 
+  // Name of mBean if jmx monitoring is enabled
+  private ObjectName mBeanName;
+
+  // A boolean to turn on or off a JMX metric as required.
+  private volatile boolean enableJMXMonitoring;
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SnowflakeTelemetryBasicInfo.class);
+
+  private static final String JMX_METRIC_PREFIX = "snowflake.kafka.connector";
+
   SnowflakeTelemetryBasicInfo(
-      final String tableName, final String stageName, final String pipeName) {
+      final String tableName,
+      final String stageName,
+      final String pipeName,
+      final String connectorName,
+      final boolean enableJMXMonitoring) {
     this.tableName = tableName;
     this.stageName = stageName;
     this.pipeName = pipeName;
+    this.enableJMXMonitoring = enableJMXMonitoring;
+    if (enableJMXMonitoring) {
+      mBeanName = metricName(pipeName, connectorName);
+    }
   }
 
   abstract void dumpTo(ObjectNode msg);
+
+  /**
+   * Registers a metrics MBean into the platform MBean server. The method is intentionally
+   * synchronized to prevent preemption between registration and unregistration.
+   */
+  public synchronized void registerMBean() {
+    try {
+      final MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+      if (mBeanServer == null) {
+        LOGGER.info(Logging.logMessage("JMX not supported, bean '{}' not registered", mBeanName));
+        return;
+      }
+      mBeanServer.registerMBean(this, mBeanName);
+      LOGGER.info(Logging.logMessage("Registered Mbean:{}", mBeanName));
+    } catch (JMException e) {
+      LOGGER.warn(
+          Logging.logMessage("Unable to register the MBean '{}': {}", mBeanName, e.getMessage()));
+    }
+  }
+
+  /**
+   * Unregisters a metrics MBean from the platform MBean server. The method is intentionally
+   * synchronized to prevent preemption between registration and un-registration.
+   */
+  public synchronized void unregisterMBean() {
+    if (this.mBeanName != null && enableJMXMonitoring) {
+      try {
+        final MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+        if (mBeanServer == null) {
+          LOGGER.info(Logging.logMessage("JMX not supported, bean '{}' not registered"));
+          return;
+        }
+        mBeanServer.unregisterMBean(mBeanName);
+      } catch (JMException e) {
+        LOGGER.warn(
+            Logging.logMessage(
+                "Unable to unregister the MBean '{}': {}", mBeanName, e.getMessage()));
+      }
+    }
+  }
+
+  /**
+   * Create a JMX metric name for the given metric.
+   *
+   * @param pipeName the name of the context
+   * @return the JMX metric name
+   * @throws com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException if the name is
+   *     invalid
+   */
+  public static ObjectName metricName(String pipeName, String connectorName) {
+    final String metricName = JMX_METRIC_PREFIX + ":type=" + connectorName + ",name=" + pipeName;
+    try {
+      return new ObjectName(metricName);
+    } catch (MalformedObjectNameException e) {
+      throw SnowflakeErrors.ERROR_5020.getException();
+    }
+  }
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeTelemetryPipeCreation.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeTelemetryPipeCreation.java
@@ -20,8 +20,11 @@ public class SnowflakeTelemetryPipeCreation extends SnowflakeTelemetryBasicInfo 
   static final String FILE_COUNT_REPROCESS_PURGE = "file_count_reprocess_purge";
 
   SnowflakeTelemetryPipeCreation(
-      final String tableName, final String stageName, final String pipeName) {
-    super(tableName, stageName, pipeName);
+      final String tableName,
+      final String stageName,
+      final String pipeName,
+      final String connectorName) {
+    super(tableName, stageName, pipeName, connectorName, false /* Disable JMX Monitoring for now*/);
     this.startTime = System.currentTimeMillis();
   }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeTelemetryPipeStatusMBean.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeTelemetryPipeStatusMBean.java
@@ -1,0 +1,83 @@
+package com.snowflake.kafka.connector.internal;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Mbean Interface for registering JMX metrics. These are the metrics visible as Mbeans when JMX
+ * hostname and port are configured.
+ *
+ * <p>Contains metrics related to Offsets (Kafka Offsets)
+ *
+ * <p>Contains metrics related to files(Files that were created from offsets and were ingested
+ * through Snowpipe)
+ */
+public interface SnowflakeTelemetryPipeStatusMBean {
+
+  // ------------ Metrics related to Offsets (Kafka Offsets) ------------ //
+
+  /**
+   * Offset number that is most recent inside the buffer (In memory buffer)
+   *
+   * <p>This is updated every time an offset is sent as put API of SinkTask {@link
+   * org.apache.kafka.connect.sink.SinkTask#put(Collection)}
+   *
+   * @return long offset
+   */
+  long getProcessedOffset();
+
+  /**
+   * Offset number(Record) that is being flushed into an internal stage after the buffer threshold
+   * was reached. Buffer can reach its threshold by either time, number of records or size.
+   *
+   * @return long offset
+   */
+  long getFlushedOffset();
+
+  /**
+   * Offset number (Record) for which precommit {@link
+   * org.apache.kafka.connect.sink.SinkTask#preCommit(Map)} API was called and we called snowpipe's
+   * insertFiles API.
+   *
+   * @return long offset
+   */
+  long getCommittedOffset();
+
+  /**
+   * Offsets which are being purged from internal stage. (This number is the highest recent most
+   * offset which was purged from internal stage)
+   *
+   * @return long offset
+   */
+  long getPurgedOffset();
+
+  // ------------ Metrics related to File counts at various stage ------------ //
+
+  /**
+   * @return number of files currently on an internal stage. The value will be decremented once
+   *     files are being purged. These gives an estimate on how many files are present on an
+   *     internal stage at any given point of time.
+   */
+  long getFileCountOnInternalStage();
+
+  /**
+   * @return number of files we call insertFiles API in snowpipe. Note: There is currently a
+   *     limitation of 10k files being sent to a single rest request. So these metric has no one to
+   *     one relation between files and number of REST API calls. Number of REST API call for
+   *     insertFiles can be larger than this value. The value drop backs to zero if there are no
+   *     more files to be ingested.
+   */
+  long getFileCountOnIngestion();
+
+  /**
+   * @return number of files present on table stage due to failed ingestion (Missing Ingestion
+   *     Status).
+   */
+  long getFileCountFailedIngestionOnTableStage();
+
+  /**
+   * @return number of files present on table stage because files corresponds to broken offset
+   *     (Broken record)
+   */
+  long getFileCountBrokenRecordOnTableStage();
+}

--- a/src/test/java/com/snowflake/kafka/connector/internal/SnowflakeTelemetryPipeStatusMetricsIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/SnowflakeTelemetryPipeStatusMetricsIT.java
@@ -1,0 +1,97 @@
+package com.snowflake.kafka.connector.internal;
+
+import com.snowflake.kafka.connector.Utils;
+import com.snowflake.kafka.connector.records.SnowflakeConverter;
+import com.snowflake.kafka.connector.records.SnowflakeJsonConverter;
+import java.lang.management.ManagementFactory;
+import java.nio.charset.StandardCharsets;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SnowflakeTelemetryPipeStatusMetricsIT {
+  private String topic = "test";
+  private int partition = 0;
+  private String tableName = TestUtils.randomTableName();
+  private String stageName = Utils.stageName(TestUtils.TEST_CONNECTOR_NAME, tableName);
+  private String pipeName = Utils.pipeName(TestUtils.TEST_CONNECTOR_NAME, tableName, partition);
+  private SnowflakeConnectionService conn = TestUtils.getConnectionService();
+  private ObjectMapper mapper = new ObjectMapper();
+
+  @After
+  public void afterEach() {
+    conn.dropStage(stageName);
+    TestUtils.dropTable(tableName);
+    conn.dropPipe(pipeName);
+  }
+
+  @Test
+  public void testJMXMetricsInMBeanServer() throws Exception {
+    conn.createTable(tableName);
+    conn.createStage(stageName);
+    final String pipeName = Utils.pipeName(conn.getConnectorName(), tableName, partition);
+
+    SnowflakeSinkService service =
+        SnowflakeSinkServiceFactory.builder(conn)
+            .addTask(tableName, topic, partition)
+            .setRecordNumber(1)
+            .build();
+
+    SnowflakeConverter converter = new SnowflakeJsonConverter();
+    SchemaAndValue result =
+        converter.toConnectData(topic, ("{\"name\":\"test\"}").getBytes(StandardCharsets.UTF_8));
+    SinkRecord record =
+        new SinkRecord(
+            topic, partition, Schema.STRING_SCHEMA, "key1", result.schema(), result.value(), 0);
+
+    service.insert(record);
+
+    record =
+        new SinkRecord(
+            topic, partition, Schema.STRING_SCHEMA, "key2", result.schema(), result.value(), 1);
+
+    service.insert(record);
+
+    // required for committedOffset metric
+    service.callAllGetOffset();
+
+    final MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
+    final ObjectName objectName =
+        SnowflakeTelemetryBasicInfo.metricName(pipeName, TestUtils.TEST_CONNECTOR_NAME);
+
+    Assert.assertTrue(mBeanServer.getAttribute(objectName, "ProcessedOffset").equals(1l));
+    Assert.assertTrue(mBeanServer.getAttribute(objectName, "FlushedOffset").equals(1l));
+
+    // wait for ingest
+    // Since number of records are 2, we expect two entries in table
+    TestUtils.assertWithRetry(() -> TestUtils.tableSize(tableName) == 2, 30, 20);
+
+    // change cleaner
+    TestUtils.assertWithRetry(
+        () ->
+            conn.listStage(
+                        stageName,
+                        FileNameUtils.filePrefix(
+                            TestUtils.TEST_CONNECTOR_NAME, tableName, partition))
+                    .size()
+                == 0,
+        30,
+        20);
+    Assert.assertTrue(mBeanServer.getAttribute(objectName, "CommittedOffset").equals(1l));
+    Assert.assertTrue(mBeanServer.getAttribute(objectName, "PurgedOffset").equals(1l));
+
+    // Since we have purged everything, all other file counters will be 0
+    Assert.assertTrue(mBeanServer.getAttribute(objectName, "FileCountOnInternalStage").equals(0l));
+    Assert.assertTrue(mBeanServer.getAttribute(objectName, "FileCountOnIngestion").equals(0l));
+    Assert.assertTrue(
+        mBeanServer.getAttribute(objectName, "FileCountFailedIngestionOnTableStage").equals(0l));
+    Assert.assertTrue(
+        mBeanServer.getAttribute(objectName, "FileCountBrokenRecordOnTableStage").equals(0l));
+  }
+}

--- a/src/test/java/com/snowflake/kafka/connector/internal/TelemetryUnitTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/TelemetryUnitTest.java
@@ -9,7 +9,9 @@ public class TelemetryUnitTest {
     String table = "table";
     String stage = "stage";
     String pipe = "pipe";
-    SnowflakeTelemetryPipeStatus pipeStatus = new SnowflakeTelemetryPipeStatus(table, stage, pipe);
+    String connectorName = "testConnector";
+    SnowflakeTelemetryPipeStatus pipeStatus =
+        new SnowflakeTelemetryPipeStatus(table, stage, pipe, connectorName);
     assert pipeStatus.empty();
     pipeStatus.averageCommitLagFileCount.set(1);
     assert !pipeStatus.empty();


### PR DESCRIPTION
- Here are the screenshots of the jconsole. 
- Here are the settings needed on client side - (Which is already documented here)
  - https://docs.confluent.io/home/connect/monitoring.html#using-jmx-to-monitor-kconnect
  - export JMX_PORT=PORT
- If running remotely:
  - ``` KAFKA_JMX_OPTS="-Dcom.sun.management.jmxremote=true -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=your.kafka.broker.hostname -Djava.net.preferIPv4Stack=true"```

![Screen Shot 2021-07-07 at 5 53 04 PM](https://user-images.githubusercontent.com/57274584/124957774-4cd1b180-dfce-11eb-859b-bb124d504e47.png)
![Screen Shot 2021-07-07 at 5 53 17 PM](https://user-images.githubusercontent.com/57274584/124957781-4e02de80-dfce-11eb-9f4b-d0f726392615.png)
