### PR TITLE
Add buffer metrics as Histogram

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkService.java
@@ -6,6 +6,7 @@ import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
 import com.snowflake.kafka.connector.records.SnowflakeMetadataConfig;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Optional;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.sink.SinkRecord;
 
@@ -130,5 +131,5 @@ public interface SnowflakeSinkService {
 
   /* Get metric registry of an associated pipe */
   @VisibleForTesting
-  MetricRegistry getMetricRegistry(final String pipeName);
+  Optional<MetricRegistry> getMetricRegistry(final String pipeName);
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkService.java
@@ -128,6 +128,7 @@ public interface SnowflakeSinkService {
   /* Only used in testing and verifying what was the passed value of this behavior from config to sink service*/
   SnowflakeSinkConnectorConfig.BehaviorOnNullValues getBehaviorOnNullValuesConfig();
 
+  /* Get metric registry of an associated pipe */
   @VisibleForTesting
-  MetricRegistry getMetricRegistry();
+  MetricRegistry getMetricRegistry(final String pipeName);
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
@@ -4,7 +4,6 @@ import static com.snowflake.kafka.connector.internal.metrics.MetricsUtil.*;
 import static org.apache.kafka.common.record.TimestampType.NO_TIMESTAMP_TYPE;
 
 import com.codahale.metrics.Meter;
-import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.annotations.VisibleForTesting;
 import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
@@ -361,7 +360,7 @@ class SnowflakeSinkServiceV1 extends Logging implements SnowflakeSinkService {
   /** Equivalent to unregistering all mbeans with a prefix JMX_METRIC_PREFIX */
   private void unregisterAllSnowflakeJMXMetrics() {
     if (enableCustomJMXMonitoring) {
-      metricRegistry.removeMatching(MetricFilter.startsWith(MetricsUtil.JMX_METRIC_PREFIX));
+      MetricsJmxReporter.removeMetricsFromRegistry(this.metricRegistry);
     }
   }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeTelemetryPipeStatus.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeTelemetryPipeStatus.java
@@ -175,7 +175,11 @@ public class SnowflakeTelemetryPipeStatus extends SnowflakeTelemetryBasicInfo {
     }
   }
 
-  /** When either key or value is broken. */
+  /**
+   * When either key or value is broken.
+   *
+   * @param n number of records
+   */
   public void updateBrokenRecordMetrics(long n) {
     this.fileCountTableStageBrokenRecord.addAndGet(n);
     if (enableCustomJMXConfig) {
@@ -183,7 +187,11 @@ public class SnowflakeTelemetryPipeStatus extends SnowflakeTelemetryBasicInfo {
     }
   }
 
-  /** When Ingestion status of n number of files is not found/failed. */
+  /**
+   * When Ingestion status of n number of files is not found/failed.
+   *
+   * @param n number of files failed ingestion
+   */
   public void updateFailedIngestionMetrics(long n) {
     this.fileCountTableStageIngestFail.addAndGet(n);
     if (enableCustomJMXConfig) {
@@ -264,7 +272,7 @@ public class SnowflakeTelemetryPipeStatus extends SnowflakeTelemetryBasicInfo {
       final String pipeName, final String connectorName, MetricRegistry metricRegistry) {
     // Lazily remove all registered metrics from the registry since this can be invoked during
     // partition reassignment
-    MetricsJmxReporter.removeMetricsFromRegistry(metricRegistry);
+    MetricsJmxReporter.removeMetricsFromRegistry(metricRegistry, pipeName);
     try {
       // Latency JMX
       // create meter per event type

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeTelemetryPipeStatus.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeTelemetryPipeStatus.java
@@ -329,6 +329,11 @@ public class SnowflakeTelemetryPipeStatus extends SnowflakeTelemetryBasicInfo {
 
       JmxReporter jmxReporter = createJMXReporter(metricRegistry, connectorName);
       jmxReporter.start();
+      LOGGER.debug(
+          Logging.logMessage(
+              "Registered {} metrics for pipeName:{}",
+              metricRegistry.getMetrics().size(),
+              pipeName));
     } catch (IllegalArgumentException ex) {
       LOGGER.warn("Metrics already present:{}", ex.getMessage());
     }

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeTelemetryPipeStatus.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeTelemetryPipeStatus.java
@@ -7,6 +7,7 @@ import com.codahale.metrics.*;
 import com.codahale.metrics.Timer;
 import com.codahale.metrics.jmx.JmxReporter;
 import com.google.common.collect.Maps;
+import com.snowflake.kafka.connector.internal.metrics.MetricsJmxReporter;
 import com.snowflake.kafka.connector.internal.metrics.MetricsUtil;
 import com.snowflake.kafka.connector.internal.metrics.MetricsUtil.EventType;
 import java.util.*;
@@ -261,10 +262,12 @@ public class SnowflakeTelemetryPipeStatus extends SnowflakeTelemetryBasicInfo {
    */
   private void initializeJMXMetrics(
       final String pipeName, final String connectorName, MetricRegistry metricRegistry) {
-    // For JMX Reporter
-    // create meter per event type
+    // Lazily remove all registered metrics from the registry since this can be invoked during
+    // partition reassignment
+    MetricsJmxReporter.removeMetricsFromRegistry(metricRegistry);
     try {
       // Latency JMX
+      // create meter per event type
       Arrays.stream(EventType.values())
           .forEach(
               eventType ->

--- a/src/main/java/com/snowflake/kafka/connector/internal/metrics/MetricsJmxReporter.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/metrics/MetricsJmxReporter.java
@@ -47,14 +47,19 @@ public class MetricsJmxReporter {
         .build();
   }
 
+  /**
+   * This method is called to fetch an object name for all registered metrics. It can be called
+   * during registration or unregistration.
+   *
+   * @param connectorName name of the connector. (From Config)
+   * @param jmxDomain JMX Domain
+   * @param metricName metric name used while registering the metric. (Check {@link
+   *     MetricsUtil#constructMetricName(String, String, String)}
+   * @return Object Name constructed from above three args
+   */
   @VisibleForTesting
   public static ObjectName getObjectName(
       String connectorName, String jmxDomain, String metricName) {
-    LOGGER.debug(
-        "registering JMX objectName - instanceName: {}, jmxDomain: {}, metricName: {}",
-        connectorName,
-        jmxDomain,
-        metricName);
     try {
       StringBuilder sb =
           new StringBuilder(jmxDomain).append(":connector=").append(connectorName).append(',');
@@ -81,8 +86,10 @@ public class MetricsJmxReporter {
    * De register all snowflake KC related metrics from registry
    *
    * @param metricRegistry to remove all metrics from
+   * @param prefixFilter prefix for removing the filter.
    */
-  public static void removeMetricsFromRegistry(MetricRegistry metricRegistry) {
-    metricRegistry.removeMatching(MetricFilter.startsWith(MetricsUtil.JMX_METRIC_PREFIX));
+  public static void removeMetricsFromRegistry(
+      MetricRegistry metricRegistry, final String prefixFilter) {
+    metricRegistry.removeMatching(MetricFilter.startsWith(prefixFilter));
   }
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/metrics/MetricsJmxReporter.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/metrics/MetricsJmxReporter.java
@@ -83,13 +83,21 @@ public class MetricsJmxReporter {
   }
 
   /**
-   * De register all snowflake KC related metrics from registry
+   * Unregister all snowflake KC related metrics from registry
    *
    * @param metricRegistry to remove all metrics from
    * @param prefixFilter prefix for removing the filter.
    */
   public static void removeMetricsFromRegistry(
       MetricRegistry metricRegistry, final String prefixFilter) {
-    metricRegistry.removeMatching(MetricFilter.startsWith(prefixFilter));
+    if (metricRegistry.getMetrics().size() != 0) {
+      LOGGER.debug(Logging.logMessage("Unregistering all metrics for pipe:{}", prefixFilter));
+      metricRegistry.removeMatching(MetricFilter.startsWith(prefixFilter));
+      LOGGER.debug(
+          Logging.logMessage(
+              "Metric registry size for pipe:{} is:{}",
+              prefixFilter,
+              metricRegistry.getMetrics().size()));
+    }
   }
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/metrics/MetricsJmxReporter.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/metrics/MetricsJmxReporter.java
@@ -2,6 +2,7 @@ package com.snowflake.kafka.connector.internal.metrics;
 
 import static com.snowflake.kafka.connector.internal.metrics.MetricsUtil.JMX_METRIC_PREFIX;
 
+import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.jmx.JmxReporter;
 import com.google.common.annotations.VisibleForTesting;
@@ -74,5 +75,14 @@ public class MetricsJmxReporter {
       LOGGER.warn(Logging.logMessage("Could not create Object name for MetricName:{}", metricName));
       throw SnowflakeErrors.ERROR_5020.getException();
     }
+  }
+
+  /**
+   * De register all snowflake KC related metrics from registry
+   *
+   * @param metricRegistry to remove all metrics from
+   */
+  public static void removeMetricsFromRegistry(MetricRegistry metricRegistry) {
+    metricRegistry.removeMatching(MetricFilter.startsWith(MetricsUtil.JMX_METRIC_PREFIX));
   }
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/metrics/MetricsUtil.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/metrics/MetricsUtil.java
@@ -70,6 +70,15 @@ public class MetricsUtil {
    */
   public static final String PURGED_OFFSET = "purged-offset";
 
+  // Buffer related constants
+  public static final String BUFFER_SUB_DOMAIN = "buffer";
+
+  // the inmemory buffer size in bytes
+  public static final String BUFFER_SIZE_BYTES = "buffer-size-bytes";
+
+  // in memory buffer count representing the number of records in kafka
+  public static final String BUFFER_RECORD_COUNT = "buffer-record-count";
+
   // Event Latency related constants
 
   public static final String LATENCY_SUB_DOMAIN = "latencies";

--- a/src/test/java/com/snowflake/kafka/connector/internal/SnowflakeTelemetryPipeStatusMetricsIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/SnowflakeTelemetryPipeStatusMetricsIT.java
@@ -65,7 +65,7 @@ public class SnowflakeTelemetryPipeStatusMetricsIT {
     // required for committedOffset metric
     service.callAllGetOffset();
 
-    MetricRegistry metricRegistry = service.getMetricRegistry();
+    MetricRegistry metricRegistry = service.getMetricRegistry(pipeName);
     Assert.assertFalse(metricRegistry.getMetrics().isEmpty());
     Assert.assertTrue(metricRegistry.getMetrics().size() == 14);
 
@@ -198,7 +198,7 @@ public class SnowflakeTelemetryPipeStatusMetricsIT {
     // required for committedOffset metric
     service.callAllGetOffset();
 
-    MetricRegistry metricRegistry = service.getMetricRegistry();
+    MetricRegistry metricRegistry = service.getMetricRegistry(pipeName);
     Assert.assertTrue(metricRegistry.getMetrics().isEmpty());
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/internal/SnowflakeTelemetryPipeStatusMetricsIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/SnowflakeTelemetryPipeStatusMetricsIT.java
@@ -65,7 +65,7 @@ public class SnowflakeTelemetryPipeStatusMetricsIT {
     // required for committedOffset metric
     service.callAllGetOffset();
 
-    MetricRegistry metricRegistry = service.getMetricRegistry(pipeName);
+    MetricRegistry metricRegistry = service.getMetricRegistry(pipeName).get();
     Assert.assertFalse(metricRegistry.getMetrics().isEmpty());
     Assert.assertTrue(metricRegistry.getMetrics().size() == 14);
 
@@ -198,7 +198,7 @@ public class SnowflakeTelemetryPipeStatusMetricsIT {
     // required for committedOffset metric
     service.callAllGetOffset();
 
-    MetricRegistry metricRegistry = service.getMetricRegistry(pipeName);
+    MetricRegistry metricRegistry = service.getMetricRegistry(pipeName).get();
     Assert.assertTrue(metricRegistry.getMetrics().isEmpty());
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/internal/SnowflakeTelemetryPipeStatusMetricsIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/SnowflakeTelemetryPipeStatusMetricsIT.java
@@ -1,6 +1,7 @@
 package com.snowflake.kafka.connector.internal;
 
 import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.snowflake.kafka.connector.Utils;
@@ -66,7 +67,7 @@ public class SnowflakeTelemetryPipeStatusMetricsIT {
 
     MetricRegistry metricRegistry = service.getMetricRegistry();
     Assert.assertFalse(metricRegistry.getMetrics().isEmpty());
-    Assert.assertTrue(metricRegistry.getMetrics().size() == 12);
+    Assert.assertTrue(metricRegistry.getMetrics().size() == 14);
 
     Map<String, Gauge> registeredGauges = metricRegistry.getGauges();
 
@@ -146,6 +147,29 @@ public class SnowflakeTelemetryPipeStatusMetricsIT {
             MetricsUtil.FILE_COUNT_TABLE_STAGE_INGESTION_FAIL);
     Assert.assertTrue(registeredMeters.containsKey(metricFileCountIngestionFailed));
     Assert.assertEquals(0L, registeredMeters.get(metricFileCountIngestionFailed).getCount());
+
+    // buffer metrics
+    Map<String, Histogram> registeredHistograms = metricRegistry.getHistograms();
+    final String metricBufferRecordCount =
+        MetricsUtil.constructMetricName(
+            pipeName, MetricsUtil.BUFFER_SUB_DOMAIN, MetricsUtil.BUFFER_RECORD_COUNT);
+    Assert.assertTrue(registeredHistograms.containsKey(metricBufferRecordCount));
+    Assert.assertEquals(2L, registeredHistograms.get(metricBufferRecordCount).getCount());
+
+    // two files will be generated both with one record each
+    Assert.assertEquals(
+        1.0, registeredHistograms.get(metricBufferRecordCount).getSnapshot().getMean(), 0.001);
+    Assert.assertEquals(
+        1.0, registeredHistograms.get(metricBufferRecordCount).getSnapshot().getMax(), 0.001);
+
+    final String metricBufferSizeBytes =
+        MetricsUtil.constructMetricName(
+            pipeName, MetricsUtil.BUFFER_SUB_DOMAIN, MetricsUtil.BUFFER_SIZE_BYTES);
+    Assert.assertTrue(registeredHistograms.containsKey(metricBufferSizeBytes));
+    Assert.assertEquals(2L, registeredHistograms.get(metricBufferSizeBytes).getCount());
+
+    // two files will be generated both with one record each
+    Assert.assertEquals(2, registeredHistograms.get(metricBufferRecordCount).getSnapshot().size());
   }
 
   @Test

--- a/src/test/java/com/snowflake/kafka/connector/internal/TelemetryUnitTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/TelemetryUnitTest.java
@@ -1,6 +1,7 @@
 package com.snowflake.kafka.connector.internal;
 
 import com.codahale.metrics.MetricRegistry;
+import com.snowflake.kafka.connector.internal.metrics.MetricsJmxReporter;
 import org.junit.Test;
 
 public class TelemetryUnitTest {
@@ -11,9 +12,11 @@ public class TelemetryUnitTest {
     String stage = "stage";
     String pipe = "pipe";
     String connectorName = "testConnector";
+    MetricsJmxReporter metricsJmxReporter =
+        new MetricsJmxReporter(new MetricRegistry(), connectorName);
     SnowflakeTelemetryPipeStatus pipeStatus =
         new SnowflakeTelemetryPipeStatus(
-            table, stage, pipe, connectorName, true /* Set true for test*/, new MetricRegistry());
+            table, stage, pipe, true /* Set true for test*/, metricsJmxReporter);
     assert pipeStatus.empty();
     pipeStatus.averageCommitLagFileCount.set(1);
     assert !pipeStatus.empty();


### PR DESCRIPTION
- Added histogram for buffer metric
- Improved unregistration code. 
- Lazily invoke remove metrics before registering them. (This can happen if there are rebalances) So rebalancing would start from all over again. 
- Fixed test
Example metric with 1000 records and 10 as buffer threshold. 
<img width="1206" alt="Screen Shot 2021-07-28 at 7 48 51 PM" src="https://user-images.githubusercontent.com/57274584/127423810-5b28d6a7-ec29-42f1-b604-12a12b5bc01d.png">
<img width="1192" alt="Screen Shot 2021-07-28 at 7 48 44 PM" src="https://user-images.githubusercontent.com/57274584/127423807-4ab9e1b1-5b00-4c81-a64c-765954fd9c73.png">
