### PR TITLE
Vulnerable Jersey transitive dependency through schema-registry-client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -356,7 +356,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-schema-registry-client</artifactId>
-            <version>5.5.1</version>
+            <version>6.2.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>io.confluent</groupId>


### PR DESCRIPTION
SNOW-439510
CVE-2021-28168
Newer version dependencies: https://mvnrepository.com/artifact/io.confluent/kafka-schema-registry-client/6.2.0

https://github.com/confluentinc/schema-registry/compare/v5.5.1...v6.2.0

I dont see any issues with this bump up, but we will know from the tests. 
`SnowflakeAvroConverter` is the only file using schema registry client and there are no significant changes based on [this](https://github.com/confluentinc/schema-registry/compare/v5.5.1...v6.2.0) link. 