### PR TITLE
Regionless url regex support

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeURL.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeURL.java
@@ -34,9 +34,11 @@ public class SnowflakeURL extends Logging {
 
   private int port;
 
+  private static final String SNOWFLAKE_URL_REGEX_PATTERN =
+      "^(https?://)?((([\\w\\d]+)(\\.[\\w\\d-]+){2,})(:(\\d+))?)/?$";
+
   public SnowflakeURL(String urlStr) {
-    Pattern pattern =
-        Pattern.compile("^(https?://)?((([\\w\\d]+)(\\" + ".[\\w\\d-]+){2,})(:(\\d+))?)/?$");
+    Pattern pattern = Pattern.compile(SNOWFLAKE_URL_REGEX_PATTERN);
 
     Matcher matcher = pattern.matcher(urlStr.trim().toLowerCase());
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeURL.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeURL.java
@@ -34,8 +34,24 @@ public class SnowflakeURL extends Logging {
 
   private int port;
 
+  /**
+   * There are several matching groups here. Matching groups numbers are identified as the opening
+   * braces start and are indexed from number 1.
+   *
+   * <p>Group 1: If https is present or not. (Not required)
+   *
+   * <p>Group 2: Is the entire URL including the port number
+   *
+   * <p>Group 3: URL until .com
+   *
+   * <p>Group 4: Account name (may include org-account/alias)
+   *
+   * <p>Group 5: (Everything after accountname or org-accountname until .com)
+   *
+   * <p>Group 7: port number
+   */
   private static final String SNOWFLAKE_URL_REGEX_PATTERN =
-      "^(https?://)?((([\\w\\d]+)(\\.[\\w\\d-]+){2,})(:(\\d+))?)/?$";
+      "^(https?://)?((([\\w\\d-]+)(\\.[\\w\\d-]+){2,})(:(\\d+))?)/?$";
 
   public SnowflakeURL(String urlStr) {
     Pattern pattern = Pattern.compile(SNOWFLAKE_URL_REGEX_PATTERN);

--- a/src/test/java/com/snowflake/kafka/connector/internal/SnowflakeURLTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/SnowflakeURLTest.java
@@ -118,4 +118,43 @@ public class SnowflakeURLTest {
 
     new SnowflakeURL(url);
   }
+
+  @Test
+  public void testRegionlessURLString() {
+    String url = "http://org-account.snowflake.com:80";
+
+    SnowflakeURL sfurl = new SnowflakeURL(url);
+
+    assert !sfurl.sslEnabled();
+
+    assert sfurl.getAccount().equals("org-account");
+
+    assert sfurl.getFullUrl().equals("org-account.snowflake.com:80");
+
+    assert sfurl.getPort() == 80;
+
+    assert sfurl.getScheme().equals("http");
+
+    assert sfurl.getJdbcUrl().equals("jdbc:snowflake://" + sfurl.getFullUrl());
+  }
+
+  @Test
+  public void testRegionlessWithPrivateLinkURL() {
+    // test with privatelink too
+    String url = "https://org-account.privatelink.snowflake.com:80";
+
+    SnowflakeURL sfurl = new SnowflakeURL(url);
+
+    assert sfurl.sslEnabled();
+
+    assert sfurl.getAccount().equals("org-account");
+
+    assert sfurl.getFullUrl().equals("org-account.privatelink.snowflake.com:80");
+
+    assert sfurl.getPort() == 80;
+
+    assert sfurl.getScheme().equals("https");
+
+    assert sfurl.getJdbcUrl().equals("jdbc:snowflake://" + sfurl.getFullUrl());
+  }
 }


### PR DESCRIPTION
SNOW-445660

**Commit 1:**
- The string before google reformat didnt have + inside the matcher.
Changing this to a single line without a concatenation so that the
matcher string doesnt confuse with +

**Commit 2:**
- Adding a hyphen in account matcher group to support regionless URL along with tests. 