### PR TITLE
Do not update committed offset(In memory) and eventually to Kafka if insertFiles has failed

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
@@ -65,6 +65,7 @@ public class SnowflakeConnectionServiceV1 extends Logging implements SnowflakeCo
         logDebug("Proxy properties are set, passing in JDBC while creating the connection");
         this.conn = new SnowflakeDriver().connect(url.getJdbcUrl(), combinedProperties);
       } else {
+        logInfo("Establishing a JDBC connection with url:{}", url.getJdbcUrl());
         this.conn = new SnowflakeDriver().connect(url.getJdbcUrl(), prop);
       }
     } catch (SQLException e) {


### PR DESCRIPTION
Consider this scenario:
1. insertFiles has failed three times which results into no offsets being committed to return response of precommit. (Empty [HashMap](https://github.com/snowflakedb/snowflake-kafka-connector/blob/master/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java#L291)) 
2. There is no restart/rebalance. 
3. InsertFiles API has been successful for newer offsets. 
4. Because we update the committedOffset, even though we would have unsuccessfully called insertFiles, our committedOffset pointer would have moved forward and we would skip those offsets. 