### PR TITLE
Match pom for confluent with pom for apache maven repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.snowflake</groupId>
     <artifactId>snowflake-kafka-connector</artifactId>
-    <version>1.6.0</version>
+    <version>1.6.1</version>
     <packaging>jar</packaging>
     <name>Snowflake Kafka Connector</name>
     <description>Snowflake Kafka Connect Sink Connector</description>

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -13,7 +13,7 @@
 
     <groupId>com.snowflake</groupId>
     <artifactId>snowflake-kafka-connector</artifactId>
-    <version>1.6.0</version>
+    <version>1.6.1</version>
     <packaging>jar</packaging>
     <name>Snowflake Kafka Connector</name>
     <description>Snowflake Kafka Connect Sink Connector</description>
@@ -401,7 +401,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.10.0</version>
+            <version>2.10.5.1</version>
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>
@@ -469,7 +469,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -46,7 +46,7 @@ import org.slf4j.LoggerFactory;
 public class Utils {
 
   // Connector version, change every release
-  public static final String VERSION = "1.6.0";
+  public static final String VERSION = "1.6.1";
 
   // connector parameter list
   public static final String NAME = "name";


### PR DESCRIPTION
- Upgrade version to 1.6.1

A customer is using KC jar from confluent which is using confluent_pom.xml as opposed to being used from apache maven repo (pom.xml)

Also, upgrading the patch. 