### PR TITLE
SNOW-508730  Introduce new config: processing.guarantee

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -364,7 +364,7 @@ public class SnowflakeSinkConnectorConfig {
         .define(
             PROCESSING_GUARANTEE,
             Type.STRING,
-            ProcessingGuarantee.AT_LEAST_ONCE.name(),
+            IngestionProcessingGuarantee.AT_LEAST_ONCE.name(),
             PROCESSING_GUARANTEE_VALIDATOR,
             Importance.LOW,
             "Determines the ingest semantics for snowflake connector, currently support"
@@ -427,8 +427,9 @@ public class SnowflakeSinkConnectorConfig {
       final String strValue = (String) value;
       // The value can be null or empty.
       try {
-        ProcessingGuarantee processingGuarantee = ProcessingGuarantee.of(strValue);
-        LOGGER.debug("ProcessingGuarantee type is:{}", processingGuarantee.name());
+        IngestionProcessingGuarantee ingestionProcessingGuarantee =
+            IngestionProcessingGuarantee.of(strValue);
+        LOGGER.debug("ProcessingGuarantee type is:{}", ingestionProcessingGuarantee.name());
       } catch (final IllegalArgumentException e) {
         throw new ConfigException(PROVIDER_CONFIG, value, e.getMessage());
       }
@@ -436,7 +437,7 @@ public class SnowflakeSinkConnectorConfig {
 
     public String toString() {
       return "Allowed processing guarantee types:"
-          + String.join(",", ProcessingGuarantee.PROCESSING_GUARANTEE_TYPES);
+          + String.join(",", IngestionProcessingGuarantee.PROCESSING_GUARANTEE_TYPES);
     }
   }
 
@@ -531,23 +532,30 @@ public class SnowflakeSinkConnectorConfig {
    * Enum which represents the type of processing guarantees that the customer want (either
    * at_least_once (default) or exactly_once
    */
-  public enum ProcessingGuarantee {
+  public enum IngestionProcessingGuarantee {
+    /**
+     * At-least-once semantics means records received by Snowflake Connector are never lost but
+     * could be ingested multiple times
+     */
     AT_LEAST_ONCE,
+    /**
+     * Exactly-once semantics means records received by Snowflake Connector are only ingested once
+     */
     EXACTLY_ONCE,
     ;
 
     public static final List<String> PROCESSING_GUARANTEE_TYPES =
-        Arrays.stream(ProcessingGuarantee.values())
+        Arrays.stream(IngestionProcessingGuarantee.values())
             .map(processingGuarantee -> processingGuarantee.name().toLowerCase())
             .collect(Collectors.toList());
 
-    public static ProcessingGuarantee of(final String processingGuaranteeType) {
+    public static IngestionProcessingGuarantee of(final String processingGuaranteeType) {
 
       if (Strings.isNullOrEmpty(processingGuaranteeType)) {
         return AT_LEAST_ONCE;
       }
 
-      for (final ProcessingGuarantee b : ProcessingGuarantee.values()) {
+      for (final IngestionProcessingGuarantee b : IngestionProcessingGuarantee.values()) {
         if (b.name().equalsIgnoreCase(processingGuaranteeType)) {
           return b;
         }

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
@@ -16,6 +16,8 @@
  */
 package com.snowflake.kafka.connector;
 
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.PROCESSING_GUARANTEE;
+
 import com.snowflake.kafka.connector.internal.*;
 import com.snowflake.kafka.connector.records.SnowflakeMetadataConfig;
 import java.util.Collection;
@@ -139,6 +141,11 @@ public class SnowflakeSinkTask extends SinkTask {
           Boolean.parseBoolean(parsedConfig.get(SnowflakeSinkConnectorConfig.JMX_OPT));
     }
 
+    // Get the processing guarantee type from config, default to at_least_once
+    SnowflakeSinkConnectorConfig.ProcessingGuarantee processingGuarantee =
+        SnowflakeSinkConnectorConfig.ProcessingGuarantee.of(
+            parsedConfig.getOrDefault(PROCESSING_GUARANTEE, null));
+
     conn =
         SnowflakeConnectionServiceFactory.builder()
             .setProperties(parsedConfig)
@@ -157,6 +164,7 @@ public class SnowflakeSinkTask extends SinkTask {
             .setMetadataConfig(metadataConfig)
             .setBehaviorOnNullValuesConfig(behavior)
             .setCustomJMXMetrics(enableCustomJMXMonitoring)
+            .setProcessingGuarantee(processingGuarantee)
             .build();
 
     LOGGER.info(

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
@@ -142,9 +142,11 @@ public class SnowflakeSinkTask extends SinkTask {
     }
 
     // Get the processing guarantee type from config, default to at_least_once
-    SnowflakeSinkConnectorConfig.ProcessingGuarantee processingGuarantee =
-        SnowflakeSinkConnectorConfig.ProcessingGuarantee.of(
-            parsedConfig.getOrDefault(PROCESSING_GUARANTEE, null));
+    SnowflakeSinkConnectorConfig.IngestionProcessingGuarantee ingestionProcessingGuarantee =
+        SnowflakeSinkConnectorConfig.IngestionProcessingGuarantee.of(
+            parsedConfig.getOrDefault(
+                PROCESSING_GUARANTEE,
+                SnowflakeSinkConnectorConfig.IngestionProcessingGuarantee.AT_LEAST_ONCE.name()));
 
     conn =
         SnowflakeConnectionServiceFactory.builder()
@@ -164,7 +166,7 @@ public class SnowflakeSinkTask extends SinkTask {
             .setMetadataConfig(metadataConfig)
             .setBehaviorOnNullValuesConfig(behavior)
             .setCustomJMXMetrics(enableCustomJMXMonitoring)
-            .setProcessingGuarantee(processingGuarantee)
+            .setProcessingGuarantee(ingestionProcessingGuarantee)
             .build();
 
     LOGGER.info(

--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -501,8 +501,10 @@ public class Utils {
     }
 
     try {
-      SnowflakeSinkConnectorConfig.ProcessingGuarantee.of(
-          config.getOrDefault(PROCESSING_GUARANTEE, null));
+      SnowflakeSinkConnectorConfig.IngestionProcessingGuarantee.of(
+          config.getOrDefault(
+              PROCESSING_GUARANTEE,
+              SnowflakeSinkConnectorConfig.IngestionProcessingGuarantee.AT_LEAST_ONCE.name()));
     } catch (IllegalArgumentException exception) {
       LOGGER.error(
           Logging.logMessage(

--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -16,8 +16,10 @@
  */
 package com.snowflake.kafka.connector;
 
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.*;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BehaviorOnNullValues.VALIDATOR;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.JMX_OPT;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.PROCESSING_GUARANTEE;
 
 import com.snowflake.kafka.connector.internal.Logging;
 import com.snowflake.kafka.connector.internal.SnowflakeErrors;

--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -16,9 +16,8 @@
  */
 package com.snowflake.kafka.connector;
 
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.*;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BehaviorOnNullValues.VALIDATOR;
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.JMX_OPT;
 
 import com.snowflake.kafka.connector.internal.Logging;
 import com.snowflake.kafka.connector.internal.SnowflakeErrors;
@@ -497,6 +496,18 @@ public class Utils {
         LOGGER.error(Logging.logMessage("Kafka config:{} should either be true or false", JMX_OPT));
         configIsValid = false;
       }
+    }
+
+    try {
+      SnowflakeSinkConnectorConfig.ProcessingGuarantee.of(
+          config.getOrDefault(PROCESSING_GUARANTEE, null));
+    } catch (IllegalArgumentException exception) {
+      LOGGER.error(
+          Logging.logMessage(
+              "Processing Guarantee config:{} error:{}",
+              PROCESSING_GUARANTEE,
+              exception.getMessage()));
+      configIsValid = false;
     }
 
     if (!configIsValid) {

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkService.java
@@ -129,6 +129,13 @@ public interface SnowflakeSinkService {
   /* Only used in testing and verifying what was the passed value of this behavior from config to sink service*/
   SnowflakeSinkConnectorConfig.BehaviorOnNullValues getBehaviorOnNullValuesConfig();
 
+  /**
+   * set the processing guarantee, giving user the option to enable exactly once semantic
+   *
+   * @param processingGuarantee
+   */
+  void setProcessingGuarantee(SnowflakeSinkConnectorConfig.ProcessingGuarantee processingGuarantee);
+
   /* Get metric registry of an associated pipe */
   @VisibleForTesting
   Optional<MetricRegistry> getMetricRegistry(final String pipeName);

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkService.java
@@ -132,9 +132,10 @@ public interface SnowflakeSinkService {
   /**
    * set the processing guarantee, giving user the option to enable exactly once semantic
    *
-   * @param processingGuarantee
+   * @param ingestionProcessingGuarantee
    */
-  void setProcessingGuarantee(SnowflakeSinkConnectorConfig.ProcessingGuarantee processingGuarantee);
+  void setProcessingGuarantee(
+      SnowflakeSinkConnectorConfig.IngestionProcessingGuarantee ingestionProcessingGuarantee);
 
   /* Get metric registry of an associated pipe */
   @VisibleForTesting

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceFactory.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceFactory.java
@@ -83,6 +83,13 @@ public class SnowflakeSinkServiceFactory {
       return this;
     }
 
+    public SnowflakeSinkServiceBuilder setProcessingGuarantee(
+        SnowflakeSinkConnectorConfig.ProcessingGuarantee processingGuarantee) {
+      this.service.setProcessingGuarantee(processingGuarantee);
+      logInfo("Conifg Processing Guarantee type {}.", processingGuarantee.toString());
+      return this;
+    }
+
     public SnowflakeSinkService build() {
       logInfo("{} created", SnowflakeSinkService.class.getName());
       return service;

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceFactory.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceFactory.java
@@ -84,9 +84,9 @@ public class SnowflakeSinkServiceFactory {
     }
 
     public SnowflakeSinkServiceBuilder setProcessingGuarantee(
-        SnowflakeSinkConnectorConfig.ProcessingGuarantee processingGuarantee) {
-      this.service.setProcessingGuarantee(processingGuarantee);
-      logInfo("Conifg Processing Guarantee type {}.", processingGuarantee.toString());
+        SnowflakeSinkConnectorConfig.IngestionProcessingGuarantee ingestionProcessingGuarantee) {
+      this.service.setProcessingGuarantee(ingestionProcessingGuarantee);
+      logInfo("Conifg Processing Guarantee type {}.", ingestionProcessingGuarantee.toString());
       return this;
     }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
@@ -60,8 +60,8 @@ class SnowflakeSinkServiceV1 extends Logging implements SnowflakeSinkService {
 
   // default is at_least_once semantic for data ingestion unless the configuration provided is
   // exactly_once
-  private SnowflakeSinkConnectorConfig.ProcessingGuarantee processingGuarantee =
-      SnowflakeSinkConnectorConfig.ProcessingGuarantee.AT_LEAST_ONCE;
+  private SnowflakeSinkConnectorConfig.IngestionProcessingGuarantee ingestionProcessingGuarantee =
+      SnowflakeSinkConnectorConfig.IngestionProcessingGuarantee.AT_LEAST_ONCE;
 
   SnowflakeSinkServiceV1(SnowflakeConnectionService conn) {
     if (conn == null || conn.isClosed()) {
@@ -357,8 +357,8 @@ class SnowflakeSinkServiceV1 extends Logging implements SnowflakeSinkService {
 
   @Override
   public void setProcessingGuarantee(
-      SnowflakeSinkConnectorConfig.ProcessingGuarantee processingGuarantee) {
-    this.processingGuarantee = processingGuarantee;
+      SnowflakeSinkConnectorConfig.IngestionProcessingGuarantee ingestionProcessingGuarantee) {
+    this.ingestionProcessingGuarantee = ingestionProcessingGuarantee;
   }
 
   /**

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
@@ -58,6 +58,11 @@ class SnowflakeSinkServiceV1 extends Logging implements SnowflakeSinkService {
   // If this is true, we will enable Mbean for required classes and emit JMX metrics for monitoring
   private boolean enableCustomJMXMonitoring = SnowflakeSinkConnectorConfig.JMX_OPT_DEFAULT;
 
+  // default is at_least_once semantic for data ingestion unless the configuration provided is
+  // exactly_once
+  private SnowflakeSinkConnectorConfig.ProcessingGuarantee processingGuarantee =
+      SnowflakeSinkConnectorConfig.ProcessingGuarantee.AT_LEAST_ONCE;
+
   SnowflakeSinkServiceV1(SnowflakeConnectionService conn) {
     if (conn == null || conn.isClosed()) {
       throw SnowflakeErrors.ERROR_5010.getException();
@@ -348,6 +353,12 @@ class SnowflakeSinkServiceV1 extends Logging implements SnowflakeSinkService {
   @Override
   public SnowflakeSinkConnectorConfig.BehaviorOnNullValues getBehaviorOnNullValuesConfig() {
     return this.behaviorOnNullValues;
+  }
+
+  @Override
+  public void setProcessingGuarantee(
+      SnowflakeSinkConnectorConfig.ProcessingGuarantee processingGuarantee) {
+    this.processingGuarantee = processingGuarantee;
   }
 
   /**

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
@@ -268,4 +268,27 @@ public class ConnectorConfigTest {
     config.put(SnowflakeSinkConnectorConfig.JMX_OPT, "INVALID");
     Utils.validateConfig(config);
   }
+
+  @Test
+  public void testProcessingGuarantee_valid_value() {
+    Map<String, String> config = getConfig();
+    config.put(SnowflakeSinkConnectorConfig.PROCESSING_GUARANTEE, "at_least_once");
+    Utils.validateConfig(config);
+
+    config.put(SnowflakeSinkConnectorConfig.PROCESSING_GUARANTEE, "exactly_once");
+    Utils.validateConfig(config);
+
+    config.put(SnowflakeSinkConnectorConfig.PROCESSING_GUARANTEE, "");
+    Utils.validateConfig(config);
+
+    config.put(SnowflakeSinkConnectorConfig.PROCESSING_GUARANTEE, null);
+    Utils.validateConfig(config);
+  }
+
+  @Test(expected = SnowflakeKafkaConnectorException.class)
+  public void testProcessingGuarantee_invalid_value() {
+    Map<String, String> config = getConfig();
+    config.put(SnowflakeSinkConnectorConfig.PROCESSING_GUARANTEE, "INVALID");
+    Utils.validateConfig(config);
+  }
 }


### PR DESCRIPTION
https://snowflakecomputing.atlassian.net/browse/SNOW-508731
`processing.guarantee=at_least_once/exactly_once`
Allow enable exactly once semantics property in the Kafka connector configuration file