### PR TITLE
Change name to delivery.guarantee instead of processing.gurantee

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -93,7 +93,7 @@ public class SnowflakeSinkConnectorConfig {
   // By default it will be None since this is not enforced and only used for monitoring
   public static final String PROVIDER_CONFIG = "provider";
 
-  public static final String PROCESSING_GUARANTEE = "processing.guarantee";
+  public static final String DELIVERY_GUARANTEE = "delivery.guarantee";
 
   // metrics
   public static final String JMX_OPT = "jmx";
@@ -105,8 +105,8 @@ public class SnowflakeSinkConnectorConfig {
   private static final ConfigDef.Validator nonEmptyStringValidator = new ConfigDef.NonEmptyString();
   private static final ConfigDef.Validator topicToTableValidator = new TopicToTableValidator();
   private static final ConfigDef.Validator KAFKA_PROVIDER_VALIDATOR = new KafkaProviderValidator();
-  private static final ConfigDef.Validator PROCESSING_GUARANTEE_VALIDATOR =
-      new ProcessingGuaranteeValidator();
+  private static final ConfigDef.Validator DELIVERY_GUARANTEE_VALIDATOR =
+      new DeliveryGuaranteeValidator();
 
   static void setDefaultValues(Map<String, String> config) {
     setFieldToDefaultValues(config, BUFFER_COUNT_RECORDS, BUFFER_COUNT_RECORDS_DEFAULT);
@@ -362,13 +362,13 @@ public class SnowflakeSinkConnectorConfig {
             ConfigDef.Importance.HIGH,
             "Whether to enable JMX MBeans for custom SF metrics")
         .define(
-            PROCESSING_GUARANTEE,
+            DELIVERY_GUARANTEE,
             Type.STRING,
-            IngestionProcessingGuarantee.AT_LEAST_ONCE.name(),
-            PROCESSING_GUARANTEE_VALIDATOR,
+            IngestionDeliveryGuarantee.AT_LEAST_ONCE.name(),
+            DELIVERY_GUARANTEE_VALIDATOR,
             Importance.LOW,
             "Determines the ingest semantics for snowflake connector, currently support"
-                + " at-least-once and exactly-once processing guarantees");
+                + " at-least-once and exactly-once delivery guarantees");
   }
 
   public static class TopicToTableValidator implements ConfigDef.Validator {
@@ -417,9 +417,9 @@ public class SnowflakeSinkConnectorConfig {
     }
   }
 
-  /* Validator to validate Kafka processing guarantee types    */
-  public static class ProcessingGuaranteeValidator implements ConfigDef.Validator {
-    public ProcessingGuaranteeValidator() {}
+  /* Validator to validate Kafka delivery guarantee types    */
+  public static class DeliveryGuaranteeValidator implements ConfigDef.Validator {
+    public DeliveryGuaranteeValidator() {}
 
     @Override
     public void ensureValid(String name, Object value) {
@@ -427,17 +427,17 @@ public class SnowflakeSinkConnectorConfig {
       final String strValue = (String) value;
       // The value can be null or empty.
       try {
-        IngestionProcessingGuarantee ingestionProcessingGuarantee =
-            IngestionProcessingGuarantee.of(strValue);
-        LOGGER.debug("ProcessingGuarantee type is:{}", ingestionProcessingGuarantee.name());
+        IngestionDeliveryGuarantee ingestionDeliveryGuarantee =
+            IngestionDeliveryGuarantee.of(strValue);
+        LOGGER.debug("DeliveryGuarantee type is:{}", ingestionDeliveryGuarantee.name());
       } catch (final IllegalArgumentException e) {
         throw new ConfigException(PROVIDER_CONFIG, value, e.getMessage());
       }
     }
 
     public String toString() {
-      return "Allowed processing guarantee types:"
-          + String.join(",", IngestionProcessingGuarantee.PROCESSING_GUARANTEE_TYPES);
+      return "Allowed Delivery guarantee types:"
+          + String.join(",", IngestionDeliveryGuarantee.DELIVERY_GUARANTEE_TYPES);
     }
   }
 
@@ -532,7 +532,7 @@ public class SnowflakeSinkConnectorConfig {
    * Enum which represents the type of processing guarantees that the customer want (either
    * at_least_once (default) or exactly_once
    */
-  public enum IngestionProcessingGuarantee {
+  public enum IngestionDeliveryGuarantee {
     /**
      * At-least-once semantics means records received by Snowflake Connector are never lost but
      * could be ingested multiple times
@@ -544,26 +544,26 @@ public class SnowflakeSinkConnectorConfig {
     EXACTLY_ONCE,
     ;
 
-    public static final List<String> PROCESSING_GUARANTEE_TYPES =
-        Arrays.stream(IngestionProcessingGuarantee.values())
-            .map(processingGuarantee -> processingGuarantee.name().toLowerCase())
+    public static final List<String> DELIVERY_GUARANTEE_TYPES =
+        Arrays.stream(IngestionDeliveryGuarantee.values())
+            .map(deliveryGuarantee -> deliveryGuarantee.name().toLowerCase())
             .collect(Collectors.toList());
 
-    public static IngestionProcessingGuarantee of(final String processingGuaranteeType) {
+    public static IngestionDeliveryGuarantee of(final String deliveryGuaranteeType) {
 
-      if (Strings.isNullOrEmpty(processingGuaranteeType)) {
+      if (Strings.isNullOrEmpty(deliveryGuaranteeType)) {
         return AT_LEAST_ONCE;
       }
 
-      for (final IngestionProcessingGuarantee b : IngestionProcessingGuarantee.values()) {
-        if (b.name().equalsIgnoreCase(processingGuaranteeType)) {
+      for (final IngestionDeliveryGuarantee b : IngestionDeliveryGuarantee.values()) {
+        if (b.name().equalsIgnoreCase(deliveryGuaranteeType)) {
           return b;
         }
       }
       throw new IllegalArgumentException(
           String.format(
-              "Unsupported Processing Guarantee Type: %s. Supported are: %s",
-              processingGuaranteeType, String.join(",", PROCESSING_GUARANTEE_TYPES)));
+              "Unsupported Delivery Guarantee Type: %s. Supported are: %s",
+              deliveryGuaranteeType, String.join(",", DELIVERY_GUARANTEE_TYPES)));
     }
 
     @Override

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -529,7 +529,7 @@ public class SnowflakeSinkConnectorConfig {
   }
 
   /**
-   * Enum which represents the type of processing guarantees that the customer want (either
+   * Enum which represents the type of delivery guarantees that the customer want (either
    * at_least_once (default) or exactly_once
    */
   public enum IngestionDeliveryGuarantee {

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
@@ -16,7 +16,7 @@
  */
 package com.snowflake.kafka.connector;
 
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.PROCESSING_GUARANTEE;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.DELIVERY_GUARANTEE;
 
 import com.snowflake.kafka.connector.internal.*;
 import com.snowflake.kafka.connector.records.SnowflakeMetadataConfig;
@@ -141,12 +141,12 @@ public class SnowflakeSinkTask extends SinkTask {
           Boolean.parseBoolean(parsedConfig.get(SnowflakeSinkConnectorConfig.JMX_OPT));
     }
 
-    // Get the processing guarantee type from config, default to at_least_once
-    SnowflakeSinkConnectorConfig.IngestionProcessingGuarantee ingestionProcessingGuarantee =
-        SnowflakeSinkConnectorConfig.IngestionProcessingGuarantee.of(
+    // Get the Delivery guarantee type from config, default to at_least_once
+    SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee ingestionDeliveryGuarantee =
+        SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee.of(
             parsedConfig.getOrDefault(
-                PROCESSING_GUARANTEE,
-                SnowflakeSinkConnectorConfig.IngestionProcessingGuarantee.AT_LEAST_ONCE.name()));
+                DELIVERY_GUARANTEE,
+                SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee.AT_LEAST_ONCE.name()));
 
     conn =
         SnowflakeConnectionServiceFactory.builder()
@@ -166,7 +166,7 @@ public class SnowflakeSinkTask extends SinkTask {
             .setMetadataConfig(metadataConfig)
             .setBehaviorOnNullValuesConfig(behavior)
             .setCustomJMXMetrics(enableCustomJMXMonitoring)
-            .setProcessingGuarantee(ingestionProcessingGuarantee)
+            .setDeliveryGuarantee(ingestionDeliveryGuarantee)
             .build();
 
     LOGGER.info(

--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -18,8 +18,8 @@ package com.snowflake.kafka.connector;
 
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BehaviorOnNullValues.VALIDATOR;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.DELIVERY_GUARANTEE;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.JMX_OPT;
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.PROCESSING_GUARANTEE;
 
 import com.snowflake.kafka.connector.internal.Logging;
 import com.snowflake.kafka.connector.internal.SnowflakeErrors;
@@ -501,16 +501,14 @@ public class Utils {
     }
 
     try {
-      SnowflakeSinkConnectorConfig.IngestionProcessingGuarantee.of(
+      SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee.of(
           config.getOrDefault(
-              PROCESSING_GUARANTEE,
-              SnowflakeSinkConnectorConfig.IngestionProcessingGuarantee.AT_LEAST_ONCE.name()));
+              DELIVERY_GUARANTEE,
+              SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee.AT_LEAST_ONCE.name()));
     } catch (IllegalArgumentException exception) {
       LOGGER.error(
           Logging.logMessage(
-              "Processing Guarantee config:{} error:{}",
-              PROCESSING_GUARANTEE,
-              exception.getMessage()));
+              "Delivery Guarantee config:{} error:{}", DELIVERY_GUARANTEE, exception.getMessage()));
       configIsValid = false;
     }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkService.java
@@ -130,12 +130,12 @@ public interface SnowflakeSinkService {
   SnowflakeSinkConnectorConfig.BehaviorOnNullValues getBehaviorOnNullValuesConfig();
 
   /**
-   * set the processing guarantee, giving user the option to enable exactly once semantic
+   * set the delivery guarantee, giving user the option to enable exactly once semantic
    *
-   * @param ingestionProcessingGuarantee
+   * @param ingestionDeliveryGuarantee
    */
-  void setProcessingGuarantee(
-      SnowflakeSinkConnectorConfig.IngestionProcessingGuarantee ingestionProcessingGuarantee);
+  void setDeliveryGuarantee(
+      SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee ingestionDeliveryGuarantee);
 
   /* Get metric registry of an associated pipe */
   @VisibleForTesting

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceFactory.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceFactory.java
@@ -83,10 +83,10 @@ public class SnowflakeSinkServiceFactory {
       return this;
     }
 
-    public SnowflakeSinkServiceBuilder setProcessingGuarantee(
-        SnowflakeSinkConnectorConfig.IngestionProcessingGuarantee ingestionProcessingGuarantee) {
-      this.service.setProcessingGuarantee(ingestionProcessingGuarantee);
-      logInfo("Conifg Processing Guarantee type {}.", ingestionProcessingGuarantee.toString());
+    public SnowflakeSinkServiceBuilder setDeliveryGuarantee(
+        SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee ingestionDeliveryGuarantee) {
+      this.service.setDeliveryGuarantee(ingestionDeliveryGuarantee);
+      logInfo("Config Delivery Guarantee type {}.", ingestionDeliveryGuarantee.toString());
       return this;
     }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
@@ -60,8 +60,8 @@ class SnowflakeSinkServiceV1 extends Logging implements SnowflakeSinkService {
 
   // default is at_least_once semantic for data ingestion unless the configuration provided is
   // exactly_once
-  private SnowflakeSinkConnectorConfig.IngestionProcessingGuarantee ingestionProcessingGuarantee =
-      SnowflakeSinkConnectorConfig.IngestionProcessingGuarantee.AT_LEAST_ONCE;
+  private SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee ingestionDeliveryGuarantee =
+      SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee.AT_LEAST_ONCE;
 
   SnowflakeSinkServiceV1(SnowflakeConnectionService conn) {
     if (conn == null || conn.isClosed()) {
@@ -356,9 +356,9 @@ class SnowflakeSinkServiceV1 extends Logging implements SnowflakeSinkService {
   }
 
   @Override
-  public void setProcessingGuarantee(
-      SnowflakeSinkConnectorConfig.IngestionProcessingGuarantee ingestionProcessingGuarantee) {
-    this.ingestionProcessingGuarantee = ingestionProcessingGuarantee;
+  public void setDeliveryGuarantee(
+      SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee ingestionDeliveryGuarantee) {
+    this.ingestionDeliveryGuarantee = ingestionDeliveryGuarantee;
   }
 
   /**
@@ -644,6 +644,7 @@ class SnowflakeSinkServiceV1 extends Logging implements SnowflakeSinkService {
         metricsJmxReporter.start();
         this.hasInitialized = true;
       }
+      // get offsettoken
 
       // ignore ingested files
       if (record.kafkaOffset() > processedOffset.get()) {

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
@@ -270,25 +270,25 @@ public class ConnectorConfigTest {
   }
 
   @Test
-  public void testProcessingGuarantee_valid_value() {
+  public void testDeliveryGuarantee_valid_value() {
     Map<String, String> config = getConfig();
-    config.put(SnowflakeSinkConnectorConfig.PROCESSING_GUARANTEE, "at_least_once");
+    config.put(SnowflakeSinkConnectorConfig.DELIVERY_GUARANTEE, "at_least_once");
     Utils.validateConfig(config);
 
-    config.put(SnowflakeSinkConnectorConfig.PROCESSING_GUARANTEE, "exactly_once");
+    config.put(SnowflakeSinkConnectorConfig.DELIVERY_GUARANTEE, "exactly_once");
     Utils.validateConfig(config);
 
-    config.put(SnowflakeSinkConnectorConfig.PROCESSING_GUARANTEE, "");
+    config.put(SnowflakeSinkConnectorConfig.DELIVERY_GUARANTEE, "");
     Utils.validateConfig(config);
 
-    config.put(SnowflakeSinkConnectorConfig.PROCESSING_GUARANTEE, null);
+    config.put(SnowflakeSinkConnectorConfig.DELIVERY_GUARANTEE, null);
     Utils.validateConfig(config);
   }
 
   @Test(expected = SnowflakeKafkaConnectorException.class)
-  public void testProcessingGuarantee_invalid_value() {
+  public void testDeliveryGuarantee_invalid_value() {
     Map<String, String> config = getConfig();
-    config.put(SnowflakeSinkConnectorConfig.PROCESSING_GUARANTEE, "INVALID");
+    config.put(SnowflakeSinkConnectorConfig.DELIVERY_GUARANTEE, "INVALID");
     Utils.validateConfig(config);
   }
 }


### PR DESCRIPTION
I got this idea from https://docs.confluent.io/5.5.1/connect/managing/confluent-hub/kafka-connect-maven-plugin/kafka-connect-mojo.html

Which seems a better option. 