### PR TITLE
Bugfix/break-on-reader-schema-error

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/records/SnowflakeAvroConverter.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/SnowflakeAvroConverter.java
@@ -168,7 +168,8 @@ public class SnowflakeAvroConverter extends SnowflakeConverter {
               id));
     } catch (Exception e) {
       if (breakOnSchemaRegistryError) {
-        throw SnowflakeErrors.ERROR_0010.getException(e);
+        throw SnowflakeErrors.ERROR_0010.getException(
+                "Failed to parse AVRO " + "record\n" + e.toString());
       } else {
         return logErrorAndReturnBrokenRecord(e, bytes);
       }

--- a/src/main/java/com/snowflake/kafka/connector/records/SnowflakeAvroConverter.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/SnowflakeAvroConverter.java
@@ -168,8 +168,7 @@ public class SnowflakeAvroConverter extends SnowflakeConverter {
               id));
     } catch (Exception e) {
       if (breakOnSchemaRegistryError) {
-        throw SnowflakeErrors.ERROR_0010.getException(
-                "Failed to parse AVRO " + "record\n" + e.toString());
+        throw SnowflakeErrors.ERROR_0010.getException(e);
       } else {
         return logErrorAndReturnBrokenRecord(e, bytes);
       }

--- a/src/main/java/com/snowflake/kafka/connector/records/SnowflakeAvroConverter.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/SnowflakeAvroConverter.java
@@ -167,7 +167,12 @@ public class SnowflakeAvroConverter extends SnowflakeConverter {
                   data, writerSchema, readerSchema == null ? writerSchema : readerSchema),
               id));
     } catch (Exception e) {
-      return logErrorAndReturnBrokenRecord(e, bytes);
+      if (breakOnSchemaRegistryError) {
+        throw SnowflakeErrors.ERROR_0010.getException(
+                "Failed to parse AVRO " + "record\n" + e.toString());
+      } else {
+        return logErrorAndReturnBrokenRecord(e, bytes);
+      }
     }
   }
 
@@ -188,7 +193,7 @@ public class SnowflakeAvroConverter extends SnowflakeConverter {
    * @return JsonNode array
    */
   private JsonNode parseAvroWithSchema(
-      final byte[] data, Schema writerSchema, Schema readerSchema) {
+      final byte[] data, Schema writerSchema, Schema readerSchema) throws IOException {
     final GenericData genericData = new GenericData();
     // Conversion for logical type Decimal. There are conversions for other logical types as well.
     genericData.addLogicalTypeConversion(new Conversions.DecimalConversion());
@@ -197,15 +202,10 @@ public class SnowflakeAvroConverter extends SnowflakeConverter {
     Decoder decoder = DecoderFactory.get().binaryDecoder(is, null);
     DatumReader<GenericRecord> reader =
         new GenericDatumReader<>(writerSchema, readerSchema, genericData);
-    try {
-      GenericRecord datum = reader.read(null, decoder);
-      // For byte data without logical type, this toString method handles it this way:
-      // writeEscapedString(StandardCharsets.ISO_8859_1.decode(bytes), buffer);
-      // The generated string is escaped ISO_8859_1 decoded string.
-      return mapper.readTree(datum.toString());
-    } catch (IOException e) {
-      throw SnowflakeErrors.ERROR_0010.getException(
-          "Failed to parse AVRO " + "record\n" + e.toString());
-    }
+    GenericRecord datum = reader.read(null, decoder);
+    // For byte data without logical type, this toString method handles it this way:
+    // writeEscapedString(StandardCharsets.ISO_8859_1.decode(bytes), buffer);
+    // The generated string is escaped ISO_8859_1 decoded string.
+    return mapper.readTree(datum.toString());
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/records/ConverterTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/records/ConverterTest.java
@@ -179,6 +179,22 @@ public class ConverterTest {
     assert ((SnowflakeRecordContent) input.value()).getData()[0].toString().equals("{}");
   }
 
+  @Test(expected = SnowflakeKafkaConnectorException.class)
+  public void testAvroWithSchemaRegistryAndWrongReaderSchema() throws IOException {
+    MockSchemaRegistryClient client = new MockSchemaRegistryClient();
+    SnowflakeAvroConverter converter = new SnowflakeAvroConverter();
+    Map<String, String> configs = new HashMap<String, String>();
+    configs.put(
+            SnowflakeAvroConverter.READER_SCHEMA,
+            "{\"name\":\"test_avro\",\"type\":\"record\",\"fields\":[{\"name\":\"int\",\"type\":\"int\"},{\"name\":\"newfield\",\"type\":\"int\",\"default\":"
+                    + " 1},{\"name\":\"missingfield\",\"type\"::\"int\"}]}");
+    configs.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "http://fake-url");
+    converter.configure(configs, false);
+    converter.setSchemaRegistry(client);
+
+    SchemaAndValue input = converter.toConnectData("test", client.getData());
+  }
+
   @Test
   public void testAvroWithSchemaRegistryByteInput() throws IOException {
     // Define AVRO Schema


### PR DESCRIPTION
The Avro converter for the Snowflake Kafka connector has two options in case of a record value or key can not be consumed. By default, the record is dropped with a log message. To the contrary, if break.on.schema.registry.error is enabled, an exception is raised and the task should fail.

Previously, the second option was only implemented for the case that the writer schema can not be found in the schema registry. With the introduction of a reader schema that is used to read all keys / values, another failure condition got introduced: it is possible, that a record key / value can not be read with the given reader schema, e.g., because the reader schema contains a mandatory field that is not in the record key / value.

Until know, such an error lead to a dropped record and a log message. With this PR, the error leads to an exception and a failing task when break.on.schema.registry.error is enabled.