### PR TITLE
[security] Upgrade Jackson to 2.12.6 to get rid of sonatype-2021-4682

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <jackson.version>2.12.6</jackson.version>
     </properties>
 
 
@@ -349,12 +350,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.10.0</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.10.5.1</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -47,6 +47,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <jackson.version>2.12.6</jackson.version>
     </properties>
 
 
@@ -397,12 +398,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.10.0</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.10.5.1</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>


### PR DESCRIPTION
Current version of jackson-databind is subject to https://github.com/FasterXML/jackson-databind/issues/3328 

### Changes
* Upgraded jackson-core and jackson-databind to 2.12.6