### PR TITLE
SNOW-529753 Handle rebalance in SnowflakeSinkTask

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -259,10 +259,12 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
    * This function is called during rebalance. Please ensure we dont wipe of state when we are
    * invoking this function.
    *
-   * <p>The channel is not closed since we would need to reiniate the channel.
+   * <p>The channel is not closed since we would need to re-initiate the channel.
    *
-   * <p>Also, wiping off partitionsToChannel map would mean we would will need to reinitialise and
-   * we will lose processedOffset information.
+   * <p>Also, wiping off partitionsToChannel map would mean we would need to reinitialise and we
+   * will lose processedOffset information.
+   *
+   * <p>We will only close the client.
    *
    * @param partitions a list of topic partition
    */
@@ -424,6 +426,7 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
     streamingClientProps.putAll(streamingPropertiesMap);
     if (this.streamingIngestClient == null || this.streamingIngestClient.isClosed()) {
       try {
+        LOGGER.info("Initializing Streaming Client. ClientName:{}", this.streamingIngestClientName);
         this.streamingIngestClient =
             SnowflakeStreamingIngestClientFactory.builder(this.streamingIngestClientName)
                 .setProperties(streamingClientProps)
@@ -437,9 +440,10 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
     }
   }
 
+  /**
+   * Closes the streaming client.
+   */
   private void closeStreamingClient() {
-    // do we need to close the client? If I close, I will have to re init the client upon rebalance
-    // in open()
     LOGGER.info("Closing Streaming Client:{}", this.streamingIngestClientName);
     try {
       streamingIngestClient.close();

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -440,9 +440,7 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
     }
   }
 
-  /**
-   * Closes the streaming client.
-   */
+  /** Closes the streaming client. */
   private void closeStreamingClient() {
     LOGGER.info("Closing Streaming Client:{}", this.streamingIngestClientName);
     try {

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
@@ -42,9 +42,11 @@ public class TopicPartitionChannel {
 
   /**
    * States whether this channel has had any data before. If this is false, the
-   * topicPartitionChannel has recently been initialised and didnt receive any records before
+   * topicPartitionChannel has recently been initialised and didnt receive any records before.
+   *
+   * <p>If the channel is closed, this state remains unchanged.
    */
-  private boolean hasChannelInitialized = false;
+  private boolean hasChannelReceivedAnyRecordsBefore = false;
 
   /* Buffer to hold JSON converted incoming SinkRecords */
   /* Eventually this buffer will only be a transient buffer and wont exist across multiple PUT api calls */
@@ -89,12 +91,12 @@ public class TopicPartitionChannel {
 
   // inserts the record into buffer
   public void insertRecordToBuffer(SinkRecord record) {
-    if (!hasChannelInitialized) {
+    if (!hasChannelReceivedAnyRecordsBefore) {
       // This will only be called once at the beginning when an offset arrives for first time
       // after connector starts/rebalance
       init(record.kafkaOffset());
       //            metricsJmxReporter.start();
-      this.hasChannelInitialized = true;
+      this.hasChannelReceivedAnyRecordsBefore = true;
     }
 
     // ignore ingested files
@@ -326,7 +328,7 @@ public class TopicPartitionChannel {
         + "previousFlushTimeStampMs="
         + previousFlushTimeStampMs
         + ", hasChannelInitialized="
-        + hasChannelInitialized
+        + hasChannelReceivedAnyRecordsBefore
         + ", channel="
         + this.getChannelName()
         + ", committedOffset="

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
@@ -320,11 +320,20 @@ public class TopicPartitionChannel {
     return this.channel.getFullyQualifiedName();
   }
 
+  @Override
   public String toString() {
-    return "StreamingChannelName:"
-        + getChannelName()
-        + ", FullyQualifiedTableName:{}"
-        + this.channel.getFullyQualifiedTableName();
+    return "TopicPartitionChannel{"
+        + "previousFlushTimeStampMs="
+        + previousFlushTimeStampMs
+        + ", hasChannelInitialized="
+        + hasChannelInitialized
+        + ", channel="
+        + this.getChannelName()
+        + ", committedOffset="
+        + committedOffset
+        + ", processedOffset="
+        + processedOffset
+        + '}';
   }
 
   // ------ INNER CLASS ------ //

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
@@ -41,8 +41,8 @@ public class TopicPartitionChannel {
   private long previousFlushTimeStampMs;
 
   /**
-   * States whether this channel has had any data before.
-   * If this is false, the topicPartitionChannel has recently been initialised and didnt receive any records before
+   * States whether this channel has had any data before. If this is false, the
+   * topicPartitionChannel has recently been initialised and didnt receive any records before
    */
   private boolean hasChannelInitialized = false;
 
@@ -72,8 +72,7 @@ public class TopicPartitionChannel {
   private final AtomicLong processedOffset; // processed offset
 
   // Ctor
-  public TopicPartitionChannel(
-      SnowflakeStreamingIngestChannel channel) {
+  public TopicPartitionChannel(SnowflakeStreamingIngestChannel channel) {
     this.channel = channel;
     this.recordService = new RecordService();
     this.previousFlushTimeStampMs = System.currentTimeMillis();
@@ -110,10 +109,6 @@ public class TopicPartitionChannel {
 
       // broken record
       if (isRecordBroken(snowflakeRecord)) {
-        LOGGER.info(
-            "Inserting broken record for topic:{}, offset:{}",
-            snowflakeRecord.topic(),
-            snowflakeRecord.kafkaOffset());
         // write it to DLQ SNOW-451197
       } else {
         // lag telemetry, note that sink record timestamp might be null

--- a/src/test/java/com/snowflake/kafka/connector/SnowflakeSinkTaskForStreamingIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/SnowflakeSinkTaskForStreamingIT.java
@@ -1,0 +1,200 @@
+package com.snowflake.kafka.connector;
+
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT;
+import static com.snowflake.kafka.connector.internal.TestUtils.TEST_CONNECTOR_NAME;
+
+import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
+import com.snowflake.kafka.connector.internal.TestUtils;
+import com.snowflake.kafka.connector.internal.streaming.IngestionMethodConfig;
+import com.snowflake.kafka.connector.records.SnowflakeJsonSchema;
+import com.snowflake.kafka.connector.records.SnowflakeRecordContent;
+
+import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import net.snowflake.client.jdbc.internal.fasterxml.jackson.core.JsonProcessingException;
+import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.JsonNode;
+import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * Sink Task IT test which uses {@link
+ * com.snowflake.kafka.connector.internal.streaming.SnowflakeSinkServiceV2}
+ */
+public class SnowflakeSinkTaskForStreamingIT {
+
+  private String topicName;
+  private SnowflakeConnectionService snowflakeConnectionService;
+  private static int partition = 0;
+
+  @Before
+  public void setup() {
+    topicName = TestUtils.randomTableName();
+    snowflakeConnectionService = TestUtils.getConnectionServiceForStreamingIngest();
+  }
+
+  @After
+  public void after() {
+    TestUtils.dropTable(topicName);
+  }
+
+  @Ignore
+  @Test
+  public void testSinkTask() throws Exception {
+    Map<String, String> config = TestUtils.getConfForStreaming();
+    SnowflakeSinkConnectorConfig.setDefaultValues(config);
+    config.put(BUFFER_COUNT_RECORDS, "1"); // override
+
+    config.put(INGESTION_METHOD_OPT, IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
+
+    SnowflakeSinkTask sinkTask = new SnowflakeSinkTask();
+
+    sinkTask.start(config);
+    ArrayList<TopicPartition> topicPartitions = new ArrayList<>();
+    topicPartitions.add(new TopicPartition(topicName, partition));
+    sinkTask.open(topicPartitions);
+
+    // send regular data
+    List<SinkRecord> records = createJsonStringSinkRecords(1, topicName, partition);
+    sinkTask.put(records);
+
+    // commit offset
+    final Map<TopicPartition, OffsetAndMetadata> offsetMap = new HashMap<>();
+    offsetMap.put(topicPartitions.get(0), new OffsetAndMetadata(10000));
+
+    TestUtils.assertWithRetry(() -> sinkTask.preCommit(offsetMap).size() == 1, 20, 5);
+
+    TestUtils.assertWithRetry(
+            () -> sinkTask.preCommit(offsetMap).get(topicPartitions.get(0)).offset() == 1, 20, 5);
+
+    sinkTask.close(topicPartitions);
+    sinkTask.stop();
+  }
+
+  @Ignore
+  @Test
+  public void testSinkTaskWithMultipleOpenClose() throws Exception {
+    Map<String, String> config = TestUtils.getConfForStreaming();
+    SnowflakeSinkConnectorConfig.setDefaultValues(config);
+    config.put(BUFFER_COUNT_RECORDS, "1"); // override
+
+    config.put(INGESTION_METHOD_OPT, IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
+
+    SnowflakeSinkTask sinkTask = new SnowflakeSinkTask();
+
+    sinkTask.start(config);
+    ArrayList<TopicPartition> topicPartitions = new ArrayList<>();
+    topicPartitions.add(new TopicPartition(topicName, partition));
+    sinkTask.open(topicPartitions);
+
+    final long noOfRecords = 1l;
+    final long lastOffsetNo = noOfRecords - 1;
+
+    // send regular data
+    List<SinkRecord> records = createJsonStringSinkRecords(noOfRecords, topicName, partition);
+    sinkTask.put(records);
+
+    // commit offset
+    final Map<TopicPartition, OffsetAndMetadata> offsetMap = new HashMap<>();
+    offsetMap.put(topicPartitions.get(0), new OffsetAndMetadata(lastOffsetNo));
+
+
+    TestUtils.assertWithRetry(() -> sinkTask.preCommit(offsetMap).size() == 1, 20, 5);
+
+    // precommit is one more than offset last inserted
+    TestUtils.assertWithRetry(
+            () -> sinkTask.preCommit(offsetMap).get(topicPartitions.get(0)).offset() == noOfRecords, 20, 5);
+
+    sinkTask.close(topicPartitions);
+
+    // Add one more partition
+    topicPartitions.add(new TopicPartition(topicName, partition + 1));
+
+    sinkTask.open(topicPartitions);
+
+    // trying to put same records
+    sinkTask.put(records);
+
+    List<SinkRecord> recordsWithAnotherPartition = createJsonStringSinkRecords(noOfRecords, topicName, partition + 1);
+    sinkTask.put(recordsWithAnotherPartition);
+
+    // Adding to offsetMap so that this gets into precommit
+    offsetMap.put(topicPartitions.get(1), new OffsetAndMetadata(lastOffsetNo));
+
+    TestUtils.assertWithRetry(() -> sinkTask.preCommit(offsetMap).size() == 2, 20, 5);
+
+    TestUtils.assertWithRetry(
+            () -> sinkTask.preCommit(offsetMap).get(topicPartitions.get(0)).offset() == 1, 20, 5);
+
+    TestUtils.assertWithRetry(
+            () -> sinkTask.preCommit(offsetMap).get(topicPartitions.get(1)).offset() == 1, 20, 5);
+
+    sinkTask.close(topicPartitions);
+
+    sinkTask.stop();
+
+    ResultSet resultSet = TestUtils.showTableForStreaming(topicName);
+    LinkedList<String> contentResult = new LinkedList<>();
+    LinkedList<String> metadataResult = new LinkedList<>();
+
+    while (resultSet.next()) {
+      contentResult.add(resultSet.getString("RECORD_CONTENT"));
+      metadataResult.add(resultSet.getString("RECORD_METADATA"));
+    }
+    resultSet.close();
+    assert metadataResult.size() == 2;
+    assert contentResult.size() == 2;
+    ObjectMapper mapper = new ObjectMapper();
+
+    Set<Long> partitionsInTable = new HashSet<>();
+    metadataResult.forEach(s -> {
+      try {
+        JsonNode metadata = mapper.readTree(s);
+        metadata.get("offset").asText().equals("0");
+        partitionsInTable.add(metadata.get("partition").asLong());
+      } catch (JsonProcessingException e) {
+        e.printStackTrace();
+      }
+    });
+
+    assert partitionsInTable.size() == 2;
+
+  }
+
+  private List<SinkRecord> createJsonStringSinkRecords(final long noOfRecords, final String topicName, final int partitionNo) throws Exception {
+    ArrayList<SinkRecord> records = new ArrayList<>();
+    String json = "{ \"f1\" : \"v1\" } ";
+    ObjectMapper objectMapper = new ObjectMapper();
+    Schema snowflakeSchema = new SnowflakeJsonSchema();
+    SnowflakeRecordContent content = new SnowflakeRecordContent(objectMapper.readTree(json));
+    for (int i = 0; i < noOfRecords; ++i) {
+      records.add(
+              new SinkRecord(
+                      topicName,
+                      partitionNo,
+                      snowflakeSchema,
+                      content,
+                      snowflakeSchema,
+                      content,
+                      i,
+                      System.currentTimeMillis(),
+                      TimestampType.CREATE_TIME));
+    }
+    return records;
+  }
+}

--- a/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
@@ -282,6 +282,12 @@ public class TestUtils {
     return executeQuery(query);
   }
 
+  public static ResultSet showTableForStreaming(String tableName) {
+    String query = "select * from " + tableName;
+
+    return executeQueryForStreaming(query);
+  }
+
   static String getDesRsaKey() {
     return getProfile(PROFILE_PATH).get(DES_RSA_KEY).asText();
   }


### PR DESCRIPTION
Rebalance [documentation](https://kafka.apache.org/11/javadoc/org/apache/kafka/connect/sink/SinkTask.html): 

- Close() will not invoke close on channel
  - `close()` in sinktask is invoked before rebalance and `open()` is called. 
  - It will also not clear the partitionsToChannel map. 
    - One can argue that this map can grow but most of the times, same partitions are assigned and very rarely partitions are added. Even then this map cant grow more than no of partitions. 
- Made channel object in TopicPartitionChannel mutable. This is because TopicPartitionChannel object doesnt need to be wiped off when rebalance happens, but client is closed (Which results into channel being closed) So we have to open channel after rebalance. 
- Moved code for more readability. 
- Added test which replicates the rebalance scenario and also kind of tests exactly once. 

Note: EOS case will be handled in separate PR but this one handles the case when there was a rebalance and not restart. 