### PR TITLE
SNOW-536429 ☝️ exactly once for Streaming Ingest

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
@@ -171,11 +171,16 @@ public class SnowflakeSinkTask extends SinkTask {
         Boolean.parseBoolean(parsedConfig.get(SnowflakeSinkConnectorConfig.REBALANCING));
 
     // default to snowpipe
+    // If it is snowpipe_streaming, set delivery guarantee to exactly once.
     IngestionMethodConfig ingestionType = IngestionMethodConfig.SNOWPIPE;
     if (parsedConfig.containsKey(SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT)) {
       ingestionType =
           IngestionMethodConfig.valueOf(
               parsedConfig.get(SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT).toUpperCase());
+      if (ingestionType.equals(IngestionMethodConfig.SNOWPIPE_STREAMING)) {
+        ingestionDeliveryGuarantee =
+            SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee.EXACTLY_ONCE;
+      }
     }
 
     conn =

--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -548,6 +548,14 @@ public class Utils {
                     config.get(INGESTION_METHOD_OPT)));
             configIsValid = false;
           }
+          // setting delivery guarantee to EOS.
+          // It is fine for customer to not set this value if Streaming SNOWPIPE is used.
+          deliveryGuarantee =
+              SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee.of(
+                  config.getOrDefault(
+                      DELIVERY_GUARANTEE,
+                      SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee.EXACTLY_ONCE.name()));
+
           if (deliveryGuarantee.equals(
               SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee.AT_LEAST_ONCE)) {
             LOGGER.error(

--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -552,10 +552,11 @@ public class Utils {
               SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee.AT_LEAST_ONCE)) {
             LOGGER.error(
                 Logging.logMessage(
-                    "Config:{} should be:{}",
+                    "Config:{} should be:{} if ingestion method is:{}",
                     DELIVERY_GUARANTEE,
-                    SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee.EXACTLY_ONCE
-                        .toString()));
+                    SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee.EXACTLY_ONCE.toString(),
+                    IngestionMethodConfig.SNOWPIPE_STREAMING.toString()));
+            configIsValid = false;
           }
         }
       } catch (ConfigException exception) {

--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -512,11 +512,15 @@ public class Utils {
       }
     }
 
+    // This is default for SNOWPIPE based KC because that is GA.
+    SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee deliveryGuarantee =
+        SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee.AT_LEAST_ONCE;
     try {
-      SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee.of(
-          config.getOrDefault(
-              DELIVERY_GUARANTEE,
-              SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee.AT_LEAST_ONCE.name()));
+      deliveryGuarantee =
+          SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee.of(
+              config.getOrDefault(
+                  DELIVERY_GUARANTEE,
+                  SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee.AT_LEAST_ONCE.name()));
     } catch (IllegalArgumentException exception) {
       LOGGER.error(
           Logging.logMessage(
@@ -524,6 +528,8 @@ public class Utils {
       configIsValid = false;
     }
 
+    // For snowpipe_streaming, role should be non empty and delivery guarantee should be exactly
+    // once. (Which is default)
     if (config.containsKey(INGESTION_METHOD_OPT)) {
       try {
         // This throws an exception if config value is invalid.
@@ -541,6 +547,15 @@ public class Utils {
                     Utils.SF_ROLE,
                     config.get(INGESTION_METHOD_OPT)));
             configIsValid = false;
+          }
+          if (deliveryGuarantee.equals(
+              SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee.AT_LEAST_ONCE)) {
+            LOGGER.error(
+                Logging.logMessage(
+                    "Config:{} should be:{}",
+                    DELIVERY_GUARANTEE,
+                    SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee.EXACTLY_ONCE
+                        .toString()));
           }
         }
       } catch (ConfigException exception) {

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -73,7 +73,7 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
   // If this is true, we will enable Mbean for required classes and emit JMX metrics for monitoring
   private boolean enableCustomJMXMonitoring = SnowflakeSinkConnectorConfig.JMX_OPT_DEFAULT;
 
-  // We will make this non configurable if ingestion method is SNOWOPIPE_STREAMING
+  // We will make this non configurable if ingestion method is SNOWPIPE_STREAMING
   private SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee ingestionDeliveryGuarantee =
       SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee.EXACTLY_ONCE;
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -73,10 +73,9 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
   // If this is true, we will enable Mbean for required classes and emit JMX metrics for monitoring
   private boolean enableCustomJMXMonitoring = SnowflakeSinkConnectorConfig.JMX_OPT_DEFAULT;
 
-  // default is at_least_once semantic (To begin with)
-  // TODO: SNOW-526435
+  // We will make this non configurable if ingestion method is SNOWOPIPE_STREAMING
   private SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee ingestionDeliveryGuarantee =
-      SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee.AT_LEAST_ONCE;
+      SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee.EXACTLY_ONCE;
 
   // ------ Streaming Ingest ------ //
   // needs url, username. p8 key, role name
@@ -383,6 +382,8 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
   @Override
   public void setDeliveryGuarantee(
       SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee ingestionDeliveryGuarantee) {
+    assert ingestionDeliveryGuarantee
+        == SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee.EXACTLY_ONCE;
     this.ingestionDeliveryGuarantee = ingestionDeliveryGuarantee;
   }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
@@ -137,7 +137,7 @@ public class TopicPartitionChannel {
     }
   }
 
-  /* For EOS, fetch the offset from snowflake during only during first time the connector starts. */
+  /* For EOS, fetch the offset from snowflake during only during first time after connector starts and record is received in Kafka Connector */
   private void fetchLastCommittedOffsetToken() {
     String offsetToken = this.channel.getLatestCommittedOffsetToken();
     try {

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
@@ -330,4 +330,30 @@ public class ConnectorConfigTest {
     config.put(SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT, "INVALID_VALUE");
     Utils.validateConfig(config);
   }
+
+  @Test(expected = SnowflakeKafkaConnectorException.class)
+  public void testIngestionTypeConfig_streaming_invalid_delivery_guarantee() {
+    Map<String, String> config = getConfig();
+    config.put(
+        SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
+        IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
+    config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
+    config.put(
+        SnowflakeSinkConnectorConfig.DELIVERY_GUARANTEE,
+        SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee.AT_LEAST_ONCE.name());
+    Utils.validateConfig(config);
+  }
+
+  @Test
+  public void testIngestionTypeConfig_streaming_valid_delivery_guarantee() {
+    Map<String, String> config = getConfig();
+    config.put(
+        SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
+        IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
+    config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
+    config.put(
+        SnowflakeSinkConnectorConfig.DELIVERY_GUARANTEE,
+        SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee.EXACTLY_ONCE.name());
+    Utils.validateConfig(config);
+  }
 }

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
@@ -356,4 +356,14 @@ public class ConnectorConfigTest {
         SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee.EXACTLY_ONCE.name());
     Utils.validateConfig(config);
   }
+
+  @Test
+  public void testIngestionTypeConfig_streaming_default_delivery_guarantee() {
+    Map<String, String> config = getConfig();
+    config.put(
+        SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
+        IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
+    config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
+    Utils.validateConfig(config);
+  }
 }

--- a/src/test/java/com/snowflake/kafka/connector/internal/SinkServiceIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/SinkServiceIT.java
@@ -1227,7 +1227,7 @@ public class SinkServiceIT {
     // call snowpipe ingest api
     service2.callAllGetOffset();
     // wait for ingest
-    TestUtils.assertWithRetry(() -> TestUtils.tableSize(table) == 1, 30, 20);
+    TestUtils.assertWithRetry(() -> TestUtils.tableSize(table) == 2, 30, 20);
     // change cleaner
     TestUtils.assertWithRetry(() -> getStageSize(stage, table, partition) == 0, 30, 20);
     assert service2.getOffset(new TopicPartition(topic, partition)) == offset + 1;

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelTest.java
@@ -1,0 +1,139 @@
+package com.snowflake.kafka.connector.internal.streaming;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+import javax.annotation.Nullable;
+import net.snowflake.ingest.streaming.InsertValidationResponse;
+import net.snowflake.ingest.streaming.SnowflakeStreamingIngestChannel;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TopicPartitionChannelTest {
+
+  private SnowflakeStreamingIngestChannel mockStreamingChannel;
+
+  private final String streamingChannelName =
+      SnowflakeSinkServiceV2.partitionChannelKey(TOPIC, PARTITION);
+
+  private static final String TOPIC = "TEST";
+
+  private static final int PARTITION = 0;
+
+  private static final String TEST_DB = "TEST_DB";
+  private static final String TEST_SC = "TEST_SC";
+
+  @Test
+  public void testFetchLastCommittedOffsetToken_null() {
+
+    mockStreamingChannel = new MockStreamingIngestChannel(() -> null);
+
+    TopicPartitionChannel topicPartitionChannel = new TopicPartitionChannel(mockStreamingChannel);
+
+    topicPartitionChannel.fetchLastCommittedOffsetToken();
+
+    Assert.assertEquals(-1L, topicPartitionChannel.getOffsetPersistedInSnowflake());
+  }
+
+  @Test
+  public void testFetchLastCommittedOffsetToken_validLong() {
+
+    mockStreamingChannel = new MockStreamingIngestChannel(() -> "100");
+
+    TopicPartitionChannel topicPartitionChannel = new TopicPartitionChannel(mockStreamingChannel);
+
+    topicPartitionChannel.fetchLastCommittedOffsetToken();
+
+    Assert.assertEquals(100L, topicPartitionChannel.getOffsetPersistedInSnowflake());
+  }
+
+  @Test(expected = ConnectException.class)
+  public void testFetchLastCommittedOffsetToken_InvalidNumber() {
+
+    mockStreamingChannel = new MockStreamingIngestChannel(() -> "invalidNo");
+
+    TopicPartitionChannel topicPartitionChannel = new TopicPartitionChannel(mockStreamingChannel);
+
+    try {
+      topicPartitionChannel.fetchLastCommittedOffsetToken();
+      Assert.fail("Should throw exception");
+    } catch (ConnectException exception) {
+      Assert.assertTrue(exception.getMessage().contains("invalidNo"));
+      throw exception;
+    }
+  }
+
+  private class MockStreamingIngestChannel implements SnowflakeStreamingIngestChannel {
+
+    Supplier<String> getOffsetTokenSupplier;
+
+    MockStreamingIngestChannel(Supplier<String> getOffsetTokenSupplier) {
+      this.getOffsetTokenSupplier = getOffsetTokenSupplier;
+    }
+
+    @Override
+    public String getFullyQualifiedName() {
+      return streamingChannelName;
+    }
+
+    @Override
+    public String getName() {
+      return streamingChannelName;
+    }
+
+    @Override
+    public String getDBName() {
+      return TEST_DB;
+    }
+
+    @Override
+    public String getSchemaName() {
+      return TEST_SC;
+    }
+
+    @Override
+    public String getTableName() {
+      return TOPIC;
+    }
+
+    @Override
+    public String getFullyQualifiedTableName() {
+      return null;
+    }
+
+    @Override
+    public boolean isValid() {
+      return true;
+    }
+
+    @Override
+    public boolean isClosed() {
+      return false;
+    }
+
+    @Override
+    public CompletableFuture<Void> close() {
+      return null;
+    }
+
+    @Override
+    public InsertValidationResponse insertRow(Map<String, Object> map, @Nullable String s) {
+      return null;
+    }
+
+    @Override
+    public InsertValidationResponse insertRows(
+        Iterable<Map<String, Object>> iterable, @Nullable String s) {
+      return null;
+    }
+
+    @Override
+    public String getLatestCommittedOffsetToken() {
+      return getOffsetTokenSupplier.get();
+    }
+  }
+}


### PR DESCRIPTION
TLDR:

- No need to pass in `delivery.guarantee` into config.
- If they pass in, it should be EXACTLY_ONCE
- `AT_LEAST_ONCE` will error out. 

Logic:
- Cases where we need to be cautious. 
  - The insertRows was called but precommit didnt send that because of a rebalance or shutdown. 
  - In this case the offset can be resent back to KC and then we will discard it because we will also fetch it from Snowflake. 

- On a connector start, just fetch offsetToken for this channel. 
  - The channel would have been already opened before. (from startTask)
  - This value will be the source of truth and we will compare it with the incoming offset from Kafka. 

