### PR TITLE
Implement ErrantRecordReporter - kafka records from Sink Connector to DLQ

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
@@ -18,6 +18,8 @@ package com.snowflake.kafka.connector;
 
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.DELIVERY_GUARANTEE;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.snowflake.kafka.connector.dlq.KafkaRecordErrorReporter;
 import com.snowflake.kafka.connector.internal.Logging;
 import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
 import com.snowflake.kafka.connector.internal.SnowflakeConnectionServiceFactory;
@@ -30,11 +32,14 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.RetriableException;
+import org.apache.kafka.connect.sink.ErrantRecordReporter;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTask;
 import org.slf4j.Logger;
@@ -170,6 +175,8 @@ public class SnowflakeSinkTask extends SinkTask {
     enableRebalancing =
         Boolean.parseBoolean(parsedConfig.get(SnowflakeSinkConnectorConfig.REBALANCING));
 
+    KafkaRecordErrorReporter kafkaRecordErrorReporter = noOpKafkaRecordErrorReporter();
+
     // default to snowpipe
     // If it is snowpipe_streaming, set delivery guarantee to exactly once.
     IngestionMethodConfig ingestionType = IngestionMethodConfig.SNOWPIPE;
@@ -180,6 +187,7 @@ public class SnowflakeSinkTask extends SinkTask {
       if (ingestionType.equals(IngestionMethodConfig.SNOWPIPE_STREAMING)) {
         ingestionDeliveryGuarantee =
             SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee.EXACTLY_ONCE;
+        kafkaRecordErrorReporter = createKafkaRecordErrorReporter();
       }
     }
 
@@ -202,6 +210,7 @@ public class SnowflakeSinkTask extends SinkTask {
             .setBehaviorOnNullValuesConfig(behavior)
             .setCustomJMXMetrics(enableCustomJMXMonitoring)
             .setDeliveryGuarantee(ingestionDeliveryGuarantee)
+            .setErrorReporter(kafkaRecordErrorReporter)
             .build();
 
     LOGGER.info(
@@ -414,5 +423,47 @@ public class SnowflakeSinkTask extends SinkTask {
         e.printStackTrace();
       }
     }
+  }
+
+  /* Useful to report a record back to DLQ if error tolerance is specified */
+  private KafkaRecordErrorReporter createKafkaRecordErrorReporter() {
+    KafkaRecordErrorReporter result = noOpKafkaRecordErrorReporter();
+    if (context != null) {
+      try {
+        ErrantRecordReporter errantRecordReporter = context.errantRecordReporter();
+        if (errantRecordReporter != null) {
+          result =
+              (record, error) -> {
+                try {
+                  // Blocking this until record is delivered to DLQ
+                  errantRecordReporter.report(record, error).get();
+                } catch (InterruptedException | ExecutionException e) {
+                  final String errMsg = "ERROR reporting records to ErrantRecordReporter";
+                  LOGGER.error(errMsg, e);
+                  throw new ConnectException(errMsg, e);
+                }
+              };
+        } else {
+          LOGGER.info("Errant record reporter is not configured.");
+        }
+      } catch (NoClassDefFoundError | NoSuchMethodError e) {
+        // Will occur in Connect runtimes earlier than 2.6
+        LOGGER.info("Kafka versions prior to 2.6 do not support the errant record reporter.");
+      }
+    }
+    return result;
+  }
+
+  /**
+   * For versions older than 2.6
+   *
+   * @see <a
+   *     href="https://javadoc.io/doc/org.apache.kafka/connect-api/2.6.0/org/apache/kafka/connect/sink/ErrantRecordReporter.html">
+   *     link </a>
+   * @return
+   */
+  @VisibleForTesting
+  static KafkaRecordErrorReporter noOpKafkaRecordErrorReporter() {
+    return (record, e) -> {};
   }
 }

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
@@ -425,7 +425,7 @@ public class SnowflakeSinkTask extends SinkTask {
     }
   }
 
-  /* Useful to report a record back to DLQ if error tolerance is specified */
+  /* Used to report a record back to DLQ if error tolerance is specified */
   private KafkaRecordErrorReporter createKafkaRecordErrorReporter() {
     KafkaRecordErrorReporter result = noOpKafkaRecordErrorReporter();
     if (context != null) {

--- a/src/main/java/com/snowflake/kafka/connector/dlq/KafkaRecordErrorReporter.java
+++ b/src/main/java/com/snowflake/kafka/connector/dlq/KafkaRecordErrorReporter.java
@@ -1,0 +1,17 @@
+package com.snowflake.kafka.connector.dlq;
+
+import org.apache.kafka.connect.sink.ErrantRecordReporter;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+/**
+ * This interface is a wrapper on top of {@link ErrantRecordReporter}. This allows tolerating
+ * situations when the class {@link ErrantRecordReporter} is not available because it was recently
+ * added and backported to older versions.
+ *
+ * @see <a
+ *     href="https://javadoc.io/doc/org.apache.kafka/connect-api/2.6.0/org/apache/kafka/connect/sink/ErrantRecordReporter.html">
+ *     Documentation </a>
+ */
+public interface KafkaRecordErrorReporter {
+  void reportError(SinkRecord record, Exception e);
+}

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkService.java
@@ -3,6 +3,7 @@ package com.snowflake.kafka.connector.internal;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.annotations.VisibleForTesting;
 import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
+import com.snowflake.kafka.connector.dlq.KafkaRecordErrorReporter;
 import com.snowflake.kafka.connector.records.SnowflakeMetadataConfig;
 import java.util.Collection;
 import java.util.Map;
@@ -136,6 +137,9 @@ public interface SnowflakeSinkService {
    */
   void setDeliveryGuarantee(
       SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee ingestionDeliveryGuarantee);
+
+  /* Set Error reporter which can be used to send records to DLQ (Dead Letter Queue) */
+  default void setErrorReporter(KafkaRecordErrorReporter kafkaRecordErrorReporter) {}
 
   /* Get metric registry of an associated pipe */
   @VisibleForTesting

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceFactory.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceFactory.java
@@ -1,6 +1,7 @@
 package com.snowflake.kafka.connector.internal;
 
 import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
+import com.snowflake.kafka.connector.dlq.KafkaRecordErrorReporter;
 import com.snowflake.kafka.connector.internal.streaming.IngestionMethodConfig;
 import com.snowflake.kafka.connector.internal.streaming.SnowflakeSinkServiceV2;
 import com.snowflake.kafka.connector.records.SnowflakeMetadataConfig;
@@ -116,6 +117,12 @@ public class SnowflakeSinkServiceFactory {
         SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee ingestionDeliveryGuarantee) {
       this.service.setDeliveryGuarantee(ingestionDeliveryGuarantee);
       logInfo("Config Delivery Guarantee type {}.", ingestionDeliveryGuarantee.toString());
+      return this;
+    }
+
+    public SnowflakeSinkServiceBuilder setErrorReporter(
+        KafkaRecordErrorReporter kafkaRecordErrorReporter) {
+      this.service.setErrorReporter(kafkaRecordErrorReporter);
       return this;
     }
 

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelTest.java
@@ -1,5 +1,6 @@
 package com.snowflake.kafka.connector.internal.streaming;
 
+import com.snowflake.kafka.connector.dlq.KafkaRecordErrorReporter;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
@@ -10,10 +11,13 @@ import org.apache.kafka.connect.errors.ConnectException;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class TopicPartitionChannelTest {
+
+  @Mock private KafkaRecordErrorReporter mockKafkaRecordErrorReporter;
 
   private SnowflakeStreamingIngestChannel mockStreamingChannel;
 
@@ -32,7 +36,8 @@ public class TopicPartitionChannelTest {
 
     mockStreamingChannel = new MockStreamingIngestChannel(() -> null);
 
-    TopicPartitionChannel topicPartitionChannel = new TopicPartitionChannel(mockStreamingChannel);
+    TopicPartitionChannel topicPartitionChannel =
+        new TopicPartitionChannel(mockStreamingChannel, mockKafkaRecordErrorReporter);
 
     topicPartitionChannel.fetchLastCommittedOffsetToken();
 
@@ -44,7 +49,8 @@ public class TopicPartitionChannelTest {
 
     mockStreamingChannel = new MockStreamingIngestChannel(() -> "100");
 
-    TopicPartitionChannel topicPartitionChannel = new TopicPartitionChannel(mockStreamingChannel);
+    TopicPartitionChannel topicPartitionChannel =
+        new TopicPartitionChannel(mockStreamingChannel, mockKafkaRecordErrorReporter);
 
     topicPartitionChannel.fetchLastCommittedOffsetToken();
 
@@ -56,7 +62,8 @@ public class TopicPartitionChannelTest {
 
     mockStreamingChannel = new MockStreamingIngestChannel(() -> "invalidNo");
 
-    TopicPartitionChannel topicPartitionChannel = new TopicPartitionChannel(mockStreamingChannel);
+    TopicPartitionChannel topicPartitionChannel =
+        new TopicPartitionChannel(mockStreamingChannel, mockKafkaRecordErrorReporter);
 
     try {
       topicPartitionChannel.fetchLastCommittedOffsetToken();


### PR DESCRIPTION
- This is only available after 2.6.0
- Tested this with confluent 6.2.0

Background
- For snowpipe based implementation of KC, we used to send broken records coming from Native converters into tableStage. 
  - Native converters are custom converters created for snowflake so that we can put records into tablestage. https://www.confluent.io/blog/kafka-connect-deep-dive-converters-serialization-explained/
  - Take a look at `SnowflakeRecordContent` class to know more about what extra fields we add in converter logic before it reaches Kafka connector. 
  - Also take a look at `SnowflakeConverter` abstract class and its implementation which essentially creates JSON bytes from kafka record and then send it to KC. 

Segway to why we dont need TableStage
- We can send records to DLQ. 
- DLQ is like any other topic but just has special name. 
- Messages can be fed into snowflake again from DLQ. (Using that at source topic and using SF KC with a simpler converter like String)
- It can be used for any failures.   
  - Network failures. 
  - Connection issues with Snowflake. 
  - Failures after multiple retries. 
  - Broken records. (When we cannot convert data to schema based json)
    - These broken records are special records which are sent to KC when custom converters are used. 
    - They can directly be sent to DLQ if community converters are used. 
    - So only benefit of using custom converters is to be able to send it to tablestage. 

This PR:
This PR is just setting up the framework and is backwards compatible with Custom Snowflake converter. It is just that it wont work for Apache Kafka version < 2.6.0

For version < 2.6.0 we can only support logging it as error and stopping connector. 