### PR TITLE
SNOW-543664 offset token retries + Refactor to reopen channel on SFException 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -424,6 +424,13 @@
             <version>31.0.1-jre</version>
         </dependency>
 
+        <!-- https://github.com/failsafe-lib/failsafe-->
+        <dependency>
+            <groupId>dev.failsafe</groupId>
+            <artifactId>failsafe</artifactId>
+            <version>3.2.1</version>
+        </dependency>
+
         <!--junit for unit test-->
         <dependency>
             <groupId>junit</groupId>

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -472,6 +472,13 @@
             <version>31.0.1-jre</version>
         </dependency>
 
+        <!-- https://github.com/failsafe-lib/failsafe-->
+        <dependency>
+            <groupId>dev.failsafe</groupId>
+            <artifactId>failsafe</artifactId>
+            <version>3.2.1</version>
+        </dependency>
+
         <!--junit for unit test-->
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -151,7 +151,7 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
             this.streamingIngestClient,
             partitionChannelKey,
             this.connectorConfig.get(Utils.SF_DATABASE),
-            this.connectorConfig.get(Utils.SF_DATABASE),
+            this.connectorConfig.get(Utils.SF_SCHEMA),
             tableName,
             this.kafkaRecordErrorReporter));
   }

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -144,16 +144,16 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
    */
   private void createStreamingChannelForTopicPartition(
       final String partitionChannelKey, final String tableName) {
-    // This will always open the channel.
-    TopicPartitionChannel topicPartitionChannel =
+    // Create new instance of TopicPartitionChannel which will always open the channel.
+    partitionsToChannel.put(
+        partitionChannelKey,
         new TopicPartitionChannel(
             this.streamingIngestClient,
             partitionChannelKey,
             this.connectorConfig.get(Utils.SF_DATABASE),
             this.connectorConfig.get(Utils.SF_DATABASE),
             tableName,
-            this.kafkaRecordErrorReporter);
-    partitionsToChannel.put(partitionChannelKey, topicPartitionChannel);
+            this.kafkaRecordErrorReporter));
   }
 
   /**

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -18,8 +18,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
-import net.snowflake.ingest.streaming.OpenChannelRequest;
-import net.snowflake.ingest.streaming.SnowflakeStreamingIngestChannel;
 import net.snowflake.ingest.streaming.SnowflakeStreamingIngestClient;
 import net.snowflake.ingest.streaming.SnowflakeStreamingIngestClientFactory;
 import net.snowflake.ingest.utils.SFException;
@@ -146,11 +144,15 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
    */
   private void createStreamingChannelForTopicPartition(
       final String partitionChannelKey, final String tableName) {
-    // Always open a new channel.
-    SnowflakeStreamingIngestChannel partitionChannel =
-        openChannelForTable(partitionChannelKey, tableName);
+    // This will always open the channel.
     TopicPartitionChannel topicPartitionChannel =
-        new TopicPartitionChannel(partitionChannel, this.kafkaRecordErrorReporter);
+        new TopicPartitionChannel(
+            this.streamingIngestClient,
+            partitionChannelKey,
+            this.connectorConfig.get(Utils.SF_DATABASE),
+            this.connectorConfig.get(Utils.SF_DATABASE),
+            tableName,
+            this.kafkaRecordErrorReporter);
     partitionsToChannel.put(partitionChannelKey, topicPartitionChannel);
   }
 
@@ -421,23 +423,6 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
   }
 
   // ------ Streaming Ingest Related Functions ------ //
-
-  /* Open a channel for Table with given channel name and tableName */
-  private SnowflakeStreamingIngestChannel openChannelForTable(
-      final String channelName, final String tableName) {
-    OpenChannelRequest channelRequest =
-        OpenChannelRequest.builder(channelName)
-            .setDBName(this.connectorConfig.get(Utils.SF_DATABASE))
-            .setSchemaName(this.connectorConfig.get(Utils.SF_SCHEMA))
-            .setTableName(tableName)
-            .setOnErrorOption(OpenChannelRequest.OnErrorOption.CONTINUE)
-            .build();
-    if (streamingIngestClient.isClosed()) {
-      initStreamingClient();
-    }
-    LOGGER.info("Opening a channel with name:{} for table name:{}", channelName, tableName);
-    return streamingIngestClient.openChannel(channelRequest);
-  }
 
   /* Init Streaming client. If is also used to re-init the client if client was closed before. */
   private void initStreamingClient() {

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
@@ -1,12 +1,19 @@
 package com.snowflake.kafka.connector.internal.streaming;
 
 import com.snowflake.kafka.connector.Utils;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import net.snowflake.ingest.utils.Constants;
 
 /* Utility class/Helper methods for streaming related ingestion. */
 public class StreamingUtils {
+  // Streaming Ingest API related fields
+
+  protected static final Duration DURATION_BETWEEN_GET_OFFSET_TOKEN_RETRY = Duration.ofSeconds(1);
+
+  protected static final int MAX_GET_OFFSET_TOKEN_RETRIES = 3;
+
   /* Maps streaming client's property keys to what we got from snowflake KC config file. */
   public static Map<String, String> convertConfigForStreamingClient(
       Map<String, String> connectorConfig) {

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelTest.java
@@ -3,20 +3,23 @@ package com.snowflake.kafka.connector.internal.streaming;
 import com.snowflake.kafka.connector.dlq.KafkaRecordErrorReporter;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Supplier;
-import javax.annotation.Nullable;
 import net.snowflake.ingest.streaming.InsertValidationResponse;
+import net.snowflake.ingest.streaming.OpenChannelRequest;
 import net.snowflake.ingest.streaming.SnowflakeStreamingIngestChannel;
+import net.snowflake.ingest.streaming.SnowflakeStreamingIngestClient;
+import net.snowflake.ingest.utils.ErrorCode;
+import net.snowflake.ingest.utils.SFException;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -26,25 +29,52 @@ public class TopicPartitionChannelTest {
 
   @Mock private KafkaRecordErrorReporter mockKafkaRecordErrorReporter;
 
-  private SnowflakeStreamingIngestChannel mockStreamingChannel;
+  @Mock private SnowflakeStreamingIngestClient mockStreamingClient;
 
-  private final String streamingChannelName =
-      SnowflakeSinkServiceV2.partitionChannelKey(TOPIC, PARTITION);
+  @Mock private SnowflakeStreamingIngestChannel mockStreamingChannel;
 
   private static final String TOPIC = "TEST";
 
   private static final int PARTITION = 0;
 
+  private static final String TEST_CHANNEL_NAME =
+      SnowflakeSinkServiceV2.partitionChannelKey(TOPIC, PARTITION);
   private static final String TEST_DB = "TEST_DB";
   private static final String TEST_SC = "TEST_SC";
+  private static final String TEST_TABLE_NAME = "TEST_TABLE";
+
+  @Before
+  public void setupEachTest() {
+    Mockito.when(mockStreamingClient.isClosed()).thenReturn(false);
+    Mockito.when(mockStreamingClient.openChannel(ArgumentMatchers.any(OpenChannelRequest.class)))
+        .thenReturn(mockStreamingChannel);
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testTopicPartitionChannelInit_streamingClientClosed() {
+    Mockito.when(mockStreamingClient.isClosed()).thenReturn(true);
+    TopicPartitionChannel topicPartitionChannel =
+        new TopicPartitionChannel(
+            mockStreamingClient,
+            TEST_CHANNEL_NAME,
+            TEST_DB,
+            TEST_SC,
+            TEST_TABLE_NAME,
+            mockKafkaRecordErrorReporter);
+  }
 
   @Test
   public void testFetchLastCommittedOffsetToken_null() {
-
-    mockStreamingChannel = new MockStreamingIngestChannel(() -> null);
+    Mockito.when(mockStreamingChannel.getLatestCommittedOffsetToken()).thenReturn(null);
 
     TopicPartitionChannel topicPartitionChannel =
-        new TopicPartitionChannel(mockStreamingChannel, mockKafkaRecordErrorReporter);
+        new TopicPartitionChannel(
+            mockStreamingClient,
+            TEST_CHANNEL_NAME,
+            TEST_DB,
+            TEST_SC,
+            TEST_TABLE_NAME,
+            mockKafkaRecordErrorReporter);
 
     Assert.assertEquals(-1L, topicPartitionChannel.fetchLatestCommittedOffsetFromSnowflake());
   }
@@ -52,10 +82,16 @@ public class TopicPartitionChannelTest {
   @Test
   public void testFetchLastCommittedOffsetToken_validLong() {
 
-    mockStreamingChannel = new MockStreamingIngestChannel(() -> "100");
+    Mockito.when(mockStreamingChannel.getLatestCommittedOffsetToken()).thenReturn("100");
 
     TopicPartitionChannel topicPartitionChannel =
-        new TopicPartitionChannel(mockStreamingChannel, mockKafkaRecordErrorReporter);
+        new TopicPartitionChannel(
+            mockStreamingClient,
+            TEST_CHANNEL_NAME,
+            TEST_DB,
+            TEST_SC,
+            TEST_TABLE_NAME,
+            mockKafkaRecordErrorReporter);
 
     Assert.assertEquals(100L, topicPartitionChannel.fetchLatestCommittedOffsetFromSnowflake());
   }
@@ -63,10 +99,16 @@ public class TopicPartitionChannelTest {
   @Test(expected = ConnectException.class)
   public void testFetchLastCommittedOffsetToken_InvalidNumber() {
 
-    mockStreamingChannel = new MockStreamingIngestChannel(() -> "invalidNo");
+    Mockito.when(mockStreamingChannel.getLatestCommittedOffsetToken()).thenReturn("invalidNo");
 
     TopicPartitionChannel topicPartitionChannel =
-        new TopicPartitionChannel(mockStreamingChannel, mockKafkaRecordErrorReporter);
+        new TopicPartitionChannel(
+            mockStreamingClient,
+            TEST_CHANNEL_NAME,
+            TEST_DB,
+            TEST_SC,
+            TEST_TABLE_NAME,
+            mockKafkaRecordErrorReporter);
 
     try {
       topicPartitionChannel.fetchLatestCommittedOffsetFromSnowflake();
@@ -79,11 +121,22 @@ public class TopicPartitionChannelTest {
 
   @Test
   public void testFirstRecordForChannel() {
-    mockStreamingChannel =
-        new MockStreamingIngestChannel(() -> new InsertValidationResponse(), () -> null);
+    Mockito.when(mockStreamingChannel.getLatestCommittedOffsetToken()).thenReturn(null);
+
+    Mockito.when(
+            mockStreamingChannel.insertRows(
+                ArgumentMatchers.any(Iterable.class), ArgumentMatchers.any(String.class)))
+        .thenReturn(new InsertValidationResponse());
 
     TopicPartitionChannel topicPartitionChannel =
-        new TopicPartitionChannel(mockStreamingChannel, mockKafkaRecordErrorReporter);
+        new TopicPartitionChannel(
+            mockStreamingClient,
+            TEST_CHANNEL_NAME,
+            TEST_DB,
+            TEST_SC,
+            TEST_TABLE_NAME,
+            mockKafkaRecordErrorReporter);
+
     JsonConverter converter = new JsonConverter();
     HashMap<String, String> converterConfig = new HashMap<String, String>();
     converterConfig.put("schemas.enable", "false");
@@ -112,104 +165,44 @@ public class TopicPartitionChannelTest {
     topicPartitionChannel.insertBufferedRows();
 
     Assert.assertTrue(topicPartitionChannel.isPartitionBufferEmpty());
-
-    // After insertRows API is called, the offsetToken would return 0
-
-    mockStreamingChannel =
-        new MockStreamingIngestChannel(() -> new InsertValidationResponse(), () -> "0");
   }
 
   @Test
   public void testCloseChannelException() throws Exception {
-    SnowflakeStreamingIngestChannel mockChannel =
-        Mockito.mock(SnowflakeStreamingIngestChannel.class);
     CompletableFuture mockFuture = Mockito.mock(CompletableFuture.class);
 
-    Mockito.when(mockChannel.close()).thenReturn(mockFuture);
+    Mockito.when(mockStreamingChannel.close()).thenReturn(mockFuture);
+    Mockito.when(mockStreamingChannel.getFullyQualifiedName()).thenReturn(TEST_CHANNEL_NAME);
 
     Mockito.when(mockFuture.get()).thenThrow(new InterruptedException("Interrupted Exception"));
     TopicPartitionChannel topicPartitionChannel =
-        new TopicPartitionChannel(mockChannel, mockKafkaRecordErrorReporter);
+        new TopicPartitionChannel(
+            mockStreamingClient,
+            TEST_CHANNEL_NAME,
+            TEST_DB,
+            TEST_SC,
+            TEST_TABLE_NAME,
+            mockKafkaRecordErrorReporter);
 
     topicPartitionChannel.closeChannel();
   }
 
-  private class MockStreamingIngestChannel implements SnowflakeStreamingIngestChannel {
+  @Test
+  public void testFetchLatestCommittedOffsetFromSnowflake_SFException() {
+    SFException exception = new SFException(ErrorCode.INVALID_CHANNEL, "INVALID_CHANNEL");
+    Mockito.when(mockStreamingChannel.getLatestCommittedOffsetToken()).thenThrow(exception);
 
-    Supplier<InsertValidationResponse> insertRowValidationResponseSupplier;
+    TopicPartitionChannel topicPartitionChannel =
+        new TopicPartitionChannel(
+            mockStreamingClient,
+            TEST_CHANNEL_NAME,
+            TEST_DB,
+            TEST_SC,
+            TEST_TABLE_NAME,
+            mockKafkaRecordErrorReporter);
 
-    Supplier<String> getOffsetTokenSupplier;
+    Assert.assertEquals(-1L, topicPartitionChannel.fetchLatestCommittedOffsetFromSnowflake());
 
-    MockStreamingIngestChannel(Supplier<String> getOffsetTokenSupplier) {
-      this(null, getOffsetTokenSupplier);
-    }
-
-    MockStreamingIngestChannel(
-        Supplier<InsertValidationResponse> insertRowValidationResponseSupplier,
-        Supplier<String> getOffsetTokenSupplier) {
-      this.insertRowValidationResponseSupplier = insertRowValidationResponseSupplier;
-      this.getOffsetTokenSupplier = getOffsetTokenSupplier;
-    }
-
-    @Override
-    public String getFullyQualifiedName() {
-      return streamingChannelName;
-    }
-
-    @Override
-    public String getName() {
-      return streamingChannelName;
-    }
-
-    @Override
-    public String getDBName() {
-      return TEST_DB;
-    }
-
-    @Override
-    public String getSchemaName() {
-      return TEST_SC;
-    }
-
-    @Override
-    public String getTableName() {
-      return TOPIC;
-    }
-
-    @Override
-    public String getFullyQualifiedTableName() {
-      return null;
-    }
-
-    @Override
-    public boolean isValid() {
-      return true;
-    }
-
-    @Override
-    public boolean isClosed() {
-      return false;
-    }
-
-    @Override
-    public CompletableFuture<Void> close() {
-      return null;
-    }
-
-    @Override
-    public InsertValidationResponse insertRow(Map<String, Object> map, @Nullable String s) {
-      return insertRowValidationResponseSupplier.get();
-    }
-
-    @Override
-    public InsertValidationResponse insertRows(
-        Iterable<Map<String, Object>> iterable, @Nullable String s) {
-      return insertRowValidationResponseSupplier.get();
-    }
-
-    @Override
-    public String getLatestCommittedOffsetToken() {
-      return getOffsetTokenSupplier.get();
-    }
+    Mockito.verify(mockStreamingClient, Mockito.times(2)).openChannel(ArgumentMatchers.any());
   }
 }


### PR DESCRIPTION
Refactor 1:
- Move openChannel inside TopicPartitionChannel since it can be used to re-open in case of failures. 
- Introducing a new library which implements retries, fallback and circuitbreaker. 
  - https://github.com/failsafe-lib/failsafe
  - I decided to not implement this because this can also be extended to various other retry mechanisms such as exponential and jitters. 
  - Also, this library is very widely used. 
- Added tests to verify the behavior of retries. 
  - TLDR: Only SFException will be retried and fallback to opening the channel. 
  - No other exception will result into retry. 