### PR TITLE
SNOW-530369 insert rows failure handling and delivery to DLQ

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -320,7 +320,7 @@
         <dependency>
             <groupId>net.snowflake</groupId>
             <artifactId>snowflake-ingest-sdk</artifactId>
-            <version>0.10.5-beta</version>
+            <version>1.0.0-beta</version>
         </dependency>
 
         <dependency>

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -368,7 +368,7 @@
         <dependency>
             <groupId>net.snowflake</groupId>
             <artifactId>snowflake-ingest-sdk</artifactId>
-            <version>0.10.5-beta</version>
+            <version>1.0.0-beta</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -680,7 +680,10 @@ public class SnowflakeSinkConnectorConfig {
     /** Tolerate all errors. */
     ALL;
 
-    /* Validator to validate behavior.on.null.values which says whether kafka should keep null value records or ignore them while ingesting into snowflake table. */
+    /**
+     * Validator to validate behavior.on.null.values which says whether kafka should keep null value
+     * records or ignore them while ingesting into snowflake table.
+     */
     public static final ConfigDef.Validator VALIDATOR =
         new ConfigDef.Validator() {
           private final ConfigDef.ValidString validator =
@@ -700,7 +703,7 @@ public class SnowflakeSinkConnectorConfig {
           }
         };
 
-    // All valid enum values
+    /** All valid enum values */
     public static String[] names() {
       ErrorTolerance[] errorTolerances = values();
       String[] result = new String[errorTolerances.length];

--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -17,8 +17,11 @@
 package com.snowflake.kafka.connector;
 
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BOOLEAN_VALIDATOR;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BehaviorOnNullValues.VALIDATOR;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.DELIVERY_GUARANTEE;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_LOG_ENABLE_CONFIG;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_TOLERANCE_CONFIG;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.JMX_OPT;
 
@@ -565,6 +568,19 @@ public class Utils {
                     SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee.EXACTLY_ONCE.toString(),
                     IngestionMethodConfig.SNOWPIPE_STREAMING.toString()));
             configIsValid = false;
+          }
+
+          /**
+           * Only checking in streaming since we are utilizing the values before we send it to
+           * DLQ/output to log file
+           */
+          if (config.containsKey(ERRORS_TOLERANCE_CONFIG)) {
+            SnowflakeSinkConnectorConfig.ErrorTolerance.VALIDATOR.ensureValid(
+                ERRORS_TOLERANCE_CONFIG, config.get(ERRORS_TOLERANCE_CONFIG));
+          }
+          if (config.containsKey(ERRORS_LOG_ENABLE_CONFIG)) {
+            BOOLEAN_VALIDATOR.ensureValid(
+                ERRORS_LOG_ENABLE_CONFIG, config.get(ERRORS_LOG_ENABLE_CONFIG));
           }
         }
       } catch (ConfigException exception) {

--- a/src/main/java/com/snowflake/kafka/connector/internal/PartitionBuffer.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/PartitionBuffer.java
@@ -1,6 +1,5 @@
 package com.snowflake.kafka.connector.internal;
 
-import java.util.Collection;
 import java.util.List;
 import org.apache.kafka.connect.sink.SinkRecord;
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/PartitionBuffer.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/PartitionBuffer.java
@@ -92,6 +92,10 @@ public abstract class PartitionBuffer<T> {
    */
   public abstract T getData();
 
-  /* Return the sinkrecords corresponding to this buffer */
+  /**
+   * TODO:SNOW-552576 Avoid extra memory in buffer.
+   *
+   * @return the sinkrecords corresponding to this buffer
+   */
   public abstract List<SinkRecord> getSinkRecords();
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/PartitionBuffer.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/PartitionBuffer.java
@@ -1,5 +1,6 @@
 package com.snowflake.kafka.connector.internal;
 
+import com.google.common.base.MoreObjects;
 import java.util.List;
 import org.apache.kafka.connect.sink.SinkRecord;
 
@@ -98,4 +99,22 @@ public abstract class PartitionBuffer<T> {
    * @return the sinkrecords corresponding to this buffer
    */
   public abstract List<SinkRecord> getSinkRecords();
+
+  /**
+   * @return true if no of buffered records == lastOffsetNumber - firstOffsetNumber + 1
+   *     <p>(+1 because first and last offset are inclusive)
+   */
+  public boolean isBufferCountValid() {
+    return this.getNumOfRecords() == (this.getLastOffset() - this.getFirstOffset() + 1);
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("numOfRecords", this.getNumOfRecords())
+        .add("bufferSizeBytes", this.getBufferSizeBytes())
+        .add("firstOffset", this.getFirstOffset())
+        .add("lastOffset", this.getLastOffset())
+        .toString();
+  }
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/PartitionBuffer.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/PartitionBuffer.java
@@ -1,5 +1,7 @@
 package com.snowflake.kafka.connector.internal;
 
+import java.util.Collection;
+import java.util.List;
 import org.apache.kafka.connect.sink.SinkRecord;
 
 /**
@@ -90,4 +92,7 @@ public abstract class PartitionBuffer<T> {
    * @return respective data type implemented by the class.
    */
   public abstract T getData();
+
+  /* Return the sinkrecords corresponding to this buffer */
+  public abstract List<SinkRecord> getSinkRecords();
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
@@ -1147,6 +1147,12 @@ class SnowflakeSinkServiceV1 extends Logging implements SnowflakeSinkService {
         pipeStatus.totalNumberOfRecord.addAndGet(getNumOfRecords());
         return result;
       }
+
+      @Override
+      public List<SinkRecord> getSinkRecords() {
+        throw new UnsupportedOperationException(
+            "SnowflakeSinkServiceV1 doesnt support getSinkRecords method");
+      }
     }
   }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -164,9 +164,8 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
             this.streamingIngestClient,
             topicPartition,
             partitionChannelKey, // Streaming channel name
-            this.connectorConfig.get(Utils.SF_DATABASE),
-            this.connectorConfig.get(Utils.SF_SCHEMA),
             tableName,
+            this.connectorConfig,
             this.kafkaRecordErrorReporter,
             this.sinkTaskContext));
   }

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
@@ -63,7 +63,7 @@ public class StreamingUtils {
   /* Returns true if sf connector config has error.tolerance = ALL */
   public static boolean tolerateErrors(Map<String, String> sfConnectorConfig) {
     String errorsTolerance =
-        sfConnectorConfig.getOrDefault(ERRORS_TOLERANCE_CONFIG, ErrorTolerance.NONE.value());
+        sfConnectorConfig.getOrDefault(ERRORS_TOLERANCE_CONFIG, ErrorTolerance.NONE.toString());
 
     return ErrorTolerance.valueOf(errorsTolerance.toUpperCase()).equals(ErrorTolerance.ALL);
   }

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
@@ -1,5 +1,8 @@
 package com.snowflake.kafka.connector.internal.streaming;
 
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.*;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_TOLERANCE_CONFIG;
+
 import com.snowflake.kafka.connector.Utils;
 import java.time.Duration;
 import java.util.HashMap;
@@ -55,5 +58,23 @@ public class StreamingUtils {
           return value;
         });
     return streamingPropertiesMap;
+  }
+
+  /* Returns true if sf connector config has error.tolerance = ALL */
+  public static boolean tolerateErrors(Map<String, String> sfConnectorConfig) {
+    String errorsTolerance =
+        sfConnectorConfig.getOrDefault(ERRORS_TOLERANCE_CONFIG, ErrorTolerance.NONE.value());
+
+    return ErrorTolerance.valueOf(errorsTolerance.toUpperCase()).equals(ErrorTolerance.ALL);
+  }
+
+  /* Returns true if connector config has errors.log.enable = true */
+  public static boolean logErrors(Map<String, String> sfConnectorConfig) {
+    return Boolean.parseBoolean(sfConnectorConfig.getOrDefault(ERRORS_LOG_ENABLE_CONFIG, "false"));
+  }
+
+  /* Returns dlq topic name if connector config has errors.deadletterqueue.topic.name set */
+  public static String getDlqTopicName(Map<String, String> sfConnectorConfig) {
+    return sfConnectorConfig.getOrDefault(ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG, "");
   }
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
@@ -445,6 +445,8 @@ public class TopicPartitionChannel {
             ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG);
       } else {
         for (int i = 0; i < insertErrors.size(); i++) {
+          // Write now I am assuming each error maps to its original row which is incorrect.
+          // TODO: SNOW-545729 would handle mapping errors with original SinkRecord.
           this.kafkaRecordErrorReporter.reportError(
               insertedRecordsToBuffer.get(i), insertErrors.get(i).getException());
         }

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
@@ -434,10 +434,7 @@ public class TopicPartitionChannel {
       List<SinkRecord> insertedRecordsToBuffer) {
     if (logErrors) {
       for (InsertValidationResponse.InsertError insertError : insertErrors) {
-        LOGGER.error(
-            "Insert row Error message:{}, with ex:{}",
-            insertError.getMessage(),
-            insertError.getException().getMessage());
+        LOGGER.error("Insert Row Error message", insertError.getException());
       }
     }
     if (errorTolerance) {

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
@@ -1,9 +1,12 @@
 package com.snowflake.kafka.connector;
 
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_LOG_ENABLE_CONFIG;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_TOLERANCE_CONFIG;
 import static com.snowflake.kafka.connector.internal.TestUtils.getConfig;
 
 import com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException;
 import com.snowflake.kafka.connector.internal.streaming.IngestionMethodConfig;
+import java.util.Locale;
 import java.util.Map;
 import org.junit.Test;
 
@@ -329,7 +332,7 @@ public class ConnectorConfigTest {
     Map<String, String> config = getConfig();
     config.put(
         SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
-        IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
+        IngestionMethodConfig.SNOWPIPE_STREAMING.toString().toUpperCase(Locale.ROOT));
     config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
     config.put(
         SnowflakeSinkConnectorConfig.DELIVERY_GUARANTEE,
@@ -340,6 +343,64 @@ public class ConnectorConfigTest {
   @Test
   public void testIngestionTypeConfig_streaming_default_delivery_guarantee() {
     Map<String, String> config = getConfig();
+    config.put(
+        SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
+        IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
+    config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
+    Utils.validateConfig(config);
+  }
+
+  /** These error tests are not going to enforce errors if they are not passed as configs. */
+  @Test
+  public void testErrorTolerance_AllowedValues() {
+    Map<String, String> config = getConfig();
+    config.put(ERRORS_TOLERANCE_CONFIG, SnowflakeSinkConnectorConfig.ErrorTolerance.ALL.toString());
+    config.put(
+        SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
+        IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
+    config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
+    Utils.validateConfig(config);
+
+    config.put(
+        ERRORS_TOLERANCE_CONFIG, SnowflakeSinkConnectorConfig.ErrorTolerance.NONE.toString());
+    Utils.validateConfig(config);
+
+    config.put(ERRORS_TOLERANCE_CONFIG, "all");
+    Utils.validateConfig(config);
+  }
+
+  @Test(expected = SnowflakeKafkaConnectorException.class)
+  public void testErrorTolerance_DisallowedValues() {
+    Map<String, String> config = getConfig();
+    config.put(ERRORS_TOLERANCE_CONFIG, "INVALID");
+    config.put(
+        SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
+        IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
+    config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
+    Utils.validateConfig(config);
+  }
+
+  @Test
+  public void testErrorLog_AllowedValues() {
+    Map<String, String> config = getConfig();
+    config.put(ERRORS_LOG_ENABLE_CONFIG, "true");
+    config.put(
+        SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
+        IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
+    config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
+    Utils.validateConfig(config);
+
+    config.put(ERRORS_LOG_ENABLE_CONFIG, "FALSE");
+    Utils.validateConfig(config);
+
+    config.put(ERRORS_LOG_ENABLE_CONFIG, "TRUE");
+    Utils.validateConfig(config);
+  }
+
+  @Test(expected = SnowflakeKafkaConnectorException.class)
+  public void testErrorLog_DisallowedValues() {
+    Map<String, String> config = getConfig();
+    config.put(ERRORS_LOG_ENABLE_CONFIG, "INVALID");
     config.put(
         SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
         IngestionMethodConfig.SNOWPIPE_STREAMING.toString());

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
@@ -1,33 +1,13 @@
 package com.snowflake.kafka.connector;
 
+import static com.snowflake.kafka.connector.internal.TestUtils.getConfig;
+
 import com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException;
 import com.snowflake.kafka.connector.internal.streaming.IngestionMethodConfig;
-import java.util.HashMap;
 import java.util.Map;
 import org.junit.Test;
 
 public class ConnectorConfigTest {
-  static Map<String, String> getConfig() {
-    Map<String, String> config = new HashMap<>();
-    config.put(SnowflakeSinkConnectorConfig.NAME, "test");
-    config.put(SnowflakeSinkConnectorConfig.TOPICS, "topic1,topic2");
-    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_URL, "https://testaccount.snowflake.com:443");
-    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_USER, "userName");
-    config.put(
-        SnowflakeSinkConnectorConfig.SNOWFLAKE_PRIVATE_KEY, "fdsfsdfsdfdsfdsrqwrwewrwrew42314424");
-    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_SCHEMA, "testSchema");
-    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_DATABASE, "testDatabase");
-    config.put(
-        SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS,
-        SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS_DEFAULT + "");
-    config.put(
-        SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES,
-        SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES_DEFAULT + "");
-    config.put(
-        SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC,
-        SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC_DEFAULT + "");
-    return config;
-  }
 
   @Test
   public void testConfig() {

--- a/src/test/java/com/snowflake/kafka/connector/SecurityTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/SecurityTest.java
@@ -1,5 +1,7 @@
 package com.snowflake.kafka.connector;
 
+import static com.snowflake.kafka.connector.internal.TestUtils.getConfig;
+
 import com.snowflake.kafka.connector.internal.EncryptionUtils;
 import com.snowflake.kafka.connector.internal.FIPSTest;
 import com.snowflake.kafka.connector.internal.TestUtils;
@@ -17,7 +19,7 @@ public class SecurityTest {
   public void testRSAPasswordOutput() throws IOException, OperatorCreationException {
     String testPasswd = "TestPassword1234!";
     String testKey = FIPSTest.generateAESKey(TestUtils.getPrivateKey(), testPasswd.toCharArray());
-    Map<String, String> testConf = ConnectorConfigTest.getConfig();
+    Map<String, String> testConf = getConfig();
     testConf.remove(SnowflakeSinkConnectorConfig.SNOWFLAKE_PRIVATE_KEY);
     testConf.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_PRIVATE_KEY, testKey);
     testConf.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_PRIVATE_KEY_PASSPHRASE, testPasswd);

--- a/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
@@ -19,6 +19,7 @@ package com.snowflake.kafka.connector.internal;
 import static com.snowflake.kafka.connector.Utils.*;
 
 import com.snowflake.client.jdbc.SnowflakeDriver;
+import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
 import com.snowflake.kafka.connector.Utils;
 import com.snowflake.kafka.connector.records.SnowflakeJsonSchema;
 import com.snowflake.kafka.connector.records.SnowflakeRecordContent;
@@ -520,5 +521,26 @@ public class TestUtils {
               TimestampType.CREATE_TIME));
     }
     return records;
+  }
+
+  public static Map<String, String> getConfig() {
+    Map<String, String> config = new HashMap<>();
+    config.put(Utils.NAME, "test");
+    config.put(SnowflakeSinkConnectorConfig.TOPICS, "topic1,topic2");
+    config.put(SF_URL, "https://testaccount.snowflake.com:443");
+    config.put(SF_USER, "userName");
+    config.put(Utils.SF_PRIVATE_KEY, "fdsfsdfsdfdsfdsrqwrwewrwrew42314424");
+    config.put(SF_SCHEMA, "testSchema");
+    config.put(SF_DATABASE, "testDatabase");
+    config.put(
+        SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS,
+        SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS_DEFAULT + "");
+    config.put(
+        SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES,
+        SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES_DEFAULT + "");
+    config.put(
+        SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC,
+        SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC_DEFAULT + "");
+    return config;
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
@@ -543,4 +543,43 @@ public class TestUtils {
         SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC_DEFAULT + "");
     return config;
   }
+
+  /**
+   * retrieve client Sequencer for passed channel name associated with table
+   *
+   * @param tableName table name
+   * @param channelName name of channel
+   * @throws SQLException if meet connection issue
+   */
+  public static long getClientSequencerForChannelAndTable(
+      String tableName, final String channelName) throws SQLException {
+    String query = "show channels in table " + tableName;
+    ResultSet result = executeQueryForStreaming(query);
+
+    if (result.next()) {
+      if (result.getString("name").equalsIgnoreCase(channelName)) {
+        return result.getInt("client_sequencer");
+      }
+    }
+    return -1;
+  }
+
+  /**
+   * retrieve offset_token for passed channel name associated with table
+   *
+   * @param tableName table name * @param channelName name of channel * @throws SQLException if meet
+   *     connection issue
+   */
+  public static long getOffsetTokenForChannelAndTable(String tableName, final String channelName)
+      throws SQLException {
+    String query = "show channels in table " + tableName;
+    ResultSet result = executeQueryForStreaming(query);
+
+    if (result.next()) {
+      if (result.getString("name").equalsIgnoreCase(channelName)) {
+        return result.getInt("client_sequencer");
+      }
+    }
+    return -1;
+  }
 }

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelIT.java
@@ -1,8 +1,5 @@
 package com.snowflake.kafka.connector.internal.streaming;
 
-import static com.snowflake.kafka.connector.Utils.SF_DATABASE;
-import static com.snowflake.kafka.connector.Utils.SF_SCHEMA;
-
 import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
 import com.snowflake.kafka.connector.dlq.InMemoryKafkaRecordErrorReporter;
 import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
@@ -29,7 +26,7 @@ public class TopicPartitionChannelIT {
   private String topic;
   private TopicPartition topicPartition;
 
-  private String testChannelName, testDb, testSc;
+  private String testChannelName;
 
   @Before
   public void beforeEach() {
@@ -50,8 +47,6 @@ public class TopicPartitionChannelIT {
   public void testAutoChannelReopenOnSFException() throws Exception {
     Map<String, String> config = TestUtils.getConfForStreaming();
     SnowflakeSinkConnectorConfig.setDefaultValues(config);
-    testDb = config.get(SF_DATABASE);
-    testSc = config.get(SF_SCHEMA);
 
     InMemorySinkTaskContext inMemorySinkTaskContext =
         new InMemorySinkTaskContext(Collections.singleton(topicPartition));
@@ -84,9 +79,8 @@ public class TopicPartitionChannelIT {
             snowflakeSinkServiceV2.getStreamingIngestClient(),
             topicPartition,
             testChannelName,
-            testDb,
-            testSc,
             testTableName,
+            config,
             new InMemoryKafkaRecordErrorReporter(),
             new InMemorySinkTaskContext(Collections.singleton(topicPartition)));
 
@@ -106,8 +100,6 @@ public class TopicPartitionChannelIT {
   public void testInsertRowsOnChannelClosed() throws Exception {
     Map<String, String> config = TestUtils.getConfForStreaming();
     SnowflakeSinkConnectorConfig.setDefaultValues(config);
-    testDb = config.get(SF_DATABASE);
-    testSc = config.get(SF_SCHEMA);
 
     InMemorySinkTaskContext inMemorySinkTaskContext =
         new InMemorySinkTaskContext(Collections.singleton(topicPartition));

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelIT.java
@@ -149,7 +149,7 @@ public class TopicPartitionChannelIT {
 
   @Ignore
   @Test
-  public void testAutoChannelReopenOn_InsertRowsSFException() throws Exception {
+  public void testAutoChannelReopen_InsertRowsSFException() throws Exception {
     Map<String, String> config = TestUtils.getConfForStreaming();
     SnowflakeSinkConnectorConfig.setDefaultValues(config);
 

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelIT.java
@@ -9,6 +9,7 @@ import com.snowflake.kafka.connector.internal.TestUtils;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import net.snowflake.ingest.streaming.InsertValidationResponse;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.After;
@@ -44,7 +45,7 @@ public class TopicPartitionChannelIT {
 
   @Ignore
   @Test
-  public void testAutoChannelReopenOnSFException() throws Exception {
+  public void testAutoChannelReopenOn_OffsetTokenSFException() throws Exception {
     Map<String, String> config = TestUtils.getConfForStreaming();
     SnowflakeSinkConnectorConfig.setDefaultValues(config);
 
@@ -144,5 +145,64 @@ public class TopicPartitionChannelIT {
 
     TestUtils.assertWithRetry(
         () -> service.getOffset(new TopicPartition(topic, PARTITION)) == 2, 20, 5);
+  }
+
+  @Ignore
+  @Test
+  public void testAutoChannelReopenOn_InsertRowsSFException() throws Exception {
+    Map<String, String> config = TestUtils.getConfForStreaming();
+    SnowflakeSinkConnectorConfig.setDefaultValues(config);
+
+    InMemorySinkTaskContext inMemorySinkTaskContext =
+        new InMemorySinkTaskContext(Collections.singleton(topicPartition));
+
+    // This will automatically create a channel for topicPartition.
+    SnowflakeSinkService service =
+        SnowflakeSinkServiceFactory.builder(conn, IngestionMethodConfig.SNOWPIPE_STREAMING, config)
+            .setRecordNumber(1)
+            .setErrorReporter(new InMemoryKafkaRecordErrorReporter())
+            .setSinkTaskContext(inMemorySinkTaskContext)
+            .addTask(testTableName, topicPartition)
+            .build();
+
+    final long noOfRecords = 1;
+
+    // send regular data
+    List<SinkRecord> records =
+        TestUtils.createJsonStringSinkRecords(0, noOfRecords, topic, PARTITION);
+
+    service.insert(records);
+
+    TestUtils.assertWithRetry(
+        () -> service.getOffset(new TopicPartition(topic, PARTITION)) == noOfRecords, 20, 5);
+
+    SnowflakeSinkServiceV2 snowflakeSinkServiceV2 = (SnowflakeSinkServiceV2) service;
+
+    // Closing the channel for mimicking SFException in insertRows
+    TopicPartitionChannel topicPartitionChannel =
+        snowflakeSinkServiceV2.getTopicPartitionChannelFromCacheKey(testChannelName).get();
+
+    Assert.assertNotNull(topicPartitionChannel);
+
+    // close channel
+    topicPartitionChannel.closeChannel();
+
+    // verify channel is closed.
+    Assert.assertTrue(topicPartitionChannel.isChannelClosed());
+
+    // send offset 1
+    records = TestUtils.createJsonStringSinkRecords(1, noOfRecords, topic, PARTITION);
+
+    topicPartitionChannel.insertRecordToBuffer(records.get(0));
+
+    InsertValidationResponse response = topicPartitionChannel.insertBufferedRows();
+
+    assert !response.hasErrors();
+
+    TestUtils.assertWithRetry(
+        () -> service.getOffset(new TopicPartition(topic, PARTITION)) == 2, 20, 5);
+
+    assert TestUtils.getClientSequencerForChannelAndTable(testTableName, testChannelName) == 1;
+    assert TestUtils.getOffsetTokenForChannelAndTable(testTableName, testChannelName) == 1;
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelTest.java
@@ -3,8 +3,10 @@ package com.snowflake.kafka.connector.internal.streaming;
 import static com.snowflake.kafka.connector.internal.streaming.StreamingUtils.MAX_GET_OFFSET_TOKEN_RETRIES;
 
 import com.snowflake.kafka.connector.dlq.KafkaRecordErrorReporter;
+import com.snowflake.kafka.connector.internal.TestUtils;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import net.snowflake.ingest.streaming.InsertValidationResponse;
 import net.snowflake.ingest.streaming.OpenChannelRequest;
@@ -45,11 +47,11 @@ public class TopicPartitionChannelTest {
 
   private static final String TEST_CHANNEL_NAME =
       SnowflakeSinkServiceV2.partitionChannelKey(TOPIC, PARTITION);
-  private static final String TEST_DB = "TEST_DB";
-  private static final String TEST_SC = "TEST_SC";
   private static final String TEST_TABLE_NAME = "TEST_TABLE";
 
   private TopicPartition topicPartition;
+
+  private Map<String, String> sfConnectorConfig;
 
   @Before
   public void setupEachTest() {
@@ -58,6 +60,7 @@ public class TopicPartitionChannelTest {
         .thenReturn(mockStreamingChannel);
     Mockito.when(mockStreamingChannel.getFullyQualifiedName()).thenReturn(TEST_CHANNEL_NAME);
     topicPartition = new TopicPartition(TOPIC, PARTITION);
+    sfConnectorConfig = TestUtils.getConfig();
   }
 
   @Test(expected = IllegalStateException.class)
@@ -68,9 +71,8 @@ public class TopicPartitionChannelTest {
             mockStreamingClient,
             topicPartition,
             TEST_CHANNEL_NAME,
-            TEST_DB,
-            TEST_SC,
             TEST_TABLE_NAME,
+            sfConnectorConfig,
             mockKafkaRecordErrorReporter,
             mockSinkTaskContext);
   }
@@ -84,9 +86,8 @@ public class TopicPartitionChannelTest {
             mockStreamingClient,
             topicPartition,
             TEST_CHANNEL_NAME,
-            TEST_DB,
-            TEST_SC,
             TEST_TABLE_NAME,
+            sfConnectorConfig,
             mockKafkaRecordErrorReporter,
             mockSinkTaskContext);
 
@@ -103,9 +104,8 @@ public class TopicPartitionChannelTest {
             mockStreamingClient,
             topicPartition,
             TEST_CHANNEL_NAME,
-            TEST_DB,
-            TEST_SC,
             TEST_TABLE_NAME,
+            sfConnectorConfig,
             mockKafkaRecordErrorReporter,
             mockSinkTaskContext);
 
@@ -126,9 +126,8 @@ public class TopicPartitionChannelTest {
             mockStreamingClient,
             topicPartition,
             TEST_CHANNEL_NAME,
-            TEST_DB,
-            TEST_SC,
             TEST_TABLE_NAME,
+            sfConnectorConfig,
             mockKafkaRecordErrorReporter,
             mockSinkTaskContext);
 
@@ -175,9 +174,8 @@ public class TopicPartitionChannelTest {
             mockStreamingClient,
             topicPartition,
             TEST_CHANNEL_NAME,
-            TEST_DB,
-            TEST_SC,
             TEST_TABLE_NAME,
+            sfConnectorConfig,
             mockKafkaRecordErrorReporter,
             mockSinkTaskContext);
 
@@ -199,9 +197,8 @@ public class TopicPartitionChannelTest {
             mockStreamingClient,
             topicPartition,
             TEST_CHANNEL_NAME,
-            TEST_DB,
-            TEST_SC,
             TEST_TABLE_NAME,
+            sfConnectorConfig,
             mockKafkaRecordErrorReporter,
             mockSinkTaskContext);
 
@@ -233,9 +230,8 @@ public class TopicPartitionChannelTest {
             mockStreamingClient,
             topicPartition,
             TEST_CHANNEL_NAME,
-            TEST_DB,
-            TEST_SC,
             TEST_TABLE_NAME,
+            sfConnectorConfig,
             mockKafkaRecordErrorReporter,
             mockSinkTaskContext);
 
@@ -259,9 +255,8 @@ public class TopicPartitionChannelTest {
             mockStreamingClient,
             topicPartition,
             TEST_CHANNEL_NAME,
-            TEST_DB,
-            TEST_SC,
             TEST_TABLE_NAME,
+            sfConnectorConfig,
             mockKafkaRecordErrorReporter,
             mockSinkTaskContext);
 
@@ -290,9 +285,8 @@ public class TopicPartitionChannelTest {
             mockStreamingClient,
             topicPartition,
             TEST_CHANNEL_NAME,
-            TEST_DB,
-            TEST_SC,
             TEST_TABLE_NAME,
+            sfConnectorConfig,
             mockKafkaRecordErrorReporter,
             mockSinkTaskContext);
 
@@ -317,9 +311,8 @@ public class TopicPartitionChannelTest {
             mockStreamingClient,
             topicPartition,
             TEST_CHANNEL_NAME,
-            TEST_DB,
-            TEST_SC,
             TEST_TABLE_NAME,
+            sfConnectorConfig,
             mockKafkaRecordErrorReporter,
             mockSinkTaskContext);
 

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelTest.java
@@ -473,7 +473,7 @@ public class TopicPartitionChannelTest {
 
     Map<String, String> sfConnectorConfigWithErrors = new HashMap<>(sfConnectorConfig);
     sfConnectorConfigWithErrors.put(
-        ERRORS_TOLERANCE_CONFIG, SnowflakeSinkConnectorConfig.ErrorTolerance.ALL.value());
+        ERRORS_TOLERANCE_CONFIG, SnowflakeSinkConnectorConfig.ErrorTolerance.ALL.toString());
     sfConnectorConfigWithErrors.put(ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG, "test_DLQ");
     InMemoryKafkaRecordErrorReporter kafkaRecordErrorReporter =
         new InMemoryKafkaRecordErrorReporter();
@@ -509,7 +509,7 @@ public class TopicPartitionChannelTest {
 
     Map<String, String> sfConnectorConfigWithErrors = new HashMap<>(sfConnectorConfig);
     sfConnectorConfigWithErrors.put(
-        ERRORS_TOLERANCE_CONFIG, SnowflakeSinkConnectorConfig.ErrorTolerance.ALL.value());
+        ERRORS_TOLERANCE_CONFIG, SnowflakeSinkConnectorConfig.ErrorTolerance.ALL.toString());
     sfConnectorConfigWithErrors.put(ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG, "test_DLQ");
     sfConnectorConfigWithErrors.put(ERRORS_LOG_ENABLE_CONFIG, "true");
 


### PR DESCRIPTION
Error handling in insertRows + Logging/delivery to DLQ

- Add few configs for error handling. 
- [Here](https://www.confluent.io/blog/kafka-connect-deep-dive-error-handling-dead-letter-queues/) is how it will work. 
  - error.tolerance = NONE 
    - fail fast
  - error.tolerance = ALL
    - similar to on error continue. 
    - can provide DLQ to send those records to DLQ (`errors.deadletterqueue.topic.name`)
  - errors.log.enable = false by default
    - can be used to log errors in log file. 

- Fallback for SFException
 - No retry for insertRows. 
 - Reopen the channel and reset kafka with offset found in snowflake. 
 - Send retriableexception back from the put API. https://kafka.apache.org/31/javadoc/org/apache/kafka/connect/sink/SinkTask.html#put(java.util.Collection)

- Added test
- Will fix SNOW-545729 in later commits. 