### PR TITLE
Japatel snow 549265 flush time min 1 sec

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -19,6 +19,7 @@ package com.snowflake.kafka.connector;
 import com.google.common.base.Strings;
 import com.snowflake.kafka.connector.internal.Logging;
 import com.snowflake.kafka.connector.internal.streaming.IngestionMethodConfig;
+import com.snowflake.kafka.connector.internal.streaming.StreamingUtils;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
@@ -339,7 +340,7 @@ public class SnowflakeSinkConnectorConfig {
             BUFFER_FLUSH_TIME_SEC,
             Type.LONG,
             BUFFER_FLUSH_TIME_SEC_DEFAULT,
-            ConfigDef.Range.atLeast(BUFFER_FLUSH_TIME_SEC_MIN),
+            ConfigDef.Range.atLeast(StreamingUtils.STREAMING_BUFFER_FLUSH_TIME_MINIMUM_SEC),
             Importance.LOW,
             "The time in seconds to flush cached data",
             CONNECTOR_CONFIG,

--- a/src/main/java/com/snowflake/kafka/connector/internal/BufferThreshold.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/BufferThreshold.java
@@ -1,0 +1,213 @@
+package com.snowflake.kafka.connector.internal;
+
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC_MIN;
+import static com.snowflake.kafka.connector.internal.streaming.StreamingUtils.STREAMING_BUFFER_FLUSH_TIME_MINIMUM_SEC;
+
+import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
+import com.snowflake.kafka.connector.internal.streaming.IngestionMethodConfig;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Helper class Associated to runtime of Kafka Connect which can help to identify if there is a need
+ * to flush the buffered records.
+ */
+public abstract class BufferThreshold {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(BufferThreshold.class);
+
+  // What ingestion method is defined in connector.
+  private final IngestionMethodConfig ingestionMethodConfig;
+
+  // Buffer flush thresholds set in connector
+  // Set in config (Time based flush) in seconds
+  /**
+   * Set in config (Time based flush) in seconds
+   *
+   * <p>Config parameter: {@link
+   * com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig#BUFFER_FLUSH_TIME_SEC}
+   */
+  private final long flushTimeThresholdSeconds;
+
+  /**
+   * Set in config (buffer size based flush) in bytes
+   *
+   * <p>Config parameter: {@link
+   * com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig#BUFFER_SIZE_BYTES}
+   */
+  private final long bufferSizeThresholdBytes;
+
+  /**
+   * Set in config (Threshold before we call insertRows API) corresponds to # of records in kafka
+   *
+   * <p>Config parameter: {@link
+   * com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig#BUFFER_COUNT_RECORDS}
+   */
+  private final long bufferKafkaRecordCountThreshold;
+
+  private final long SECOND_TO_MILLIS = TimeUnit.SECONDS.toMillis(1);
+
+  public BufferThreshold(
+      IngestionMethodConfig ingestionMethodConfig,
+      long flushTimeThresholdSeconds,
+      long bufferSizeThresholdBytes,
+      long bufferKafkaRecordCountThreshold) {
+    this.ingestionMethodConfig = ingestionMethodConfig;
+    this.flushTimeThresholdSeconds = flushTimeThresholdSeconds;
+    this.bufferSizeThresholdBytes = bufferSizeThresholdBytes;
+    this.bufferKafkaRecordCountThreshold = bufferKafkaRecordCountThreshold;
+  }
+
+  /**
+   * Returns true if size of current buffer is more than threshold provided (Both in bytes).
+   *
+   * <p>Threshold is config parameter: {@link
+   * com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig#BUFFER_SIZE_BYTES}
+   *
+   * @param currentBufferSizeInBytes current size of buffer in bytes
+   * @return true if bytes threshold has reached.
+   */
+  public boolean isFlushBufferedBytesBased(final long currentBufferSizeInBytes) {
+    return currentBufferSizeInBytes >= bufferSizeThresholdBytes;
+  }
+
+  /**
+   * Returns true if number of ({@link SinkRecord})s in current buffer is more than threshold
+   * provided.
+   *
+   * <p>Threshold is config parameter: {@link
+   * com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig#BUFFER_COUNT_RECORDS}
+   *
+   * @param currentBufferedRecordCount current size of buffer in terms of number of kafka records
+   * @return true if number of kafka threshold has reached in buffer.
+   */
+  public boolean isFlushBufferedRecordCountBased(final long currentBufferedRecordCount) {
+    return currentBufferedRecordCount != 0
+        && currentBufferedRecordCount >= bufferKafkaRecordCountThreshold;
+  }
+
+  /**
+   * If difference between current time and previous flush time is more than threshold return true.
+   *
+   * @param previousFlushTimeStampMs when were previous buffered records were flushed into internal
+   *     stage for snowpipe based implementation or previous buffered records were sent in
+   *     insertRows API of Streaming Snowpipe.
+   * @return true if time based threshold has reached.
+   */
+  public boolean isFlushTimeBased(final long previousFlushTimeStampMs) {
+    final long currentTimeMs = System.currentTimeMillis();
+    return (currentTimeMs - previousFlushTimeStampMs)
+        >= (this.flushTimeThresholdSeconds * SECOND_TO_MILLIS);
+  }
+
+  /** Get flush time threshold in seconds */
+  public long getFlushTimeThresholdSeconds() {
+    return flushTimeThresholdSeconds;
+  }
+
+  /**
+   * Check if provided snowflake kafka connector buffer properties are within permissible values
+   *
+   * @param providedSFConnectorConfig provided by customer
+   * @return true if valid.
+   */
+  public static boolean validateBufferThreshold(
+      Map<String, String> providedSFConnectorConfig, IngestionMethodConfig ingestionMethodConfig) {
+    if (!providedSFConnectorConfig.containsKey(
+        SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC)) {
+      LOGGER.error(
+          Logging.logMessage("{} is empty", SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC));
+      return false;
+    } else {
+      try {
+        long time =
+            Long.parseLong(
+                providedSFConnectorConfig.get(SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC));
+        if (ingestionMethodConfig.equals(IngestionMethodConfig.SNOWPIPE)) {
+          if (time < BUFFER_FLUSH_TIME_SEC_MIN) {
+            LOGGER.error(
+                (Logging.logMessage(
+                    "{} is {}, it should be greater than {}",
+                    SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC,
+                    time,
+                    BUFFER_FLUSH_TIME_SEC_MIN)));
+            return false;
+          }
+        } else {
+          if (time < STREAMING_BUFFER_FLUSH_TIME_MINIMUM_SEC) {
+            LOGGER.error(
+                (Logging.logMessage(
+                    "{} is {}, it should be greater than {}",
+                    SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC,
+                    time,
+                    STREAMING_BUFFER_FLUSH_TIME_MINIMUM_SEC)));
+            return false;
+          }
+        }
+      } catch (Exception e) {
+        LOGGER.error(
+            Logging.logMessage(
+                "{} should be an integer", SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC));
+        return false;
+      }
+    }
+
+    // verify buffer.count.records
+    if (!providedSFConnectorConfig.containsKey(SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS)) {
+      LOGGER.error(
+          Logging.logMessage("{} is empty", SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS));
+      return false;
+    } else {
+      try {
+        long num =
+            Long.parseLong(
+                providedSFConnectorConfig.get(SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS));
+        if (num < 0) {
+          LOGGER.error(
+              Logging.logMessage(
+                  "{} is {}, it should not be negative",
+                  SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS,
+                  num));
+          return false;
+        }
+      } catch (Exception e) {
+        LOGGER.error(
+            Logging.logMessage(
+                "{} should be an integer", SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS));
+        return false;
+      }
+    }
+
+    // verify buffer.size.bytes
+    if (providedSFConnectorConfig.containsKey(SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES)) {
+      try {
+        long bsb =
+            Long.parseLong(
+                providedSFConnectorConfig.get(SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES));
+        if (bsb < SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES_MIN) // 1 byte
+        {
+          LOGGER.error(
+              Logging.logMessage(
+                  "{} is too low at {}. It must be {} or greater.",
+                  SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES,
+                  bsb,
+                  SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES_MIN));
+          return false;
+        }
+      } catch (Exception e) {
+        LOGGER.error(
+            Logging.logMessage(
+                "{} should be an integer", SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES));
+        return false;
+      }
+    } else {
+      LOGGER.error(
+          Logging.logMessage("{} is empty", SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES));
+      return false;
+    }
+    return true;
+  }
+}

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkService.java
@@ -85,6 +85,11 @@ public interface SnowflakeSinkService {
    * change data size of buffer to control the flush rate, the minimum file size is controlled by
    * {@link com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig#BUFFER_SIZE_BYTES_MIN}
    *
+   * <p>Please note: The buffer size for Streaming and snowpipe doesnt necessarily translate to same
+   * file size in Snowflake.
+   *
+   * <p>There is Java to UTF conversion followed by file compression in gzip.
+   *
    * @param size a non negative long number represents data size limitation
    */
   void setFileSize(long size);

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -1,5 +1,9 @@
 package com.snowflake.kafka.connector.internal.streaming;
 
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES_DEFAULT;
+import static com.snowflake.kafka.connector.internal.streaming.StreamingUtils.STREAMING_BUFFER_COUNT_RECORDS_DEFAULT;
+import static com.snowflake.kafka.connector.internal.streaming.StreamingUtils.STREAMING_BUFFER_FLUSH_TIME_DEFAULT_SEC;
+
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.annotations.VisibleForTesting;
 import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
@@ -113,9 +117,9 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
       throw SnowflakeErrors.ERROR_5010.getException();
     }
 
-    this.fileSizeBytes = SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES_DEFAULT;
-    this.recordNum = SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS_DEFAULT;
-    this.flushTimeSeconds = SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC_DEFAULT;
+    this.fileSizeBytes = StreamingUtils.STREAMING_BUFFER_BYTES_DEFAULT;
+    this.recordNum = STREAMING_BUFFER_COUNT_RECORDS_DEFAULT;
+    this.flushTimeSeconds = STREAMING_BUFFER_FLUSH_TIME_DEFAULT_SEC;
     this.conn = conn;
     this.recordService = new RecordService();
     this.telemetryService = conn.getTelemetryClient();
@@ -305,29 +309,28 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
   public void setRecordNumber(long num) {
     if (num < 0) {
       LOGGER.error("number of record in each file is {}, it is negative, reset to 0", num);
-      this.recordNum = 0;
+      this.recordNum = STREAMING_BUFFER_COUNT_RECORDS_DEFAULT;
     } else {
       this.recordNum = num;
-      LOGGER.info("set number of record limitation to {}", num);
+      LOGGER.info("Set number of records for buffer threshold to {}", num);
     }
   }
 
   /**
    * Assume this is buffer size in bytes, since this is streaming ingestion
    *
-   * <p>Copying this from SinkServiceV1 and we will get away from this in future
-   *
-   * @param size a non negative long number represents data size limitation
+   * @param size in bytes - a non negative long number representing size of internal buffer for
+   *     flush.
    */
   @Override
   public void setFileSize(long size) {
     if (size < SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES_MIN) {
       LOGGER.error(
           "Buffer size is {} bytes, it is smaller than the minimum buffer "
-              + "size {} bytes, reset to the default file size",
+              + "size {} bytes, reset to the default buffer size",
           size,
-          SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES_DEFAULT);
-      this.fileSizeBytes = SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES_DEFAULT;
+          BUFFER_SIZE_BYTES_DEFAULT);
+      this.fileSizeBytes = BUFFER_SIZE_BYTES_DEFAULT;
     } else {
       this.fileSizeBytes = size;
       LOGGER.info("set buffer size limitation to {} bytes", size);
@@ -341,13 +344,13 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
 
   @Override
   public void setFlushTime(long time) {
-    if (time < SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC_MIN) {
+    if (time < StreamingUtils.STREAMING_BUFFER_FLUSH_TIME_MINIMUM_SEC) {
       LOGGER.error(
           "flush time is {} seconds, it is smaller than the minimum "
-              + "flush time {} seconds, reset to the minimum flush time",
+              + "flush time {} seconds, reset to the default flush time",
           time,
-          SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC_MIN);
-      this.flushTimeSeconds = SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC_MIN;
+          STREAMING_BUFFER_FLUSH_TIME_DEFAULT_SEC);
+      this.flushTimeSeconds = STREAMING_BUFFER_FLUSH_TIME_DEFAULT_SEC;
     } else {
       this.flushTimeSeconds = time;
       LOGGER.info("set flush time to {} seconds", time);

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -94,9 +94,6 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
   // needs url, username. p8 key, role name
   private SnowflakeStreamingIngestClient streamingIngestClient;
 
-  // This cant be private final since we have setters for various fields.
-  private StreamingBufferThreshold streamingBufferThreshold;
-
   // Config set in JSON
   private final Map<String, String> connectorConfig;
 
@@ -118,8 +115,8 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
     }
 
     this.fileSizeBytes = StreamingUtils.STREAMING_BUFFER_BYTES_DEFAULT;
-    this.recordNum = STREAMING_BUFFER_COUNT_RECORDS_DEFAULT;
-    this.flushTimeSeconds = STREAMING_BUFFER_FLUSH_TIME_DEFAULT_SEC;
+    this.recordNum = StreamingUtils.STREAMING_BUFFER_COUNT_RECORDS_DEFAULT;
+    this.flushTimeSeconds = StreamingUtils.STREAMING_BUFFER_FLUSH_TIME_DEFAULT_SEC;
     this.conn = conn;
     this.recordService = new RecordService();
     this.telemetryService = conn.getTelemetryClient();

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingBufferThreshold.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingBufferThreshold.java
@@ -1,7 +1,6 @@
 package com.snowflake.kafka.connector.internal.streaming;
 
-import java.util.concurrent.TimeUnit;
-import org.apache.kafka.connect.sink.SinkRecord;
+import com.snowflake.kafka.connector.internal.BufferThreshold;
 
 /**
  * Helper class Associated to Streaming Snowpipe runtime of Kafka Connect which can help to identify
@@ -11,87 +10,15 @@ import org.apache.kafka.connect.sink.SinkRecord;
  * net.snowflake.ingest.streaming.SnowflakeStreamingIngestChannel#insertRows(Iterable, String)} API
  * with suitable buffered rows.
  */
-public final class StreamingBufferThreshold {
-  // Buffer flush thresholds set in connector
-  // Set in config (Time based flush) in seconds
-  /**
-   * Set in config (Time based flush) in seconds
-   *
-   * <p>Config parameter: {@link
-   * com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig#BUFFER_FLUSH_TIME_SEC}
-   */
-  private final long flushTimeThresholdSeconds;
-
-  /**
-   * Set in config (buffer size based flush) in bytes
-   *
-   * <p>Config parameter: {@link
-   * com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig#BUFFER_SIZE_BYTES}
-   */
-  private final long bufferSizeThresholdBytes;
-
-  /**
-   * Set in config (Threshold before we call insertRows API) corresponds to # of records in kafka
-   *
-   * <p>Config parameter: {@link
-   * com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig#BUFFER_COUNT_RECORDS}
-   */
-  private final long bufferKafkaRecordCountThreshold;
-
-  private final long SECOND_TO_MILLIS = TimeUnit.SECONDS.toMillis(1);
-
+public class StreamingBufferThreshold extends BufferThreshold {
   public StreamingBufferThreshold(
       long flushTimeThresholdSeconds,
       long bufferSizeThresholdBytes,
       long bufferKafkaRecordCountThreshold) {
-    this.flushTimeThresholdSeconds = flushTimeThresholdSeconds;
-    this.bufferSizeThresholdBytes = bufferSizeThresholdBytes;
-    this.bufferKafkaRecordCountThreshold = bufferKafkaRecordCountThreshold;
-  }
-
-  /**
-   * Returns true if size of current buffer is more than threshold provided (Both in bytes).
-   *
-   * <p>Threshold is config parameter: {@link
-   * com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig#BUFFER_SIZE_BYTES}
-   *
-   * @param currentBufferSizeInBytes current size of buffer in bytes
-   * @return true if bytes threshold has reached.
-   */
-  public boolean isFlushBufferedBytesBased(final long currentBufferSizeInBytes) {
-    return currentBufferSizeInBytes >= bufferSizeThresholdBytes;
-  }
-
-  /**
-   * Returns true if number of ({@link SinkRecord})s in current buffer is more than threshold
-   * provided.
-   *
-   * <p>Threshold is config parameter: {@link
-   * com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig#BUFFER_COUNT_RECORDS}
-   *
-   * @param currentBufferedRecordCount current size of buffer in terms of number of kafka records
-   * @return true if number of kafka threshold has reached in buffer.
-   */
-  public boolean isFlushBufferedRecordCountBased(final long currentBufferedRecordCount) {
-    return currentBufferedRecordCount != 0
-        && currentBufferedRecordCount >= bufferKafkaRecordCountThreshold;
-  }
-
-  /**
-   * If difference between current time and previous flush time is more than threshold return true.
-   *
-   * @param previousFlushTimeStampMs passed from TopicPartitionChannel to know when was previous
-   *     partition flushed.
-   * @return true if time based threshold has reached.
-   */
-  public boolean isFlushTimeBased(final long previousFlushTimeStampMs) {
-    final long currentTimeMs = System.currentTimeMillis();
-    return (currentTimeMs - previousFlushTimeStampMs)
-        >= (this.flushTimeThresholdSeconds * SECOND_TO_MILLIS);
-  }
-
-  /** Get flush time threshold in seconds */
-  public long getFlushTimeThresholdSeconds() {
-    return flushTimeThresholdSeconds;
+    super(
+        IngestionMethodConfig.SNOWPIPE_STREAMING,
+        flushTimeThresholdSeconds,
+        bufferSizeThresholdBytes,
+        bufferKafkaRecordCountThreshold);
   }
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
@@ -18,10 +18,10 @@ public class StreamingUtils {
   protected static final int MAX_GET_OFFSET_TOKEN_RETRIES = 3;
 
   // Buffer related defaults and minimum set at connector level by clients/customers.
-  protected static final long STREAMING_BUFFER_FLUSH_TIME_MINIMUM_SEC =
+  public static final long STREAMING_BUFFER_FLUSH_TIME_MINIMUM_SEC =
       Duration.ofSeconds(1).getSeconds();
 
-  protected static final long STREAMING_BUFFER_FLUSH_TIME_DEFAULT_SEC =
+  public static final long STREAMING_BUFFER_FLUSH_TIME_DEFAULT_SEC =
       Duration.ofSeconds(30).getSeconds();
 
   protected static final long STREAMING_BUFFER_COUNT_RECORDS_DEFAULT = 10_000L;

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
@@ -17,6 +17,25 @@ public class StreamingUtils {
 
   protected static final int MAX_GET_OFFSET_TOKEN_RETRIES = 3;
 
+  // Buffer related defaults and minimum set at connector level by clients/customers.
+  protected static final long STREAMING_BUFFER_FLUSH_TIME_MINIMUM_SEC =
+      Duration.ofSeconds(1).getSeconds();
+
+  protected static final long STREAMING_BUFFER_FLUSH_TIME_DEFAULT_SEC =
+      Duration.ofSeconds(30).getSeconds();
+
+  protected static final long STREAMING_BUFFER_COUNT_RECORDS_DEFAULT = 10_000L;
+
+  /**
+   * Keeping this default as ~ 20MB.
+   *
+   * <p>Logic behind this optimium value is we will do gzip compression and json to UTF conversion
+   * which will account to almost 95% compression.
+   *
+   * <p>1 MB is an ideal size for streaming ingestion so 95% if 20MB = 1MB
+   */
+  protected static final long STREAMING_BUFFER_BYTES_DEFAULT = 20_000_000;
+
   /* Maps streaming client's property keys to what we got from snowflake KC config file. */
   public static Map<String, String> convertConfigForStreamingClient(
       Map<String, String> connectorConfig) {

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
@@ -11,6 +11,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.snowflake.kafka.connector.Utils;
 import com.snowflake.kafka.connector.dlq.KafkaRecordErrorReporter;
+import com.snowflake.kafka.connector.internal.BufferThreshold;
 import com.snowflake.kafka.connector.internal.Logging;
 import com.snowflake.kafka.connector.internal.PartitionBuffer;
 import com.snowflake.kafka.connector.records.RecordService;
@@ -141,7 +142,7 @@ public class TopicPartitionChannel {
   private final boolean isDLQTopicSet;
 
   // Used to identify when to flush (Time, bytes or number of records)
-  private final StreamingBufferThreshold streamingBufferThreshold;
+  private final BufferThreshold streamingBufferThreshold;
 
   /**
    * @param streamingIngestClient client created specifically for this task
@@ -159,7 +160,7 @@ public class TopicPartitionChannel {
       TopicPartition topicPartition,
       final String channelName,
       final String tableName,
-      final StreamingBufferThreshold streamingBufferThreshold,
+      final BufferThreshold streamingBufferThreshold,
       final Map<String, String> sfConnectorConfig,
       KafkaRecordErrorReporter kafkaRecordErrorReporter,
       SinkTaskContext sinkTaskContext) {

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
@@ -6,6 +6,7 @@ import static com.snowflake.kafka.connector.internal.TestUtils.getConfig;
 
 import com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException;
 import com.snowflake.kafka.connector.internal.streaming.IngestionMethodConfig;
+import com.snowflake.kafka.connector.internal.streaming.StreamingUtils;
 import java.util.Locale;
 import java.util.Map;
 import org.junit.Test;
@@ -405,6 +406,86 @@ public class ConnectorConfigTest {
         SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
         IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
     config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
+    Utils.validateConfig(config);
+  }
+
+  // ---------- Streaming Buffer tests ---------- //
+  @Test(expected = SnowflakeKafkaConnectorException.class)
+  public void testStreamingEmptyFlushTime() {
+    Map<String, String> config = getConfig();
+    config.put(
+        SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
+        IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
+    config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
+    config.remove(SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC);
+    Utils.validateConfig(config);
+  }
+
+  @Test(expected = SnowflakeKafkaConnectorException.class)
+  public void testStreamingFlushTimeSmall() {
+    Map<String, String> config = getConfig();
+    config.put(
+        SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
+        IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
+    config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
+    config.put(
+        SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC,
+        (StreamingUtils.STREAMING_BUFFER_FLUSH_TIME_MINIMUM_SEC - 1) + "");
+    Utils.validateConfig(config);
+  }
+
+  @Test(expected = SnowflakeKafkaConnectorException.class)
+  public void testStreamingFlushTimeNotNumber() {
+    Map<String, String> config = getConfig();
+    config.put(
+        SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
+        IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
+    config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
+    config.put(SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC, "fdas");
+    Utils.validateConfig(config);
+  }
+
+  @Test(expected = SnowflakeKafkaConnectorException.class)
+  public void testStreamingEmptyBufferSize() {
+    Map<String, String> config = getConfig();
+    config.put(
+        SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
+        IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
+    config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
+    config.remove(SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES);
+    Utils.validateConfig(config);
+  }
+
+  @Test(expected = SnowflakeKafkaConnectorException.class)
+  public void testStreamingEmptyBufferCount() {
+    Map<String, String> config = getConfig();
+    config.put(
+        SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
+        IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
+    config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
+    config.remove(SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS);
+    Utils.validateConfig(config);
+  }
+
+  @Test(expected = SnowflakeKafkaConnectorException.class)
+  public void testStreamingBufferCountNegative() {
+    Map<String, String> config = getConfig();
+    config.put(
+        SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
+        IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
+    config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
+    config.put(SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS, "-1");
+    Utils.validateConfig(config);
+  }
+
+  @Test(expected = SnowflakeKafkaConnectorException.class)
+  public void testStreamingBufferCountValue() {
+    Map<String, String> config = getConfig();
+    config.put(
+        SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
+        IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
+    config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
+    config.put(SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS, "adssadsa");
     Utils.validateConfig(config);
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorIT.java
@@ -76,7 +76,7 @@ public class ConnectorIT {
     config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_DATABASE, "");
     config.put(SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS, "0");
     config.put(SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES, "0");
-    config.put(SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC, "2");
+    config.put(SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC, "-1");
     config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_ALL, "falseee");
     config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_TOPIC, "falseee");
     config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_OFFSET_AND_PARTITION, "falseee");

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingBufferThresholdTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingBufferThresholdTest.java
@@ -1,5 +1,6 @@
 package com.snowflake.kafka.connector.internal.streaming;
 
+import com.snowflake.kafka.connector.internal.BufferThreshold;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -9,7 +10,7 @@ public class StreamingBufferThresholdTest {
 
     final long bytesThresholdForBuffer = 10_000;
 
-    StreamingBufferThreshold streamingBufferThreshold =
+    BufferThreshold streamingBufferThreshold =
         new StreamingBufferThreshold(10, bytesThresholdForBuffer, 100);
 
     Assert.assertTrue(streamingBufferThreshold.isFlushBufferedBytesBased(bytesThresholdForBuffer));

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelTest.java
@@ -8,6 +8,7 @@ import static com.snowflake.kafka.connector.internal.streaming.StreamingUtils.MA
 import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
 import com.snowflake.kafka.connector.dlq.InMemoryKafkaRecordErrorReporter;
 import com.snowflake.kafka.connector.dlq.KafkaRecordErrorReporter;
+import com.snowflake.kafka.connector.internal.BufferThreshold;
 import com.snowflake.kafka.connector.internal.TestUtils;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
@@ -61,7 +62,7 @@ public class TopicPartitionChannelTest {
 
   private Map<String, String> sfConnectorConfig;
 
-  private StreamingBufferThreshold streamingBufferThreshold;
+  private BufferThreshold streamingBufferThreshold;
 
   private SFException SF_EXCEPTION = new SFException(ErrorCode.INVALID_CHANNEL, "INVALID_CHANNEL");
 


### PR DESCRIPTION
- Refactor code to validate buffer thresholds. 
- Set streaming buffer threshold to different values. 

- "Buffer.flush.time":"30" 
  - Default: 30
  - [Min,Max]: [1,30]
- "Buffer.count.records":"10000" 
  - Default: 10,000
  - [Min, Max]: [1, Inf] 
- "Buffer.size.bytes":"20_000_000"
  - Default: 20,000,000 (~20MB)
  - [Min, Max]: [1, Inf]
