### PR TITLE
SNOW-551298  Use kafka connect-api 3.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -290,7 +290,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-api</artifactId>
-            <version>2.8.1</version>
+            <version>3.1.0</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -338,7 +338,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-api</artifactId>
-            <version>2.8.1</version>
+            <version>3.1.0</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
I reviewed the change notes from 2.8.1 to 3.1.0 
https://kafka.apache.org/downloads

There are no significant changes in connect API. Hence this is safe to update. 