### PR TITLE
Japatel snow 552576 avoid extra memory buffer

### DIFF
--- a/.github/workflows/End2EndFullTest.yml
+++ b/.github/workflows/End2EndFullTest.yml
@@ -29,7 +29,7 @@ jobs:
         pip3 install requests certifi "confluent-kafka[avro,json,protobuf]==1.7.0"
         pip3 install avro-python3 kafka-python
         pip3 install protobuf
-        pip3 install --upgrade snowflake-connector-python
+        pip3 install --upgrade snowflake-connector-python==2.7.4
         curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
         sudo apt-get -y install jq
         sudo apt-get -y install protobuf-compiler

--- a/.github/workflows/End2EndFullTestAzure.yml
+++ b/.github/workflows/End2EndFullTestAzure.yml
@@ -29,7 +29,7 @@ jobs:
         pip3 install requests certifi "confluent-kafka[avro,json,protobuf]==1.7.0"
         pip3 install avro-python3 kafka-python
         pip3 install protobuf
-        pip3 install --upgrade snowflake-connector-python
+        pip3 install --upgrade snowflake-connector-python==2.7.4
         curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
         sudo apt-get -y install jq
         sudo apt-get -y install protobuf-compiler

--- a/.github/workflows/End2EndFullTestGCS.yml
+++ b/.github/workflows/End2EndFullTestGCS.yml
@@ -29,7 +29,7 @@ jobs:
           pip3 install requests certifi "confluent-kafka[avro,json,protobuf]==1.7.0"
           pip3 install avro-python3 kafka-python
           pip3 install protobuf
-          pip3 install --upgrade snowflake-connector-python
+          pip3 install --upgrade snowflake-connector-python==2.7.4
           curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
           sudo apt-get -y install jq
           sudo apt-get -y install protobuf-compiler

--- a/.github/workflows/End2EndTestApacheAws.yml
+++ b/.github/workflows/End2EndTestApacheAws.yml
@@ -31,7 +31,7 @@ jobs:
         pip3 install requests certifi "confluent-kafka[avro,json,protobuf]==1.7.0"
         pip3 install avro-python3 kafka-python
         pip3 install protobuf
-        pip3 install --upgrade snowflake-connector-python
+        pip3 install --upgrade snowflake-connector-python==2.7.4
         curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
         sudo apt-get -y install jq vim
         sudo apt-get -y install protobuf-compiler

--- a/.github/workflows/End2EndTestApacheAzure.yml
+++ b/.github/workflows/End2EndTestApacheAzure.yml
@@ -31,7 +31,7 @@ jobs:
         pip3 install requests certifi "confluent-kafka[avro,json,protobuf]==1.7.0"
         pip3 install avro-python3 kafka-python
         pip3 install protobuf
-        pip3 install --upgrade snowflake-connector-python
+        pip3 install --upgrade snowflake-connector-python==2.7.4
         curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
         sudo apt-get -y install jq
         sudo apt-get -y install protobuf-compiler

--- a/.github/workflows/End2EndTestApacheGCS.yml
+++ b/.github/workflows/End2EndTestApacheGCS.yml
@@ -31,7 +31,7 @@ jobs:
           pip3 install requests certifi "confluent-kafka[avro,json,protobuf]==1.7.0"
           pip3 install avro-python3 kafka-python
           pip3 install protobuf
-          pip3 install --upgrade snowflake-connector-python
+          pip3 install --upgrade snowflake-connector-python==2.7.4
           curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
           sudo apt-get -y install jq vim
           sudo apt-get -y install protobuf-compiler

--- a/.github/workflows/End2EndTestConfluentAws.yml
+++ b/.github/workflows/End2EndTestConfluentAws.yml
@@ -31,7 +31,7 @@ jobs:
         pip3 install requests certifi "confluent-kafka[avro,json,protobuf]==1.7.0"
         pip3 install avro-python3 kafka-python
         pip3 install protobuf
-        pip3 install --upgrade snowflake-connector-python
+        pip3 install --upgrade snowflake-connector-python==2.7.4
         curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
         sudo apt-get -y install jq vim
         sudo apt-get -y install protobuf-compiler

--- a/.github/workflows/End2EndTestConfluentAzure.yml
+++ b/.github/workflows/End2EndTestConfluentAzure.yml
@@ -31,7 +31,7 @@ jobs:
         pip3 install requests certifi "confluent-kafka[avro,json,protobuf]==1.7.0"
         pip3 install avro-python3 kafka-python
         pip3 install protobuf
-        pip3 install --upgrade snowflake-connector-python
+        pip3 install --upgrade snowflake-connector-python==2.7.4
         curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
         sudo apt-get -y install jq vim
         sudo apt-get -y install protobuf-compiler

--- a/.github/workflows/End2EndTestConfluentGCS.yml
+++ b/.github/workflows/End2EndTestConfluentGCS.yml
@@ -31,7 +31,7 @@ jobs:
           pip3 install requests certifi "confluent-kafka[avro,json,protobuf]==1.7.0"
           pip3 install avro-python3 kafka-python
           pip3 install protobuf
-          pip3 install --upgrade snowflake-connector-python
+          pip3 install --upgrade snowflake-connector-python==2.7.4
           curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
           sudo apt-get update
           sudo apt-get -y install jq vim

--- a/.github/workflows/IntegrationTestAws.yml
+++ b/.github/workflows/IntegrationTestAws.yml
@@ -31,7 +31,7 @@ jobs:
         pip3 install requests certifi "confluent-kafka[avro,json,protobuf]==1.7.0"
         pip3 install avro-python3 kafka-python
         pip3 install protobuf
-        pip3 install --upgrade snowflake-connector-python
+        pip3 install --upgrade snowflake-connector-python==2.7.4
         curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
         sudo apt-get -y install jq vim
         sudo apt-get -y install protobuf-compiler

--- a/.github/workflows/IntegrationTestAzure.yml
+++ b/.github/workflows/IntegrationTestAzure.yml
@@ -31,7 +31,7 @@ jobs:
           pip3 install requests certifi "confluent-kafka[avro,json,protobuf]==1.7.0"
           pip3 install avro-python3 kafka-python
           pip3 install protobuf
-          pip3 install --upgrade snowflake-connector-python
+          pip3 install --upgrade snowflake-connector-python==2.7.4
           curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
           sudo apt-get -y install jq vim
           sudo apt-get -y install protobuf-compiler

--- a/.github/workflows/IntegrationTestGCS.yml
+++ b/.github/workflows/IntegrationTestGCS.yml
@@ -31,7 +31,7 @@ jobs:
           pip3 install requests certifi "confluent-kafka[avro,json,protobuf]==1.7.0"
           pip3 install avro-python3 kafka-python
           pip3 install protobuf
-          pip3 install --upgrade snowflake-connector-python
+          pip3 install --upgrade snowflake-connector-python==2.7.4
           curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
           sudo apt-get -y install jq vim
           sudo apt-get -y install protobuf-compiler

--- a/.github/workflows/PerfTest.yml
+++ b/.github/workflows/PerfTest.yml
@@ -35,7 +35,7 @@ jobs:
         pip3 install --upgrade setuptools
         pip3 install "confluent-kafka[avro]"
         pip3 install avro-python3
-        pip3 install --upgrade snowflake-connector-python
+        pip3 install --upgrade snowflake-connector-python==2.7.4
         pip3 install pycrypto
 
     - name: Perf Test

--- a/.github/workflows/StressTest.yml
+++ b/.github/workflows/StressTest.yml
@@ -29,7 +29,7 @@ jobs:
         pip3 install requests certifi "confluent-kafka[avro,json,protobuf]==1.7.0"
         pip3 install avro-python3 kafka-python
         pip3 install protobuf
-        pip3 install --upgrade snowflake-connector-python
+        pip3 install --upgrade snowflake-connector-python==2.7.4
         curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
         sudo apt-get -y install jq
         sudo apt-get -y install protobuf-compiler

--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,8 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.0</version>
                 <configuration>
+                    <!--  https://stackoverflow.com/questions/50498102/how-to-set-jdk-attach-allowattachself-true-globally-->
+                    <argLine>-Djdk.attach.allowAttachSelf=true </argLine>
                     <excludes>
                         <exclude>**/*IT.java</exclude>
                     </excludes>
@@ -429,6 +431,12 @@
             <groupId>dev.failsafe</groupId>
             <artifactId>failsafe</artifactId>
             <version>3.2.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jol</groupId>
+            <artifactId>jol-core</artifactId>
+            <version>0.16</version>
         </dependency>
 
         <!--junit for unit test-->

--- a/pom.xml
+++ b/pom.xml
@@ -152,8 +152,6 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.0</version>
                 <configuration>
-                    <!--  https://stackoverflow.com/questions/50498102/how-to-set-jdk-attach-allowattachself-true-globally-->
-                    <argLine>-Djdk.attach.allowAttachSelf=true </argLine>
                     <excludes>
                         <exclude>**/*IT.java</exclude>
                     </excludes>
@@ -431,12 +429,6 @@
             <groupId>dev.failsafe</groupId>
             <artifactId>failsafe</artifactId>
             <version>3.2.1</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.openjdk.jol</groupId>
-            <artifactId>jol-core</artifactId>
-            <version>0.16</version>
         </dependency>
 
         <!--junit for unit test-->

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -724,7 +724,7 @@ public class SnowflakeSinkConnectorConfig {
           }
         };
 
-    /** All valid enum values */
+    /** @return All valid enum values */
     public static String[] names() {
       ErrorTolerance[] errorTolerances = values();
       String[] result = new String[errorTolerances.length];

--- a/src/main/java/com/snowflake/kafka/connector/internal/BufferThreshold.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/BufferThreshold.java
@@ -111,7 +111,7 @@ public abstract class BufferThreshold {
         >= (this.flushTimeThresholdSeconds * SECOND_TO_MILLIS);
   }
 
-  /** Get flush time threshold in seconds */
+  /** @return Get flush time threshold in seconds */
   public long getFlushTimeThresholdSeconds() {
     return flushTimeThresholdSeconds;
   }

--- a/src/main/java/com/snowflake/kafka/connector/internal/BufferThreshold.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/BufferThreshold.java
@@ -3,6 +3,7 @@ package com.snowflake.kafka.connector.internal;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC_MIN;
 import static com.snowflake.kafka.connector.internal.streaming.StreamingUtils.STREAMING_BUFFER_FLUSH_TIME_MINIMUM_SEC;
 
+import com.google.common.base.MoreObjects;
 import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
 import com.snowflake.kafka.connector.internal.streaming.IngestionMethodConfig;
 import java.util.Map;
@@ -237,5 +238,14 @@ public abstract class BufferThreshold {
       }
     }
     return true;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("flushTimeThresholdSeconds", this.flushTimeThresholdSeconds)
+        .add("bufferSizeThresholdBytes", this.bufferSizeThresholdBytes)
+        .add("bufferKafkaRecordCountThreshold", this.bufferKafkaRecordCountThreshold)
+        .toString();
   }
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -198,7 +198,7 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
     // check all partitions to see if they need to be flushed based on time
     for (TopicPartitionChannel partitionChannel : partitionsToChannel.values()) {
       // Time based flushing
-      partitionChannel.insertBufferedRowsIfFlushTimeThresholdReached();
+      partitionChannel.insertBufferedRecordsIfFlushTimeThresholdReached();
     }
   }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
@@ -16,9 +16,6 @@ import java.util.Set;
 import net.snowflake.ingest.utils.Constants;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.record.DefaultRecord;
-import org.apache.kafka.connect.header.Header;
-import org.apache.kafka.connect.sink.SinkRecord;
-import org.openjdk.jol.info.GraphLayout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -121,8 +118,10 @@ public class StreamingUtils {
   }
 
   /**
-   * Check if Streaming snowpipe related config provided by config(customer's config) has valid and allowed values
-   * @param inputConfig
+   * Check if Streaming snowpipe related config provided by config(customer's config) has valid and
+   * allowed values
+   *
+   * @param inputConfig given in connector json file
    * @return true if valid, also logs error if invalid.
    */
   public static boolean isStreamingSnowpipeConfigValid(final Map<String, String> inputConfig) {
@@ -229,44 +228,5 @@ public class StreamingUtils {
       }
     }
     return true;
-  }
-
-  /**
-   * Get Approximate size of Sink Record which we get from Kafka. This is useful to find out how
-   * much data(records) we have buffered per channel/partition.
-   *
-   * <p>This is an approximate size since there is no API available to find out size of record.
-   *
-   * @param kafkaSinkRecord sink record received as is from Kafka (With connector specific converter
-   *     being invoked)
-   * @return long size of record in bytes.
-   */
-  public static long getApproxSizeOfRecordInBytes(SinkRecord kafkaSinkRecord) {
-    long sinkRecordBufferSizeInBytes = MAX_RECORD_OVERHEAD_BYTES;
-    if (kafkaSinkRecord.keySchema() != null) {
-      sinkRecordBufferSizeInBytes +=
-          GraphLayout.parseInstance(kafkaSinkRecord.keySchema()).totalSize();
-    }
-    if (kafkaSinkRecord.key() != null) {
-      sinkRecordBufferSizeInBytes += GraphLayout.parseInstance(kafkaSinkRecord.key()).totalSize();
-    }
-    if (kafkaSinkRecord.valueSchema() != null) {
-      sinkRecordBufferSizeInBytes +=
-          GraphLayout.parseInstance(kafkaSinkRecord.valueSchema()).totalSize();
-    }
-    if (kafkaSinkRecord.value() != null) {
-      sinkRecordBufferSizeInBytes += GraphLayout.parseInstance(kafkaSinkRecord.value()).totalSize();
-    }
-    if (!kafkaSinkRecord.headers().isEmpty()) {
-      for (Header header : kafkaSinkRecord.headers()) {
-        if (header.key() != null && !header.key().isEmpty()) {
-          sinkRecordBufferSizeInBytes += GraphLayout.parseInstance(header.key()).totalSize();
-        }
-        if (header.value() != null) {
-          sinkRecordBufferSizeInBytes += GraphLayout.parseInstance(header.value()).totalSize();
-        }
-      }
-    }
-    return sinkRecordBufferSizeInBytes;
   }
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
@@ -54,7 +54,9 @@ public class StreamingUtils {
   private static final Set<String> DISALLOWED_CONVERTERS_STREAMING = CUSTOM_SNOWFLAKE_CONVERTERS;
 
   // excluding key, value and headers: 5 bytes length + 10 bytes timestamp + 5 bytes offset + 1
-  // byte attributes
+  // byte attributes. (This is not for record metadata, this is before we transform to snowflake
+  // understood JSON)
+  // This is overhead size for calculating while buffering Kafka records.
   public static final int MAX_RECORD_OVERHEAD_BYTES = DefaultRecord.MAX_RECORD_OVERHEAD;
 
   /* Maps streaming client's property keys to what we got from snowflake KC config file. */

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
@@ -220,11 +220,13 @@ public class TopicPartitionChannel {
           copiedStreamingBuffer = streamingBuffer;
           this.streamingBuffer = new StreamingBuffer();
           LOGGER.debug(
-              "Flush based on buffered bytes or buffered number of records for channel:{},"
-                  + "currentBufferSizeInBytes:{}, currentBufferedRecordCount:{}",
+              "Flush based on buffered bytes or buffered number of records for"
+                  + " channel:{},currentBufferSizeInBytes:{}, currentBufferedRecordCount:{},"
+                  + " connectorBufferThresholds:{}",
               this.getChannelName(),
               copiedStreamingBuffer.getBufferSizeBytes(),
-              copiedStreamingBuffer.getSinkRecords().size());
+              copiedStreamingBuffer.getSinkRecords().size(),
+              this.streamingBufferThreshold);
         }
       } finally {
         bufferLock.unlock();

--- a/src/main/java/com/snowflake/kafka/connector/records/RecordService.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/RecordService.java
@@ -169,7 +169,7 @@ public class RecordService extends Logging {
    * <p>Remember, Snowflake table has two columns, both of them are VARIANT columns whose contents
    * are in JSON
    *
-   * @param record record from Kafka Broker
+   * @param record record from Kafka to (Which was serialized in Json)
    * @return Json String with metadata and actual Payload from Kafka Record
    */
   public Map<String, Object> getProcessedRecordForStreamingIngest(SinkRecord record) {

--- a/src/test/java/com/snowflake/kafka/connector/internal/SinkServiceIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/SinkServiceIT.java
@@ -41,33 +41,6 @@ public class SinkServiceIT {
   private String topic = "test";
   private static ObjectMapper MAPPER = new ObjectMapper();
 
-  private static final String jsonWithSchema =
-      ""
-          + "{\n"
-          + "  \"schema\": {\n"
-          + "    \"type\": \"struct\",\n"
-          + "    \"fields\": [\n"
-          + "      {\n"
-          + "        \"type\": \"string\",\n"
-          + "        \"optional\": false,\n"
-          + "        \"field\": \"regionid\"\n"
-          + "      },\n"
-          + "      {\n"
-          + "        \"type\": \"string\",\n"
-          + "        \"optional\": false,\n"
-          + "        \"field\": \"gender\"\n"
-          + "      }\n"
-          + "    ],\n"
-          + "    \"optional\": false,\n"
-          + "    \"name\": \"ksql.users\"\n"
-          + "  },\n"
-          + "  \"payload\": {\n"
-          + "    \"regionid\": \"Region_5\",\n"
-          + "    \"gender\": \"MALE\"\n"
-          + "  }\n"
-          + "}";
-  private static final String jsonWithoutSchema = "{\"userid\": \"User_1\"}";
-
   @After
   public void afterEach() {
     conn.dropStage(stage);
@@ -352,14 +325,16 @@ public class SinkServiceIT {
     converterConfig.put("schemas.enable", "false");
     converter.configure(converterConfig, false);
     SchemaAndValue noSchemaInputValue =
-        converter.toConnectData(topic, jsonWithoutSchema.getBytes(StandardCharsets.UTF_8));
+        converter.toConnectData(
+            topic, TestUtils.JSON_WITHOUT_SCHEMA.getBytes(StandardCharsets.UTF_8));
 
     converter = new JsonConverter();
     converterConfig = new HashMap<>();
     converterConfig.put("schemas.enable", "false");
     converter.configure(converterConfig, true);
     SchemaAndValue noSchemaInputKey =
-        converter.toConnectData(topic, jsonWithoutSchema.getBytes(StandardCharsets.UTF_8));
+        converter.toConnectData(
+            topic, TestUtils.JSON_WITHOUT_SCHEMA.getBytes(StandardCharsets.UTF_8));
 
     // json with schema
     converter = new JsonConverter();
@@ -367,14 +342,14 @@ public class SinkServiceIT {
     converterConfig.put("schemas.enable", "true");
     converter.configure(converterConfig, false);
     SchemaAndValue schemaInputValue =
-        converter.toConnectData(topic, jsonWithSchema.getBytes(StandardCharsets.UTF_8));
+        converter.toConnectData(topic, TestUtils.JSON_WITH_SCHEMA.getBytes(StandardCharsets.UTF_8));
 
     converter = new JsonConverter();
     converterConfig = new HashMap<>();
     converterConfig.put("schemas.enable", "true");
     converter.configure(converterConfig, true);
     SchemaAndValue schemaInputKey =
-        converter.toConnectData(topic, jsonWithSchema.getBytes(StandardCharsets.UTF_8));
+        converter.toConnectData(topic, TestUtils.JSON_WITH_SCHEMA.getBytes(StandardCharsets.UTF_8));
 
     long startOffset = 0;
     long endOffset = 3;

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2IT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2IT.java
@@ -44,34 +44,6 @@ public class SnowflakeSinkServiceV2IT {
   private TopicPartition topicPartition = new TopicPartition(topic, partition);
   private static ObjectMapper MAPPER = new ObjectMapper();
 
-  private static final String JSON_WITHOUT_SCHEMA = "{\"userid\": \"User_1\"}";
-
-  private static final String JSON_WITH_SCHEMA =
-      ""
-          + "{\n"
-          + "  \"schema\": {\n"
-          + "    \"type\": \"struct\",\n"
-          + "    \"fields\": [\n"
-          + "      {\n"
-          + "        \"type\": \"string\",\n"
-          + "        \"optional\": false,\n"
-          + "        \"field\": \"regionid\"\n"
-          + "      },\n"
-          + "      {\n"
-          + "        \"type\": \"string\",\n"
-          + "        \"optional\": false,\n"
-          + "        \"field\": \"gender\"\n"
-          + "      }\n"
-          + "    ],\n"
-          + "    \"optional\": false,\n"
-          + "    \"name\": \"ksql.users\"\n"
-          + "  },\n"
-          + "  \"payload\": {\n"
-          + "    \"regionid\": \"Region_5\",\n"
-          + "    \"gender\": \"MALE\"\n"
-          + "  }\n"
-          + "}";
-
   @After
   public void afterEach() {
     TestUtils.dropTableStreaming(table);
@@ -314,14 +286,16 @@ public class SnowflakeSinkServiceV2IT {
     converterConfig.put("schemas.enable", "false");
     converter.configure(converterConfig, false);
     SchemaAndValue noSchemaInputValue =
-        converter.toConnectData(topic, JSON_WITHOUT_SCHEMA.getBytes(StandardCharsets.UTF_8));
+        converter.toConnectData(
+            topic, TestUtils.JSON_WITHOUT_SCHEMA.getBytes(StandardCharsets.UTF_8));
 
     converter = new JsonConverter();
     converterConfig = new HashMap<>();
     converterConfig.put("schemas.enable", "false");
     converter.configure(converterConfig, true);
     SchemaAndValue noSchemaInputKey =
-        converter.toConnectData(topic, JSON_WITHOUT_SCHEMA.getBytes(StandardCharsets.UTF_8));
+        converter.toConnectData(
+            topic, TestUtils.JSON_WITHOUT_SCHEMA.getBytes(StandardCharsets.UTF_8));
 
     // json with schema
     converter = new JsonConverter();
@@ -329,14 +303,14 @@ public class SnowflakeSinkServiceV2IT {
     converterConfig.put("schemas.enable", "true");
     converter.configure(converterConfig, false);
     SchemaAndValue schemaInputValue =
-        converter.toConnectData(topic, JSON_WITH_SCHEMA.getBytes(StandardCharsets.UTF_8));
+        converter.toConnectData(topic, TestUtils.JSON_WITH_SCHEMA.getBytes(StandardCharsets.UTF_8));
 
     converter = new JsonConverter();
     converterConfig = new HashMap<>();
     converterConfig.put("schemas.enable", "true");
     converter.configure(converterConfig, true);
     SchemaAndValue schemaInputKey =
-        converter.toConnectData(topic, JSON_WITH_SCHEMA.getBytes(StandardCharsets.UTF_8));
+        converter.toConnectData(topic, TestUtils.JSON_WITH_SCHEMA.getBytes(StandardCharsets.UTF_8));
 
     long startOffset = 0;
     long endOffset = 3;

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelIT.java
@@ -200,9 +200,10 @@ public class TopicPartitionChannelIT {
     streamingBuffer.insert(records.get(0));
 
     try {
-      topicPartitionChannel.insertBufferedRows(streamingBuffer);
+      topicPartitionChannel.insertBufferedRecords(streamingBuffer);
     } catch (RetriableException ex) {
-      InsertValidationResponse response = topicPartitionChannel.insertBufferedRows(streamingBuffer);
+      InsertValidationResponse response =
+          topicPartitionChannel.insertBufferedRecords(streamingBuffer);
       assert !response.hasErrors();
       TestUtils.assertWithRetry(
           () -> service.getOffset(new TopicPartition(topic, PARTITION)) == 2, 20, 5);

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelTest.java
@@ -3,6 +3,7 @@ package com.snowflake.kafka.connector.internal.streaming;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_LOG_ENABLE_CONFIG;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_TOLERANCE_CONFIG;
+import static com.snowflake.kafka.connector.internal.TestUtils.createNativeJsonSinkRecords;
 import static com.snowflake.kafka.connector.internal.streaming.StreamingUtils.MAX_GET_OFFSET_TOKEN_RETRIES;
 
 import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
@@ -605,10 +606,9 @@ public class TopicPartitionChannelTest {
             mockKafkaRecordErrorReporter,
             mockSinkTaskContext);
 
-    // size of each record == 821 bytes
-    // Sending three records will trigger a buffer bytes based threshold after 2 records have been
-    // added
-    List<SinkRecord> records = TestUtils.createJsonStringSinkRecords(0, 3, TOPIC, PARTITION);
+    // Sending 5 records will trigger a buffer bytes based threshold after 4 records have been
+    // added. Size of each record after serialization to Json is 260 Bytes
+    List<SinkRecord> records = createNativeJsonSinkRecords(0, 5, "test", 0);
 
     records.forEach(topicPartitionChannel::insertRecordToBuffer);
 

--- a/test/setup_k8s.sh
+++ b/test/setup_k8s.sh
@@ -46,7 +46,7 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
 
     # install confluent producer and snowflake python driver
     pip3 install --user "confluent-kafka[avro]"
-    pip3 install --user --upgrade snowflake-connector-python
+    pip3 install --user --upgrade snowflake-connector-python==2.7.4
 
 elif [[ "$OSTYPE" == "darwin"* ]]; then
     # Mac OSX


### PR DESCRIPTION
- Transform record only when records are ready to invoke insertRows API.
- Move around code to only buffer kafka record.
- Add utility method to find out size of kafka record.


PS:
- Suggestions are welcomed for finding out size of kafka record. I couldnt find the best possible way hence this hack. 
- The size of this record is a bit more than when we were just calculating the entire row size. (In Snowpipe Ingestion)
- But this size is still lesser than both row + kafka record combined. 
  - Please note, we have to store Kafka record to be able to send it to kafka DLQ. 

I did the testing:
- Approximate number of records buffered in snowpipe and streaming snowpipe case is same even though the objects buffered in memory are different. 

Most recent commit:

- Process the record and find out the size of serialized record.
- Buffer the original kafka record and throw away the serialized version of kafka which we calculated above.
- Once the threshold has reached, we would go over through the buffered kafka records and serialize them again so as to call insertRows API from streaming snowpipe.
- At the moment, we are not allowed to use open jdk library and we might regress in future if we find accurate object size instead of above mentioned hacky way. (Note that size of object from jol library >> size of serialized record, at least 2-3x)
    - Regress because we might buffer less number of records than before even though size of record might have remained same.
    - Long term solution is to not use buffer bytes at all.



