### PR TITLE
NO-SNOW: BUGFIX - Remove unnecessary check for buffer count and add a test

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/PartitionBuffer.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/PartitionBuffer.java
@@ -100,14 +100,6 @@ public abstract class PartitionBuffer<T> {
    */
   public abstract List<SinkRecord> getSinkRecords();
 
-  /**
-   * @return true if no of buffered records == lastOffsetNumber - firstOffsetNumber + 1
-   *     <p>(+1 because first and last offset are inclusive)
-   */
-  public boolean isBufferCountValid() {
-    return this.getNumOfRecords() == (this.getLastOffset() - this.getFirstOffset() + 1);
-  }
-
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
@@ -467,12 +467,6 @@ public class TopicPartitionChannel {
           "Invoking insertRows API for Channel:{}, streamingBuffer:{}",
           this.channel.getFullyQualifiedName(),
           streamingBuffer);
-      Preconditions.checkState(
-          this.streamingBuffer.isBufferCountValid(),
-          String.format(
-              "Number of records in buffer doesn't match with difference of last and first offset"
-                  + " number for channel:%s, buffer:%s",
-              this.channel.getFullyQualifiedName(), streamingBuffer));
       return this.channel.insertRows(
           streamingBuffer.getData(), Long.toString(streamingBuffer.getLastOffset()));
     }

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelIT.java
@@ -149,7 +149,6 @@ public class TopicPartitionChannelIT {
         () -> service.getOffset(new TopicPartition(topic, PARTITION)) == 2, 20, 5);
   }
 
-  @Ignore
   @Test
   public void testAutoChannelReopen_InsertRowsSFException() throws Exception {
     Map<String, String> config = TestUtils.getConfForStreaming();

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelIT.java
@@ -149,6 +149,7 @@ public class TopicPartitionChannelIT {
         () -> service.getOffset(new TopicPartition(topic, PARTITION)) == 2, 20, 5);
   }
 
+  @Ignore
   @Test
   public void testAutoChannelReopen_InsertRowsSFException() throws Exception {
     Map<String, String> config = TestUtils.getConfForStreaming();


### PR DESCRIPTION
Bug:
No need to check for count of records in buffer == (lastOffset number - firstOffset number + 1)

This will not be true when there are bad records sent to Kafka but we would not buffer those bad records resulting into incorrect exception being thrown rather than inserting remaining rows. 


Test included