### PR TITLE
Add a debug statement for insert rows failure

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
@@ -433,6 +433,12 @@ public class TopicPartitionChannel {
     Fallback<Object> reopenChannelFallbackExecutorForInsertRows =
         Fallback.builder(() -> insertRowsFallbackSupplier(buffer))
             .handle(SFException.class)
+            .onFailedAttempt(
+                event ->
+                    LOGGER.warn(
+                        String.format(
+                            "Failed Attempt to invoke the insertRows API for buffer:%s", buffer),
+                        event.getLastException()))
             .onFailure(
                 event ->
                     LOGGER.error(

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelTest.java
@@ -350,7 +350,6 @@ public class TopicPartitionChannelTest {
     Mockito.when(
             mockStreamingChannel.insertRows(
                 ArgumentMatchers.any(Iterable.class), ArgumentMatchers.any(String.class)))
-        .thenThrow(SF_EXCEPTION)
         .thenThrow(SF_EXCEPTION);
 
     // get null from snowflake first time it is called and null for second time too since insert


### PR DESCRIPTION
Found this could be helpful. I wasnt able to figure out why the insertRows API was failing. 