### PR TITLE
Add more connector properties during kafka connect start

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnector.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnector.java
@@ -98,12 +98,7 @@ public class SnowflakeSinkConnector extends SinkConnector {
 
     telemetryClient = conn.getTelemetryClient();
 
-    // maxTasks value isn't visible if the user leaves it at default. So 0
-    // means unknown.
-    int maxTasks =
-        (config.containsKey("tasks.max")) ? Integer.parseInt(config.get("tasks.max")) : 0;
-
-    telemetryClient.reportKafkaStart(connectorStartTime, maxTasks);
+    telemetryClient.reportKafkaConnectStart(connectorStartTime, this.config);
 
     setupComplete = true;
   }

--- a/src/main/java/com/snowflake/kafka/connector/internal/telemetry/SnowflakeTelemetryService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/telemetry/SnowflakeTelemetryService.java
@@ -1,5 +1,7 @@
 package com.snowflake.kafka.connector.internal.telemetry;
 
+import java.util.Map;
+
 public interface SnowflakeTelemetryService {
 
   /**
@@ -20,9 +22,9 @@ public interface SnowflakeTelemetryService {
    * Event of connector start
    *
    * @param startTime task start time
-   * @param maxTasks max number of tasks
+   * @param userProvidedConfig max number of tasks
    */
-  void reportKafkaStart(long startTime, int maxTasks);
+  void reportKafkaConnectStart(long startTime, Map<String, String> userProvidedConfig);
 
   /**
    * Event of connector stop

--- a/src/main/java/com/snowflake/kafka/connector/internal/telemetry/SnowflakeTelemetryServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/telemetry/SnowflakeTelemetryServiceV1.java
@@ -1,8 +1,20 @@
 package com.snowflake.kafka.connector.internal.telemetry;
 
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.DELIVERY_GUARANTEE;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.INGESTION_METHOD_DEFAULT_SNOWPIPE;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.KEY_CONVERTER_CONFIG_FIELD;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.VALUE_CONVERTER_CONFIG_FIELD;
+
+import com.google.common.annotations.VisibleForTesting;
 import com.snowflake.kafka.connector.Utils;
 import com.snowflake.kafka.connector.internal.Logging;
 import java.sql.Connection;
+import java.util.Map;
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.JsonNode;
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.ObjectMapper;
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.node.ObjectNode;
@@ -38,6 +50,11 @@ public class SnowflakeTelemetryServiceV1 extends Logging implements SnowflakeTel
     this.telemetry = TelemetryClient.createTelemetry(conn);
   }
 
+  @VisibleForTesting
+  SnowflakeTelemetryServiceV1(Telemetry telemetry) {
+    this.telemetry = telemetry;
+  }
+
   @Override
   public void setAppName(final String name) {
     this.name = name;
@@ -48,6 +65,18 @@ public class SnowflakeTelemetryServiceV1 extends Logging implements SnowflakeTel
     this.taskID = taskID;
   }
 
+  /**
+   * This is the minimum JsonNode which will be present in each telemetry Payload. Format:
+   *
+   * <pre>
+   * {
+   *  "app_name": "<connector_app_name>",
+   *  "task_id": 1,
+   * }
+   * </pre>
+   *
+   * @return An ObjectNode which is by default always created with certain defined properties in it.
+   */
   private ObjectNode getObjectNode() {
     ObjectNode msg = MAPPER.createObjectNode();
     msg.put(APP_NAME, getAppName());
@@ -56,14 +85,15 @@ public class SnowflakeTelemetryServiceV1 extends Logging implements SnowflakeTel
   }
 
   @Override
-  public void reportKafkaStart(final long startTime, final int maxTasks) {
-    ObjectNode msg = getObjectNode();
+  public void reportKafkaConnectStart(
+      final long startTime, final Map<String, String> userProvidedConfig) {
+    ObjectNode dataObjectNode = getObjectNode();
 
-    msg.put(START_TIME, startTime);
-    msg.put(MAX_TASKS, maxTasks);
-    msg.put(KAFKA_VERSION, AppInfoParser.getVersion());
+    dataObjectNode.put(START_TIME, startTime);
+    dataObjectNode.put(KAFKA_VERSION, AppInfoParser.getVersion());
+    addUserConnectorPropertiesToDataNode(userProvidedConfig, dataObjectNode);
 
-    send(TelemetryType.KAFKA_START, msg);
+    send(TelemetryType.KAFKA_START, dataObjectNode);
   }
 
   @Override
@@ -109,6 +139,25 @@ public class SnowflakeTelemetryServiceV1 extends Logging implements SnowflakeTel
     send(TelemetryType.KAFKA_PIPE_START, msg);
   }
 
+  /**
+   * JsonNode data is wrapped into another ObjectNode which looks like this:
+   *
+   * <pre>
+   *   {
+   *   "data": {
+   *     "app_name": "<app_name>",
+   *     "task_id": "-1"
+   *   },
+   *   "source": "kafka_connector",
+   *   "type": "kafka_start/<One of TelemetryType Enums>",
+   *   "version": "snowflake_kc_version"
+   * }
+   *
+   * </pre>
+   *
+   * @param type type of Data
+   * @param data JsonData to wrap in a json field called data
+   */
   private void send(TelemetryType type, JsonNode data) {
     ObjectNode msg = MAPPER.createObjectNode();
     msg.put(SOURCE, KAFKA_CONNECTOR);
@@ -138,6 +187,49 @@ public class SnowflakeTelemetryServiceV1 extends Logging implements SnowflakeTel
       return "empty_taskID";
     }
     return taskID;
+  }
+
+  /**
+   * Adds specific user provided connector properties to ObjectNode
+   *
+   * @param userProvidedConfig user provided key value pairs in a Map
+   * @param dataObjectNode Object node in which specific properties to add
+   */
+  protected void addUserConnectorPropertiesToDataNode(
+      final Map<String, String> userProvidedConfig, ObjectNode dataObjectNode) {
+    // maxTasks value isn't visible if the user leaves it at default. So 0
+    // means unknown.
+    int maxTasks =
+        (userProvidedConfig.containsKey("tasks.max"))
+            ? Integer.parseInt(userProvidedConfig.get("tasks.max"))
+            : 0;
+    dataObjectNode.put(MAX_TASKS, maxTasks);
+
+    dataObjectNode.put(BUFFER_SIZE_BYTES, userProvidedConfig.get(BUFFER_SIZE_BYTES));
+    dataObjectNode.put(BUFFER_COUNT_RECORDS, userProvidedConfig.get(BUFFER_COUNT_RECORDS));
+    dataObjectNode.put(BUFFER_FLUSH_TIME_SEC, userProvidedConfig.get(BUFFER_FLUSH_TIME_SEC));
+
+    // Set default to Snowpipe if not provided.
+    dataObjectNode.put(
+        INGESTION_METHOD_OPT,
+        userProvidedConfig.getOrDefault(INGESTION_METHOD_OPT, INGESTION_METHOD_DEFAULT_SNOWPIPE));
+
+    // put delivery guarantee only when ingestion method is snowpipe.
+    // For SNOWPIPE_STREAMING, delivery guarantee is always EXACTLY_ONCE
+    if (userProvidedConfig
+        .getOrDefault(INGESTION_METHOD_OPT, INGESTION_METHOD_DEFAULT_SNOWPIPE)
+        .equalsIgnoreCase(INGESTION_METHOD_DEFAULT_SNOWPIPE)) {
+      dataObjectNode.put(
+          DELIVERY_GUARANTEE,
+          userProvidedConfig.getOrDefault(
+              DELIVERY_GUARANTEE, IngestionDeliveryGuarantee.AT_LEAST_ONCE.toString()));
+    }
+
+    // Key and value converters to gauge if Snowflake Native converters are used.
+    dataObjectNode.put(
+        KEY_CONVERTER_CONFIG_FIELD, userProvidedConfig.get(KEY_CONVERTER_CONFIG_FIELD));
+    dataObjectNode.put(
+        VALUE_CONVERTER_CONFIG_FIELD, userProvidedConfig.get(VALUE_CONVERTER_CONFIG_FIELD));
   }
 
   private enum TelemetryType {

--- a/src/test/java/com/snowflake/kafka/connector/internal/telemetry/SnowflakeTelemetryServiceV1Test.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/telemetry/SnowflakeTelemetryServiceV1Test.java
@@ -1,0 +1,243 @@
+package com.snowflake.kafka.connector.internal.telemetry;
+
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.DELIVERY_GUARANTEE;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.KEY_CONVERTER_CONFIG_FIELD;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.VALUE_CONVERTER_CONFIG_FIELD;
+import static com.snowflake.kafka.connector.internal.TestUtils.getConfig;
+
+import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
+import com.snowflake.kafka.connector.internal.streaming.IngestionMethodConfig;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.JsonNode;
+import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.node.ObjectNode;
+import net.snowflake.client.jdbc.telemetry.Telemetry;
+import net.snowflake.client.jdbc.telemetry.TelemetryData;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class SnowflakeTelemetryServiceV1Test {
+
+  MockTelemetryClient mockTelemetryClient;
+
+  SnowflakeTelemetryServiceV1 snowflakeTelemetryServiceV1;
+
+  public static final String KAFKA_STRING_CONVERTER =
+      "org.apache.kafka.connect.storage.StringConverter";
+  public static final String KAFKA_CONFLUENT_AVRO_CONVERTER =
+      "io.confluent.connect.avro.AvroConverter";
+
+  @Before
+  public void beforeEachTest() {
+    mockTelemetryClient = new MockTelemetryClient();
+    snowflakeTelemetryServiceV1 = new SnowflakeTelemetryServiceV1(mockTelemetryClient);
+    snowflakeTelemetryServiceV1.setAppName("TEST_APP");
+
+    snowflakeTelemetryServiceV1.setTaskID("1");
+  }
+
+  @Test
+  public void testReportKafkaStartSnowpipeAtleastOnce() {
+
+    Map<String, String> userProvidedConfig = getConfig();
+    userProvidedConfig.put(INGESTION_METHOD_OPT, IngestionMethodConfig.SNOWPIPE.toString());
+    addKeyAndValueConvertersToConfigMap(userProvidedConfig);
+
+    snowflakeTelemetryServiceV1.reportKafkaConnectStart(
+        System.currentTimeMillis(), userProvidedConfig);
+
+    Assert.assertEquals(1, mockTelemetryClient.getSentTelemetryData().size());
+
+    TelemetryData kafkaStartTelemetryData = mockTelemetryClient.getSentTelemetryData().get(0);
+
+    ObjectNode messageSent = kafkaStartTelemetryData.getMessage();
+
+    JsonNode dataNode = messageSent.get("data");
+
+    Assert.assertNotNull(dataNode);
+    Assert.assertTrue(dataNode.has(INGESTION_METHOD_OPT));
+    Assert.assertTrue(
+        dataNode
+            .get(INGESTION_METHOD_OPT)
+            .asText()
+            .equalsIgnoreCase(IngestionMethodConfig.SNOWPIPE.toString()));
+
+    Assert.assertTrue(dataNode.has(DELIVERY_GUARANTEE));
+    Assert.assertTrue(
+        dataNode
+            .get(DELIVERY_GUARANTEE)
+            .asText()
+            .equalsIgnoreCase(
+                SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee.AT_LEAST_ONCE.toString()));
+
+    validateBufferProperties(dataNode);
+
+    validateKeyAndValueConverter(dataNode);
+  }
+
+  @Test
+  public void testReportKafkaStartSnowpipeExactlyOnce() {
+
+    Map<String, String> userProvidedConfig = getConfig();
+    userProvidedConfig.put(
+        SnowflakeSinkConnectorConfig.DELIVERY_GUARANTEE,
+        SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee.EXACTLY_ONCE.name());
+    addKeyAndValueConvertersToConfigMap(userProvidedConfig);
+
+    snowflakeTelemetryServiceV1.reportKafkaConnectStart(
+        System.currentTimeMillis(), userProvidedConfig);
+
+    Assert.assertEquals(1, mockTelemetryClient.getSentTelemetryData().size());
+
+    TelemetryData kafkaStartTelemetryData = mockTelemetryClient.getSentTelemetryData().get(0);
+
+    ObjectNode messageSent = kafkaStartTelemetryData.getMessage();
+
+    JsonNode dataNode = messageSent.get("data");
+
+    Assert.assertNotNull(dataNode);
+    Assert.assertTrue(dataNode.has(INGESTION_METHOD_OPT));
+    Assert.assertTrue(
+        dataNode
+            .get(INGESTION_METHOD_OPT)
+            .asText()
+            .equalsIgnoreCase(IngestionMethodConfig.SNOWPIPE.toString()));
+
+    Assert.assertTrue(dataNode.has(DELIVERY_GUARANTEE));
+    Assert.assertTrue(
+        dataNode
+            .get(DELIVERY_GUARANTEE)
+            .asText()
+            .equalsIgnoreCase(
+                SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee.EXACTLY_ONCE.toString()));
+
+    validateBufferProperties(dataNode);
+
+    validateKeyAndValueConverter(dataNode);
+  }
+
+  @Test
+  public void testReportKafkaStartSnowpipeStreaming() {
+
+    Map<String, String> userProvidedConfig = getConfig();
+    userProvidedConfig.put(
+        INGESTION_METHOD_OPT, IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
+    userProvidedConfig.put(
+        SnowflakeSinkConnectorConfig.DELIVERY_GUARANTEE,
+        SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee.EXACTLY_ONCE.name());
+
+    addKeyAndValueConvertersToConfigMap(userProvidedConfig);
+
+    snowflakeTelemetryServiceV1.reportKafkaConnectStart(
+        System.currentTimeMillis(), userProvidedConfig);
+
+    Assert.assertEquals(1, mockTelemetryClient.getSentTelemetryData().size());
+
+    TelemetryData kafkaStartTelemetryData = mockTelemetryClient.getSentTelemetryData().get(0);
+
+    ObjectNode messageSent = kafkaStartTelemetryData.getMessage();
+
+    JsonNode dataNode = messageSent.get("data");
+
+    Assert.assertNotNull(dataNode);
+    Assert.assertTrue(dataNode.has(INGESTION_METHOD_OPT));
+    Assert.assertTrue(
+        dataNode
+            .get(INGESTION_METHOD_OPT)
+            .asText()
+            .equalsIgnoreCase(IngestionMethodConfig.SNOWPIPE_STREAMING.toString()));
+
+    validateBufferProperties(dataNode);
+
+    validateKeyAndValueConverter(dataNode);
+  }
+
+  private void addKeyAndValueConvertersToConfigMap(Map<String, String> userProvidedConfig) {
+    userProvidedConfig.put(KEY_CONVERTER_CONFIG_FIELD, KAFKA_STRING_CONVERTER);
+    userProvidedConfig.put(
+        SnowflakeSinkConnectorConfig.VALUE_CONVERTER_CONFIG_FIELD, KAFKA_CONFLUENT_AVRO_CONVERTER);
+  }
+
+  private void validateKeyAndValueConverter(JsonNode dataNode) {
+    Assert.assertTrue(dataNode.has(KEY_CONVERTER_CONFIG_FIELD));
+    Assert.assertTrue(
+        dataNode.get(KEY_CONVERTER_CONFIG_FIELD).asText().equalsIgnoreCase(KAFKA_STRING_CONVERTER));
+
+    Assert.assertTrue(dataNode.has(VALUE_CONVERTER_CONFIG_FIELD));
+    Assert.assertTrue(
+        dataNode
+            .get(VALUE_CONVERTER_CONFIG_FIELD)
+            .asText()
+            .equalsIgnoreCase(KAFKA_CONFLUENT_AVRO_CONVERTER));
+  }
+
+  private void validateBufferProperties(JsonNode dataNode) {
+    Assert.assertTrue(dataNode.has(BUFFER_SIZE_BYTES));
+    Assert.assertTrue(isNumeric(dataNode.get(BUFFER_SIZE_BYTES).asText()));
+
+    Assert.assertTrue(dataNode.has(BUFFER_COUNT_RECORDS));
+    Assert.assertTrue(isNumeric(dataNode.get(BUFFER_COUNT_RECORDS).asText()));
+
+    Assert.assertTrue(dataNode.has(BUFFER_FLUSH_TIME_SEC));
+    Assert.assertTrue(isNumeric(dataNode.get(BUFFER_FLUSH_TIME_SEC).asText()));
+  }
+
+  private static boolean isNumeric(String strNum) {
+    if (strNum == null) {
+      return false;
+    }
+    try {
+      Long.parseLong(strNum);
+    } catch (NumberFormatException nfe) {
+      return false;
+    }
+    return true;
+  }
+
+  private static class MockTelemetryClient implements Telemetry {
+
+    private final LinkedList<TelemetryData> telemetryDataList;
+
+    private final LinkedList<TelemetryData> sentTelemetryData;
+
+    private ExecutorService executor = Executors.newSingleThreadExecutor();
+
+    public MockTelemetryClient() {
+      this.telemetryDataList = new LinkedList<>();
+      this.sentTelemetryData = new LinkedList<>();
+    }
+
+    @Override
+    public void addLogToBatch(TelemetryData telemetryData) {
+      this.telemetryDataList.add(telemetryData);
+    }
+
+    @Override
+    public void close() {
+      this.telemetryDataList.clear();
+      this.sentTelemetryData.clear();
+    }
+
+    @Override
+    public Future<Boolean> sendBatchAsync() {
+      return executor.submit(() -> true);
+    }
+
+    @Override
+    public void postProcess(String s, String s1, int i, Throwable throwable) {}
+
+    public LinkedList<TelemetryData> getSentTelemetryData() {
+      this.sentTelemetryData.addAll(telemetryDataList);
+      this.telemetryDataList.clear();
+      return sentTelemetryData;
+    }
+  }
+}


### PR DESCRIPTION
- No behavior change to existing data format. (Anyways it was not visible to
  customers) But the format is backward compatible for existing SQL
  queries
- Adding new fields to the data node of Json sent during kafka connecter
  start.
- Added unit test for checking format.
- Verified results internally. (on Snowhouse view)