### PR TITLE
no-snow set default flush time to 10 seconds

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
@@ -34,7 +34,7 @@ public class StreamingUtils {
       Duration.ofSeconds(1).getSeconds();
 
   public static final long STREAMING_BUFFER_FLUSH_TIME_DEFAULT_SEC =
-      Duration.ofSeconds(30).getSeconds();
+      Duration.ofSeconds(10).getSeconds();
 
   protected static final long STREAMING_BUFFER_COUNT_RECORDS_DEFAULT = 10_000L;
 


### PR DESCRIPTION
I had forgotten to change the default time to 10 seconds. 

(I had done the cost comparison for 10 seconds too, which was still cheaper than 120 seconds snowpipe for trickle)

I will also make changes in docs, and I think it is still fine to go with 10 seconds even if docs are not updated by the time we release (30 seconds)