### PR TITLE
NO-SNOW join all futures in channel Close

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -261,7 +261,8 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
 
   @Override
   public void closeAll() {
-    LOGGER.info("Closing All partitions:{}", partitionsToChannel.entrySet());
+    LOGGER.info(
+        "Closing All partitions:{}", Arrays.toString(partitionsToChannel.keySet().toArray()));
     closeStreamingIngestChannels(partitionsToChannel.values());
     partitionsToChannel.clear();
     closeStreamingClient();
@@ -274,7 +275,8 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
     topicPartitionChannels.forEach(
         topicPartitionChannel -> partitionCloseFutures.add(topicPartitionChannel.closeChannel()));
     try {
-      // waits for all channels to close and finally does a join on result all futures.
+      // waits for all channels to close and eventually does a join on Future result. (Returned by
+      // allOf)
       CompletableFuture.allOf(
               partitionCloseFutures.toArray(new CompletableFuture[partitionCloseFutures.size()]))
           .join();

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
@@ -13,7 +13,6 @@ import com.google.common.base.Strings;
 import com.snowflake.kafka.connector.Utils;
 import com.snowflake.kafka.connector.dlq.KafkaRecordErrorReporter;
 import com.snowflake.kafka.connector.internal.BufferThreshold;
-import com.snowflake.kafka.connector.internal.Logging;
 import com.snowflake.kafka.connector.internal.PartitionBuffer;
 import com.snowflake.kafka.connector.records.RecordService;
 import com.snowflake.kafka.connector.records.SnowflakeJsonSchema;
@@ -27,7 +26,7 @@ import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Lock;
@@ -870,17 +869,8 @@ public class TopicPartitionChannel {
    * Close channel associated to this partition Not rethrowing connect exception because the
    * connector will stop. Channel will eventually be reopened.
    */
-  public void closeChannel() {
-    try {
-      this.channel.close().get();
-    } catch (InterruptedException | ExecutionException e) {
-      LOGGER.error(
-          Logging.logMessage(
-              "Failure closing Streaming Channel name:{} msg:{}",
-              this.getChannelName(),
-              e.getMessage()),
-          e);
-    }
+  public CompletableFuture<Void> closeChannel() {
+    return this.channel.close();
   }
 
   /* Return true is channel is closed. Caller should handle the logic for reopening the channel if it is closed. */

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
@@ -866,8 +866,11 @@ public class TopicPartitionChannel {
   }
 
   /**
-   * Close channel associated to this partition Not rethrowing connect exception because the
-   * connector will stop. Channel will eventually be reopened.
+   * Close channel associated to this partition
+   *
+   * <p>Not rethrowing connect exception because the connector will stop.
+   *
+   * <p>Channel will eventually be reopened.
    */
   public CompletableFuture<Void> closeChannel() {
     return this.channel.close();

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelTest.java
@@ -16,7 +16,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
 import net.snowflake.ingest.streaming.InsertValidationResponse;
 import net.snowflake.ingest.streaming.OpenChannelRequest;
 import net.snowflake.ingest.streaming.SnowflakeStreamingIngestChannel;
@@ -174,28 +173,6 @@ public class TopicPartitionChannelTest {
     Assert.assertEquals(-1l, topicPartitionChannel.getOffsetPersistedInSnowflake());
 
     Assert.assertTrue(topicPartitionChannel.isPartitionBufferEmpty());
-  }
-
-  @Test
-  public void testCloseChannelException() throws Exception {
-    CompletableFuture mockFuture = Mockito.mock(CompletableFuture.class);
-
-    Mockito.when(mockStreamingChannel.close()).thenReturn(mockFuture);
-    Mockito.when(mockStreamingChannel.getFullyQualifiedName()).thenReturn(TEST_CHANNEL_NAME);
-
-    Mockito.when(mockFuture.get()).thenThrow(new InterruptedException("Interrupted Exception"));
-    TopicPartitionChannel topicPartitionChannel =
-        new TopicPartitionChannel(
-            mockStreamingClient,
-            topicPartition,
-            TEST_CHANNEL_NAME,
-            TEST_TABLE_NAME,
-            streamingBufferThreshold,
-            sfConnectorConfig,
-            mockKafkaRecordErrorReporter,
-            mockSinkTaskContext);
-
-    topicPartitionChannel.closeChannel();
   }
 
   /* Only SFExceptions are retried and goes into fallback. */


### PR DESCRIPTION
- Add IT test, remove a test. 


I was seeing ExecutionException from channelClose() and also,  `CompletableFuture.get()` waits for one channel individually and also throws a checked exception, it is better handled by `allOf` based on best practices. 