### PR TITLE
Add Failed Buffer needed for Schema evolution 

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -152,6 +152,8 @@ public class SnowflakeSinkConnectorConfig {
           + "By default messages are not sent to the dead letter queue. "
           + "Requires property `errors.tolerance=all`.";
 
+  public static final String SCHEMATIZATION_ENABLE_CONFIG = "enable.schematization";
+
   /**
    * Used to serialize the incoming records to kafka connector. Note: Converter code is invoked
    * before actually sending records to Kafka connector.

--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -364,6 +364,18 @@ public class Utils {
       if (!BufferThreshold.validateBufferThreshold(config, IngestionMethodConfig.SNOWPIPE)) {
         configIsValid = false;
       }
+      if (config.containsKey(SnowflakeSinkConnectorConfig.SCHEMATIZATION_ENABLE_CONFIG)) {
+        boolean enableSchematization =
+            Boolean.parseBoolean(
+                config.get(SnowflakeSinkConnectorConfig.SCHEMATIZATION_ENABLE_CONFIG));
+        if (enableSchematization) {
+          configIsValid = false;
+          LOGGER.error(
+              Logging.logMessage(
+                  "Schematization is only available with {}.",
+                  IngestionMethodConfig.SNOWPIPE_STREAMING.toString()));
+        }
+      }
     }
 
     if (config.containsKey(SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP)

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionService.java
@@ -211,6 +211,7 @@ public interface SnowflakeConnectionService {
    * @param content file content
    */
   void putToTableStage(String tableName, String fileName, byte[] content);
+
   /** @return telemetry client */
   SnowflakeTelemetryService getTelemetryClient();
 
@@ -234,4 +235,13 @@ public interface SnowflakeConnectionService {
 
   /** @return the raw jdbc connection */
   Connection getConnection();
+
+  /**
+   * Append a VARIANT type column "RECORD_METADATA" to the table if it is not present.
+   *
+   * <p>This method is only called when schematization is enabled
+   *
+   * @param tableName table name
+   */
+  void appendMetaColIfNotExist(String tableName);
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
@@ -46,6 +46,10 @@ public class SnowflakeConnectionServiceV1 extends Logging implements SnowflakeCo
   // User agent suffix we want to pass in to ingest service
   public static final String USER_AGENT_SUFFIX_FORMAT = "SFKafkaConnector/%s provider/%s";
 
+  private static final String METADATA_COLUMN = "RECORD_METADATA";
+
+  private static final String CONTENT_COLUMN = "RECORD_CONTENT";
+
   SnowflakeConnectionServiceV1(
       Properties prop,
       SnowflakeURL url,
@@ -286,12 +290,12 @@ public class SnowflakeConnectionServiceV1 extends Logging implements SnowflakeCo
       boolean allNullable = true;
       while (result.next()) {
         switch (result.getString(1)) {
-          case "RECORD_METADATA":
+          case METADATA_COLUMN:
             if (result.getString(2).equals("VARIANT")) {
               hasMeta = true;
             }
             break;
-          case "RECORD_CONTENT":
+          case CONTENT_COLUMN:
             if (result.getString(2).equals("VARIANT")) {
               hasContent = true;
             }
@@ -324,6 +328,50 @@ public class SnowflakeConnectionServiceV1 extends Logging implements SnowflakeCo
       }
     }
     return compatible;
+  }
+
+  @Override
+  public void appendMetaColIfNotExist(final String tableName) {
+    checkConnection();
+    InternalUtils.assertNotEmpty("tableName", tableName);
+    String query = "desc table identifier(?)";
+    PreparedStatement stmt = null;
+    ResultSet result = null;
+    boolean hasMeta = false;
+    boolean isVariant = false;
+    try {
+      stmt = conn.prepareStatement(query);
+      stmt.setString(1, tableName);
+      result = stmt.executeQuery();
+      while (result.next()) {
+        // The result schema is row idx | column name | data type | kind | null? | ...
+        if (result.getString(1).equals(METADATA_COLUMN)) {
+          hasMeta = true;
+          if (result.getString(2).equals("VARIANT")) {
+            isVariant = true;
+          }
+          break;
+        }
+      }
+    } catch (SQLException e) {
+      logError("table {} doesn't exist", tableName);
+      throw SnowflakeErrors.ERROR_2014.getException("table name: " + tableName);
+    }
+    try {
+      if (!isVariant) {
+        String metaQuery;
+        if (!hasMeta) {
+          metaQuery = "alter table identifier(?) add RECORD_METADATA VARIANT";
+        } else {
+          throw SnowflakeErrors.ERROR_2012.getException("table name: " + tableName);
+        }
+        stmt = conn.prepareStatement(metaQuery);
+        stmt.setString(1, tableName);
+        stmt.executeQuery();
+      }
+    } catch (SQLException e) {
+      throw SnowflakeErrors.ERROR_2013.getException("table name: " + tableName);
+    }
   }
 
   @Override

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeErrors.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeErrors.java
@@ -150,6 +150,17 @@ public enum SnowflakeErrors {
       "2011",
       "Failed to upload file with cache",
       "Failed to upload file to Snowflake Stage though credential caching"),
+  ERROR_2012(
+      "2012",
+      "Failed to append metadata column",
+      "Failed to append metadata column due to an existing metadata column with non-VARIANT"
+          + " type."),
+  ERROR_2013(
+      "2013",
+      "Failed to append metadata column",
+      "Failed to append metadata column, please check that you have permission to do so."),
+  ERROR_2014(
+      "2014", "Table not exists", "Table not exists. It might have been deleted externally."),
   // Snowpipe related issues 3---
   ERROR_3001("3001", "Failed to ingest file", "Exception reported by Ingest SDK"),
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -130,7 +130,8 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
 
     this.connectorConfig = connectorConfig;
 
-    this.enableSchematization = this.recordService.setEnableSchematization(this.connectorConfig);
+    this.enableSchematization =
+        this.recordService.setEnableSchematizationFromConfig(this.connectorConfig);
 
     this.taskId = connectorConfig.getOrDefault(Utils.TASK_ID, "-1");
     this.streamingIngestClientName =

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -101,6 +101,8 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
 
   private final String streamingIngestClientName;
 
+  private boolean enableSchematization;
+
   /**
    * Key is formulated in {@link #partitionChannelKey(String, int)} }
    *
@@ -127,6 +129,9 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
     this.behaviorOnNullValues = SnowflakeSinkConnectorConfig.BehaviorOnNullValues.DEFAULT;
 
     this.connectorConfig = connectorConfig;
+
+    this.enableSchematization = this.recordService.setSchematizationEnable(this.connectorConfig);
+
     this.taskId = connectorConfig.getOrDefault(Utils.TASK_ID, "-1");
     this.streamingIngestClientName =
         STREAMING_CLIENT_PREFIX_NAME + conn.getConnectorName() + "_" + taskId;
@@ -197,6 +202,7 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
       // threshold.
       insert(record);
     }
+
     // check all partitions to see if they need to be flushed based on time
     for (TopicPartitionChannel partitionChannel : partitionsToChannel.values()) {
       // Time based flushing
@@ -491,10 +497,14 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
 
   private void createTableIfNotExists(final String tableName) {
     if (this.conn.tableExist(tableName)) {
-      if (this.conn.isTableCompatible(tableName)) {
-        LOGGER.info("Using existing table {}.", tableName);
+      if (!this.enableSchematization) {
+        if (this.conn.isTableCompatible(tableName)) {
+          LOGGER.info("Using existing table {}.", tableName);
+        } else {
+          throw SnowflakeErrors.ERROR_5003.getException("table name: " + tableName);
+        }
       } else {
-        throw SnowflakeErrors.ERROR_5003.getException("table name: " + tableName);
+        this.conn.appendMetaColIfNotExist(tableName);
       }
     } else {
       LOGGER.info("Creating new table {}.", tableName);

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -130,7 +130,7 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
 
     this.connectorConfig = connectorConfig;
 
-    this.enableSchematization = this.recordService.setSchematizationEnable(this.connectorConfig);
+    this.enableSchematization = this.recordService.setEnableSchematization(this.connectorConfig);
 
     this.taskId = connectorConfig.getOrDefault(Utils.TASK_ID, "-1");
     this.streamingIngestClientName =

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
@@ -202,7 +202,7 @@ public class TopicPartitionChannel {
     this.sinkTaskContext = Preconditions.checkNotNull(sinkTaskContext);
 
     this.recordService = new RecordService();
-    this.recordService.setEnableSchematization(sfConnectorConfig);
+    this.recordService.setEnableSchematizationFromConfig(sfConnectorConfig);
 
     this.previousFlushTimeStampMs = System.currentTimeMillis();
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
@@ -72,7 +72,10 @@ public class TopicPartitionChannel {
   /* Buffer to hold JSON converted incoming SinkRecords */
   private StreamingBuffer streamingBuffer;
 
-  final Lock bufferLock = new ReentrantLock(true);
+  /* Buffer to hold SinkRecords that failed to get inserted */
+  private StreamingBuffer failedBuffer;
+
+  private final Lock bufferLock = new ReentrantLock(true);
 
   /**
    * States whether this channel has received any records before.
@@ -170,6 +173,9 @@ public class TopicPartitionChannel {
   // Used to identify when to flush (Time, bytes or number of records)
   private final BufferThreshold streamingBufferThreshold;
 
+  // Whether schematization has been enabled.
+  private boolean enableSchematization;
+
   /**
    * @param streamingIngestClient client created specifically for this task
    * @param topicPartition topic partition corresponding to this Streaming Channel
@@ -202,7 +208,8 @@ public class TopicPartitionChannel {
     this.sinkTaskContext = Preconditions.checkNotNull(sinkTaskContext);
 
     this.recordService = new RecordService();
-    this.recordService.setEnableSchematizationFromConfig(sfConnectorConfig);
+    this.enableSchematization =
+        this.recordService.setEnableSchematizationFromConfig(sfConnectorConfig);
 
     this.previousFlushTimeStampMs = System.currentTimeMillis();
 
@@ -578,6 +585,20 @@ public class TopicPartitionChannel {
             offsetRecoveredFromSnowflake),
         ex);
   }
+
+  /**
+   * Collect the extra columns reported by the insertErrors.
+   *
+   * @param insertErrors errors from validation response. (Only if it has errors)
+   * @return whether the errors in insertErrors are all 'extra columns' error (so that
+   *     schematization could be performed)
+   */
+  private boolean collectExtraColumns(List<InsertValidationResponse.InsertError> insertErrors) {
+    for (InsertValidationResponse.InsertError insertError : insertErrors) {}
+  }
+
+  /** */
+  private void insertRecordsToFailedBuffer() {}
 
   /**
    * Invoked only when {@link InsertValidationResponse} has errors.

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
@@ -202,7 +202,7 @@ public class TopicPartitionChannel {
     this.sinkTaskContext = Preconditions.checkNotNull(sinkTaskContext);
 
     this.recordService = new RecordService();
-    this.recordService.setSchematizationEnable(sfConnectorConfig);
+    this.recordService.setEnableSchematization(sfConnectorConfig);
 
     this.previousFlushTimeStampMs = System.currentTimeMillis();
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
@@ -239,11 +239,11 @@ public class TopicPartitionChannel {
    *
    * @param kafkaSinkRecord input record from Kafka
    */
-  public boolean insertRecordToBuffer(SinkRecord kafkaSinkRecord) {
+  public void insertRecordToBuffer(SinkRecord kafkaSinkRecord) {
     precomputeOffsetTokenForChannel(kafkaSinkRecord);
 
     if (shouldIgnoreAddingRecordToBuffer(kafkaSinkRecord)) {
-      return false;
+      return;
     }
 
     // discard the record if the record offset is smaller or equal to server side offset, or if
@@ -291,7 +291,7 @@ public class TopicPartitionChannel {
           currentOffsetPersistedInSnowflake,
           currentProcessedOffset);
     }
-    return false;
+    return;
   }
 
   /**
@@ -438,7 +438,7 @@ public class TopicPartitionChannel {
    *
    * <p>Previous flush time here means last time we called insertRows API with rows present in
    */
-  protected InsertValidationResponse insertBufferedRecordsIfFlushTimeThresholdReached() {
+  protected void insertBufferedRecordsIfFlushTimeThresholdReached() {
     if (this.streamingBufferThreshold.isFlushTimeBased(this.previousFlushTimeStampMs)) {
       LOGGER.debug(
           "Time based flush for channel:{}, CurrentTimeMs:{}, previousFlushTimeMs:{},"
@@ -456,10 +456,9 @@ public class TopicPartitionChannel {
         bufferLock.unlock();
       }
       if (copiedStreamingBuffer != null) {
-        return insertBufferedRecords(copiedStreamingBuffer);
+        insertBufferedRecords(copiedStreamingBuffer);
       }
     }
-    return null;
   }
 
   /**

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
@@ -202,6 +202,8 @@ public class TopicPartitionChannel {
     this.sinkTaskContext = Preconditions.checkNotNull(sinkTaskContext);
 
     this.recordService = new RecordService();
+    this.recordService.setSchematizationEnable(sfConnectorConfig);
+
     this.previousFlushTimeStampMs = System.currentTimeMillis();
 
     this.streamingBuffer = new StreamingBuffer();
@@ -368,6 +370,10 @@ public class TopicPartitionChannel {
     return content != null && ((SnowflakeRecordContent) content).isBroken();
   }
 
+  /**
+   * TODO: SNOW-630885 - When schematization is enabled, we should create the map directly from the
+   * SinkRecord instead of first turning it into json
+   */
   private SinkRecord handleNativeRecord(SinkRecord record, boolean isKey) {
     SnowflakeRecordContent newSFContent;
     Schema schema = isKey ? record.keySchema() : record.valueSchema();
@@ -408,6 +414,7 @@ public class TopicPartitionChannel {
   }
 
   // --------------- BUFFER FLUSHING LOGIC --------------- //
+
   /**
    * If difference between current time and previous flush time is more than threshold, insert the
    * buffered Rows.
@@ -611,6 +618,7 @@ public class TopicPartitionChannel {
   }
 
   // TODO: SNOW-529755 POLL committed offsets in backgraound thread
+
   /**
    * Get committed offset from Snowflake. It does an HTTP call internally to find out what was the
    * last offset inserted.
@@ -998,6 +1006,7 @@ public class TopicPartitionChannel {
   }
 
   // ------ INNER CLASS ------ //
+
   /**
    * A buffer which holds the rows before calling insertRows API. It implements the PartitionBuffer
    * class which has all common fields about a buffer.

--- a/src/main/java/com/snowflake/kafka/connector/records/RecordService.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/RecordService.java
@@ -64,7 +64,7 @@ public class RecordService extends Logging {
   private static final String KEY_SCHEMA_ID = "key_schema_id";
   static final String HEADERS = "headers";
 
-  private boolean schematizationEnable = false;
+  private boolean enableSchematization = false;
 
   // For each task, we require a separate instance of SimpleDataFormat, since they are not
   // inherently thread safe
@@ -96,15 +96,23 @@ public class RecordService extends Logging {
     metadataConfig = metadataConfigIn;
   }
 
-  public boolean setSchematizationEnable(final Map<String, String> connectorConfig) {
+  /**
+   * extract enableSchematization from the connector config and set the value for the recordService
+   *
+   * <p>The extracted boolean is returned for external usage.
+   *
+   * @param connectorConfig the connector config map
+   * @return a boolean indicating whether schematization is enabled
+   */
+  public boolean setEnableSchematization(final Map<String, String> connectorConfig) {
     if (connectorConfig.containsKey(SnowflakeSinkConnectorConfig.SCHEMATIZATION_ENABLE_CONFIG)) {
-      schematizationEnable =
+      enableSchematization =
           Boolean.parseBoolean(
               connectorConfig.get(SnowflakeSinkConnectorConfig.SCHEMATIZATION_ENABLE_CONFIG));
     } else {
-      schematizationEnable = false;
+      enableSchematization = false;
     }
-    return schematizationEnable;
+    return enableSchematization;
   }
 
   /**
@@ -199,7 +207,7 @@ public class RecordService extends Logging {
     final Map<String, Object> streamingIngestRow = new HashMap<>();
     for (JsonNode node : row.content.getData()) {
       try {
-        if (schematizationEnable) {
+        if (enableSchematization) {
           Iterator<String> fieldNames = node.fieldNames();
           while (fieldNames.hasNext()) {
             String fieldName = fieldNames.next();

--- a/src/main/java/com/snowflake/kafka/connector/records/RecordService.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/RecordService.java
@@ -28,6 +28,7 @@ import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.TimeZone;
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.core.JsonProcessingException;
@@ -37,8 +38,14 @@ import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.node.ArrayN
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.node.JsonNodeFactory;
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.kafka.common.record.TimestampType;
-import org.apache.kafka.connect.data.*;
+import org.apache.kafka.connect.data.ConnectSchema;
 import org.apache.kafka.connect.data.Date;
+import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.data.Time;
+import org.apache.kafka.connect.data.Timestamp;
 import org.apache.kafka.connect.header.Header;
 import org.apache.kafka.connect.header.Headers;
 import org.apache.kafka.connect.sink.SinkRecord;
@@ -56,6 +63,8 @@ public class RecordService extends Logging {
   static final String SCHEMA_ID = "schema_id";
   private static final String KEY_SCHEMA_ID = "key_schema_id";
   static final String HEADERS = "headers";
+
+  private boolean schematizationEnable = false;
 
   // For each task, we require a separate instance of SimpleDataFormat, since they are not
   // inherently thread safe
@@ -85,6 +94,17 @@ public class RecordService extends Logging {
 
   public void setMetadataConfig(SnowflakeMetadataConfig metadataConfigIn) {
     metadataConfig = metadataConfigIn;
+  }
+
+  public boolean setSchematizationEnable(final Map<String, String> connectorConfig) {
+    if (connectorConfig.containsKey(SnowflakeSinkConnectorConfig.SCHEMATIZATION_ENABLE_CONFIG)) {
+      schematizationEnable =
+          Boolean.parseBoolean(
+              connectorConfig.get(SnowflakeSinkConnectorConfig.SCHEMATIZATION_ENABLE_CONFIG));
+    } else {
+      schematizationEnable = false;
+    }
+    return schematizationEnable;
   }
 
   /**
@@ -169,6 +189,8 @@ public class RecordService extends Logging {
    * <p>Remember, Snowflake table has two columns, both of them are VARIANT columns whose contents
    * are in JSON
    *
+   * <p>When schematization is enabled, the content of the record is extracted into a map
+   *
    * @param record record from Kafka to (Which was serialized in Json)
    * @return Json String with metadata and actual Payload from Kafka Record
    */
@@ -177,7 +199,20 @@ public class RecordService extends Logging {
     final Map<String, Object> streamingIngestRow = new HashMap<>();
     for (JsonNode node : row.content.getData()) {
       try {
-        streamingIngestRow.put(TABLE_COLUMN_CONTENT, MAPPER.writeValueAsString(node));
+        if (schematizationEnable) {
+          Iterator<String> fieldNames = node.fieldNames();
+          while (fieldNames.hasNext()) {
+            String fieldName = fieldNames.next();
+            JsonNode fieldNode = node.get(fieldName);
+            String filedContent =
+                fieldNode.isTextual()
+                    ? fieldNode.textValue()
+                    : MAPPER.writeValueAsString(fieldNode);
+            streamingIngestRow.put(fieldName, filedContent);
+          }
+        } else {
+          streamingIngestRow.put(TABLE_COLUMN_CONTENT, MAPPER.writeValueAsString(node));
+        }
         if (metadataConfig.allFlag) {
           streamingIngestRow.put(TABLE_COLUMN_METADATA, MAPPER.writeValueAsString(row.metadata));
         }
@@ -420,11 +455,11 @@ public class RecordService extends Logging {
    *
    * <p>If the value is an empty JSON node, we could assume the value passed was null.
    *
-   * @see com.snowflake.kafka.connector.records.SnowflakeJsonConverter#toConnectData when bytes ==
-   *     null case
    * @param record record sent from Kafka to KC
    * @param behaviorOnNullValues behavior passed inside KC
    * @return true if we would skip adding it to buffer
+   * @see com.snowflake.kafka.connector.records.SnowflakeJsonConverter#toConnectData when bytes ==
+   *     null case
    */
   public boolean shouldSkipNullValue(
       SinkRecord record,

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
@@ -560,4 +560,26 @@ public class ConnectorConfigTest {
         "org.apache.kafka.connect.storage.StringConverter");
     Utils.validateConfig(config);
   }
+
+  @Test(expected = SnowflakeKafkaConnectorException.class)
+  public void testInvalidSchematizationForSnowpipe() {
+    Map<String, String> config = getConfig();
+    config.put(
+        SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
+        IngestionMethodConfig.SNOWPIPE.toString());
+    config.put(SnowflakeSinkConnectorConfig.SCHEMATIZATION_ENABLE_CONFIG, "true");
+    config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
+    Utils.validateConfig(config);
+  }
+
+  @Test
+  public void testValidSchematizationForStreamingSnowpipe() {
+    Map<String, String> config = getConfig();
+    config.put(
+        SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
+        IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
+    config.put(SnowflakeSinkConnectorConfig.SCHEMATIZATION_ENABLE_CONFIG, "true");
+    config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
+    Utils.validateConfig(config);
+  }
 }

--- a/test/rest_request_template/travis_correct_schema_mapping.json
+++ b/test/rest_request_template/travis_correct_schema_mapping.json
@@ -1,0 +1,28 @@
+{
+  "name": "SNOWFLAKE_CONNECTOR_NAME",
+  "config": {
+    "connector.class": "com.snowflake.kafka.connector.SnowflakeSinkConnector",
+    "snowflake.role.name": "TESTROLE_KAFKA",
+    "topics": "SNOWFLAKE_TEST_TOPIC",
+    "tasks.max": "1",
+    "buffer.flush.time": "10",
+    "buffer.count.records": "100",
+    "buffer.size.bytes": "5000000",
+    "snowflake.url.name": "SNOWFLAKE_HOST",
+    "snowflake.user.name": "SNOWFLAKE_USER",
+    "snowflake.private.key": "SNOWFLAKE_PRIVATE_KEY",
+    "snowflake.database.name": "SNOWFLAKE_DATABASE",
+    "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
+    "snowflake.role.name": "SNOWFLAKE_ROLE",
+    "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
+    "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+    "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+    "value.converter.schemas.enable": "false",
+    "jmx": "true",
+    "errors.tolerance": "all",
+    "errors.log.enable": true,
+    "errors.deadletterqueue.topic.name": "DLQ_TOPIC",
+    "errors.deadletterqueue.topic.replication.factor": 1,
+    "schematization.enable": true
+  }
+}

--- a/test/rest_request_template/travis_correct_schema_mapping.json
+++ b/test/rest_request_template/travis_correct_schema_mapping.json
@@ -23,6 +23,6 @@
     "errors.log.enable": true,
     "errors.deadletterqueue.topic.name": "DLQ_TOPIC",
     "errors.deadletterqueue.topic.replication.factor": 1,
-    "schematization.enable": true
+    "enable.schematization": true
   }
 }

--- a/test/test_suit/test_schema_mapping.py
+++ b/test/test_suit/test_schema_mapping.py
@@ -1,7 +1,8 @@
 from test_suit.test_utils import RetryableError, NonRetryableError
 import json
 
-
+# test if each type of data fit into the right column with the right type
+# also test if the metadata column is automatically added
 class TestSchemaMapping:
     def __init__(self, driver, nameSalt):
         self.driver = driver
@@ -9,7 +10,7 @@ class TestSchemaMapping:
         self.topic = self.fileName + nameSalt
 
         self.driver.snowflake_conn.cursor().execute(
-            "Create or replace table {} (PERFORMANCE_STRING STRING, PERFORMANCE_CHAR CHAR, PERFORMANCE_HEX BINARY, RATING_INT NUMBER, RATING_DOUBLE DOUBLE, APPROVAL BOOLEAN, APPROVAL_DATE DATE, APPROVAL_TIME TIME)".format(self.topic))
+            "Create or replace table {} (PERFORMANCE_STRING STRING, PERFORMANCE_CHAR CHAR, PERFORMANCE_HEX BINARY, RATING_INT NUMBER, RATING_DOUBLE DOUBLE, APPROVAL BOOLEAN, APPROVAL_DATE DATE, APPROVAL_TIME TIME, INFO_ARRAY ARRAY, INFO VARIANT)".format(self.topic))
 
         self.record = {
             'PERFORMANCE_STRING': 'Excellent',
@@ -19,9 +20,14 @@ class TestSchemaMapping:
             'RATING_DOUBLE': 0.99,
             'APPROVAL': 'true',
             'APPROVAL_DATE': '15-Jun-2022',
-            'APPROVAL_TIME': '23:59:59.999999999'
+            'APPROVAL_TIME': '23:59:59.999999999',
+            'INFO_ARRAY': ['HELLO', 'WORLD'],
+            'INFO': {
+                'TREE_1': 'APPLE',
+                'TREE_2': 'PINEAPPLE'
+            }
         }
-        self.record_literal = r"{'PERFORMANCE_STRING': 'Excellent', 'PERFORMANCE_CHAR': 'A','PERFORMANCE_HEX': 'FFFFFFFF','RATING_INT': 100,'RATING_DOUBLE': 0.99,'APPROVAL': 'true','APPROVAL_DATE': '15-Jun-2022','APPROVAL_TIME': '23:59:59.999999999'}"
+        self.record_literal = r"{'PERFORMANCE_STRING': 'Excellent', 'PERFORMANCE_CHAR': 'A','PERFORMANCE_HEX': 'FFFFFFFF','RATING_INT': 100,'RATING_DOUBLE': 0.99,'APPROVAL': 'true','APPROVAL_DATE': '15-Jun-2022','APPROVAL_TIME': '23:59:59.999999999','INFO_ARRAY': ['HELLO', 'WORLD'],'INFO': {'TREE_1': 'APPLE','TREE_2': 'PINEAPPLE'}}"
 
     def getConfigFileName(self):
         return self.fileName + ".json"
@@ -65,8 +71,6 @@ class TestSchemaMapping:
         goldMeta = r'{"key":{"number":"0"},"offset":0,"partition":0}'
         self.record['RECORD_METADATA'] = goldMeta
         self.driver.regexMatchOneLineSchematized(res, res_col, self.record)
-        
-        # self.driver.regexMatchOneLine(res, goldMeta, self.record_literal)
 
     def clean(self):
         self.driver.cleanTableStagePipe(self.topic)

--- a/test/test_suit/test_schema_mapping.py
+++ b/test/test_suit/test_schema_mapping.py
@@ -1,0 +1,72 @@
+from test_suit.test_utils import RetryableError, NonRetryableError
+import json
+
+
+class TestSchemaMapping:
+    def __init__(self, driver, nameSalt):
+        self.driver = driver
+        self.fileName = "travis_correct_schema_mapping"
+        self.topic = self.fileName + nameSalt
+
+        self.driver.snowflake_conn.cursor().execute(
+            "Create or replace table {} (PERFORMANCE_STRING STRING, PERFORMANCE_CHAR CHAR, PERFORMANCE_HEX BINARY, RATING_INT NUMBER, RATING_DOUBLE DOUBLE, APPROVAL BOOLEAN, APPROVAL_DATE DATE, APPROVAL_TIME TIME)".format(self.topic))
+
+        self.record = {
+            'PERFORMANCE_STRING': 'Excellent',
+            'PERFORMANCE_CHAR': 'A',
+            'PERFORMANCE_HEX': 'FFFFFFFF',
+            'RATING_INT': 100,
+            'RATING_DOUBLE': 0.99,
+            'APPROVAL': 'true',
+            'APPROVAL_DATE': '15-Jun-2022',
+            'APPROVAL_TIME': '23:59:59.999999999'
+        }
+        self.record_literal = r"{'PERFORMANCE_STRING': 'Excellent', 'PERFORMANCE_CHAR': 'A','PERFORMANCE_HEX': 'FFFFFFFF','RATING_INT': 100,'RATING_DOUBLE': 0.99,'APPROVAL': 'true','APPROVAL_DATE': '15-Jun-2022','APPROVAL_TIME': '23:59:59.999999999'}"
+
+    def getConfigFileName(self):
+        return self.fileName + ".json"
+
+    def send(self):
+        key = []
+        value = []
+        for e in range(100):
+            key.append(json.dumps({'number': str(e)}).encode('utf-8'))
+            value.append(json.dumps(self.record).encode('utf-8'))
+        self.driver.sendBytesData(self.topic, value, key)
+
+    def verify(self, round):
+        rows = self.driver.snowflake_conn.cursor().execute(
+            "desc table {}".format(self.topic)).fetchall()
+
+        metadata_exist = False
+        for row in rows:
+            if row[0] == 'RECORD_METADATA':
+                metadata_exist = True
+        if not metadata_exist:
+            raise NonRetryableError("Metadata column was not created")
+
+        res = self.driver.snowflake_conn.cursor().execute(
+            "SELECT count(*) FROM {}".format(self.topic)).fetchone()[0]
+        if res == 0:
+            raise RetryableError()
+        elif res != 100:
+            raise NonRetryableError("Number of record in table is different from number of record sent")
+
+        # validate content of line 1
+        res = self.driver.snowflake_conn.cursor().execute(
+            "Select * from {} limit 1".format(self.topic)).fetchone()
+        res_col_info = self.driver.snowflake_conn.cursor().execute(
+            "Select * from INFORMATION_SCHEMA.COLUMNS where TABLE_NAME = '{}'".format(self.topic)).fetchall();
+        res_col = {}
+        for col in res_col_info:
+            res_col[col[3]] = col[4] - 1
+        # res_col maps column names to column index
+
+        goldMeta = r'{"key":{"number":"0"},"offset":0,"partition":0}'
+        self.record['RECORD_METADATA'] = goldMeta
+        self.driver.regexMatchOneLineSchematized(res, res_col, self.record)
+        
+        # self.driver.regexMatchOneLine(res, goldMeta, self.record_literal)
+
+    def clean(self):
+        self.driver.cleanTableStagePipe(self.topic)

--- a/test/test_verify.py
+++ b/test/test_verify.py
@@ -242,7 +242,7 @@ class KafkaTest:
                 .replace("[", "\\[").replace("]", "\\]").replace("+", "\\+") + "$"
             if re.search(goldRegex, content) is None:
                 raise test_suit.test_utils.NonRetryableError("Record column:\n{}\ndoes not match gold regex "
-                                                             "label:\n{}".format(content, gol))
+                                                             "label:\n{}".format(content, goldRegex))
 
     def updateConnectorConfig(self, fileName, connectorName, configMap):
         with open('./rest_request_generated/' + fileName + '.json') as f:
@@ -448,7 +448,7 @@ def runTestSet(driver, testSet, nameSalt, pressure):
 
     testStringJsonProxy = TestStringJsonProxy(driver, nameSalt)
 
-    # # Run this test on both confluent and apache kafka
+    # Run this test on both confluent and apache kafka
     testSnowpipeStreamingStringJson = TestSnowpipeStreamingStringJson(driver, nameSalt)
 
     # will run this only in confluent cloud since, since in apache kafka e2e tests, we don't start schema registry


### PR DESCRIPTION
Added logic related to a buffer containing the records that failed to get inserted. Only records with 'extra columns error will be inserted. 

When there are errors with type other than 'extra column', or enableSchematization is not enabled, it will fall back to normal behavior.