### PR TITLE
SNOW-645776 Part 2 Stress Tests run on Confluent's Different Versions Against Different Cloud

### DIFF
--- a/.github/workflows/StressTest.yml
+++ b/.github/workflows/StressTest.yml
@@ -1,9 +1,6 @@
 name: Kafka Connector Stress Test
 
 on:
-  schedule:
-    - cron:  '0 8 * * 6' # at 8.00 on Saturday
-  # This is for Testing against this PR, remove it later before pushing
   push:
     branches: [ master ]
   pull_request:

--- a/.github/workflows/StressTest.yml
+++ b/.github/workflows/StressTest.yml
@@ -3,10 +3,19 @@ name: Kafka Connector Stress Test
 on:
   schedule:
     - cron:  '0 8 * * 6' # at 8.00 on Saturday
+  # This is for Testing against this PR, remove it later before pushing
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: '**'
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        confluent_version: [ '5.5.11', '6.2.6', '7.2.1' ]
+        snowflake_cloud: [ 'AWS', 'AZURE', 'GCS' ]
     steps:
     - name: Checkout Code
       uses: actions/checkout@v2
@@ -15,20 +24,21 @@ jobs:
       with:
         java-version: 1.8
     - name: Install Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
-        python-version: '3.6'
+        python-version: '3.9'
         architecture: 'x64'
-    - name: Decrypt profile.json
-      run: ./.github/scripts/decrypt_secret.sh 'aws'
+    - name: Decrypt profile.json in Snowflake Cloud ${{ matrix.snowflake_cloud }}
+      run: ./.github/scripts/decrypt_secret.sh ${{ matrix.snowflake_cloud }}
       env:
         SNOWFLAKE_TEST_PROFILE_SECRET: ${{ secrets.SNOWFLAKE_TEST_PROFILE_SECRET }}
     - name: Install Dependency
       run: |
         pip3 install --upgrade setuptools
+        sudo apt-get install librdkafka-dev
         pip3 install requests certifi "confluent-kafka[avro,json,protobuf]==1.7.0"
         pip3 install avro-python3 kafka-python
-        pip3 install protobuf
+        pip3 install --upgrade protobuf==3.20.0
         pip3 install --upgrade snowflake-connector-python==2.7.4
         curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
         sudo apt-get -y install jq
@@ -48,7 +58,7 @@ jobs:
         sudo mv .github/scripts/squid.conf /etc/squid/squid.conf
         sudo service squid start
     
-    - name: Build with Unit and Integration Test
+    - name: Build with Unit Test
       env:
         JACOCO_COVERAGE: true
         SNOWFLAKE_CREDENTIAL_FILE: "../profile.json"
@@ -57,13 +67,10 @@ jobs:
         cd test
         ./build_apache.sh ../../snowflake-kafka-connector package
 
-    - name: End to End Test of Confluent Platform 5.5
+    - name: Stress Tests of Confluent Platform Version ${{ matrix.confluent_version }} against Snowflake in ${{ matrix.snowflake_cloud }}
       env:
         SNOWFLAKE_CREDENTIAL_FILE: "../profile.json"
+      continue-on-error: true
       run: |
         cd test
-        ./run_test_confluent.sh 5.5.0 ./apache_properties true
-
-
-
-
+        ./run_test_confluent.sh ${{ matrix.confluent_version }} ./apache_properties true

--- a/test/test_suit/test_pressure.py
+++ b/test/test_suit/test_pressure.py
@@ -7,7 +7,7 @@ class TestPressure:
     def __init__(self, driver, nameSalt):
         self.driver = driver
         self.topics = []
-        self.topicNum = 200
+        self.topicNum = 2
         self.partitionNum = 12
         self.recordNum = 10000
         self.curTest = 0
@@ -50,6 +50,7 @@ class TestPressure:
             res = self.driver.snowflake_conn.cursor().execute(
                 "SELECT count(*) FROM {}".format(self.topics[t])).fetchone()[0]
             if res != self.partitionNum * self.recordNum * (round + 1):
+                print("Round", round, "Result", res, "topicNum", t)
                 raise RetryableError()
 
             if self.curTest <= t:

--- a/test/test_suit/test_pressure.py
+++ b/test/test_suit/test_pressure.py
@@ -7,7 +7,7 @@ class TestPressure:
     def __init__(self, driver, nameSalt):
         self.driver = driver
         self.topics = []
-        self.topicNum = 2
+        self.topicNum = 200
         self.partitionNum = 12
         self.recordNum = 10000
         self.curTest = 0

--- a/test/test_suit/test_pressure.py
+++ b/test/test_suit/test_pressure.py
@@ -17,14 +17,16 @@ class TestPressure:
         for i in range(self.topicNum):
             self.topics.append(self.fileName + str(i) + nameSalt)
 
+        for t in range(self.topicNum):
+            self.driver.createTopics(self.topics[t], self.partitionNum, 1)
+
+        sleep(5)
+
     def getConfigFileName(self):
         return self.fileName + ".json"
 
     def send(self):
         threadPool = ThreadPool(self.threadCount)
-        for t in range(self.topicNum):
-            self.driver.createTopics(self.topics[t], self.partitionNum, 1)
-        sleep(5)
 
         args = []
         for t in range(self.topicNum):

--- a/test/test_suit/test_pressure_restart.py
+++ b/test/test_suit/test_pressure_restart.py
@@ -1,5 +1,6 @@
 from test_suit.test_utils import RetryableError, NonRetryableError, ResetAndRetry
 import json
+from time import sleep
 
 class TestPressureRestart:
     def __init__(self, driver, nameSalt):
@@ -16,13 +17,15 @@ class TestPressureRestart:
         for i in range(self.topicNum):
             self.topics.append(self.fileName + str(i) + nameSalt)
 
+        for t in range(self.topicNum):
+            self.driver.createTopics(self.topics[t], self.partitionNum, 1)
+
+        sleep(5)
+
     def getConfigFileName(self):
         return self.fileName + ".json"
 
     def send(self):
-        for t in range(self.topicNum):
-            self.driver.createTopics(self.topics[t], self.partitionNum, 1)
-
         for p in range(self.partitionNum):
             for t in range(self.topicNum):
                 value = []

--- a/test/test_verify.py
+++ b/test/test_verify.py
@@ -438,7 +438,7 @@ def runStressTests(driver, testSet, nameSalt):
     elif testSet != "clean":
         errorExit("Unknown testSet option {}, please input confluent, apache or clean".format(testSet))
 
-    execution(testSet, testSuitList, testCleanEnableList, testSuitEnableList, driver, nameSalt, round=1)
+    execution(testSet, testSuitList, testCleanEnableList, testSuitEnableList, driver, nameSalt, round=2)
     ############################ Stress Tests Round 2 ############################
 
 def runTestSet(driver, testSet, nameSalt, enable_stress_test):

--- a/test/test_verify.py
+++ b/test/test_verify.py
@@ -47,7 +47,7 @@ class KafkaTest:
 
         self.SEND_INTERVAL = 0.01  # send a record every 10 ms
         self.VERIFY_INTERVAL = 60  # verify every 60 secs
-        self.MAX_RETRY = 120  # max wait time 120 mins
+        self.MAX_RETRY = 30  # max wait time 30 mins
         self.MAX_FLUSH_BUFFER_SIZE = 5000  # flush buffer when 10000 data was in the queue
 
         self.kafkaConnectAddress = kafkaConnectAddress
@@ -413,12 +413,12 @@ def runStressTests(driver, testSet, nameSalt):
     print(datetime.now().strftime("\n%H:%M:%S "), "=== Stress Tests Round 1 ===")
     testSuitList = [testPressureRestart]
 
-    testCleanEnableList = [True]
+    testCleanEnableList = [False]
     testSuitEnableList = []
     if testSet == "confluent":
-        testSuitEnableList = [True]
+        testSuitEnableList = [False]
     elif testSet == "apache":
-        testSuitEnableList = [True]
+        testSuitEnableList = [False]
     elif testSet != "clean":
         errorExit("Unknown testSet option {}, please input confluent, apache or clean".format(testSet))
 
@@ -438,7 +438,7 @@ def runStressTests(driver, testSet, nameSalt):
     elif testSet != "clean":
         errorExit("Unknown testSet option {}, please input confluent, apache or clean".format(testSet))
 
-    execution(testSet, testSuitList, testCleanEnableList, testSuitEnableList, driver, nameSalt, round=4)
+    execution(testSet, testSuitList, testCleanEnableList, testSuitEnableList, driver, nameSalt, round=1)
     ############################ Stress Tests Round 2 ############################
 
 def runTestSet(driver, testSet, nameSalt, enable_stress_test):

--- a/test/test_verify.py
+++ b/test/test_verify.py
@@ -413,16 +413,16 @@ def runStressTests(driver, testSet, nameSalt):
     print(datetime.now().strftime("\n%H:%M:%S "), "=== Stress Tests Round 1 ===")
     testSuitList = [testPressureRestart]
 
-    testCleanEnableList = [False]
+    testCleanEnableList = [True]
     testSuitEnableList = []
     if testSet == "confluent":
-        testSuitEnableList = [False]
+        testSuitEnableList = [True]
     elif testSet == "apache":
-        testSuitEnableList = [False]
+        testSuitEnableList = [True]
     elif testSet != "clean":
         errorExit("Unknown testSet option {}, please input confluent, apache or clean".format(testSet))
 
-    execution(testSet, testSuitList, testCleanEnableList, testSuitEnableList, driver, nameSalt, round=2)
+    execution(testSet, testSuitList, testCleanEnableList, testSuitEnableList, driver, nameSalt, round=1)
     ############################ Stress Tests Round 1 ############################
 
     ############################ Stress Tests Round 2 ############################

--- a/test/test_verify.py
+++ b/test/test_verify.py
@@ -438,7 +438,7 @@ def runStressTests(driver, testSet, nameSalt):
     elif testSet != "clean":
         errorExit("Unknown testSet option {}, please input confluent, apache or clean".format(testSet))
 
-    execution(testSet, testSuitList, testCleanEnableList, testSuitEnableList, driver, nameSalt, round=2)
+    execution(testSet, testSuitList, testCleanEnableList, testSuitEnableList, driver, nameSalt, round=1)
     ############################ Stress Tests Round 2 ############################
 
 def runTestSet(driver, testSet, nameSalt, enable_stress_test):

--- a/test/test_verify.py
+++ b/test/test_verify.py
@@ -337,7 +337,7 @@ class KafkaTest:
         print("Post HTTP request to Create Connector:{0}".format(post_url))
         r = requests.post(post_url, json=json.loads(fileContent), headers=self.httpHeader)
         print("Response Content Json " + json.dumps(r.json()))
-        print(datetime.now().strftime("%H:%M:%S "), json.loads(r.content.decode("utf-8"))["name"], r.status_code)
+        print(datetime.now().strftime("%H:%M:%S "), r.status_code)
         getConnectorResponse = requests.get(post_url)
         print("Get Connectors status:{0}, response:{1}".format(getConnectorResponse.status_code, getConnectorResponse.content))
 
@@ -396,170 +396,181 @@ def runDeliveryGuaranteeTests(driver, testSet, nameSalt):
 
     execution(testSet, testSuitList6, testCleanEnableList6, testSuitEnableList6, driver, nameSalt)
 
-def runTestSet(driver, testSet, nameSalt, enable_stress_test):
-    from test_suit.test_string_json import TestStringJson
-    from test_suit.test_string_json_proxy import TestStringJsonProxy
-    from test_suit.test_json_json import TestJsonJson
-    from test_suit.test_string_avro import TestStringAvro
-    from test_suit.test_avro_avro import TestAvroAvro
-    from test_suit.test_string_avrosr import TestStringAvrosr
-    from test_suit.test_avrosr_avrosr import TestAvrosrAvrosr
 
-    from test_suit.test_native_string_avrosr import TestNativeStringAvrosr
-    from test_suit.test_native_string_json_without_schema import TestNativeStringJsonWithoutSchema
-    from test_suit.test_native_complex_smt import TestNativeComplexSmt
+
+# These tests run from StressTest.yml file and not ran while running End-To-End Tests
+def runStressTests(driver, testSet, nameSalt):
     from test_suit.test_pressure import TestPressure
     from test_suit.test_pressure_restart import TestPressureRestart
 
-    from test_suit.test_native_string_protobuf import TestNativeStringProtobuf
-    from test_suit.test_confluent_protobuf_protobuf import TestConfluentProtobufProtobuf
-
-    from test_suit.test_snowpipe_streaming_string_json import TestSnowpipeStreamingStringJson
-    from test_suit.test_snowpipe_streaming_string_avro_sr import TestSnowpipeStreamingStringAvroSR
-
-    from test_suit.test_multiple_topic_to_one_table_snowpipe_streaming import TestMultipleTopicToOneTableSnowpipeStreaming
-    from test_suit.test_multiple_topic_to_one_table_snowpipe import TestMultipleTopicToOneTableSnowpipe
-
-    from test_suit.test_schema_mapping import TestSchemaMapping
-
-    from test_suit.test_auto_table_creation import TestAutoTableCreation
-    from test_suit.test_auto_table_creation_topic2table import TestAutoTableCreationTopic2Table
-
-    testStringJson = TestStringJson(driver, nameSalt)
-    testJsonJson = TestJsonJson(driver, nameSalt)
-    testStringAvro = TestStringAvro(driver, nameSalt)
-    testAvroAvro = TestAvroAvro(driver, nameSalt)
-    testStringAvrosr = TestStringAvrosr(driver, nameSalt)
-    testAvrosrAvrosr = TestAvrosrAvrosr(driver, nameSalt)
-
-    testNativeStringAvrosr = TestNativeStringAvrosr(driver, nameSalt)
-    testNativeStringJsonWithoutSchema = TestNativeStringJsonWithoutSchema(driver, nameSalt)
-    testNativeComplexSmt = TestNativeComplexSmt(driver, nameSalt)
     testPressure = TestPressure(driver, nameSalt)
+
+    # This test is more of a chaos test where we pause, delete, restart connectors to verify behavior.
     testPressureRestart = TestPressureRestart(driver, nameSalt)
 
-    testNativeStringProtobuf = TestNativeStringProtobuf(driver, nameSalt)
-    testConfluentProtobufProtobuf = TestConfluentProtobufProtobuf(driver, nameSalt)
+    ############################ Stress Tests Round 1 ############################
+    # TestPressure and TestPressureRestart will only run when Running StressTests
+    print(datetime.now().strftime("\n%H:%M:%S "), "=== Stress Tests Round 1 ===")
+    testSuitList = [testPressureRestart]
 
-    testStringJsonProxy = TestStringJsonProxy(driver, nameSalt)
-
-    # Run this test on both confluent and apache kafka
-    testSnowpipeStreamingStringJson = TestSnowpipeStreamingStringJson(driver, nameSalt)
-
-    # will run this only in confluent cloud since, since in apache kafka e2e tests, we don't start schema registry
-    testSnowpipeStreamingStringAvro = TestSnowpipeStreamingStringAvroSR(driver, nameSalt)
-
-    testMultipleTopicToOneTableSnowpipeStreaming = TestMultipleTopicToOneTableSnowpipeStreaming(driver, nameSalt)
-    testMultipleTopicToOneTableSnowpipe = TestMultipleTopicToOneTableSnowpipe(driver, nameSalt)
-
-    testSchemaMapping = TestSchemaMapping(driver, nameSalt)
-
-    testAutoTableCreation = TestAutoTableCreation(driver, nameSalt, schemaRegistryAddress, testSet)
-    testAutoTableCreationTopic2Table = TestAutoTableCreationTopic2Table(driver, nameSalt, schemaRegistryAddress, testSet)
-
-    ############################ round 1 ############################
-    print(datetime.now().strftime("\n%H:%M:%S "), "=== Round 1 ===")
-    testSuitList1 = [
-        testStringJson, testJsonJson, testStringAvro, testAvroAvro, testStringAvrosr,
-        testAvrosrAvrosr, testNativeStringAvrosr, testNativeStringJsonWithoutSchema,
-        testNativeComplexSmt, testNativeStringProtobuf, testConfluentProtobufProtobuf,
-        testSnowpipeStreamingStringJson, testSnowpipeStreamingStringAvro,
-        testMultipleTopicToOneTableSnowpipeStreaming, testMultipleTopicToOneTableSnowpipe,
-        testSchemaMapping,
-        testAutoTableCreation, testAutoTableCreationTopic2Table
-    ]
-
-    # Adding StringJsonProxy test at the end
-    testCleanEnableList1 = [
-        True, True, True, True, True, True, True, True, True, True, True,
-        True, True,
-        True, True,
-        True,
-        True, True
-    ]
-    testSuitEnableList1 = []
+    testCleanEnableList = [True]
+    testSuitEnableList = []
     if testSet == "confluent":
-        testSuitEnableList1 = [
-            True, True, True, True, True, True, True, True, True, True, False,
+        testSuitEnableList = [True]
+    elif testSet == "apache":
+        testSuitEnableList = [True]
+    elif testSet != "clean":
+        errorExit("Unknown testSet option {}, please input confluent, apache or clean".format(testSet))
+
+    execution(testSet, testSuitList, testCleanEnableList, testSuitEnableList, driver, nameSalt, round=2)
+    ############################ Stress Tests Round 1 ############################
+
+    ############################ Stress Tests Round 2 ############################
+    print(datetime.now().strftime("\n%H:%M:%S "), "=== Stress Tests Round 2 ===")
+    testSuitList = [testPressure]
+
+    testCleanEnableList = [True]
+    testSuitEnableList = []
+    if testSet == "confluent":
+        testSuitEnableList = [True]
+    elif testSet == "apache":
+        testSuitEnableList = [True]
+    elif testSet != "clean":
+        errorExit("Unknown testSet option {}, please input confluent, apache or clean".format(testSet))
+
+    execution(testSet, testSuitList, testCleanEnableList, testSuitEnableList, driver, nameSalt, round=4)
+    ############################ Stress Tests Round 2 ############################
+
+def runTestSet(driver, testSet, nameSalt, enable_stress_test):
+    if enable_stress_test:
+        runStressTests(driver, testSet, nameSalt)
+    else:
+        from test_suit.test_string_json import TestStringJson
+        from test_suit.test_string_json_proxy import TestStringJsonProxy
+        from test_suit.test_json_json import TestJsonJson
+        from test_suit.test_string_avro import TestStringAvro
+        from test_suit.test_avro_avro import TestAvroAvro
+        from test_suit.test_string_avrosr import TestStringAvrosr
+        from test_suit.test_avrosr_avrosr import TestAvrosrAvrosr
+
+        from test_suit.test_native_string_avrosr import TestNativeStringAvrosr
+        from test_suit.test_native_string_json_without_schema import TestNativeStringJsonWithoutSchema
+        from test_suit.test_native_complex_smt import TestNativeComplexSmt
+
+        from test_suit.test_native_string_protobuf import TestNativeStringProtobuf
+        from test_suit.test_confluent_protobuf_protobuf import TestConfluentProtobufProtobuf
+
+        from test_suit.test_snowpipe_streaming_string_json import TestSnowpipeStreamingStringJson
+        from test_suit.test_snowpipe_streaming_string_avro_sr import TestSnowpipeStreamingStringAvroSR
+
+        from test_suit.test_multiple_topic_to_one_table_snowpipe_streaming import TestMultipleTopicToOneTableSnowpipeStreaming
+        from test_suit.test_multiple_topic_to_one_table_snowpipe import TestMultipleTopicToOneTableSnowpipe
+
+        from test_suit.test_schema_mapping import TestSchemaMapping
+
+        from test_suit.test_auto_table_creation import TestAutoTableCreation
+        from test_suit.test_auto_table_creation_topic2table import TestAutoTableCreationTopic2Table
+
+        testStringJson = TestStringJson(driver, nameSalt)
+        testJsonJson = TestJsonJson(driver, nameSalt)
+        testStringAvro = TestStringAvro(driver, nameSalt)
+        testAvroAvro = TestAvroAvro(driver, nameSalt)
+        testStringAvrosr = TestStringAvrosr(driver, nameSalt)
+        testAvrosrAvrosr = TestAvrosrAvrosr(driver, nameSalt)
+
+        testNativeStringAvrosr = TestNativeStringAvrosr(driver, nameSalt)
+        testNativeStringJsonWithoutSchema = TestNativeStringJsonWithoutSchema(driver, nameSalt)
+        testNativeComplexSmt = TestNativeComplexSmt(driver, nameSalt)
+
+        testNativeStringProtobuf = TestNativeStringProtobuf(driver, nameSalt)
+        testConfluentProtobufProtobuf = TestConfluentProtobufProtobuf(driver, nameSalt)
+
+        testStringJsonProxy = TestStringJsonProxy(driver, nameSalt)
+
+        # Run this test on both confluent and apache kafka
+        testSnowpipeStreamingStringJson = TestSnowpipeStreamingStringJson(driver, nameSalt)
+
+        # will run this only in confluent cloud since, since in apache kafka e2e tests, we don't start schema registry
+        testSnowpipeStreamingStringAvro = TestSnowpipeStreamingStringAvroSR(driver, nameSalt)
+
+        testMultipleTopicToOneTableSnowpipeStreaming = TestMultipleTopicToOneTableSnowpipeStreaming(driver, nameSalt)
+        testMultipleTopicToOneTableSnowpipe = TestMultipleTopicToOneTableSnowpipe(driver, nameSalt)
+
+        testSchemaMapping = TestSchemaMapping(driver, nameSalt)
+
+        testAutoTableCreation = TestAutoTableCreation(driver, nameSalt, schemaRegistryAddress, testSet)
+        testAutoTableCreationTopic2Table = TestAutoTableCreationTopic2Table(driver, nameSalt, schemaRegistryAddress, testSet)
+
+        ############################ round 1 ############################
+        print(datetime.now().strftime("\n%H:%M:%S "), "=== Round 1 ===")
+        testSuitList1 = [
+            testStringJson, testJsonJson, testStringAvro, testAvroAvro, testStringAvrosr,
+            testAvrosrAvrosr, testNativeStringAvrosr, testNativeStringJsonWithoutSchema,
+            testNativeComplexSmt, testNativeStringProtobuf, testConfluentProtobufProtobuf,
+            testSnowpipeStreamingStringJson, testSnowpipeStreamingStringAvro,
+            testMultipleTopicToOneTableSnowpipeStreaming, testMultipleTopicToOneTableSnowpipe,
+            testSchemaMapping,
+            testAutoTableCreation, testAutoTableCreationTopic2Table
+        ]
+
+        # Adding StringJsonProxy test at the end
+        testCleanEnableList1 = [
+            True, True, True, True, True, True, True, True, True, True, True,
             True, True,
             True, True,
             True,
             True, True
         ]
-    elif testSet == "apache":
-        testSuitEnableList1 = [
-            True, True, True, True, False, False, False, True, True, True, False,
-            True, False,
-            True, True,
-            True,
-            False, False
-        ]
-    elif testSet != "clean":
-        errorExit("Unknown testSet option {}, please input confluent, apache or clean".format(testSet))
+        testSuitEnableList1 = []
+        if testSet == "confluent":
+            testSuitEnableList1 = [
+                True, True, True, True, True, True, True, True, True, True, False,
+                True, True,
+                True, True,
+                True,
+                True, True
+            ]
+        elif testSet == "apache":
+            testSuitEnableList1 = [
+                True, True, True, True, False, False, False, True, True, True, False,
+                True, False,
+                True, True,
+                True,
+                False, False
+            ]
+        elif testSet != "clean":
+            errorExit("Unknown testSet option {}, please input confluent, apache or clean".format(testSet))
 
-    execution(testSet, testSuitList1, testCleanEnableList1, testSuitEnableList1, driver, nameSalt)
-    ############################ round 1 ############################
+        execution(testSet, testSuitList1, testCleanEnableList1, testSuitEnableList1, driver, nameSalt)
+        ############################ round 1 ############################
 
-    ############################ round 2 ############################
-    # TestPressure and TestPressureRestart will only run when Running StressTests
-    print(datetime.now().strftime("\n%H:%M:%S "), "=== Round 2 ===")
-    testSuitList2 = [testPressureRestart]
-
-    testCleanEnableList2 = [enable_stress_test]
-    testSuitEnableList2 = []
-    if testSet == "confluent":
-        testSuitEnableList2 = [enable_stress_test]
-    elif testSet == "apache":
-        testSuitEnableList2 = [enable_stress_test]
-    elif testSet != "clean":
-        errorExit("Unknown testSet option {}, please input confluent, apache or clean".format(testSet))
-
-    execution(testSet, testSuitList2, testCleanEnableList2, testSuitEnableList2, driver, nameSalt, 2)
-    ############################ round 2 ############################
-
-    ############################ round 3 ############################
-    print(datetime.now().strftime("\n%H:%M:%S "), "=== Round 3 ===")
-    testSuitList3 = [testPressure]
-
-    testCleanEnableList3 = [enable_stress_test]
-    testSuitEnableList3 = []
-    if testSet == "confluent":
-        testSuitEnableList3 = [enable_stress_test]
-    elif testSet == "apache":
-        testSuitEnableList3 = [enable_stress_test]
-    elif testSet != "clean":
-        errorExit("Unknown testSet option {}, please input confluent, apache or clean".format(testSet))
-
-    execution(testSet, testSuitList3, testCleanEnableList3, testSuitEnableList3, driver, nameSalt, 4)
-    ############################ round 3 ############################
-
-    print("Enable Delivery Guarantee tests:" + str(driver.enableDeliveryGuaranteeTests))
-    if driver.enableDeliveryGuaranteeTests:
-        # At least once and exactly once guarantee tests runs only in AWS and AZURE
-        runDeliveryGuaranteeTests(driver, testSet, nameSalt)
+        print("Enable Delivery Guarantee tests:" + str(driver.enableDeliveryGuaranteeTests))
+        if driver.enableDeliveryGuaranteeTests:
+            # At least once and exactly once guarantee tests runs only in AWS and AZURE
+            runDeliveryGuaranteeTests(driver, testSet, nameSalt)
 
 
-    ############################ Always run Proxy tests in the end ############################
+        ############################ Always run Proxy tests in the end ############################
 
-    ############################ Proxy End To End Test ############################
-    print(datetime.now().strftime("\n%H:%M:%S "), "=== Last Round: Proxy E2E Test ===")
-    print("Proxy Test should be the last test, since it modifies the JVM values")
-    testSuitList4 = [testStringJsonProxy]
+        ############################ Proxy End To End Test ############################
+        print(datetime.now().strftime("\n%H:%M:%S "), "=== Last Round: Proxy E2E Test ===")
+        print("Proxy Test should be the last test, since it modifies the JVM values")
+        testSuitList4 = [testStringJsonProxy]
 
-    # Should we invoke clean before and after the test
-    testCleanEnableList4 = [True]
+        # Should we invoke clean before and after the test
+        testCleanEnableList4 = [True]
 
-    # should we enable this? Set to false to disable
-    testSuitEnableList4 = []
-    if testSet == "confluent":
-        testSuitEnableList4 = [True]
-    elif testSet == "apache":
-        testSuitEnableList4 = [True]
-    elif testSet != "clean":
-        errorExit("Unknown testSet option {}, please input confluent, apache or clean".format(testSet))
+        # should we enable this? Set to false to disable
+        testSuitEnableList4 = []
+        if testSet == "confluent":
+            testSuitEnableList4 = [True]
+        elif testSet == "apache":
+            testSuitEnableList4 = [True]
+        elif testSet != "clean":
+            errorExit("Unknown testSet option {}, please input confluent, apache or clean".format(testSet))
 
-    execution(testSet, testSuitList4, testCleanEnableList4, testSuitEnableList4, driver, nameSalt)
-    ############################ Proxy End To End Test End ############################
+        execution(testSet, testSuitList4, testCleanEnableList4, testSuitEnableList4, driver, nameSalt)
+        ############################ Proxy End To End Test End ############################
 
 
 def execution(testSet, testSuitList, testCleanEnableList, testSuitEnableList, driver, nameSalt, round = 1):


### PR DESCRIPTION
This Change:
- Required to identify if we can support future versions of Confluent Platform. 
- End to End tests are already passing, these two tests were the most flakiest. 
- Refactor stress tests to different functions so as to not run along
  with End to End Tests
- Stress Tests wont run on master push or PR, will only run once every
  week on saturday (Check Schedule in StressTest.yml file)


Future Improvements: (Filed JIRAs)
- Run a lot of Job Pre Steps inside a docker container and just pull that image. 
- Refactor test suits to a map instead of a list of Tests and List of True False, makes it easier for reading and enabling/disabling tests. 