### PR TITLE
Upgrade Ingest SDK to 1.0.2-beta.4 for KC release 1.8.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -320,7 +320,7 @@
         <dependency>
             <groupId>net.snowflake</groupId>
             <artifactId>snowflake-ingest-sdk</artifactId>
-            <version>1.0.2-beta.3</version>
+            <version>1.0.2-beta.4</version>
         </dependency>
 
         <dependency>

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -368,7 +368,7 @@
         <dependency>
             <groupId>net.snowflake</groupId>
             <artifactId>snowflake-ingest-sdk</artifactId>
-            <version>1.0.2-beta.3</version>
+            <version>1.0.2-beta.4</version>
         </dependency>
 
         <dependency>

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelTest.java
@@ -486,8 +486,10 @@ public class TopicPartitionChannelTest {
   @Test(expected = DataException.class)
   public void testInsertRows_ValidationResponseHasErrors_NoErrorTolerance() throws Exception {
     InsertValidationResponse validationResponse = new InsertValidationResponse();
-    validationResponse.addError(
-        new InsertValidationResponse.InsertError("CONTENT", SF_EXCEPTION, 0));
+    InsertValidationResponse.InsertError insertErrorWithException =
+        new InsertValidationResponse.InsertError("CONTENT", 0);
+    insertErrorWithException.setException(SF_EXCEPTION);
+    validationResponse.addError(insertErrorWithException);
     Mockito.when(
             mockStreamingChannel.insertRows(
                 ArgumentMatchers.any(Iterable.class), ArgumentMatchers.any(String.class)))
@@ -519,8 +521,10 @@ public class TopicPartitionChannelTest {
   @Test
   public void testInsertRows_ValidationResponseHasErrors_ErrorTolerance_ALL() throws Exception {
     InsertValidationResponse validationResponse = new InsertValidationResponse();
-    validationResponse.addError(
-        new InsertValidationResponse.InsertError("CONTENT", SF_EXCEPTION, 0));
+    InsertValidationResponse.InsertError insertErrorWithException =
+        new InsertValidationResponse.InsertError("CONTENT", 0);
+    insertErrorWithException.setException(SF_EXCEPTION);
+    validationResponse.addError(insertErrorWithException);
     Mockito.when(
             mockStreamingChannel.insertRows(
                 ArgumentMatchers.any(Iterable.class), ArgumentMatchers.any(String.class)))
@@ -559,8 +563,10 @@ public class TopicPartitionChannelTest {
   public void testInsertRows_ValidationResponseHasErrors_ErrorTolerance_ALL_LogEnableTrue()
       throws Exception {
     InsertValidationResponse validationResponse = new InsertValidationResponse();
-    validationResponse.addError(
-        new InsertValidationResponse.InsertError("CONTENT", SF_EXCEPTION, 0));
+    InsertValidationResponse.InsertError insertErrorWithException =
+        new InsertValidationResponse.InsertError("CONTENT", 0);
+    insertErrorWithException.setException(SF_EXCEPTION);
+    validationResponse.addError(insertErrorWithException);
     Mockito.when(
             mockStreamingChannel.insertRows(
                 ArgumentMatchers.any(Iterable.class), ArgumentMatchers.any(String.class)))


### PR DESCRIPTION
Release awaited KC with newer version of ingest SDK. 

Version 1.8.1 was already bumped, but we waited for this release to happen. 