### PR TITLE
[SNOW-654492] Enable nonproxyhosts parameter 

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -80,6 +80,7 @@ public class SnowflakeSinkConnectorConfig {
   public static final String JVM_PROXY_PORT = "jvm.proxy.port";
   public static final String JVM_PROXY_USERNAME = "jvm.proxy.username";
   public static final String JVM_PROXY_PASSWORD = "jvm.proxy.password";
+  public static final String JVM_NON_PROXY_HOSTS = "jvm.non.proxy.hosts";
 
   // JDBC logging directory Info (environment variable)
   static final String SNOWFLAKE_JDBC_LOG_DIR = "JDBC_LOG_DIR";
@@ -326,6 +327,16 @@ public class SnowflakeSinkConnectorConfig {
             3,
             ConfigDef.Width.NONE,
             JVM_PROXY_PASSWORD)
+        .define(
+            JVM_NON_PROXY_HOSTS,
+            Type.STRING,
+            "",
+            Importance.LOW,
+            "JVM non proxy hosts",
+            PROXY_INFO,
+            4,
+            ConfigDef.Width.NONE,
+            JVM_NON_PROXY_HOSTS)
         // Connector Config
         .define(
             TOPICS_TABLES_MAP,

--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -16,18 +16,18 @@
  */
 package com.snowflake.kafka.connector;
 
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG;
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BehaviorOnNullValues.VALIDATOR;
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.DELIVERY_GUARANTEE;
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT;
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.JMX_OPT;
-
 import com.snowflake.kafka.connector.internal.BufferThreshold;
 import com.snowflake.kafka.connector.internal.Logging;
 import com.snowflake.kafka.connector.internal.SnowflakeErrors;
 import com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException;
 import com.snowflake.kafka.connector.internal.streaming.IngestionMethodConfig;
 import com.snowflake.kafka.connector.internal.streaming.StreamingUtils;
+import org.apache.kafka.common.config.Config;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.config.ConfigValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStream;
@@ -41,11 +41,12 @@ import java.util.Map;
 import java.util.Random;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.apache.kafka.common.config.Config;
-import org.apache.kafka.common.config.ConfigException;
-import org.apache.kafka.common.config.ConfigValue;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BehaviorOnNullValues.VALIDATOR;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.DELIVERY_GUARANTEE;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.JMX_OPT;
 
 /** Various arbitrary helper functions */
 public class Utils {
@@ -213,7 +214,6 @@ public class Utils {
 
   /**
    * validate whether proxy settings in the config is valid
-   * note: nonproxyhosts have no requirements, so they are not validated here
    *
    * @param config connector configuration
    */
@@ -246,6 +246,14 @@ public class Utils {
                 + SnowflakeSinkConnectorConfig.JVM_PROXY_PASSWORD
                 + " must be provided together");
       }
+    }
+
+    String nonProxyHost = SnowflakeSinkConnectorConfig.getProperty(config,
+      SnowflakeSinkConnectorConfig.JVM_NON_PROXY_HOSTS);
+    if (nonProxyHost != null && nonProxyHost.contains(",")) {
+      throw SnowflakeErrors.ERROR_0026.getException(
+        "nonproxyhost parameter should not have commas"
+      );
     }
   }
 

--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -82,6 +82,7 @@ public class Utils {
   public static final String HTTPS_PROXY_PORT = "https.proxyPort";
   public static final String HTTP_PROXY_HOST = "http.proxyHost";
   public static final String HTTP_PROXY_PORT = "http.proxyPort";
+  public static final String HTTP_NON_PROXY_HOSTS = "http.nonProxyHosts";
 
   public static final String JDK_HTTP_AUTH_TUNNELING = "jdk.http.auth.tunneling.disabledSchemes";
   public static final String HTTPS_PROXY_USER = "https.proxyUser";
@@ -220,6 +221,7 @@ public class Utils {
 
   /**
    * validate whether proxy settings in the config is valid
+   * note: nonproxyhosts have no requirements, so they are not validated here
    *
    * @param config connector configuration
    */
@@ -299,6 +301,17 @@ public class Utils {
         System.setProperty(HTTPS_PROXY_USER, username);
         System.setProperty(HTTPS_PROXY_PASSWORD, password);
       }
+    }
+
+    // enable nonproxyhosts
+    String nonProxyHosts =
+        SnowflakeSinkConnectorConfig.getProperty(
+            config, SnowflakeSinkConnectorConfig.JVM_NON_PROXY_HOSTS);
+
+    if (nonProxyHosts != null) {
+      LOGGER.info(Logging.logMessage("enabling nonproxyhosts: {} ...", nonProxyHosts));
+      System.setProperty(HTTP_NON_PROXY_HOSTS, nonProxyHosts);
+      LOGGER.info(Logging.logMessage("enabled nonproxyhosts: {}", nonProxyHosts));
     }
 
     return true;

--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -69,13 +69,8 @@ public class Utils {
    * IngestionMethodConfig#SNOWPIPE_STREAMING}
    */
   public static final String SF_ROLE = "snowflake.role.name";
-
-  // constants strings
-  private static final String KAFKA_OBJECT_PREFIX = "SNOWFLAKE_KAFKA_CONNECTOR";
-
   // task id
   public static final String TASK_ID = "task_id";
-
   // jvm proxy
   public static final String HTTP_USE_PROXY = "http.useProxy";
   public static final String HTTPS_PROXY_HOST = "https.proxyHost";
@@ -83,25 +78,22 @@ public class Utils {
   public static final String HTTP_PROXY_HOST = "http.proxyHost";
   public static final String HTTP_PROXY_PORT = "http.proxyPort";
   public static final String HTTP_NON_PROXY_HOSTS = "http.nonProxyHosts";
-
   public static final String JDK_HTTP_AUTH_TUNNELING = "jdk.http.auth.tunneling.disabledSchemes";
   public static final String HTTPS_PROXY_USER = "https.proxyUser";
   public static final String HTTPS_PROXY_PASSWORD = "https.proxyPassword";
   public static final String HTTP_PROXY_USER = "http.proxyUser";
   public static final String HTTP_PROXY_PASSWORD = "http.proxyPassword";
-
   // jdbc log dir
   public static final String JAVA_IO_TMPDIR = "java.io.tmpdir";
-
+  public static final String TABLE_COLUMN_CONTENT = "RECORD_CONTENT";
+  public static final String TABLE_COLUMN_METADATA = "RECORD_METADATA";
+  static final String[] loginPropList = {SF_URL, SF_USER, SF_SCHEMA, SF_DATABASE};
+  // constants strings
+  private static final String KAFKA_OBJECT_PREFIX = "SNOWFLAKE_KAFKA_CONNECTOR";
   private static final Random random = new Random();
-
   // mvn repo
   private static final String MVN_REPO =
       "https://repo1.maven.org/maven2/com/snowflake/snowflake-kafka-connector/";
-
-  public static final String TABLE_COLUMN_CONTENT = "RECORD_CONTENT";
-  public static final String TABLE_COLUMN_METADATA = "RECORD_METADATA";
-
   private static final Logger LOGGER = LoggerFactory.getLogger(Utils.class.getName());
 
   /**
@@ -604,8 +596,6 @@ public class Utils {
     }
     return topic2Table;
   }
-
-  static final String loginPropList[] = {SF_URL, SF_USER, SF_SCHEMA, SF_DATABASE};
 
   public static boolean isSingleFieldValid(Config result) {
     // if any single field validation failed

--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -16,18 +16,18 @@
  */
 package com.snowflake.kafka.connector;
 
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BehaviorOnNullValues.VALIDATOR;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.DELIVERY_GUARANTEE;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.JMX_OPT;
+
 import com.snowflake.kafka.connector.internal.BufferThreshold;
 import com.snowflake.kafka.connector.internal.Logging;
 import com.snowflake.kafka.connector.internal.SnowflakeErrors;
 import com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException;
 import com.snowflake.kafka.connector.internal.streaming.IngestionMethodConfig;
 import com.snowflake.kafka.connector.internal.streaming.StreamingUtils;
-import org.apache.kafka.common.config.Config;
-import org.apache.kafka.common.config.ConfigException;
-import org.apache.kafka.common.config.ConfigValue;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStream;
@@ -41,12 +41,11 @@ import java.util.Map;
 import java.util.Random;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG;
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BehaviorOnNullValues.VALIDATOR;
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.DELIVERY_GUARANTEE;
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT;
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.JMX_OPT;
+import org.apache.kafka.common.config.Config;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.config.ConfigValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Various arbitrary helper functions */
 public class Utils {
@@ -248,12 +247,12 @@ public class Utils {
       }
     }
 
-    String nonProxyHost = SnowflakeSinkConnectorConfig.getProperty(config,
-      SnowflakeSinkConnectorConfig.JVM_NON_PROXY_HOSTS);
+    String nonProxyHost =
+        SnowflakeSinkConnectorConfig.getProperty(
+            config, SnowflakeSinkConnectorConfig.JVM_NON_PROXY_HOSTS);
     if (nonProxyHost != null && nonProxyHost.contains(",")) {
       throw SnowflakeErrors.ERROR_0026.getException(
-        "nonproxyhost parameter should not have commas"
-      );
+          "nonproxyhost parameter should not have commas");
     }
   }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/BufferThreshold.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/BufferThreshold.java
@@ -70,53 +70,6 @@ public abstract class BufferThreshold {
   }
 
   /**
-   * Returns true if size of current buffer is more than threshold provided (Both in bytes).
-   *
-   * <p>Threshold is config parameter: {@link
-   * com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig#BUFFER_SIZE_BYTES}
-   *
-   * @param currentBufferSizeInBytes current size of buffer in bytes
-   * @return true if bytes threshold has reached.
-   */
-  public boolean isFlushBufferedBytesBased(final long currentBufferSizeInBytes) {
-    return currentBufferSizeInBytes >= bufferSizeThresholdBytes;
-  }
-
-  /**
-   * Returns true if number of ({@link SinkRecord})s in current buffer is more than threshold
-   * provided.
-   *
-   * <p>Threshold is config parameter: {@link
-   * com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig#BUFFER_COUNT_RECORDS}
-   *
-   * @param currentBufferedRecordCount current size of buffer in terms of number of kafka records
-   * @return true if number of kafka threshold has reached in buffer.
-   */
-  public boolean isFlushBufferedRecordCountBased(final long currentBufferedRecordCount) {
-    return currentBufferedRecordCount != 0
-        && currentBufferedRecordCount >= bufferKafkaRecordCountThreshold;
-  }
-
-  /**
-   * If difference between current time and previous flush time is more than threshold return true.
-   *
-   * @param previousFlushTimeStampMs when were previous buffered records were flushed into internal
-   *     stage for snowpipe based implementation or previous buffered records were sent in
-   *     insertRows API of Streaming Snowpipe.
-   * @return true if time based threshold has reached.
-   */
-  public boolean isFlushTimeBased(final long previousFlushTimeStampMs) {
-    final long currentTimeMs = System.currentTimeMillis();
-    return (currentTimeMs - previousFlushTimeStampMs)
-        >= (this.flushTimeThresholdSeconds * SECOND_TO_MILLIS);
-  }
-
-  /** @return Get flush time threshold in seconds */
-  public long getFlushTimeThresholdSeconds() {
-    return flushTimeThresholdSeconds;
-  }
-
-  /**
    * Check if provided snowflake kafka connector buffer properties are within permissible values.
    *
    * <p>This method invokes three verifiers - Time based threshold, buffer size and buffer count
@@ -238,6 +191,53 @@ public abstract class BufferThreshold {
       }
     }
     return true;
+  }
+
+  /**
+   * Returns true if size of current buffer is more than threshold provided (Both in bytes).
+   *
+   * <p>Threshold is config parameter: {@link
+   * com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig#BUFFER_SIZE_BYTES}
+   *
+   * @param currentBufferSizeInBytes current size of buffer in bytes
+   * @return true if bytes threshold has reached.
+   */
+  public boolean isFlushBufferedBytesBased(final long currentBufferSizeInBytes) {
+    return currentBufferSizeInBytes >= bufferSizeThresholdBytes;
+  }
+
+  /**
+   * Returns true if number of ({@link SinkRecord})s in current buffer is more than threshold
+   * provided.
+   *
+   * <p>Threshold is config parameter: {@link
+   * com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig#BUFFER_COUNT_RECORDS}
+   *
+   * @param currentBufferedRecordCount current size of buffer in terms of number of kafka records
+   * @return true if number of kafka threshold has reached in buffer.
+   */
+  public boolean isFlushBufferedRecordCountBased(final long currentBufferedRecordCount) {
+    return currentBufferedRecordCount != 0
+        && currentBufferedRecordCount >= bufferKafkaRecordCountThreshold;
+  }
+
+  /**
+   * If difference between current time and previous flush time is more than threshold return true.
+   *
+   * @param previousFlushTimeStampMs when were previous buffered records were flushed into internal
+   *     stage for snowpipe based implementation or previous buffered records were sent in
+   *     insertRows API of Streaming Snowpipe.
+   * @return true if time based threshold has reached.
+   */
+  public boolean isFlushTimeBased(final long previousFlushTimeStampMs) {
+    final long currentTimeMs = System.currentTimeMillis();
+    return (currentTimeMs - previousFlushTimeStampMs)
+        >= (this.flushTimeThresholdSeconds * SECOND_TO_MILLIS);
+  }
+
+  /** @return Get flush time threshold in seconds */
+  public long getFlushTimeThresholdSeconds() {
+    return flushTimeThresholdSeconds;
   }
 
   @Override

--- a/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
@@ -215,7 +215,7 @@ class InternalUtils {
       }
     }
 
-    if (conf.get(SnowflakeSinkConnectorConfig.JVM_NON_PROXY_HOSTS) != null){
+    if (conf.get(SnowflakeSinkConnectorConfig.JVM_NON_PROXY_HOSTS) != null) {
       proxyProperties.put(
           SFSessionProperty.NON_PROXY_HOSTS.getPropertyKey(),
           conf.get(SnowflakeSinkConnectorConfig.JVM_NON_PROXY_HOSTS));

--- a/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
@@ -214,6 +214,13 @@ class InternalUtils {
         proxyProperties.put(SFSessionProperty.PROXY_PASSWORD.getPropertyKey(), password);
       }
     }
+
+    if (conf.get(SnowflakeSinkConnectorConfig.JVM_NON_PROXY_HOSTS) != null){
+      proxyProperties.put(
+          SFSessionProperty.NON_PROXY_HOSTS,
+          conf.get(SnowflakeSinkConnectorConfig.JVM_NON_PROXY_HOSTS));
+    }
+
     return proxyProperties;
   }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
@@ -217,7 +217,7 @@ class InternalUtils {
 
     if (conf.get(SnowflakeSinkConnectorConfig.JVM_NON_PROXY_HOSTS) != null){
       proxyProperties.put(
-          SFSessionProperty.NON_PROXY_HOSTS,
+          SFSessionProperty.NON_PROXY_HOSTS.getPropertyKey(),
           conf.get(SnowflakeSinkConnectorConfig.JVM_NON_PROXY_HOSTS));
     }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeErrors.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeErrors.java
@@ -108,9 +108,9 @@ public enum SnowflakeErrors {
       "Duplicate case-insensitive column names detected. Schematization currently does not support"
           + " this."),
   ERROR_0026(
-    "0026",
-    "Invalid nonproxyhost parameter",
-    "Since JVM uses '|' as delimiters, the nonproxyhost parameter should not contain ','"),
+      "0026",
+      "Invalid nonproxyhost parameter",
+      "Since JVM uses '|' as delimiters, the nonproxyhost parameter should not contain ','"),
   // Snowflake connection issues 1---
   ERROR_1001(
       "1001",

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeErrors.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeErrors.java
@@ -107,6 +107,10 @@ public enum SnowflakeErrors {
       "Duplicate case-insensitive column names detected",
       "Duplicate case-insensitive column names detected. Schematization currently does not support"
           + " this."),
+  ERROR_0026(
+    "0026",
+    "Invalid nonproxyhost parameter",
+    "Since JVM uses '|' as delimiters, the nonproxyhost parameter should not contain ','"),
   // Snowflake connection issues 1---
   ERROR_1001(
       "1001",

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
@@ -21,21 +21,20 @@ import org.slf4j.LoggerFactory;
 
 /* Utility class/Helper methods for streaming related ingestion. */
 public class StreamingUtils {
-  private static final Logger LOGGER = LoggerFactory.getLogger(StreamingUtils.class);
-
-  // Streaming Ingest API related fields
-
-  protected static final Duration DURATION_BETWEEN_GET_OFFSET_TOKEN_RETRY = Duration.ofSeconds(1);
-
-  protected static final int MAX_GET_OFFSET_TOKEN_RETRIES = 3;
-
   // Buffer related defaults and minimum set at connector level by clients/customers.
   public static final long STREAMING_BUFFER_FLUSH_TIME_MINIMUM_SEC =
       Duration.ofSeconds(1).getSeconds();
 
+  // Streaming Ingest API related fields
   public static final long STREAMING_BUFFER_FLUSH_TIME_DEFAULT_SEC =
       Duration.ofSeconds(10).getSeconds();
-
+  // excluding key, value and headers: 5 bytes length + 10 bytes timestamp + 5 bytes offset + 1
+  // byte attributes. (This is not for record metadata, this is before we transform to snowflake
+  // understood JSON)
+  // This is overhead size for calculating while buffering Kafka records.
+  public static final int MAX_RECORD_OVERHEAD_BYTES = DefaultRecord.MAX_RECORD_OVERHEAD;
+  protected static final Duration DURATION_BETWEEN_GET_OFFSET_TOKEN_RETRY = Duration.ofSeconds(1);
+  protected static final int MAX_GET_OFFSET_TOKEN_RETRIES = 3;
   protected static final long STREAMING_BUFFER_COUNT_RECORDS_DEFAULT = 10_000L;
 
   /**
@@ -47,14 +46,8 @@ public class StreamingUtils {
    * <p>1 MB is an ideal size for streaming ingestion so 95% if 20MB = 1MB
    */
   protected static final long STREAMING_BUFFER_BYTES_DEFAULT = 20_000_000;
-
+  private static final Logger LOGGER = LoggerFactory.getLogger(StreamingUtils.class);
   private static final Set<String> DISALLOWED_CONVERTERS_STREAMING = CUSTOM_SNOWFLAKE_CONVERTERS;
-
-  // excluding key, value and headers: 5 bytes length + 10 bytes timestamp + 5 bytes offset + 1
-  // byte attributes. (This is not for record metadata, this is before we transform to snowflake
-  // understood JSON)
-  // This is overhead size for calculating while buffering Kafka records.
-  public static final int MAX_RECORD_OVERHEAD_BYTES = DefaultRecord.MAX_RECORD_OVERHEAD;
 
   /* Maps streaming client's property keys to what we got from snowflake KC config file. */
   public static Map<String, String> convertConfigForStreamingClient(

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
@@ -46,6 +46,7 @@ public class StreamingUtils {
    * <p>1 MB is an ideal size for streaming ingestion so 95% if 20MB = 1MB
    */
   protected static final long STREAMING_BUFFER_BYTES_DEFAULT = 20_000_000;
+
   private static final Logger LOGGER = LoggerFactory.getLogger(StreamingUtils.class);
   private static final Set<String> DISALLOWED_CONVERTERS_STREAMING = CUSTOM_SNOWFLAKE_CONVERTERS;
 

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorIT.java
@@ -1,11 +1,11 @@
 package com.snowflake.kafka.connector;
 
-import com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException;
-import org.apache.kafka.common.config.Config;
-import org.apache.kafka.common.config.ConfigValue;
-import org.junit.Assert;
-import org.junit.Test;
+import static com.snowflake.kafka.connector.Utils.NAME;
+import static com.snowflake.kafka.connector.Utils.TASK_ID;
+import static com.snowflake.kafka.connector.internal.TestUtils.TEST_CONNECTOR_NAME;
+import static com.snowflake.kafka.connector.internal.TestUtils.getConf;
 
+import com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -14,11 +14,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-
-import static com.snowflake.kafka.connector.Utils.NAME;
-import static com.snowflake.kafka.connector.Utils.TASK_ID;
-import static com.snowflake.kafka.connector.internal.TestUtils.TEST_CONNECTOR_NAME;
-import static com.snowflake.kafka.connector.internal.TestUtils.getConf;
+import org.apache.kafka.common.config.Config;
+import org.apache.kafka.common.config.ConfigValue;
+import org.junit.Assert;
+import org.junit.Test;
 
 public class ConnectorIT {
   static final String allPropertiesList[] = {

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorIT.java
@@ -1,18 +1,24 @@
 package com.snowflake.kafka.connector;
 
-import static com.snowflake.kafka.connector.Utils.NAME;
-import static com.snowflake.kafka.connector.Utils.TASK_ID;
-import static com.snowflake.kafka.connector.internal.TestUtils.TEST_CONNECTOR_NAME;
-import static com.snowflake.kafka.connector.internal.TestUtils.getConf;
-
 import com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException;
-import java.util.*;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigValue;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static com.snowflake.kafka.connector.Utils.NAME;
+import static com.snowflake.kafka.connector.Utils.TASK_ID;
+import static com.snowflake.kafka.connector.internal.TestUtils.TEST_CONNECTOR_NAME;
+import static com.snowflake.kafka.connector.internal.TestUtils.getConf;
 
 public class ConnectorIT {
   static final String allPropertiesList[] = {
@@ -309,6 +315,26 @@ public class ConnectorIT {
     config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_PORT, "3128");
     config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_USERNAME, "admin");
     config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_PASSWORD, "test");
+    Utils.validateProxySetting(config);
+  }
+
+  @Test
+  public void testErrorNonProxyHostConfig() {
+    Map<String, String> config = getCorrectConfig();
+    config.put(SnowflakeSinkConnectorConfig.JVM_NON_PROXY_HOSTS, "host1, host2");
+    try {
+      Utils.validateProxySetting(config);
+    } catch (SnowflakeKafkaConnectorException e) {
+      Assert.assertEquals("0026", e.getCode());
+      return;
+    }
+    Assert.fail();
+  }
+
+  @Test
+  public void testNonProxyHostConfig() {
+    Map<String, String> config = getCorrectConfig();
+    config.put(SnowflakeSinkConnectorConfig.JVM_NON_PROXY_HOSTS, "host1|host2");
     Utils.validateProxySetting(config);
   }
 

--- a/src/test/java/com/snowflake/kafka/connector/SinkTaskProxyIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/SinkTaskProxyIT.java
@@ -19,7 +19,7 @@ public class SinkTaskProxyIT {
 
   @Test(expected = SnowflakeKafkaConnectorException.class)
   @Ignore
-  public void testSinkTaskProxyConfigMock() {
+  public void testSinkTaskProxyConfigFailure() {
     Map<String, String> config = TestUtils.getConf();
     SnowflakeSinkConnectorConfig.setDefaultValues(config);
 
@@ -42,9 +42,10 @@ public class SinkTaskProxyIT {
       assert System.getProperty(Utils.HTTPS_PROXY_USER).equals("user");
       assert System.getProperty(Utils.HTTPS_PROXY_PASSWORD).equals("password");
 
+      throw e;
+    } finally {
       // unset the system parameters please.
       TestUtils.resetProxyParametersInJVM();
-      throw e;
     }
   }
 
@@ -104,5 +105,7 @@ public class SinkTaskProxyIT {
     ingestionService.ingestFile(fileName);
     List<String> names = new ArrayList<>(1);
     names.add(fileName);
+
+    TestUtils.resetProxyParametersInJVM();
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/SinkTaskProxyIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/SinkTaskProxyIT.java
@@ -65,6 +65,7 @@ public class SinkTaskProxyIT {
     config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_PORT, "3128");
     config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_USERNAME, "admin");
     config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_PASSWORD, "test");
+    config.put(SnowflakeSinkConnectorConfig.JVM_NON_PROXY_HOSTS, "host1|host2");
     SnowflakeSinkTask sinkTask = new SnowflakeSinkTask();
 
     sinkTask.start(config);
@@ -79,6 +80,7 @@ public class SinkTaskProxyIT {
     assert System.getProperty(Utils.HTTP_PROXY_PASSWORD).equals("test");
     assert System.getProperty(Utils.HTTPS_PROXY_USER).equals("admin");
     assert System.getProperty(Utils.HTTPS_PROXY_PASSWORD).equals("test");
+    assert System.getProperty(Utils.HTTP_NON_PROXY_HOSTS).equals("host1|host2");
 
     // get the snowflakeconnection service which was made during sinkTask
 

--- a/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
@@ -70,41 +70,7 @@ import org.apache.kafka.connect.sink.SinkRecord;
 import static com.snowflake.kafka.connector.Utils.*;
 
 public class TestUtils {
-  // test profile properties
-  private static final String USER = "user";
-  private static final String DATABASE = "database";
-  private static final String SCHEMA = "schema";
-  private static final String HOST = "host";
-  private static final String ROLE = "role";
-  private static final String WAREHOUSE = "warehouse";
-  private static final String PRIVATE_KEY = "private_key";
-  private static final String ENCRYPTED_PRIVATE_KEY = "encrypted_private_key";
-  private static final String PRIVATE_KEY_PASSPHRASE = "private_key_passphrase";
-  private static final Random random = new Random();
-  private static final String DES_RSA_KEY = "des_rsa_key";
   public static final String TEST_CONNECTOR_NAME = "TEST_CONNECTOR";
-  private static final Pattern BROKEN_RECORD_PATTERN =
-      Pattern.compile("^[^/]+/[^/]+/(\\d+)/(\\d+)_(key|value)_(\\d+)\\.gz$");
-
-  // profile path
-  private static final String PROFILE_PATH = "profile.json";
-
-  private static final ObjectMapper mapper = new ObjectMapper();
-
-  private static Connection conn = null;
-
-  private static Connection connForStreamingIngestTests = null;
-
-  private static Map<String, String> conf = null;
-
-  private static Map<String, String> confForStreaming = null;
-
-  private static SnowflakeURL url = null;
-
-  private static JsonNode profile = null;
-
-  private static JsonNode profileForStreaming = null;
-
   public static final String JSON_WITH_SCHEMA =
       ""
           + "{\n"
@@ -131,6 +97,30 @@ public class TestUtils {
           + "  }\n"
           + "}";
   public static final String JSON_WITHOUT_SCHEMA = "{\"userid\": \"User_1\"}";
+  // test profile properties
+  private static final String USER = "user";
+  private static final String DATABASE = "database";
+  private static final String SCHEMA = "schema";
+  private static final String HOST = "host";
+  private static final String ROLE = "role";
+  private static final String WAREHOUSE = "warehouse";
+  private static final String PRIVATE_KEY = "private_key";
+  private static final String ENCRYPTED_PRIVATE_KEY = "encrypted_private_key";
+  private static final String PRIVATE_KEY_PASSPHRASE = "private_key_passphrase";
+  private static final Random random = new Random();
+  private static final String DES_RSA_KEY = "des_rsa_key";
+  private static final Pattern BROKEN_RECORD_PATTERN =
+      Pattern.compile("^[^/]+/[^/]+/(\\d+)/(\\d+)_(key|value)_(\\d+)\\.gz$");
+  // profile path
+  private static final String PROFILE_PATH = "profile.json";
+  private static final ObjectMapper mapper = new ObjectMapper();
+  private static final Connection conn = null;
+  private static final Connection connForStreamingIngestTests = null;
+  private static Map<String, String> conf = null;
+  private static Map<String, String> confForStreaming = null;
+  private static SnowflakeURL url = null;
+  private static JsonNode profile = null;
+  private static JsonNode profileForStreaming = null;
 
   private static JsonNode getProfile(final String profileFilePath) {
     if (profileFilePath.equalsIgnoreCase(PROFILE_PATH)) {
@@ -467,11 +457,6 @@ public class TestUtils {
     return matcher.group(index);
   }
 
-  /** Interface to define the lambda function to be used by assertWithRetry */
-  public interface AssertFunction {
-    boolean operate() throws Exception;
-  }
-
   /**
    * Assert with sleep and retry logic
    *
@@ -486,7 +471,7 @@ public class TestUtils {
       if (iteration > maxRetry) {
         throw new InterruptedException("Max retry exceeded");
       }
-      Thread.sleep(intervalSec * 1000);
+      Thread.sleep(intervalSec * 1000L);
       iteration += 1;
     }
   }
@@ -719,5 +704,10 @@ public class TestUtils {
       }
       assert value.equals(contentMap.get(columnName));
     }
+  }
+
+  /** Interface to define the lambda function to be used by assertWithRetry */
+  public interface AssertFunction {
+    boolean operate() throws Exception;
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
@@ -16,6 +16,22 @@
  */
 package com.snowflake.kafka.connector.internal;
 
+import static com.snowflake.kafka.connector.Utils.HTTPS_PROXY_HOST;
+import static com.snowflake.kafka.connector.Utils.HTTPS_PROXY_PASSWORD;
+import static com.snowflake.kafka.connector.Utils.HTTPS_PROXY_PORT;
+import static com.snowflake.kafka.connector.Utils.HTTPS_PROXY_USER;
+import static com.snowflake.kafka.connector.Utils.HTTP_PROXY_HOST;
+import static com.snowflake.kafka.connector.Utils.HTTP_PROXY_PASSWORD;
+import static com.snowflake.kafka.connector.Utils.HTTP_PROXY_PORT;
+import static com.snowflake.kafka.connector.Utils.HTTP_PROXY_USER;
+import static com.snowflake.kafka.connector.Utils.HTTP_USE_PROXY;
+import static com.snowflake.kafka.connector.Utils.HTTP_NON_PROXY_HOSTS;
+import static com.snowflake.kafka.connector.Utils.JDK_HTTP_AUTH_TUNNELING;
+import static com.snowflake.kafka.connector.Utils.SF_DATABASE;
+import static com.snowflake.kafka.connector.Utils.SF_SCHEMA;
+import static com.snowflake.kafka.connector.Utils.SF_URL;
+import static com.snowflake.kafka.connector.Utils.SF_USER;
+
 import com.snowflake.client.jdbc.SnowflakeDriver;
 import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
 import com.snowflake.kafka.connector.Utils;

--- a/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
@@ -16,16 +16,17 @@
  */
 package com.snowflake.kafka.connector.internal;
 
+import static com.snowflake.kafka.connector.Utils.*;
 import static com.snowflake.kafka.connector.Utils.HTTPS_PROXY_HOST;
 import static com.snowflake.kafka.connector.Utils.HTTPS_PROXY_PASSWORD;
 import static com.snowflake.kafka.connector.Utils.HTTPS_PROXY_PORT;
 import static com.snowflake.kafka.connector.Utils.HTTPS_PROXY_USER;
+import static com.snowflake.kafka.connector.Utils.HTTP_NON_PROXY_HOSTS;
 import static com.snowflake.kafka.connector.Utils.HTTP_PROXY_HOST;
 import static com.snowflake.kafka.connector.Utils.HTTP_PROXY_PASSWORD;
 import static com.snowflake.kafka.connector.Utils.HTTP_PROXY_PORT;
 import static com.snowflake.kafka.connector.Utils.HTTP_PROXY_USER;
 import static com.snowflake.kafka.connector.Utils.HTTP_USE_PROXY;
-import static com.snowflake.kafka.connector.Utils.HTTP_NON_PROXY_HOSTS;
 import static com.snowflake.kafka.connector.Utils.JDK_HTTP_AUTH_TUNNELING;
 import static com.snowflake.kafka.connector.Utils.SF_DATABASE;
 import static com.snowflake.kafka.connector.Utils.SF_SCHEMA;
@@ -66,8 +67,6 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.sink.SinkRecord;
-
-import static com.snowflake.kafka.connector.Utils.*;
 
 public class TestUtils {
   public static final String TEST_CONNECTOR_NAME = "TEST_CONNECTOR";

--- a/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
@@ -16,21 +16,6 @@
  */
 package com.snowflake.kafka.connector.internal;
 
-import static com.snowflake.kafka.connector.Utils.HTTPS_PROXY_HOST;
-import static com.snowflake.kafka.connector.Utils.HTTPS_PROXY_PASSWORD;
-import static com.snowflake.kafka.connector.Utils.HTTPS_PROXY_PORT;
-import static com.snowflake.kafka.connector.Utils.HTTPS_PROXY_USER;
-import static com.snowflake.kafka.connector.Utils.HTTP_PROXY_HOST;
-import static com.snowflake.kafka.connector.Utils.HTTP_PROXY_PASSWORD;
-import static com.snowflake.kafka.connector.Utils.HTTP_PROXY_PORT;
-import static com.snowflake.kafka.connector.Utils.HTTP_PROXY_USER;
-import static com.snowflake.kafka.connector.Utils.HTTP_USE_PROXY;
-import static com.snowflake.kafka.connector.Utils.JDK_HTTP_AUTH_TUNNELING;
-import static com.snowflake.kafka.connector.Utils.SF_DATABASE;
-import static com.snowflake.kafka.connector.Utils.SF_SCHEMA;
-import static com.snowflake.kafka.connector.Utils.SF_URL;
-import static com.snowflake.kafka.connector.Utils.SF_USER;
-
 import com.snowflake.client.jdbc.SnowflakeDriver;
 import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
 import com.snowflake.kafka.connector.Utils;
@@ -65,6 +50,8 @@ import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.sink.SinkRecord;
+
+import static com.snowflake.kafka.connector.Utils.*;
 
 public class TestUtils {
   // test profile properties
@@ -389,6 +376,7 @@ public class TestUtils {
     System.setProperty(HTTP_USE_PROXY, "");
     System.setProperty(HTTP_PROXY_HOST, "");
     System.setProperty(HTTP_PROXY_PORT, "");
+    System.setProperty(HTTP_NON_PROXY_HOSTS, "");
     System.setProperty(HTTPS_PROXY_HOST, "");
     System.setProperty(HTTPS_PROXY_PORT, "");
 


### PR DESCRIPTION
Status: waiting on a testing environment

JDBC allows the customer to create nonProxyHosts. Multiple hosts can be set with a '|' and a '*' wildcard. 

https://docs.snowflake.com/en/user-guide/jdbc-configure.html#specifying-a-proxy-server-by-setting-java-system-properties
