### PR TITLE
[SNOW-665898] Add log granularity instance id logging for Task

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnector.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnector.java
@@ -82,7 +82,7 @@ public class SnowflakeSinkConnector extends SinkConnector {
     Utils.checkConnectorVersion();
 
     // initialize logging with correlationId
-    LoggerHandler.setCorrelationUuid(UUID.randomUUID());
+    LoggerHandler.setKcGlobalInstanceId(UUID.randomUUID());
 
     LOGGER.info("SnowflakeSinkConnector:start");
     setupComplete = false;

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
@@ -16,6 +16,8 @@
  */
 package com.snowflake.kafka.connector;
 
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.DELIVERY_GUARANTEE;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.snowflake.kafka.connector.dlq.KafkaRecordErrorReporter;
 import com.snowflake.kafka.connector.internal.LoggerHandler;
@@ -26,14 +28,6 @@ import com.snowflake.kafka.connector.internal.SnowflakeSinkService;
 import com.snowflake.kafka.connector.internal.SnowflakeSinkServiceFactory;
 import com.snowflake.kafka.connector.internal.streaming.IngestionMethodConfig;
 import com.snowflake.kafka.connector.records.SnowflakeMetadataConfig;
-import org.apache.kafka.clients.consumer.OffsetAndMetadata;
-import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.connect.errors.ConnectException;
-import org.apache.kafka.connect.errors.RetriableException;
-import org.apache.kafka.connect.sink.ErrantRecordReporter;
-import org.apache.kafka.connect.sink.SinkRecord;
-import org.apache.kafka.connect.sink.SinkTask;
-
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -42,8 +36,13 @@ import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
-
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.DELIVERY_GUARANTEE;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.errors.RetriableException;
+import org.apache.kafka.connect.sink.ErrantRecordReporter;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.sink.SinkTask;
 
 /**
  * SnowflakeSinkTask implements SinkTask for Kafka Connect framework.
@@ -79,8 +78,8 @@ public class SnowflakeSinkTask extends SinkTask {
   // check connect-distributed.properties file used to start kafka connect
   private final int rebalancingSleepTime = 370000;
 
-  private static final LoggerHandler LOGGER = new LoggerHandler(SnowflakeSinkTask.class.getName(), UUID.randomUUID(),
-    "TASK");
+  private static final LoggerHandler LOGGER =
+      new LoggerHandler(SnowflakeSinkTask.class.getName(), UUID.randomUUID(), "TASK");
 
   /** default constructor, invoked by kafka connect framework */
   public SnowflakeSinkTask() {

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
@@ -16,8 +16,6 @@
  */
 package com.snowflake.kafka.connector;
 
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.DELIVERY_GUARANTEE;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.snowflake.kafka.connector.dlq.KafkaRecordErrorReporter;
 import com.snowflake.kafka.connector.internal.LoggerHandler;
@@ -28,13 +26,6 @@ import com.snowflake.kafka.connector.internal.SnowflakeSinkService;
 import com.snowflake.kafka.connector.internal.SnowflakeSinkServiceFactory;
 import com.snowflake.kafka.connector.internal.streaming.IngestionMethodConfig;
 import com.snowflake.kafka.connector.records.SnowflakeMetadataConfig;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
-import java.util.function.Supplier;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.errors.ConnectException;
@@ -42,6 +33,17 @@ import org.apache.kafka.connect.errors.RetriableException;
 import org.apache.kafka.connect.sink.ErrantRecordReporter;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTask;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
+
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.DELIVERY_GUARANTEE;
 
 /**
  * SnowflakeSinkTask implements SinkTask for Kafka Connect framework.
@@ -77,7 +79,8 @@ public class SnowflakeSinkTask extends SinkTask {
   // check connect-distributed.properties file used to start kafka connect
   private final int rebalancingSleepTime = 370000;
 
-  private static final LoggerHandler LOGGER = new LoggerHandler(SnowflakeSinkTask.class.getName());
+  private static final LoggerHandler LOGGER = new LoggerHandler(SnowflakeSinkTask.class.getName(), UUID.randomUUID(),
+    "TASK");
 
   /** default constructor, invoked by kafka connect framework */
   public SnowflakeSinkTask() {

--- a/src/main/java/com/snowflake/kafka/connector/internal/LoggerHandler.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/LoggerHandler.java
@@ -66,10 +66,11 @@ public class LoggerHandler {
               descriptor));
     }
 
+    String tag = "[" + descriptor + ":" + uuid.toString() + "]";
     META_LOGGER.info(
-        Utils.formatLogMessage("Setting {} instance id to '{}'", logIdName, kcGlobalInstanceIdTag));
+        Utils.formatLogMessage("Setting {} instance id to '{}'", logIdName, tag));
 
-    return "[" + descriptor + ":" + uuid.toString() + "] ";
+    return tag;
   }
 
   private Logger logger;
@@ -230,7 +231,10 @@ public class LoggerHandler {
    * @return The fully formatted string to be logged
    */
   private String getFormattedMsg(String msg, Object... vars) {
-    String fullMsg = kcGlobalInstanceIdTag + this.loggerInstanceIdTag + msg;
-    return Utils.formatLogMessage(fullMsg, vars);
+    if (!kcGlobalInstanceIdTag.isEmpty() || !this.loggerInstanceIdTag.isEmpty()) {
+      return Utils.formatLogMessage(kcGlobalInstanceIdTag + this.loggerInstanceIdTag + " " + msg, vars);
+    }
+
+    return Utils.formatLogMessage(msg, vars);
   }
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/LoggerHandler.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/LoggerHandler.java
@@ -229,10 +229,6 @@ public class LoggerHandler {
    */
   private String getFormattedMsg(String msg, Object... vars) {
     String fullMsg = kcGlobalInstanceIdTag + this.loggerInstanceIdTag + msg;
-
-    if (vars == null) {
-      return Utils.formatLogMessage(fullMsg);
-    }
     return Utils.formatLogMessage(fullMsg, vars);
   }
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/LoggerHandler.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/LoggerHandler.java
@@ -1,10 +1,9 @@
 package com.snowflake.kafka.connector.internal;
 
 import com.snowflake.kafka.connector.Utils;
+import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.UUID;
 
 /** Attaches additional fields to the logs */
 public class LoggerHandler {
@@ -24,8 +23,7 @@ public class LoggerHandler {
    * @param kcGlobalInstanceId UUID attached for every log
    */
   public static void setKcGlobalInstanceId(UUID kcGlobalInstanceId) {
-    kcGlobalInstanceIdTag =
-        parseUuidIntoTag("KC", kcGlobalInstanceId, "Kafka Connect global");
+    kcGlobalInstanceIdTag = parseUuidIntoTag("KC", kcGlobalInstanceId, "Kafka Connect global");
   }
 
   /**
@@ -38,8 +36,7 @@ public class LoggerHandler {
    * @param logIdName Name of the tag for logging
    * @return A formatted instance id tag or empty striing
    */
-  private static String parseUuidIntoTag(
-      String descriptor, UUID uuid, String logIdName) {
+  private static String parseUuidIntoTag(String descriptor, UUID uuid, String logIdName) {
     if (uuid == null || uuid.toString().isEmpty()) {
       META_LOGGER.warn(
           Utils.formatLogMessage(
@@ -67,8 +64,7 @@ public class LoggerHandler {
     }
 
     String tag = "[" + descriptor + ":" + uuid.toString() + "]";
-    META_LOGGER.info(
-        Utils.formatLogMessage("Setting {} instance id to '{}'", logIdName, tag));
+    META_LOGGER.info(Utils.formatLogMessage("Setting {} instance id to '{}'", logIdName, tag));
 
     return tag;
   }
@@ -232,7 +228,8 @@ public class LoggerHandler {
    */
   private String getFormattedMsg(String msg, Object... vars) {
     if (!kcGlobalInstanceIdTag.isEmpty() || !this.loggerInstanceIdTag.isEmpty()) {
-      return Utils.formatLogMessage(kcGlobalInstanceIdTag + this.loggerInstanceIdTag + " " + msg, vars);
+      return Utils.formatLogMessage(
+          kcGlobalInstanceIdTag + this.loggerInstanceIdTag + " " + msg, vars);
     }
 
     return Utils.formatLogMessage(msg, vars);

--- a/src/main/java/com/snowflake/kafka/connector/internal/LoggerHandler.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/LoggerHandler.java
@@ -24,7 +24,8 @@ public class LoggerHandler {
    * @param kcGlobalInstanceId UUID attached for every log
    */
   public static void setKcGlobalInstanceId(UUID kcGlobalInstanceId) {
-    kcGlobalInstanceIdTag = parseUuidIntoTag("KC", kcGlobalInstanceId, "Kafka Connect global");
+    kcGlobalInstanceIdTag =
+        parseUuidIntoTag("KC", kcGlobalInstanceId, "Kafka Connect global");
   }
 
   /**
@@ -37,7 +38,8 @@ public class LoggerHandler {
    * @param logIdName Name of the tag for logging
    * @return A formatted instance id tag or empty striing
    */
-  private static String parseUuidIntoTag(String descriptor, UUID uuid, String logIdName) {
+  private static String parseUuidIntoTag(
+      String descriptor, UUID uuid, String logIdName) {
     if (uuid == null || uuid.toString().isEmpty()) {
       META_LOGGER.warn(
           Utils.formatLogMessage(

--- a/src/main/java/com/snowflake/kafka/connector/internal/LoggerHandler.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/LoggerHandler.java
@@ -70,7 +70,7 @@ public class LoggerHandler {
     return "[" + descriptor + ":" + uuid.toString() + "] ";
   }
 
-  private final Logger logger;
+  private Logger logger;
   private String loggerInstanceIdTag = "";
 
   /**

--- a/src/test/java/com/snowflake/kafka/connector/internal/LoggerHandlerTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/LoggerHandlerTest.java
@@ -96,8 +96,7 @@ public class LoggerHandlerTest {
 
   @Test
   public void testInvalidUuid() {
-    this.loggerHandler =
-        new LoggerHandler(this.name, null, this.loggerInstanceIdDescriptor);
+    this.loggerHandler = new LoggerHandler(this.name, null, this.loggerInstanceIdDescriptor);
     MockitoAnnotations.initMocks(this);
 
     Mockito.when(logger.isInfoEnabled()).thenReturn(true);
@@ -107,8 +106,7 @@ public class LoggerHandlerTest {
 
   @Test
   public void testInvalidDescriptor() {
-    this.loggerHandler =
-      new LoggerHandler(this.name, this.loggerInstanceId, null);
+    this.loggerHandler = new LoggerHandler(this.name, this.loggerInstanceId, null);
     MockitoAnnotations.initMocks(this);
 
     Mockito.when(logger.isInfoEnabled()).thenReturn(true);
@@ -120,13 +118,13 @@ public class LoggerHandlerTest {
   public void testLongDescriptor() {
     String longDescriptor = "long descriptor yayay";
     String longTag = "[" + longDescriptor + ":" + loggerInstanceId.toString() + "]";
-    this.loggerHandler =
-      new LoggerHandler(this.name, this.loggerInstanceId, longDescriptor);
+    this.loggerHandler = new LoggerHandler(this.name, this.loggerInstanceId, longDescriptor);
     MockitoAnnotations.initMocks(this);
 
     Mockito.when(logger.isInfoEnabled()).thenReturn(true);
     this.loggerHandler.info(this.msg);
-    Mockito.verify(logger, Mockito.times(1)).info(Utils.formatLogMessage(longTag + " " + this.expectedMsg));
+    Mockito.verify(logger, Mockito.times(1))
+        .info(Utils.formatLogMessage(longTag + " " + this.expectedMsg));
   }
 
   private void testAllLogMessagesRunner(String... tagList) {

--- a/src/test/java/com/snowflake/kafka/connector/internal/LoggerHandlerTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/LoggerHandlerTest.java
@@ -29,127 +29,166 @@ import org.slf4j.Logger;
 import java.util.UUID;
 
 public class LoggerHandlerTest {
-  // constants
+  // test constants
   private final String name = "test.logger.name";
   private final String msg = "super useful logging message";
-  private final String formatMsg = "a formatted msg is totally more useful than a unformatted {}";
+  private final String expectedMsg = msg;
+  private final String formatMsg = "a formatted msg is totally more useful than a unformatted '{}'";
+  private final String expectedFormattedMsg =
+      "a formatted msg is totally more useful than a unformatted 'super "
+          + "useful logging message'";
   private final UUID kcGlobalInstanceId = UUID.randomUUID();
+  private final UUID loggerInstanceId = UUID.randomUUID();
+  private final String loggerInstanceIdDescriptor = "logger";
   private final String kcGlobalInstanceIdTag = "[KC:" + kcGlobalInstanceId.toString() + "] ";
+  private final String loggerInstanceIdTag =
+      "[" + loggerInstanceIdDescriptor + ":" + loggerInstanceId.toString() + "] ";
 
-  // mock and test setup
+  // mock and test setup, inject logger into loggerHandler
   @Mock(name = "logger")
   private Logger logger = Mockito.mock(Logger.class);
 
-  @InjectMocks private LoggerHandler loggerHandler = new LoggerHandler(name);
+  @InjectMocks private LoggerHandler loggerHandler = new LoggerHandler(this.name);
 
   @Before
   public void initMocks() {
-    LoggerHandler.setKcGlobalInstanceId(kcGlobalInstanceId);
     MockitoAnnotations.initMocks(this);
   }
 
   @After
   public void close() {
     LoggerHandler.setKcGlobalInstanceId(null);
+    this.loggerHandler = new LoggerHandler(this.name);
+  }
+
+  // test
+  @Test
+  public void testAllLogMessageNoInstanceIds() {
+    testAllLogMessageRunner();
   }
 
   @Test
-  public void testAllLogMessage() {
+  public void testAllLogMessageKcGlobalInstanceId() {
+    LoggerHandler.setKcGlobalInstanceId(this.kcGlobalInstanceId);
+    MockitoAnnotations.initMocks(this);
+
+    testAllLogMessageRunner(this.kcGlobalInstanceIdTag);
+  }
+
+  @Test
+  public void testAllLogMessageLoggingInstanceId() {
+    this.loggerHandler = new LoggerHandler(this.name, this.loggerInstanceId, this.loggerInstanceIdDescriptor);
+    MockitoAnnotations.initMocks(this);
+
+    testAllLogMessageRunner(this.loggerInstanceIdTag);
+  }
+
+  @Test
+  public void testAllLogMessageAllInstanceIds() {
+    LoggerHandler.setKcGlobalInstanceId(this.kcGlobalInstanceId);
+    this.loggerHandler = new LoggerHandler(this.name, this.loggerInstanceId, this.loggerInstanceIdDescriptor);
+    MockitoAnnotations.initMocks(this);
+
+    testAllLogMessageRunner(this.kcGlobalInstanceIdTag, this.loggerInstanceIdTag);
+  }
+
+  //  @Test
+  //  public void testLogMessageDisabled() {
+  //    Mockito.when(logger.isInfoEnabled()).thenReturn(false);
+  //    loggerHandler.info(msg);
+  //
+  //    Mockito.verify(logger, Mockito.times(0)).info(Utils.formatLogMessage(msg));
+  //  }
+  //
+  //  @Test
+  //  public void testLogMessageWithKcGlobalInstanceId() {
+  //    Mockito.when(logger.isInfoEnabled()).thenReturn(true);
+  //    //LoggerHandler.setKcGlobalInstanceId(kcGlobalInstanceId);
+  //    loggerHandler.info(msg);
+  //
+  //    Mockito.verify(logger, Mockito.times(1))
+  //      .info(Utils.formatLogMessage(kcGlobalInstanceIdTag + msg));
+  //  }
+  //
+  //  @Test
+  //  public void testLoggerHandlerCreationWithKcGlobalInstanceId() {
+  //    //LoggerHandler.setKcGlobalInstanceId(kcGlobalInstanceId);
+  //    LoggerHandler loggingHandler = new LoggerHandler(name);
+  //  }
+
+  private void testAllLogMessageRunner(String... tagList) {
+    String tags = "";
+    for (String tag : tagList) {
+      tags += tag;
+    }
+
+    this.testLogMessagesRunner(this.msg, tags + this.expectedMsg);
+    this.testLogMessagesWithFormattingRunner(
+        this.formatMsg, this.msg, tags + this.expectedFormattedMsg);
+  }
+
+  private void testLogMessagesRunner(String msg, String expectedMsg) {
     // info
     Mockito.when(logger.isInfoEnabled()).thenReturn(true);
     loggerHandler.info(msg);
 
-    Mockito.verify(logger, Mockito.times(1))
-        .info(Utils.formatLogMessage(kcGlobalInstanceIdTag + msg));
+    Mockito.verify(logger, Mockito.times(1)).info(Utils.formatLogMessage(expectedMsg));
 
     // trace
     Mockito.when(logger.isTraceEnabled()).thenReturn(true);
     loggerHandler.trace(msg);
 
-    Mockito.verify(logger, Mockito.times(1))
-        .trace(Utils.formatLogMessage(kcGlobalInstanceIdTag + msg));
+    Mockito.verify(logger, Mockito.times(1)).trace(Utils.formatLogMessage(expectedMsg));
 
     // debug
     Mockito.when(logger.isDebugEnabled()).thenReturn(true);
     loggerHandler.debug(msg);
 
-    Mockito.verify(logger, Mockito.times(1))
-        .debug(Utils.formatLogMessage(kcGlobalInstanceIdTag + msg));
+    Mockito.verify(logger, Mockito.times(1)).debug(Utils.formatLogMessage(expectedMsg));
 
     // warn
     Mockito.when(logger.isWarnEnabled()).thenReturn(true);
     loggerHandler.warn(msg);
 
-    Mockito.verify(logger, Mockito.times(1))
-        .warn(Utils.formatLogMessage(kcGlobalInstanceIdTag + msg));
+    Mockito.verify(logger, Mockito.times(1)).warn(Utils.formatLogMessage(expectedMsg));
 
     // error
     Mockito.when(logger.isErrorEnabled()).thenReturn(true);
     loggerHandler.error(msg);
 
-    Mockito.verify(logger, Mockito.times(1))
-        .error(Utils.formatLogMessage(kcGlobalInstanceIdTag + msg));
+    Mockito.verify(logger, Mockito.times(1)).error(Utils.formatLogMessage(expectedMsg));
   }
 
-  @Test
-  public void testAllLogMessageWithFormatting() {
+  private void testLogMessagesWithFormattingRunner(
+      String formatMsg, String msg, String expectedFormattedMsg) {
     // info
     Mockito.when(logger.isInfoEnabled()).thenReturn(true);
     loggerHandler.info(formatMsg, msg);
 
-    Mockito.verify(logger, Mockito.times(1))
-        .info(Utils.formatLogMessage(kcGlobalInstanceIdTag + formatMsg, msg));
+    Mockito.verify(logger, Mockito.times(1)).info(Utils.formatLogMessage(expectedFormattedMsg));
 
     // trace
     Mockito.when(logger.isTraceEnabled()).thenReturn(true);
     loggerHandler.trace(formatMsg, msg);
 
-    Mockito.verify(logger, Mockito.times(1))
-        .trace(Utils.formatLogMessage(kcGlobalInstanceIdTag + formatMsg, msg));
+    Mockito.verify(logger, Mockito.times(1)).trace(Utils.formatLogMessage(expectedFormattedMsg));
 
     // debug
     Mockito.when(logger.isDebugEnabled()).thenReturn(true);
     loggerHandler.debug(formatMsg, msg);
 
-    Mockito.verify(logger, Mockito.times(1))
-        .debug(Utils.formatLogMessage(kcGlobalInstanceIdTag + formatMsg, msg));
+    Mockito.verify(logger, Mockito.times(1)).debug(Utils.formatLogMessage(expectedFormattedMsg));
 
     // warn
     Mockito.when(logger.isWarnEnabled()).thenReturn(true);
     loggerHandler.warn(formatMsg, msg);
 
-    Mockito.verify(logger, Mockito.times(1))
-        .warn(Utils.formatLogMessage(kcGlobalInstanceIdTag + formatMsg, msg));
+    Mockito.verify(logger, Mockito.times(1)).warn(Utils.formatLogMessage(expectedFormattedMsg));
 
     // error
     Mockito.when(logger.isErrorEnabled()).thenReturn(true);
     loggerHandler.error(formatMsg, msg);
 
-    Mockito.verify(logger, Mockito.times(1))
-        .error(Utils.formatLogMessage(kcGlobalInstanceIdTag + formatMsg, msg));
-  }
-
-  @Test
-  public void testLogMessageDisabled() {
-    Mockito.when(logger.isInfoEnabled()).thenReturn(false);
-    loggerHandler.info(msg);
-
-    Mockito.verify(logger, Mockito.times(0)).info(Utils.formatLogMessage(msg));
-  }
-
-  @Test
-  public void testLogMessageWithKcGlobalInstanceId() {
-    Mockito.when(logger.isInfoEnabled()).thenReturn(true);
-    LoggerHandler.setKcGlobalInstanceId(kcGlobalInstanceId);
-    loggerHandler.info(msg);
-
-    Mockito.verify(logger, Mockito.times(1))
-        .info(Utils.formatLogMessage(kcGlobalInstanceIdTag + msg));
-  }
-
-  @Test
-  public void testLoggerHandlerCreationWithKcGlobalInstanceId() {
-    LoggerHandler.setKcGlobalInstanceId(kcGlobalInstanceId);
-    LoggerHandler loggingHandler = new LoggerHandler(name);
+    Mockito.verify(logger, Mockito.times(1)).error(Utils.formatLogMessage(expectedFormattedMsg));
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/internal/LoggerHandlerTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/LoggerHandlerTest.java
@@ -17,7 +17,6 @@
 package com.snowflake.kafka.connector.internal;
 
 import com.snowflake.kafka.connector.Utils;
-import java.util.UUID;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -27,13 +26,15 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.slf4j.Logger;
 
+import java.util.UUID;
+
 public class LoggerHandlerTest {
   // constants
   private final String name = "test.logger.name";
   private final String msg = "super useful logging message";
   private final String formatMsg = "a formatted msg is totally more useful than a unformatted {}";
-  private final UUID cid = UUID.randomUUID();
-  private final String cidStr = "[" + cid.toString() + "] ";
+  private final UUID kcGlobalInstanceId = UUID.randomUUID();
+  private final String kcGlobalInstanceIdTag = "[" + kcGlobalInstanceId.toString() + "] ";
 
   // mock and test setup
   @Mock(name = "logger")
@@ -43,13 +44,13 @@ public class LoggerHandlerTest {
 
   @Before
   public void initMocks() {
-    LoggerHandler.setCorrelationUuid(cid);
+    LoggerHandler.setKcGlobalInstanceId(kcGlobalInstanceId);
     MockitoAnnotations.initMocks(this);
   }
 
   @After
   public void close() {
-    LoggerHandler.setCorrelationUuid(null);
+    LoggerHandler.setKcGlobalInstanceId(null);
   }
 
   @Test
@@ -58,31 +59,31 @@ public class LoggerHandlerTest {
     Mockito.when(logger.isInfoEnabled()).thenReturn(true);
     loggerHandler.info(msg);
 
-    Mockito.verify(logger, Mockito.times(1)).info(Utils.formatLogMessage(cidStr + msg));
+    Mockito.verify(logger, Mockito.times(1)).info(Utils.formatLogMessage(kcGlobalInstanceIdTag + msg));
 
     // trace
     Mockito.when(logger.isTraceEnabled()).thenReturn(true);
     loggerHandler.trace(msg);
 
-    Mockito.verify(logger, Mockito.times(1)).trace(Utils.formatLogMessage(cidStr + msg));
+    Mockito.verify(logger, Mockito.times(1)).trace(Utils.formatLogMessage(kcGlobalInstanceIdTag + msg));
 
     // debug
     Mockito.when(logger.isDebugEnabled()).thenReturn(true);
     loggerHandler.debug(msg);
 
-    Mockito.verify(logger, Mockito.times(1)).debug(Utils.formatLogMessage(cidStr + msg));
+    Mockito.verify(logger, Mockito.times(1)).debug(Utils.formatLogMessage(kcGlobalInstanceIdTag + msg));
 
     // warn
     Mockito.when(logger.isWarnEnabled()).thenReturn(true);
     loggerHandler.warn(msg);
 
-    Mockito.verify(logger, Mockito.times(1)).warn(Utils.formatLogMessage(cidStr + msg));
+    Mockito.verify(logger, Mockito.times(1)).warn(Utils.formatLogMessage(kcGlobalInstanceIdTag + msg));
 
     // error
     Mockito.when(logger.isErrorEnabled()).thenReturn(true);
     loggerHandler.error(msg);
 
-    Mockito.verify(logger, Mockito.times(1)).error(Utils.formatLogMessage(cidStr + msg));
+    Mockito.verify(logger, Mockito.times(1)).error(Utils.formatLogMessage(kcGlobalInstanceIdTag + msg));
   }
 
   @Test
@@ -91,31 +92,31 @@ public class LoggerHandlerTest {
     Mockito.when(logger.isInfoEnabled()).thenReturn(true);
     loggerHandler.info(formatMsg, msg);
 
-    Mockito.verify(logger, Mockito.times(1)).info(Utils.formatLogMessage(cidStr + formatMsg, msg));
+    Mockito.verify(logger, Mockito.times(1)).info(Utils.formatLogMessage(kcGlobalInstanceIdTag + formatMsg, msg));
 
     // trace
     Mockito.when(logger.isTraceEnabled()).thenReturn(true);
     loggerHandler.trace(formatMsg, msg);
 
-    Mockito.verify(logger, Mockito.times(1)).trace(Utils.formatLogMessage(cidStr + formatMsg, msg));
+    Mockito.verify(logger, Mockito.times(1)).trace(Utils.formatLogMessage(kcGlobalInstanceIdTag + formatMsg, msg));
 
     // debug
     Mockito.when(logger.isDebugEnabled()).thenReturn(true);
     loggerHandler.debug(formatMsg, msg);
 
-    Mockito.verify(logger, Mockito.times(1)).debug(Utils.formatLogMessage(cidStr + formatMsg, msg));
+    Mockito.verify(logger, Mockito.times(1)).debug(Utils.formatLogMessage(kcGlobalInstanceIdTag + formatMsg, msg));
 
     // warn
     Mockito.when(logger.isWarnEnabled()).thenReturn(true);
     loggerHandler.warn(formatMsg, msg);
 
-    Mockito.verify(logger, Mockito.times(1)).warn(Utils.formatLogMessage(cidStr + formatMsg, msg));
+    Mockito.verify(logger, Mockito.times(1)).warn(Utils.formatLogMessage(kcGlobalInstanceIdTag + formatMsg, msg));
 
     // error
     Mockito.when(logger.isErrorEnabled()).thenReturn(true);
     loggerHandler.error(formatMsg, msg);
 
-    Mockito.verify(logger, Mockito.times(1)).error(Utils.formatLogMessage(cidStr + formatMsg, msg));
+    Mockito.verify(logger, Mockito.times(1)).error(Utils.formatLogMessage(kcGlobalInstanceIdTag + formatMsg, msg));
   }
 
   @Test
@@ -127,17 +128,17 @@ public class LoggerHandlerTest {
   }
 
   @Test
-  public void testLogMessageWithCid() {
+  public void testLogMessageWithKcGlobalInstanceId() {
     Mockito.when(logger.isInfoEnabled()).thenReturn(true);
-    LoggerHandler.setCorrelationUuid(cid);
+    LoggerHandler.setKcGlobalInstanceId(kcGlobalInstanceId);
     loggerHandler.info(msg);
 
-    Mockito.verify(logger, Mockito.times(1)).info(Utils.formatLogMessage(cidStr + msg));
+    Mockito.verify(logger, Mockito.times(1)).info(Utils.formatLogMessage(kcGlobalInstanceIdTag + msg));
   }
 
   @Test
-  public void testLoggerHandlerCreationWithCid() {
-    LoggerHandler.setCorrelationUuid(cid);
+  public void testLoggerHandlerCreationWithKcGlobalInstanceId() {
+    LoggerHandler.setKcGlobalInstanceId(kcGlobalInstanceId);
     LoggerHandler loggingHandler = new LoggerHandler(name);
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/internal/LoggerHandlerTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/LoggerHandlerTest.java
@@ -64,7 +64,7 @@ public class LoggerHandlerTest {
   // test
   @Test
   public void testAllLogMessageNoInstanceIds() {
-    testAllLogMessageRunner();
+    testAllLogMessagesRunner();
   }
 
   @Test
@@ -72,51 +72,64 @@ public class LoggerHandlerTest {
     LoggerHandler.setKcGlobalInstanceId(this.kcGlobalInstanceId);
     MockitoAnnotations.initMocks(this);
 
-    testAllLogMessageRunner(this.kcGlobalInstanceIdTag);
+    testAllLogMessagesRunner(this.kcGlobalInstanceIdTag);
   }
 
   @Test
   public void testAllLogMessageLoggingInstanceId() {
-    this.loggerHandler = new LoggerHandler(this.name, this.loggerInstanceId, this.loggerInstanceIdDescriptor);
+    this.loggerHandler =
+        new LoggerHandler(this.name, this.loggerInstanceId, this.loggerInstanceIdDescriptor);
     MockitoAnnotations.initMocks(this);
 
-    testAllLogMessageRunner(this.loggerInstanceIdTag);
+    testAllLogMessagesRunner(this.loggerInstanceIdTag);
   }
 
   @Test
   public void testAllLogMessageAllInstanceIds() {
     LoggerHandler.setKcGlobalInstanceId(this.kcGlobalInstanceId);
-    this.loggerHandler = new LoggerHandler(this.name, this.loggerInstanceId, this.loggerInstanceIdDescriptor);
+    this.loggerHandler =
+        new LoggerHandler(this.name, this.loggerInstanceId, this.loggerInstanceIdDescriptor);
     MockitoAnnotations.initMocks(this);
 
-    testAllLogMessageRunner(this.kcGlobalInstanceIdTag, this.loggerInstanceIdTag);
+    testAllLogMessagesRunner(this.kcGlobalInstanceIdTag, this.loggerInstanceIdTag);
   }
 
-  //  @Test
-  //  public void testLogMessageDisabled() {
-  //    Mockito.when(logger.isInfoEnabled()).thenReturn(false);
-  //    loggerHandler.info(msg);
-  //
-  //    Mockito.verify(logger, Mockito.times(0)).info(Utils.formatLogMessage(msg));
-  //  }
-  //
-  //  @Test
-  //  public void testLogMessageWithKcGlobalInstanceId() {
-  //    Mockito.when(logger.isInfoEnabled()).thenReturn(true);
-  //    //LoggerHandler.setKcGlobalInstanceId(kcGlobalInstanceId);
-  //    loggerHandler.info(msg);
-  //
-  //    Mockito.verify(logger, Mockito.times(1))
-  //      .info(Utils.formatLogMessage(kcGlobalInstanceIdTag + msg));
-  //  }
-  //
-  //  @Test
-  //  public void testLoggerHandlerCreationWithKcGlobalInstanceId() {
-  //    //LoggerHandler.setKcGlobalInstanceId(kcGlobalInstanceId);
-  //    LoggerHandler loggingHandler = new LoggerHandler(name);
-  //  }
+  @Test
+  public void testInvalidUuid() {
+    this.loggerHandler =
+        new LoggerHandler(this.name, null, this.loggerInstanceIdDescriptor);
+    MockitoAnnotations.initMocks(this);
 
-  private void testAllLogMessageRunner(String... tagList) {
+    Mockito.when(logger.isInfoEnabled()).thenReturn(true);
+    this.loggerHandler.info(this.msg);
+    Mockito.verify(logger, Mockito.times(1)).info(Utils.formatLogMessage(this.expectedMsg));
+  }
+
+  @Test
+  public void testInvalidDescriptor() {
+    this.loggerHandler =
+      new LoggerHandler(this.name, this.loggerInstanceId, null);
+    MockitoAnnotations.initMocks(this);
+
+    Mockito.when(logger.isInfoEnabled()).thenReturn(true);
+    this.loggerHandler.info(this.msg);
+    Mockito.verify(logger, Mockito.times(1)).info(Utils.formatLogMessage(this.expectedMsg));
+  }
+
+  @Test
+  public void testLongDescriptor() {
+    String longDescriptor = "long descriptor yayay";
+    String longTag = "[" + longDescriptor + ":" + loggerInstanceId.toString() + "] ";
+    this.loggerHandler =
+      new LoggerHandler(this.name, this.loggerInstanceId, longDescriptor);
+    MockitoAnnotations.initMocks(this);
+
+    Mockito.when(logger.isInfoEnabled()).thenReturn(true);
+    this.loggerHandler.info(this.msg);
+    Mockito.verify(logger, Mockito.times(1)).info(Utils.formatLogMessage(longTag + this.expectedMsg));
+  }
+
+  private void testAllLogMessagesRunner(String... tagList) {
     String tags = "";
     for (String tag : tagList) {
       tags += tag;

--- a/src/test/java/com/snowflake/kafka/connector/internal/LoggerHandlerTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/LoggerHandlerTest.java
@@ -40,9 +40,9 @@ public class LoggerHandlerTest {
   private final UUID kcGlobalInstanceId = UUID.randomUUID();
   private final UUID loggerInstanceId = UUID.randomUUID();
   private final String loggerInstanceIdDescriptor = "logger";
-  private final String kcGlobalInstanceIdTag = "[KC:" + kcGlobalInstanceId.toString() + "] ";
+  private final String kcGlobalInstanceIdTag = "[KC:" + kcGlobalInstanceId.toString() + "]";
   private final String loggerInstanceIdTag =
-      "[" + loggerInstanceIdDescriptor + ":" + loggerInstanceId.toString() + "] ";
+      "[" + loggerInstanceIdDescriptor + ":" + loggerInstanceId.toString() + "]";
 
   // mock and test setup, inject logger into loggerHandler
   @Mock(name = "logger")
@@ -119,20 +119,24 @@ public class LoggerHandlerTest {
   @Test
   public void testLongDescriptor() {
     String longDescriptor = "long descriptor yayay";
-    String longTag = "[" + longDescriptor + ":" + loggerInstanceId.toString() + "] ";
+    String longTag = "[" + longDescriptor + ":" + loggerInstanceId.toString() + "]";
     this.loggerHandler =
       new LoggerHandler(this.name, this.loggerInstanceId, longDescriptor);
     MockitoAnnotations.initMocks(this);
 
     Mockito.when(logger.isInfoEnabled()).thenReturn(true);
     this.loggerHandler.info(this.msg);
-    Mockito.verify(logger, Mockito.times(1)).info(Utils.formatLogMessage(longTag + this.expectedMsg));
+    Mockito.verify(logger, Mockito.times(1)).info(Utils.formatLogMessage(longTag + " " + this.expectedMsg));
   }
 
   private void testAllLogMessagesRunner(String... tagList) {
     String tags = "";
     for (String tag : tagList) {
       tags += tag;
+    }
+
+    if (!tags.isEmpty()) {
+      tags += " ";
     }
 
     this.testLogMessagesRunner(this.msg, tags + this.expectedMsg);

--- a/src/test/java/com/snowflake/kafka/connector/internal/LoggerHandlerTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/LoggerHandlerTest.java
@@ -34,7 +34,7 @@ public class LoggerHandlerTest {
   private final String msg = "super useful logging message";
   private final String formatMsg = "a formatted msg is totally more useful than a unformatted {}";
   private final UUID kcGlobalInstanceId = UUID.randomUUID();
-  private final String kcGlobalInstanceIdTag = "[" + kcGlobalInstanceId.toString() + "] ";
+  private final String kcGlobalInstanceIdTag = "[KC:" + kcGlobalInstanceId.toString() + "] ";
 
   // mock and test setup
   @Mock(name = "logger")
@@ -59,31 +59,36 @@ public class LoggerHandlerTest {
     Mockito.when(logger.isInfoEnabled()).thenReturn(true);
     loggerHandler.info(msg);
 
-    Mockito.verify(logger, Mockito.times(1)).info(Utils.formatLogMessage(kcGlobalInstanceIdTag + msg));
+    Mockito.verify(logger, Mockito.times(1))
+        .info(Utils.formatLogMessage(kcGlobalInstanceIdTag + msg));
 
     // trace
     Mockito.when(logger.isTraceEnabled()).thenReturn(true);
     loggerHandler.trace(msg);
 
-    Mockito.verify(logger, Mockito.times(1)).trace(Utils.formatLogMessage(kcGlobalInstanceIdTag + msg));
+    Mockito.verify(logger, Mockito.times(1))
+        .trace(Utils.formatLogMessage(kcGlobalInstanceIdTag + msg));
 
     // debug
     Mockito.when(logger.isDebugEnabled()).thenReturn(true);
     loggerHandler.debug(msg);
 
-    Mockito.verify(logger, Mockito.times(1)).debug(Utils.formatLogMessage(kcGlobalInstanceIdTag + msg));
+    Mockito.verify(logger, Mockito.times(1))
+        .debug(Utils.formatLogMessage(kcGlobalInstanceIdTag + msg));
 
     // warn
     Mockito.when(logger.isWarnEnabled()).thenReturn(true);
     loggerHandler.warn(msg);
 
-    Mockito.verify(logger, Mockito.times(1)).warn(Utils.formatLogMessage(kcGlobalInstanceIdTag + msg));
+    Mockito.verify(logger, Mockito.times(1))
+        .warn(Utils.formatLogMessage(kcGlobalInstanceIdTag + msg));
 
     // error
     Mockito.when(logger.isErrorEnabled()).thenReturn(true);
     loggerHandler.error(msg);
 
-    Mockito.verify(logger, Mockito.times(1)).error(Utils.formatLogMessage(kcGlobalInstanceIdTag + msg));
+    Mockito.verify(logger, Mockito.times(1))
+        .error(Utils.formatLogMessage(kcGlobalInstanceIdTag + msg));
   }
 
   @Test
@@ -92,31 +97,36 @@ public class LoggerHandlerTest {
     Mockito.when(logger.isInfoEnabled()).thenReturn(true);
     loggerHandler.info(formatMsg, msg);
 
-    Mockito.verify(logger, Mockito.times(1)).info(Utils.formatLogMessage(kcGlobalInstanceIdTag + formatMsg, msg));
+    Mockito.verify(logger, Mockito.times(1))
+        .info(Utils.formatLogMessage(kcGlobalInstanceIdTag + formatMsg, msg));
 
     // trace
     Mockito.when(logger.isTraceEnabled()).thenReturn(true);
     loggerHandler.trace(formatMsg, msg);
 
-    Mockito.verify(logger, Mockito.times(1)).trace(Utils.formatLogMessage(kcGlobalInstanceIdTag + formatMsg, msg));
+    Mockito.verify(logger, Mockito.times(1))
+        .trace(Utils.formatLogMessage(kcGlobalInstanceIdTag + formatMsg, msg));
 
     // debug
     Mockito.when(logger.isDebugEnabled()).thenReturn(true);
     loggerHandler.debug(formatMsg, msg);
 
-    Mockito.verify(logger, Mockito.times(1)).debug(Utils.formatLogMessage(kcGlobalInstanceIdTag + formatMsg, msg));
+    Mockito.verify(logger, Mockito.times(1))
+        .debug(Utils.formatLogMessage(kcGlobalInstanceIdTag + formatMsg, msg));
 
     // warn
     Mockito.when(logger.isWarnEnabled()).thenReturn(true);
     loggerHandler.warn(formatMsg, msg);
 
-    Mockito.verify(logger, Mockito.times(1)).warn(Utils.formatLogMessage(kcGlobalInstanceIdTag + formatMsg, msg));
+    Mockito.verify(logger, Mockito.times(1))
+        .warn(Utils.formatLogMessage(kcGlobalInstanceIdTag + formatMsg, msg));
 
     // error
     Mockito.when(logger.isErrorEnabled()).thenReturn(true);
     loggerHandler.error(formatMsg, msg);
 
-    Mockito.verify(logger, Mockito.times(1)).error(Utils.formatLogMessage(kcGlobalInstanceIdTag + formatMsg, msg));
+    Mockito.verify(logger, Mockito.times(1))
+        .error(Utils.formatLogMessage(kcGlobalInstanceIdTag + formatMsg, msg));
   }
 
   @Test
@@ -133,7 +143,8 @@ public class LoggerHandlerTest {
     LoggerHandler.setKcGlobalInstanceId(kcGlobalInstanceId);
     loggerHandler.info(msg);
 
-    Mockito.verify(logger, Mockito.times(1)).info(Utils.formatLogMessage(kcGlobalInstanceIdTag + msg));
+    Mockito.verify(logger, Mockito.times(1))
+        .info(Utils.formatLogMessage(kcGlobalInstanceIdTag + msg));
   }
 
   @Test


### PR DESCRIPTION
Changes:
- Refactored LoggerHandler to log a "kcGlobalInstanceId" instead of a "correlationId"
- Added logger specific instanceId to LoggingHandler. This is set during logger creation
- Refactored LoggerHandlerTest with test runners
- Added an instanceId to Task loggers

<img width="1872" alt="image" src="https://user-images.githubusercontent.com/111399397/191637567-33eef8e1-29cd-475a-bc88-c17ba989fa5b.png">
