### PR TITLE
Fix broken logging IT

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
@@ -162,7 +162,7 @@ public class SnowflakeSinkTask extends SinkTask {
     this.DYNAMIC_LOGGER.setLoggerInstanceTag(this.getTaskLoggingTag());
 
     this.DYNAMIC_LOGGER.debug("starting task...");
-    
+
     // generate topic to table map
     this.topic2table = getTopicToTableMap(parsedConfig);
 

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
@@ -161,7 +161,7 @@ public class SnowflakeSinkTask extends SinkTask {
 
     this.DYNAMIC_LOGGER.setLoggerInstanceTag(this.getTaskLoggingTag());
 
-    this.DYNAMIC_LOGGER.info("starting task...");
+    this.DYNAMIC_LOGGER.debug("starting task...");
     
     // generate topic to table map
     this.topic2table = getTopicToTableMap(parsedConfig);

--- a/src/test/java/com/snowflake/kafka/connector/SinkTaskIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/SinkTaskIT.java
@@ -237,7 +237,8 @@ public class SinkTaskIT {
 
     // verify task1 open logs
     Mockito.verify(logger, Mockito.times(1))
-        .debug(AdditionalMatchers.and(Mockito.contains(expectedTask1Tag), Mockito.contains("open")));
+        .debug(
+            AdditionalMatchers.and(Mockito.contains(expectedTask1Tag), Mockito.contains("open")));
 
     // put regular data to tasks
     ArrayList<SinkRecord> records = new ArrayList<>();
@@ -316,7 +317,8 @@ public class SinkTaskIT {
 
     // verify task1 stop logs
     Mockito.verify(logger, Mockito.times(1))
-        .debug(AdditionalMatchers.and(Mockito.contains(expectedTask1Tag), Mockito.contains("stop")));
+        .debug(
+            AdditionalMatchers.and(Mockito.contains(expectedTask1Tag), Mockito.contains("stop")));
 
     assert offsetMap1.get(topicPartitions0.get(0)).offset() == BUFFER_COUNT_RECORDS_DEFAULT;
     assert offsetMap0.get(topicPartitions1.get(0)).offset() == BUFFER_COUNT_RECORDS_DEFAULT;

--- a/src/test/java/com/snowflake/kafka/connector/SinkTaskIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/SinkTaskIT.java
@@ -193,6 +193,7 @@ public class SinkTaskIT {
     // setup log mocking for task1
     MockitoAnnotations.initMocks(this);
     Mockito.when(logger.isInfoEnabled()).thenReturn(true);
+    Mockito.when(logger.isDebugEnabled()).thenReturn(true);
     Mockito.when(logger.isWarnEnabled()).thenReturn(true);
 
     // setup tasks
@@ -220,7 +221,7 @@ public class SinkTaskIT {
     Mockito.verify(loggerHandler, Mockito.times(1))
         .setLoggerInstanceTag(Mockito.contains(expectedTask1Tag));
     Mockito.verify(logger, Mockito.times(2))
-        .info(
+        .debug(
             AdditionalMatchers.and(Mockito.contains(expectedTask1Tag), Mockito.contains("start")));
 
     // open tasks
@@ -235,8 +236,8 @@ public class SinkTaskIT {
     expectedTask1Tag = TestUtils.getExpectedLogTagWithoutCreationCount(task1Id, task1OpenCount);
 
     // verify task1 open logs
-    Mockito.verify(logger, Mockito.times(2))
-        .info(AdditionalMatchers.and(Mockito.contains(expectedTask1Tag), Mockito.contains("open")));
+    Mockito.verify(logger, Mockito.times(1))
+        .debug(AdditionalMatchers.and(Mockito.contains(expectedTask1Tag), Mockito.contains("open")));
 
     // put regular data to tasks
     ArrayList<SinkRecord> records = new ArrayList<>();
@@ -262,8 +263,8 @@ public class SinkTaskIT {
     task1.put(records);
 
     // verify task1 put logs
-    Mockito.verify(logger, Mockito.times(2))
-        .info(AdditionalMatchers.and(Mockito.contains(expectedTask1Tag), Mockito.contains("put")));
+    Mockito.verify(logger, Mockito.times(1))
+        .debug(AdditionalMatchers.and(Mockito.contains(expectedTask1Tag), Mockito.contains("put")));
 
     // send broken data to task1
     String brokenJson = "{ broken json";
@@ -283,8 +284,8 @@ public class SinkTaskIT {
     task1.put(records);
 
     // verify task1 broken put logs, 4 bc in addition to last call
-    Mockito.verify(logger, Mockito.times(4))
-        .info(AdditionalMatchers.and(Mockito.contains(expectedTask1Tag), Mockito.contains("put")));
+    Mockito.verify(logger, Mockito.times(2))
+        .debug(AdditionalMatchers.and(Mockito.contains(expectedTask1Tag), Mockito.contains("put")));
 
     // commit offset
     Map<TopicPartition, OffsetAndMetadata> offsetMap0 = new HashMap<>();
@@ -296,8 +297,8 @@ public class SinkTaskIT {
     offsetMap1 = task1.preCommit(offsetMap1);
 
     // verify task1 precommit logs
-    Mockito.verify(logger, Mockito.times(2))
-        .info(
+    Mockito.verify(logger, Mockito.times(1))
+        .debug(
             AdditionalMatchers.and(
                 Mockito.contains(expectedTask1Tag), Mockito.contains("precommit")));
 
@@ -307,20 +308,15 @@ public class SinkTaskIT {
 
     // verify task1 close logs
     Mockito.verify(logger, Mockito.times(1))
-        .info(
-            AdditionalMatchers.and(Mockito.contains(expectedTask1Tag), Mockito.contains("close")));
-    Mockito.verify(logger, Mockito.times(1))
-        .info(
-            AdditionalMatchers.and(
-                Mockito.contains(expectedTask1Tag), Mockito.contains("closing")));
-
+        .debug(
+            AdditionalMatchers.and(Mockito.contains(expectedTask1Tag), Mockito.contains("closed")));
     // stop tasks
     task0.stop();
     task1.stop();
 
     // verify task1 stop logs
     Mockito.verify(logger, Mockito.times(1))
-        .info(AdditionalMatchers.and(Mockito.contains(expectedTask1Tag), Mockito.contains("stop")));
+        .debug(AdditionalMatchers.and(Mockito.contains(expectedTask1Tag), Mockito.contains("stop")));
 
     assert offsetMap1.get(topicPartitions0.get(0)).offset() == BUFFER_COUNT_RECORDS_DEFAULT;
     assert offsetMap0.get(topicPartitions1.get(0)).offset() == BUFFER_COUNT_RECORDS_DEFAULT;

--- a/src/test/java/com/snowflake/kafka/connector/SnowflakeSinkTaskForStreamingIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/SnowflakeSinkTaskForStreamingIT.java
@@ -155,7 +155,8 @@ public class SnowflakeSinkTaskForStreamingIT {
 
     // verify task1 open logs
     Mockito.verify(logger, Mockito.times(1))
-        .debug(AdditionalMatchers.and(Mockito.contains(expectedTask1Tag), Mockito.contains("open")));
+        .debug(
+            AdditionalMatchers.and(Mockito.contains(expectedTask1Tag), Mockito.contains("open")));
 
     // send data to tasks
     List<SinkRecord> records0 = TestUtils.createJsonStringSinkRecords(0, 1, topicName, partition);
@@ -203,7 +204,8 @@ public class SnowflakeSinkTaskForStreamingIT {
 
     // verify task1 stop logs
     Mockito.verify(logger, Mockito.times(1))
-        .debug(AdditionalMatchers.and(Mockito.contains(expectedTask1Tag), Mockito.contains("stop")));
+        .debug(
+            AdditionalMatchers.and(Mockito.contains(expectedTask1Tag), Mockito.contains("stop")));
   }
 
   @Test

--- a/src/test/java/com/snowflake/kafka/connector/SnowflakeSinkTaskForStreamingIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/SnowflakeSinkTaskForStreamingIT.java
@@ -101,6 +101,7 @@ public class SnowflakeSinkTaskForStreamingIT {
     // setup log mocking for task1
     MockitoAnnotations.initMocks(this);
     Mockito.when(logger.isInfoEnabled()).thenReturn(true);
+    Mockito.when(logger.isDebugEnabled()).thenReturn(true);
     Mockito.when(logger.isWarnEnabled()).thenReturn(true);
 
     // set up configs
@@ -137,7 +138,7 @@ public class SnowflakeSinkTaskForStreamingIT {
     Mockito.verify(loggerHandler, Mockito.times(1))
         .setLoggerInstanceTag(Mockito.contains(expectedTask1Tag));
     Mockito.verify(logger, Mockito.times(2))
-        .info(
+        .debug(
             AdditionalMatchers.and(Mockito.contains(expectedTask1Tag), Mockito.contains("start")));
 
     // open tasks
@@ -153,8 +154,8 @@ public class SnowflakeSinkTaskForStreamingIT {
     expectedTask1Tag = TestUtils.getExpectedLogTagWithoutCreationCount(task1Id, taskOpen1Count);
 
     // verify task1 open logs
-    Mockito.verify(logger, Mockito.times(2))
-        .info(AdditionalMatchers.and(Mockito.contains(expectedTask1Tag), Mockito.contains("open")));
+    Mockito.verify(logger, Mockito.times(1))
+        .debug(AdditionalMatchers.and(Mockito.contains(expectedTask1Tag), Mockito.contains("open")));
 
     // send data to tasks
     List<SinkRecord> records0 = TestUtils.createJsonStringSinkRecords(0, 1, topicName, partition);
@@ -164,8 +165,8 @@ public class SnowflakeSinkTaskForStreamingIT {
     sinkTask1.put(records1);
 
     // verify task1 put logs
-    Mockito.verify(logger, Mockito.times(2))
-        .info(AdditionalMatchers.and(Mockito.contains(expectedTask1Tag), Mockito.contains("put")));
+    Mockito.verify(logger, Mockito.times(1))
+        .debug(AdditionalMatchers.and(Mockito.contains(expectedTask1Tag), Mockito.contains("put")));
 
     // commit offsets
     final Map<TopicPartition, OffsetAndMetadata> offsetMap0 = new HashMap<>();
@@ -177,8 +178,8 @@ public class SnowflakeSinkTaskForStreamingIT {
     TestUtils.assertWithRetry(() -> sinkTask1.preCommit(offsetMap1).size() == 1, 20, 5);
 
     // verify task1 precommit logs
-    Mockito.verify(logger, Mockito.times(2))
-        .info(
+    Mockito.verify(logger, Mockito.times(1))
+        .debug(
             AdditionalMatchers.and(
                 Mockito.contains(expectedTask1Tag), Mockito.contains("precommit")));
 
@@ -193,12 +194,8 @@ public class SnowflakeSinkTaskForStreamingIT {
 
     // verify task1 close logs
     Mockito.verify(logger, Mockito.times(1))
-        .info(
-            AdditionalMatchers.and(Mockito.contains(expectedTask1Tag), Mockito.contains("close")));
-    Mockito.verify(logger, Mockito.times(1))
-        .info(
-            AdditionalMatchers.and(
-                Mockito.contains(expectedTask1Tag), Mockito.contains("closing")));
+        .debug(
+            AdditionalMatchers.and(Mockito.contains(expectedTask1Tag), Mockito.contains("closed")));
 
     // stop tasks
     sinkTask0.stop();
@@ -206,7 +203,7 @@ public class SnowflakeSinkTaskForStreamingIT {
 
     // verify task1 stop logs
     Mockito.verify(logger, Mockito.times(1))
-        .info(AdditionalMatchers.and(Mockito.contains(expectedTask1Tag), Mockito.contains("stop")));
+        .debug(AdditionalMatchers.and(Mockito.contains(expectedTask1Tag), Mockito.contains("stop")));
   }
 
   @Test


### PR DESCRIPTION
Fixing previously broken IT from a logging change I introduced. Changes log messages and levels we use to validate functionality.

Also using debug instead of info for the tasks tart message, missed that in the last change (probably because i hadn't run the tests)