### PR TITLE
[SNOW-726924] Add New jvm.nonProxy.hosts Parameter and update JDBC to 3.13.23

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -402,7 +402,7 @@
         <dependency>
             <groupId>net.snowflake</groupId>
             <artifactId>snowflake-jdbc</artifactId>
-            <version>3.13.14</version>
+            <version>3.13.23</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/io.dropwizard.metrics/metrics-core -->

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -77,6 +77,7 @@ public class SnowflakeSinkConnectorConfig {
   private static final String PROXY_INFO = "Proxy Info";
   public static final String JVM_PROXY_HOST = "jvm.proxy.host";
   public static final String JVM_PROXY_PORT = "jvm.proxy.port";
+  public static final String JVM_NON_PROXY_HOSTS = "jvm.nonProxy.hosts";
   public static final String JVM_PROXY_USERNAME = "jvm.proxy.username";
   public static final String JVM_PROXY_PASSWORD = "jvm.proxy.password";
 
@@ -304,13 +305,23 @@ public class SnowflakeSinkConnectorConfig {
             ConfigDef.Width.NONE,
             JVM_PROXY_PORT)
         .define(
+            JVM_NON_PROXY_HOSTS,
+            Type.STRING,
+            "",
+            Importance.LOW,
+            "JVM nonProxyHosts",
+            PROXY_INFO,
+            2,
+            ConfigDef.Width.NONE,
+            JVM_NON_PROXY_HOSTS)
+        .define(
             JVM_PROXY_USERNAME,
             Type.STRING,
             "",
             Importance.LOW,
             "JVM proxy username",
             PROXY_INFO,
-            2,
+            3,
             ConfigDef.Width.NONE,
             JVM_PROXY_USERNAME)
         .define(
@@ -320,7 +331,7 @@ public class SnowflakeSinkConnectorConfig {
             Importance.LOW,
             "JVM proxy password",
             PROXY_INFO,
-            3,
+            4,
             ConfigDef.Width.NONE,
             JVM_PROXY_PASSWORD)
         // Connector Config

--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -81,6 +81,7 @@ public class Utils {
   public static final String HTTPS_PROXY_PORT = "https.proxyPort";
   public static final String HTTP_PROXY_HOST = "http.proxyHost";
   public static final String HTTP_PROXY_PORT = "http.proxyPort";
+  public static final String HTTP_NON_PROXY_HOSTS = "http.nonProxyHosts";
 
   public static final String JDK_HTTP_AUTH_TUNNELING = "jdk.http.auth.tunneling.disabledSchemes";
   public static final String HTTPS_PROXY_USER = "https.proxyUser";
@@ -262,8 +263,12 @@ public class Utils {
     String port =
         SnowflakeSinkConnectorConfig.getProperty(
             config, SnowflakeSinkConnectorConfig.JVM_PROXY_PORT);
+    String nonProxyHosts =
+            SnowflakeSinkConnectorConfig.getProperty(
+                    config, SnowflakeSinkConnectorConfig.JVM_NON_PROXY_HOSTS);
+
     if (host != null && port != null) {
-      LOGGER.info("enable jvm proxy: {}:{}", host, port);
+      LOGGER.info("enable jvm proxy: {}:{} and bypass proxy for hosts: {}", host, port, nonProxyHosts);
 
       // enable https proxy
       System.setProperty(HTTP_USE_PROXY, "true");
@@ -271,6 +276,7 @@ public class Utils {
       System.setProperty(HTTP_PROXY_PORT, port);
       System.setProperty(HTTPS_PROXY_HOST, host);
       System.setProperty(HTTPS_PROXY_PORT, port);
+      System.setProperty(HTTP_NON_PROXY_HOSTS, nonProxyHosts);
 
       // set username and password
       String username =

--- a/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
@@ -201,6 +201,12 @@ class InternalUtils {
       proxyProperties.put(
           SFSessionProperty.PROXY_PORT.getPropertyKey(),
           conf.get(SnowflakeSinkConnectorConfig.JVM_PROXY_PORT));
+    // nonProxyHosts parameter is not required. Check if it was set or not.
+    if (conf.get(SnowflakeSinkConnectorConfig.JVM_NON_PROXY_HOSTS) != null) {
+      proxyProperties.put(
+              SFSessionProperty.NON_PROXY_HOSTS.getPropertyKey(),
+              conf.get(SnowflakeSinkConnectorConfig.JVM_NON_PROXY_HOSTS));
+    }
 
       // For username and password, check if host and port are given.
       // If they are given, check if username and password are non null


### PR DESCRIPTION
[SNOW-726924] Add New jvm.nonProxy.hosts Parameter and update JDBC to 3.13.23

The jvm.nonProxy.hosts parameter can now be used to bypass a proxy server using the JVM -Dhttp.nonProxyHosts argument. The JDBC driver has to be upgraded because it didn't honor the http.nonProxyHosts JVM argument until v3.13.16.

[SNOW-726924]: https://snowflakecomputing.atlassian.net/browse/SNOW-726924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ