### PR TITLE
[SNOW-726924] Add New jvm.nonProxy.hosts Parameter and update JDBC to 3.13.23

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -402,7 +402,7 @@
         <dependency>
             <groupId>net.snowflake</groupId>
             <artifactId>snowflake-jdbc</artifactId>
-            <version>3.13.14</version>
+            <version>3.13.23</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/io.dropwizard.metrics/metrics-core -->

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -449,7 +449,7 @@
         <dependency>
             <groupId>net.snowflake</groupId>
             <artifactId>snowflake-jdbc</artifactId>
-            <version>3.13.14</version>
+            <version>3.13.23</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/io.dropwizard.metrics/metrics-core -->

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -78,6 +78,7 @@ public class SnowflakeSinkConnectorConfig {
   private static final String PROXY_INFO = "Proxy Info";
   public static final String JVM_PROXY_HOST = "jvm.proxy.host";
   public static final String JVM_PROXY_PORT = "jvm.proxy.port";
+  public static final String JVM_NON_PROXY_HOSTS = "jvm.nonProxy.hosts";
   public static final String JVM_PROXY_USERNAME = "jvm.proxy.username";
   public static final String JVM_PROXY_PASSWORD = "jvm.proxy.password";
 
@@ -303,13 +304,23 @@ public class SnowflakeSinkConnectorConfig {
             ConfigDef.Width.NONE,
             JVM_PROXY_PORT)
         .define(
+            JVM_NON_PROXY_HOSTS,
+            Type.STRING,
+            "",
+            Importance.LOW,
+            "JVM option: http.nonProxyHosts",
+            PROXY_INFO,
+            2,
+            ConfigDef.Width.NONE,
+            JVM_NON_PROXY_HOSTS)
+        .define(
             JVM_PROXY_USERNAME,
             Type.STRING,
             "",
             Importance.LOW,
             "JVM proxy username",
             PROXY_INFO,
-            2,
+            3,
             ConfigDef.Width.NONE,
             JVM_PROXY_USERNAME)
         .define(
@@ -319,7 +330,7 @@ public class SnowflakeSinkConnectorConfig {
             Importance.LOW,
             "JVM proxy password",
             PROXY_INFO,
-            3,
+            4,
             ConfigDef.Width.NONE,
             JVM_PROXY_PASSWORD)
         // Connector Config

--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -81,6 +81,7 @@ public class Utils {
   public static final String HTTPS_PROXY_PORT = "https.proxyPort";
   public static final String HTTP_PROXY_HOST = "http.proxyHost";
   public static final String HTTP_PROXY_PORT = "http.proxyPort";
+  public static final String HTTP_NON_PROXY_HOSTS = "http.nonProxyHosts";
 
   public static final String JDK_HTTP_AUTH_TUNNELING = "jdk.http.auth.tunneling.disabledSchemes";
   public static final String HTTPS_PROXY_USER = "https.proxyUser";
@@ -224,6 +225,7 @@ public class Utils {
     String port =
         SnowflakeSinkConnectorConfig.getProperty(
             config, SnowflakeSinkConnectorConfig.JVM_PROXY_PORT);
+
     // either both host and port are provided or none of them are provided
     if (host != null ^ port != null) {
       throw SnowflakeErrors.ERROR_0022.getException(
@@ -262,8 +264,12 @@ public class Utils {
     String port =
         SnowflakeSinkConnectorConfig.getProperty(
             config, SnowflakeSinkConnectorConfig.JVM_PROXY_PORT);
+    String nonProxyHosts =
+        SnowflakeSinkConnectorConfig.getProperty(
+            config, SnowflakeSinkConnectorConfig.JVM_NON_PROXY_HOSTS);
     if (host != null && port != null) {
-      LOGGER.info("enable jvm proxy: {}:{}", host, port);
+      LOGGER.info(
+          "enable jvm proxy: {}:{} and bypass proxy for hosts: {}", host, port, nonProxyHosts);
 
       // enable https proxy
       System.setProperty(HTTP_USE_PROXY, "true");
@@ -271,6 +277,17 @@ public class Utils {
       System.setProperty(HTTP_PROXY_PORT, port);
       System.setProperty(HTTPS_PROXY_HOST, host);
       System.setProperty(HTTPS_PROXY_PORT, port);
+
+      // If the user provided the jvm.nonProxy.hosts configuration then we
+      // will append that to the list provided by the JVM argument
+      // -Dhttp.nonProxyHosts and not override it altogether, if it exists.
+      if (nonProxyHosts != null) {
+        nonProxyHosts =
+            (System.getProperty(HTTP_NON_PROXY_HOSTS) != null)
+                ? System.getProperty(HTTP_NON_PROXY_HOSTS) + "|" + nonProxyHosts
+                : nonProxyHosts;
+        System.setProperty(HTTP_NON_PROXY_HOSTS, nonProxyHosts);
+      }
 
       // set username and password
       String username =

--- a/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
@@ -202,6 +202,13 @@ class InternalUtils {
           SFSessionProperty.PROXY_PORT.getPropertyKey(),
           conf.get(SnowflakeSinkConnectorConfig.JVM_PROXY_PORT));
 
+      // nonProxyHosts parameter is not required. Check if it was set or not.
+      if (conf.get(SnowflakeSinkConnectorConfig.JVM_NON_PROXY_HOSTS) != null) {
+        proxyProperties.put(
+            SFSessionProperty.NON_PROXY_HOSTS.getPropertyKey(),
+            conf.get(SnowflakeSinkConnectorConfig.JVM_NON_PROXY_HOSTS));
+      }
+
       // For username and password, check if host and port are given.
       // If they are given, check if username and password are non null
       String username = conf.get(SnowflakeSinkConnectorConfig.JVM_PROXY_USERNAME);

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
@@ -3,6 +3,7 @@ package com.snowflake.kafka.connector;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_LOG_ENABLE_CONFIG;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_TOLERANCE_CONFIG;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.NAME;
+import static com.snowflake.kafka.connector.Utils.HTTP_NON_PROXY_HOSTS;
 import static com.snowflake.kafka.connector.internal.TestUtils.getConfig;
 
 import com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException;
@@ -10,6 +11,7 @@ import com.snowflake.kafka.connector.internal.streaming.IngestionMethodConfig;
 import com.snowflake.kafka.connector.internal.streaming.StreamingUtils;
 import java.util.Locale;
 import java.util.Map;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class ConnectorConfigTest {
@@ -115,6 +117,33 @@ public class ConnectorConfigTest {
     Map<String, String> config = getConfig();
     config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_PORT, "3128");
     Utils.validateConfig(config);
+  }
+
+  @Test
+  public void testNonProxyHosts() {
+    String oldNonProxyHosts =
+        (System.getProperty(HTTP_NON_PROXY_HOSTS) != null)
+            ? System.getProperty(HTTP_NON_PROXY_HOSTS)
+            : null;
+
+    System.setProperty(HTTP_NON_PROXY_HOSTS, "host1.com|host2.com|localhost");
+    Map<String, String> config = getConfig();
+    config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_HOST, "127.0.0.1");
+    config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_PORT, "3128");
+    config.put(
+        SnowflakeSinkConnectorConfig.JVM_NON_PROXY_HOSTS,
+        "*.snowflakecomputing.com|*.amazonaws.com");
+    Utils.enableJVMProxy(config);
+    String mergedNonProxyHosts = System.getProperty(HTTP_NON_PROXY_HOSTS);
+    Assert.assertTrue(
+        mergedNonProxyHosts.equals(
+            "host1.com|host2.com|localhost|*.snowflakecomputing.com|*.amazonaws.com"));
+
+    if (oldNonProxyHosts != null) {
+      System.setProperty(HTTP_NON_PROXY_HOSTS, oldNonProxyHosts);
+    } else {
+      System.clearProperty(HTTP_NON_PROXY_HOSTS);
+    }
   }
 
   @Test(expected = SnowflakeKafkaConnectorException.class)


### PR DESCRIPTION
The jvm.nonProxy.hosts parameter can be added to the connector's configuration file and is the equivalent to the JVM argument -Dhttp.nonProxyHosts. If a user provides that parameter and the connector runs in a JVM where -Dhttp.nonProxyHosts was set, then we will merge the two lists of hosts. In the future, we'll want another method of adding proxy configurations without resorting to System.setProperty() calls