### PR TITLE
Fix client off by one issue

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/ingestsdk/StreamingClientManager.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/ingestsdk/StreamingClientManager.java
@@ -138,7 +138,8 @@ public class StreamingClientManager {
 
   /**
    * Gets the number of clients created
-   * @return
+   *
+   * @return the number of clients created
    */
   public int getClientCount() {
     return this.clientCount;

--- a/src/main/java/com/snowflake/kafka/connector/internal/ingestsdk/StreamingClientManager.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/ingestsdk/StreamingClientManager.java
@@ -83,7 +83,7 @@ public class StreamingClientManager {
         StreamingUtils.convertConfigForStreamingClient(new HashMap<>(connectorConfig)));
 
     // put a new client for every tasksToCurrClient taskIds
-    int tasksToCurrClient = numTasksPerClient;
+    int tasksToCurrClient = 0;
     KcStreamingIngestClient createdClient =
         this.getClientHelper(
             clientProperties, kcInstanceId, 0); // asserted that we have at least 1 task
@@ -134,6 +134,14 @@ public class StreamingClientManager {
     }
 
     return client;
+  }
+
+  /**
+   * Gets the number of clients created
+   * @return
+   */
+  public int getClientCount() {
+    return this.clientCount;
   }
 
   /**

--- a/src/main/java/com/snowflake/kafka/connector/internal/ingestsdk/StreamingClientManager.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/ingestsdk/StreamingClientManager.java
@@ -34,14 +34,14 @@ public class StreamingClientManager {
   private Map<Integer, KcStreamingIngestClient> taskToClientMap;
   private int maxTasks;
   private final int minTasks = 0;
-  private int clientCount; // this should only ever increase
+  private int clientId; // this should only ever increase
 
   // TESTING ONLY - inject the client map
   @VisibleForTesting
   public StreamingClientManager(Map<Integer, KcStreamingIngestClient> taskToClientMap) {
     this();
     this.taskToClientMap = taskToClientMap;
-    this.clientCount = (int) taskToClientMap.values().stream().distinct().count() - 1;
+    this.clientId = (int) taskToClientMap.values().stream().distinct().count() - 1;
   }
 
   /** Creates a new client manager */
@@ -49,7 +49,7 @@ public class StreamingClientManager {
     LOGGER = new LoggerHandler(this.getClass().getName());
     this.taskToClientMap = new HashMap<>();
     this.maxTasks = 0;
-    this.clientCount = -1; // will be incremented when a client is created
+    this.clientId = -1; // will be incremented when a client is created
   }
 
   /**
@@ -103,9 +103,9 @@ public class StreamingClientManager {
   // builds the client name and returns the created client. note taskId is used just for logging
   private KcStreamingIngestClient getClientHelper(
       Properties props, String kcInstanceId, int taskId) {
-    this.clientCount++;
+    this.clientId++;
     String clientName =
-        KcStreamingIngestClient.buildStreamingIngestClientName(kcInstanceId, this.clientCount);
+        KcStreamingIngestClient.buildStreamingIngestClientName(kcInstanceId, this.clientId);
     LOGGER.debug("Creating client {} for taskid {}", clientName, taskId);
 
     return new KcStreamingIngestClient(props, clientName);
@@ -124,7 +124,7 @@ public class StreamingClientManager {
               "taskId must be between 0 and {} but was given {}", this.maxTasks, taskId));
     }
 
-    if (this.clientCount < 0) {
+    if (this.clientId < 0) {
       throw SnowflakeErrors.ERROR_3009.getException("call the manager to create the clients");
     }
 
@@ -142,7 +142,7 @@ public class StreamingClientManager {
    * @return the number of clients created
    */
   public int getClientCount() {
-    return this.clientCount;
+    return this.clientId + 1; // clientid starts at 0, so off by one
   }
 
   /**

--- a/src/test/java/com/snowflake/kafka/connector/SnowflakeSinkTaskForStreamingIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/SnowflakeSinkTaskForStreamingIT.java
@@ -23,7 +23,6 @@ import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.JsonNode;
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.internals.Topic;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.After;
 import org.junit.Assert;
@@ -182,12 +181,14 @@ public class SnowflakeSinkTaskForStreamingIT {
     Mockito.when(logger.isDebugEnabled()).thenReturn(true);
     Mockito.when(logger.isWarnEnabled()).thenReturn(true);
     String expectedTask1Tag =
-            TestUtils.getExpectedLogTagWithoutCreationCount(task1Id + "", taskOpen1Count);
+        TestUtils.getExpectedLogTagWithoutCreationCount(task1Id + "", taskOpen1Count);
     Mockito.doCallRealMethod().when(loggerHandler).setLoggerInstanceTag(expectedTask1Tag);
 
     // init tasks
-    sinkTask0.initialize(new InMemorySinkTaskContext(Collections.singleton(topicPartitions0.get(0))));
-    sinkTask1.initialize(new InMemorySinkTaskContext(Collections.singleton(topicPartitions1.get(0))));
+    sinkTask0.initialize(
+        new InMemorySinkTaskContext(Collections.singleton(topicPartitions0.get(0))));
+    sinkTask1.initialize(
+        new InMemorySinkTaskContext(Collections.singleton(topicPartitions1.get(0))));
 
     // start tasks
     sinkTask0.start(config0);
@@ -206,7 +207,8 @@ public class SnowflakeSinkTaskForStreamingIT {
 
     // verify task1 open logs
     taskOpen1Count++;
-    expectedTask1Tag = TestUtils.getExpectedLogTagWithoutCreationCount(task1Id + "", taskOpen1Count);
+    expectedTask1Tag =
+        TestUtils.getExpectedLogTagWithoutCreationCount(task1Id + "", taskOpen1Count);
     Mockito.verify(logger, Mockito.times(1))
         .debug(
             AdditionalMatchers.and(Mockito.contains(expectedTask1Tag), Mockito.contains("open")));
@@ -345,6 +347,7 @@ public class SnowflakeSinkTaskForStreamingIT {
 
     assert partitionsInTable.size() == 2;
   }
+
   private Map<String, String> getConfig(int taskId) {
     Map<String, String> config = TestUtils.getConfForStreaming();
     config.put(BUFFER_COUNT_RECORDS, "1"); // override

--- a/src/test/java/com/snowflake/kafka/connector/SnowflakeSinkTaskForStreamingIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/SnowflakeSinkTaskForStreamingIT.java
@@ -168,6 +168,7 @@ public class SnowflakeSinkTaskForStreamingIT {
     Mockito.when(logger.isDebugEnabled()).thenReturn(true);
     Mockito.when(logger.isWarnEnabled()).thenReturn(true);
 
+    // TODO @rcheng: factor these out, has been a pain updating this test with the dupe code...
     // set up configs
     String task0Id = "0";
     int partition0 = 0;

--- a/src/test/java/com/snowflake/kafka/connector/SnowflakeSinkTaskForStreamingIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/SnowflakeSinkTaskForStreamingIT.java
@@ -23,6 +23,7 @@ import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.JsonNode;
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.internals.Topic;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.After;
 import org.junit.Assert;
@@ -162,44 +163,31 @@ public class SnowflakeSinkTaskForStreamingIT {
 
   @Test
   public void testMultipleSinkTaskWithLogs() throws Exception {
-    // setup log mocking for task1
+    // set up task0, the real one
+    int task0Id = 0;
+    String topicName0 = "topic0";
+    Map<String, String> config0 = this.getConfig(task0Id);
+    ArrayList<TopicPartition> topicPartitions0 = getTopicPartitions(topicName0, 1);
+    SnowflakeSinkTask sinkTask0 = new SnowflakeSinkTask();
+
+    // set up task1, the !real one
+    int task1Id = 1;
+    String topicName1 = "topic1";
+    Map<String, String> config1 = this.getConfig(task1Id);
+    ArrayList<TopicPartition> topicPartitions1 = getTopicPartitions(topicName1, 1);
+    // task1 logging
+    int taskOpen1Count = 0;
     MockitoAnnotations.initMocks(this);
     Mockito.when(logger.isInfoEnabled()).thenReturn(true);
     Mockito.when(logger.isDebugEnabled()).thenReturn(true);
     Mockito.when(logger.isWarnEnabled()).thenReturn(true);
-
-    // TODO @rcheng: factor these out, has been a pain updating this test with the dupe code...
-    // set up configs
-    String task0Id = "0";
-    int partition0 = 0;
-    String topicName0 = "topic0";
-    Map<String, String> config0 = TestUtils.getConfForStreaming();
-    config0.put(BUFFER_COUNT_RECORDS, "1"); // override
-    config0.put(INGESTION_METHOD_OPT, IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
-    SnowflakeSinkConnectorConfig.setDefaultValues(config0);
-    config0.put(Utils.TASK_ID, task0Id);
-    TopicPartition topicPartition0 = new TopicPartition(topicName0, partition0);
-
-    String task1Id = "1";
-    int partition1 = 1;
-    String topicName1 = "topic1";
-    Map<String, String> config1 = TestUtils.getConfForStreaming();
-    config1.put(BUFFER_COUNT_RECORDS, "1"); // override
-    config1.put(INGESTION_METHOD_OPT, IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
-    SnowflakeSinkConnectorConfig.setDefaultValues(config1);
-    config1.put(Utils.TASK_ID, task1Id);
-    TopicPartition topicPartition1 = new TopicPartition(topicName1, partition1);
-    int taskOpen1Count = 0;
-
-    SnowflakeSinkTask sinkTask0 = new SnowflakeSinkTask();
-
-    sinkTask0.initialize(new InMemorySinkTaskContext(Collections.singleton(topicPartition0)));
-    sinkTask1.initialize(new InMemorySinkTaskContext(Collections.singleton(topicPartition1)));
-
-    // set up task1 logging tag
     String expectedTask1Tag =
-        TestUtils.getExpectedLogTagWithoutCreationCount(task1Id, taskOpen1Count);
+            TestUtils.getExpectedLogTagWithoutCreationCount(task1Id + "", taskOpen1Count);
     Mockito.doCallRealMethod().when(loggerHandler).setLoggerInstanceTag(expectedTask1Tag);
+
+    // init tasks
+    sinkTask0.initialize(new InMemorySinkTaskContext(Collections.singleton(topicPartitions0.get(0))));
+    sinkTask1.initialize(new InMemorySinkTaskContext(Collections.singleton(topicPartitions1.get(0))));
 
     // start tasks
     sinkTask0.start(config0);
@@ -213,28 +201,19 @@ public class SnowflakeSinkTaskForStreamingIT {
             AdditionalMatchers.and(Mockito.contains(expectedTask1Tag), Mockito.contains("start")));
 
     // open tasks
-    ArrayList<TopicPartition> topicPartitions0 = new ArrayList<>();
-    topicPartitions0.add(topicPartition0);
-    ArrayList<TopicPartition> topicPartitions1 = new ArrayList<>();
-    topicPartitions1.add(topicPartition1);
-
     sinkTask0.open(topicPartitions0);
     sinkTask1.open(topicPartitions1);
 
-    taskOpen1Count++;
-    expectedTask1Tag = TestUtils.getExpectedLogTagWithoutCreationCount(task1Id, taskOpen1Count);
-
     // verify task1 open logs
+    taskOpen1Count++;
+    expectedTask1Tag = TestUtils.getExpectedLogTagWithoutCreationCount(task1Id + "", taskOpen1Count);
     Mockito.verify(logger, Mockito.times(1))
         .debug(
             AdditionalMatchers.and(Mockito.contains(expectedTask1Tag), Mockito.contains("open")));
 
     // send data to tasks
-    List<SinkRecord> records0 = TestUtils.createJsonStringSinkRecords(0, 1, topicName0, partition0);
-    List<SinkRecord> records1 = TestUtils.createJsonStringSinkRecords(0, 1, topicName1, partition1);
-
-    sinkTask0.put(records0);
-    sinkTask1.put(records1);
+    sinkTask0.put(TestUtils.createJsonStringSinkRecords(0, 1, topicName0, 0));
+    sinkTask1.put(TestUtils.createJsonStringSinkRecords(0, 1, topicName1, 0));
 
     // verify task1 put logs
     Mockito.verify(logger, Mockito.times(1))
@@ -365,5 +344,23 @@ public class SnowflakeSinkTaskForStreamingIT {
         });
 
     assert partitionsInTable.size() == 2;
+  }
+  private Map<String, String> getConfig(int taskId) {
+    Map<String, String> config = TestUtils.getConfForStreaming();
+    config.put(BUFFER_COUNT_RECORDS, "1"); // override
+    config.put(INGESTION_METHOD_OPT, IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
+    SnowflakeSinkConnectorConfig.setDefaultValues(config);
+    config.put(Utils.TASK_ID, taskId + "");
+
+    return config;
+  }
+
+  private ArrayList<TopicPartition> getTopicPartitions(String topicName, int numPartitions) {
+    ArrayList<TopicPartition> topicPartitions = new ArrayList<>();
+    for (int i = 0; i < numPartitions; i++) {
+      topicPartitions.add(new TopicPartition(topicName, i));
+    }
+
+    return topicPartitions;
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/internal/ingestsdk/StreamingClientManagerTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/ingestsdk/StreamingClientManagerTest.java
@@ -28,11 +28,12 @@ public class StreamingClientManagerTest {
 
   @Test
   public void testCreateAndGetAllStreamingClientsWithUnevenRatio() {
-    int maxTasks = 5;
-    int numTasksPerClient = 2;
     // test to create the following mapping
     // [0, 1] -> clientA, [2, 3] -> clientB, [4] -> clientC
     // test
+    int maxTasks = 5;
+    int numTasksPerClient = 2;
+
     StreamingClientManager manager = new StreamingClientManager();
     manager.createAllStreamingClients(
         TestUtils.getConfForStreaming(), "testkcid", maxTasks, numTasksPerClient);
@@ -51,7 +52,7 @@ public class StreamingClientManagerTest {
     assert !task4Client.equals(task0Client);
     assert !task4Client.equals(task2Client);
 
-    assert Math.ceil(maxTasks / numTasksPerClient) == manager.getClientCount();
+    assert Math.ceil((double) maxTasks / (double) numTasksPerClient) == manager.getClientCount();
 
     // close clients
     task0Client.close();
@@ -66,8 +67,12 @@ public class StreamingClientManagerTest {
     // test to create the following mapping
     // [0, 1, 2] -> clientA, [3, 4, 5] -> clientB
     // test
+    int maxTasks = 6;
+    int numTasksPerClient = 3;
+
     StreamingClientManager manager = new StreamingClientManager();
-    manager.createAllStreamingClients(TestUtils.getConfForStreaming(), "testkcid", 6, 3);
+    manager.createAllStreamingClients(
+        TestUtils.getConfForStreaming(), "testkcid", maxTasks, numTasksPerClient);
 
     // verify
     KcStreamingIngestClient task0Client = manager.getValidClient(0);
@@ -83,6 +88,8 @@ public class StreamingClientManagerTest {
     assert task4Client.equals(task5Client);
 
     assert !task0Client.equals(task5Client);
+
+    assert Math.ceil((double) maxTasks / (double) numTasksPerClient) == manager.getClientCount();
 
     // close clients
     task0Client.close();

--- a/src/test/java/com/snowflake/kafka/connector/internal/ingestsdk/StreamingClientManagerTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/ingestsdk/StreamingClientManagerTest.java
@@ -34,7 +34,8 @@ public class StreamingClientManagerTest {
     // [0, 1] -> clientA, [2, 3] -> clientB, [4] -> clientC
     // test
     StreamingClientManager manager = new StreamingClientManager();
-    manager.createAllStreamingClients(TestUtils.getConfForStreaming(), "testkcid", maxTasks, numTasksPerClient);
+    manager.createAllStreamingClients(
+        TestUtils.getConfForStreaming(), "testkcid", maxTasks, numTasksPerClient);
 
     // verify
     KcStreamingIngestClient task0Client = manager.getValidClient(0);

--- a/src/test/java/com/snowflake/kafka/connector/internal/ingestsdk/StreamingClientManagerTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/ingestsdk/StreamingClientManagerTest.java
@@ -28,11 +28,13 @@ public class StreamingClientManagerTest {
 
   @Test
   public void testCreateAndGetAllStreamingClientsWithUnevenRatio() {
+    int maxTasks = 5;
+    int numTasksPerClient = 2;
     // test to create the following mapping
     // [0, 1] -> clientA, [2, 3] -> clientB, [4] -> clientC
     // test
     StreamingClientManager manager = new StreamingClientManager();
-    manager.createAllStreamingClients(TestUtils.getConfForStreaming(), "testkcid", 5, 2);
+    manager.createAllStreamingClients(TestUtils.getConfForStreaming(), "testkcid", maxTasks, numTasksPerClient);
 
     // verify
     KcStreamingIngestClient task0Client = manager.getValidClient(0);
@@ -47,6 +49,8 @@ public class StreamingClientManagerTest {
     KcStreamingIngestClient task4Client = manager.getValidClient(4);
     assert !task4Client.equals(task0Client);
     assert !task4Client.equals(task2Client);
+
+    assert Math.ceil(maxTasks / numTasksPerClient) == manager.getClientCount();
 
     // close clients
     task0Client.close();


### PR DESCRIPTION
Client creation logic creates one extra client due to the way the for loop is configured. Made test stricter by exposing the client count.

And fix an IT test that was missed in the last PR.

Thanks @sfc-gh-japatel for catching both of these!