### PR TITLE
Fix init snowflake table issue for init kafka offset not zero

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
@@ -68,7 +68,7 @@ public class TopicPartitionChannel {
 
   private static final long NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE = -1L;
 
-  private long initKafkaOffset = -1L ;
+  private long initKafkaOffset = 0L ;
   // last time we invoked insertRows API
   private long previousFlushTimeStampMs;
 
@@ -311,7 +311,7 @@ public class TopicPartitionChannel {
    * a desired offset from kafka.
    *
    * <p>Desired Offset from Kafka = (offset persisted in snowflake + 1)
-   * <p>If the snowflake table is empty, Desired Offset from kafka = init kafka offset.
+   * <p>Or If the snowflake table is empty, Desired Offset from kafka = init kafka offset.
    *
    * <p>Check {link {@link TopicPartitionChannel#resetChannelMetadataAfterRecovery}} for reset logic
    *

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
@@ -311,7 +311,7 @@ public class TopicPartitionChannel {
    * a desired offset from kafka.
    *
    * <p>Desired Offset from Kafka = (offset persisted in snowflake + 1)
-   * <p>Or If the snowflake table is empty, Desired Offset from kafka = init kafka offset.
+   * <p>Or If the snowflake table is empty, Desired Offset from kafka = first seen kafka offset.
    *
    * <p>Check {link {@link TopicPartitionChannel#resetChannelMetadataAfterRecovery}} for reset logic
    *


### PR DESCRIPTION
I found a issue about the connector.

**Situation :** when kafka topic has expired data , it's partition offset not started with zero. 

**Kafka connector config:**  snowpipe streaming + schema detection

**Problem:**  the kafka connector will only create snowflake table  not  ingest data to snowflake table when first run the connector,  must restart the  connector can ingest data normally.
