### PR TITLE
Modify pom.xml to use jdbc defined in connector and not from ingest sdk

### DIFF
--- a/.github/workflows/End2EndTestApache.yml
+++ b/.github/workflows/End2EndTestApache.yml
@@ -10,6 +10,7 @@ jobs:
   build_and_test:
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast
       matrix:
         apache_kafka_version: [ '2.5.1', '2.8.1', '3.2.1' ]
         snowflake_cloud: [ 'AWS', 'AZURE', 'GCS' ]

--- a/.github/workflows/End2EndTestConfluent.yml
+++ b/.github/workflows/End2EndTestConfluent.yml
@@ -10,6 +10,7 @@ jobs:
   build_and_test:
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast
       matrix:
         confluent_version: [ '5.5.11', '6.2.6', '7.2.1' ]
         snowflake_cloud: [ 'AWS', 'AZURE', 'GCS' ]

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -10,6 +10,7 @@ jobs:
   build_and_test:
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast
       matrix:
         snowflake_cloud: [ 'AWS', 'AZURE', 'GCS' ]
     steps:

--- a/.github/workflows/StressTest.yml
+++ b/.github/workflows/StressTest.yml
@@ -10,6 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast
       matrix:
         confluent_version: [ '5.5.11', '6.2.6', '7.2.1' ]
         snowflake_cloud: [ 'AWS', 'AZURE', 'GCS' ]

--- a/pom.xml
+++ b/pom.xml
@@ -313,11 +313,24 @@
             </exclusions>
         </dependency>
 
+        <!--JDBC driver for building connection with Snowflake-->
+        <dependency>
+            <groupId>net.snowflake</groupId>
+            <artifactId>snowflake-jdbc</artifactId>
+            <version>3.13.23</version>
+        </dependency>
+
         <!-- Ingest SDK for copy staged file into snowflake table -->
         <dependency>
             <groupId>net.snowflake</groupId>
             <artifactId>snowflake-ingest-sdk</artifactId>
-            <version>1.0.2-beta.7</version>
+            <version>1.0.3-beta</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.snowflake</groupId>
+                    <artifactId>snowflake-jdbc</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -393,13 +406,6 @@
             <groupId>io.confluent</groupId>
             <artifactId>kafka-connect-avro-converter</artifactId>
             <version>7.2.1</version>
-        </dependency>
-
-        <!--JDBC driver for building connection with Snowflake-->
-        <dependency>
-            <groupId>net.snowflake</groupId>
-            <artifactId>snowflake-jdbc</artifactId>
-            <version>3.13.23</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/io.dropwizard.metrics/metrics-core -->

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -364,11 +364,24 @@
             </exclusions>
         </dependency>
 
+        <!--JDBC driver for building connection with Snowflake-->
+        <dependency>
+            <groupId>net.snowflake</groupId>
+            <artifactId>snowflake-jdbc</artifactId>
+            <version>3.13.23</version>
+        </dependency>
+
         <!-- Ingest SDK for copy staged file into snowflake table -->
         <dependency>
             <groupId>net.snowflake</groupId>
             <artifactId>snowflake-ingest-sdk</artifactId>
-            <version>1.0.2-beta.7</version>
+            <version>1.0.3-beta</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.snowflake</groupId>
+                    <artifactId>snowflake-jdbc</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -444,13 +457,6 @@
             <groupId>io.confluent</groupId>
             <artifactId>kafka-connect-avro-converter</artifactId>
             <version>7.2.1</version>
-        </dependency>
-
-        <!--JDBC driver for building connection with Snowflake-->
-        <dependency>
-            <groupId>net.snowflake</groupId>
-            <artifactId>snowflake-jdbc</artifactId>
-            <version>3.13.23</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/io.dropwizard.metrics/metrics-core -->

--- a/test/test_suit/test_schema_mapping.py
+++ b/test/test_suit/test_schema_mapping.py
@@ -20,7 +20,7 @@ class TestSchemaMapping:
             'RATING_INT': 100,
             'RATING_DOUBLE': 0.99,
             'APPROVAL': 'true',
-            'APPROVAL_DATE': '15-Jun-2022',
+            'APPROVAL_DATE': '2022-06-15',
             'APPROVAL_TIME': '23:59:59.999999',
             'INFO_ARRAY': ['HELLO', 'WORLD'],
             'INFO': {

--- a/test/test_suit/test_schema_not_supported_converter.py
+++ b/test/test_suit/test_schema_not_supported_converter.py
@@ -22,7 +22,7 @@ class TestSchemaNotSupportedConverter:
             'RATING_INT': 100,
             'RATING_DOUBLE': 0.99,
             'APPROVAL': 'true',
-            'APPROVAL_DATE': '15-Jun-2022',
+            'APPROVAL_DATE': '2022-06-15',
             'APPROVAL_TIME': '23:59:59.999999',
             'INFO_ARRAY': ['HELLO', 'WORLD'],
             'INFO': {


### PR DESCRIPTION
Background:

- After upgrading ingest sdk to 1.0.3-beta, GCS tests started failing. 
- Above version uses jdbc 3.13.18

- We have our own native jdbc dependency at 3.13.23. 
- Intellij bytecode never showed code corresponding to 3.13.23 and always picked up from 3.13.18 (From Ingest SDK)

Root cause:
- Previously the jdbc dependency was defined after ingest SDK and APPARENTLY ORDERING MATTERS


Solution:
- Exclude jdbc from ingest SDK. 
- Define our own jdbc version in Connector. 

Next steps:
- Fix JDBC version in Ingest SDK to use 3.13.23 instead of 3.13.18

Few more changes:
- Use fail fast strategy to not kill other running tasks in matrix if one fails. We want all of them to run parallely. 
- Fix broken tests after allowed data type formats changed in latest version of ingest SDK. 

**MAVEN  DEPENDENCY  RANT.. SCREEEAMMMM**