### PR TITLE
no-snow Add connector name in KC client name for better debugging the client …

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/ingestsdk/KcStreamingIngestClient.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/ingestsdk/KcStreamingIngestClient.java
@@ -17,11 +17,13 @@
 package com.snowflake.kafka.connector.internal.ingestsdk;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.snowflake.kafka.connector.Utils;
 import com.snowflake.kafka.connector.internal.LoggerHandler;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Properties;
+
 import net.snowflake.ingest.streaming.OpenChannelRequest;
 import net.snowflake.ingest.streaming.SnowflakeStreamingIngestChannel;
 import net.snowflake.ingest.streaming.SnowflakeStreamingIngestClient;
@@ -39,12 +41,17 @@ public class KcStreamingIngestClient {
   /**
    * Builds the client's name based on the kc instance and expected client id
    *
+   * @param connectorName Name of the connector supplied in SF Config. This cannot be null or empty.
    * @param kcInstanceId the kafka connector instance id
    * @param clientId the client id
-   * @return the client's name as 'KC_CLIENT_kcInstanceId_clientId'
+   * @return the client's name as 'KC_CLIENT_connectorName_kcInstanceId_clientId'
    */
-  public static String buildStreamingIngestClientName(String kcInstanceId, int clientId) {
-    return Utils.formatString("{}_{}_{}", STREAMING_CLIENT_PREFIX_NAME, kcInstanceId, clientId);
+  public static String buildStreamingIngestClientName(
+      String connectorName, String kcInstanceId, int clientId) {
+    Preconditions.checkNotNull(connectorName, "connectorName cannot be null");
+    Preconditions.checkNotNull(kcInstanceId, "kcInstanceId cannot be null");
+    return Utils.formatString(
+        "{}_{}_{}_{}", STREAMING_CLIENT_PREFIX_NAME, connectorName, kcInstanceId, clientId);
   }
 
   // TESTING ONLY - inject the client

--- a/src/main/java/com/snowflake/kafka/connector/internal/ingestsdk/KcStreamingIngestClient.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/ingestsdk/KcStreamingIngestClient.java
@@ -23,7 +23,6 @@ import com.snowflake.kafka.connector.internal.LoggerHandler;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Properties;
-
 import net.snowflake.ingest.streaming.OpenChannelRequest;
 import net.snowflake.ingest.streaming.SnowflakeStreamingIngestChannel;
 import net.snowflake.ingest.streaming.SnowflakeStreamingIngestClient;

--- a/src/main/java/com/snowflake/kafka/connector/internal/ingestsdk/StreamingClientManager.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/ingestsdk/StreamingClientManager.java
@@ -110,13 +110,19 @@ public class StreamingClientManager {
         this.getClientHelper(
             clientProperties,
             parameterOverrides,
+            connectorConfig.get(Utils.NAME),
             kcInstanceId,
             0); // asserted that we have at least 1 task
 
     for (int taskId = 0; taskId < this.maxTasks; taskId++) {
       if (tasksToCurrClient == numTasksPerClient) {
         createdClient =
-            this.getClientHelper(clientProperties, parameterOverrides, kcInstanceId, taskId);
+            this.getClientHelper(
+                clientProperties,
+                parameterOverrides,
+                connectorConfig.get(Utils.NAME),
+                kcInstanceId,
+                taskId);
         tasksToCurrClient = 1;
       } else {
         tasksToCurrClient++;
@@ -128,10 +134,15 @@ public class StreamingClientManager {
 
   // builds the client name and returns the created client. note taskId is used just for logging
   private KcStreamingIngestClient getClientHelper(
-      Properties props, Map<String, Object> parameterOverrides, String kcInstanceId, int taskId) {
+      Properties props,
+      Map<String, Object> parameterOverrides,
+      String connectorName,
+      String kcInstanceId,
+      int taskId) {
     this.clientId++;
     String clientName =
-        KcStreamingIngestClient.buildStreamingIngestClientName(kcInstanceId, this.clientId);
+        KcStreamingIngestClient.buildStreamingIngestClientName(
+            connectorName, kcInstanceId, this.clientId);
     LOGGER.debug("Creating client {} for taskid {}", clientName, taskId);
 
     return new KcStreamingIngestClient(props, parameterOverrides, clientName);

--- a/src/test/java/com/snowflake/kafka/connector/internal/ingestsdk/KcStreamingIngestClientTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/ingestsdk/KcStreamingIngestClientTest.java
@@ -46,9 +46,10 @@ public class KcStreamingIngestClientTest {
 
   @Before
   public void setup() {
-    this.clientName = KcStreamingIngestClient.buildStreamingIngestClientName("testKcId", 0);
-
     this.config = TestUtils.getConfForStreaming();
+    this.clientName =
+        KcStreamingIngestClient.buildStreamingIngestClientName(
+            config.getOrDefault(Utils.NAME, "TEST_CONNECTOR_NAME"), "testKcId", 0);
     SnowflakeSinkConnectorConfig.setDefaultValues(config);
     this.properties = new Properties();
     this.properties.putAll(StreamingUtils.convertConfigForStreamingClient(new HashMap<>(config)));
@@ -68,6 +69,7 @@ public class KcStreamingIngestClientTest {
 
     // verify
     assert kcActualClient.getName().equals(kcMockClient.getName());
+    Assert.assertTrue(kcActualClient.getName().contains(this.config.get(Utils.NAME)));
     Mockito.verify(this.mockClient, Mockito.times(1)).getName();
   }
 


### PR DESCRIPTION
…history view

- It becomes increasingly difficult from a user perspective to find out the client name since it contains a kcInstanceId which is a combination of timestamp and UUID. 
- Adding connector name to it helps customer narrow down their search. 

Added verification to existing tests.