### PR TITLE
Include bcpkix dependency in Confluent Uber Jar so be able to not add…

### DIFF
--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -328,10 +328,11 @@
     <dependencies>
         <!-- https://mvnrepository.com/artifact/org.bouncycastle/bcpkix-fips -->
         <dependency>
+            <!-- Do not match this with pom.xml-->
+            <!-- This dependency won't be present in the kafka connect runtime, hence we are packaging this in an uber jar -->
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-fips</artifactId>
             <version>1.0.3</version>
-            <scope>provided</scope>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.apache.kafka/connect-api -->


### PR DESCRIPTION
… them manually at runtime

### Problem
- We have confluent zip'ed uber jar which is used by customers to deploy in their own setup/aws MSK. 
  - This zip is built from a different pom.xml file called `confluent_pom.xml`. We recently changed the scope of  bcpkix dependency to be a provided one but that seems like a breaking change for customers advancing from older version to newer version. (>=1.9.0)
### Short term fix:
- They can add bcpkix and bcfips jars into the lib directory just like how they would do it if the jar was downloaded from maven. 
### More details:
Following are two unzipped jars downloaded from confluent jar. This doesnt match with our documentation. We should just add this back in confluent jar so that customers can migrate to newer jar from confluent. 
<img width="639" alt="Screenshot 2023-03-06 at 10 39 45 AM" src="https://user-images.githubusercontent.com/57274584/223201571-6b870a53-0bb8-4258-81e6-5770b89aada1.png">
<img width="541" alt="Screenshot 2023-03-06 at 10 39 58 AM" src="https://user-images.githubusercontent.com/57274584/223201576-3c93759c-9966-4916-88aa-a30ccd4a3ecb.png">


### Action item
- I am not able to repro this locally but I surely remember getting this error when I deployed a jar built from `pom.xml` into confluent runtime. 
- We need to have tests which unzips jar from confluent's pom xml and test out if it works. 