### PR TITLE
SNOW-758111 Use telemetry service for all exceptions wherever possible

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
@@ -739,7 +739,7 @@ public class SnowflakeConnectionServiceV1 extends EnableLogging
       try {
         file = sfconn.downloadStream(stageName, name, true);
       } catch (Exception e) {
-        throw SnowflakeErrors.ERROR_2002.getException(e);
+        throw SnowflakeErrors.ERROR_2002.getException(e, this.telemetry);
       }
       // put
       try {
@@ -750,7 +750,7 @@ public class SnowflakeConnectionServiceV1 extends EnableLogging
             FileNameUtils.removePrefixAndGZFromFileName(name),
             true);
       } catch (SQLException e) {
-        throw SnowflakeErrors.ERROR_2003.getException(e);
+        throw SnowflakeErrors.ERROR_2003.getException(e, this.telemetry);
       }
       LOG_INFO_MSG("moved file: {} from stage: {} to table stage: {}", name, stageName, tableName);
       // remove
@@ -792,7 +792,7 @@ public class SnowflakeConnectionServiceV1 extends EnableLogging
       stmt.close();
       resultSet.close();
     } catch (SQLException e) {
-      throw SnowflakeErrors.ERROR_2001.getException(e);
+      throw SnowflakeErrors.ERROR_2001.getException(e, this.telemetry);
     }
     LOG_INFO_MSG("list stage {} retrieved {} file names", stageName, result.size());
     return result;
@@ -850,7 +850,7 @@ public class SnowflakeConnectionServiceV1 extends EnableLogging
           stageName,
           stageType,
           fileName);
-      throw SnowflakeErrors.ERROR_2011.getException(e);
+      throw SnowflakeErrors.ERROR_2011.getException(e, this.telemetry);
     }
   }
 
@@ -874,7 +874,7 @@ public class SnowflakeConnectionServiceV1 extends EnableLogging
             return true;
           });
     } catch (Exception e) {
-      throw SnowflakeErrors.ERROR_2003.getException(e);
+      throw SnowflakeErrors.ERROR_2003.getException(e, this.telemetry);
     }
     LOG_INFO_MSG("put file: {} to table stage: {}", fileName, tableName);
   }
@@ -889,7 +889,7 @@ public class SnowflakeConnectionServiceV1 extends EnableLogging
     try {
       conn.close();
     } catch (SQLException e) {
-      throw SnowflakeErrors.ERROR_2005.getException(e);
+      throw SnowflakeErrors.ERROR_2005.getException(e, this.telemetry);
     }
 
     LOG_INFO_MSG("snowflake connection closed");
@@ -900,7 +900,7 @@ public class SnowflakeConnectionServiceV1 extends EnableLogging
     try {
       return conn.isClosed();
     } catch (SQLException e) {
-      throw SnowflakeErrors.ERROR_2006.getException(e);
+      throw SnowflakeErrors.ERROR_2006.getException(e, this.telemetry);
     }
   }
 
@@ -947,7 +947,7 @@ public class SnowflakeConnectionServiceV1 extends EnableLogging
         throw SnowflakeErrors.ERROR_1003.getException();
       }
     } catch (SQLException e) {
-      throw SnowflakeErrors.ERROR_1003.getException(e);
+      throw SnowflakeErrors.ERROR_1003.getException(e, this.telemetry);
     }
   }
 
@@ -988,7 +988,7 @@ public class SnowflakeConnectionServiceV1 extends EnableLogging
             return true;
           });
     } catch (Exception e) {
-      throw SnowflakeErrors.ERROR_2001.getException(e);
+      throw SnowflakeErrors.ERROR_2001.getException(e, this.telemetry);
     }
     LOG_DEBUG_MSG("deleted {} from stage {}", fileName, stageName);
   }

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeErrors.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeErrors.java
@@ -306,6 +306,16 @@ public enum SnowflakeErrors {
     return getException("", telemetryService);
   }
 
+  /**
+   * Convert a given message into SnowflakeKafkaConnectorException.
+   *
+   * <p>If message is null, we use Enum's toString() method to wrap inside
+   * SnowflakeKafkaConnectorException
+   *
+   * @param msg Message to send to Telemetry Service. Remember, we Strip the message
+   * @param telemetryService can be null
+   * @return Exception wrapped in Snowflake Connector Exception
+   */
   public SnowflakeKafkaConnectorException getException(
       String msg, SnowflakeTelemetryService telemetryService) {
     if (telemetryService != null) {

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeIngestionServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeIngestionServiceV1.java
@@ -59,7 +59,7 @@ public class SnowflakeIngestionServiceV1 extends EnableLogging
               port,
               userAgentSuffix);
     } catch (Exception e) {
-      throw SnowflakeErrors.ERROR_0002.getException(e);
+      throw SnowflakeErrors.ERROR_0002.getException(e, this.telemetry);
     }
     LOG_INFO_MSG("initialized the pipe connector for pipe {}", pipeName);
   }
@@ -77,7 +77,7 @@ public class SnowflakeIngestionServiceV1 extends EnableLogging
           SnowflakeInternalOperations.INSERT_FILES_SNOWPIPE_API,
           () -> ingestManager.ingestFile(new StagedFileWrapper(fileName), null));
     } catch (Exception e) {
-      throw SnowflakeErrors.ERROR_3001.getException(e);
+      throw SnowflakeErrors.ERROR_3001.getException(e, this.telemetry);
     }
     LOG_DEBUG_MSG("ingest file: {}", fileName);
   }
@@ -105,7 +105,7 @@ public class SnowflakeIngestionServiceV1 extends EnableLogging
             return true;
           });
     } catch (Exception e) {
-      throw SnowflakeErrors.ERROR_3001.getException(e);
+      throw SnowflakeErrors.ERROR_3001.getException(e, this.telemetry);
     }
   }
 
@@ -131,7 +131,7 @@ public class SnowflakeIngestionServiceV1 extends EnableLogging
                   SnowflakeInternalOperations.INSERT_REPORT_SNOWPIPE_API,
                   () -> ingestManager.getHistory(null, null, beginMark));
     } catch (Exception e) {
-      throw SnowflakeErrors.ERROR_3002.getException(e);
+      throw SnowflakeErrors.ERROR_3002.getException(e, this.telemetry);
     }
 
     int numOfRecords = 0;
@@ -209,13 +209,14 @@ public class SnowflakeIngestionServiceV1 extends EnableLogging
                         ingestManager.getHistoryRange(
                             null, (String) startTimeInclusiveFinal, endTimeExclusive));
       } catch (Exception e) {
-        throw SnowflakeErrors.ERROR_1002.getException(e);
+        throw SnowflakeErrors.ERROR_1002.getException(e, this.telemetry);
       }
       if (response != null && response.files != null) {
         response.files.forEach(
             entry -> result.put(entry.getPath(), convertIngestStatus(entry.getStatus())));
       } else {
-        throw SnowflakeErrors.ERROR_4001.getException("the response of load " + "history is null");
+        throw SnowflakeErrors.ERROR_4001.getException(
+            "the response of load history is null", this.telemetry);
       }
 
       LOG_INFO_MSG(

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
@@ -94,9 +94,9 @@ class SnowflakeSinkServiceV1 extends EnableLogging implements SnowflakeSinkServi
     this.flushTime = SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC_DEFAULT;
     this.pipes = new HashMap<>();
     this.conn = conn;
-    this.recordService = new RecordService();
     isStopped = false;
     this.telemetryService = conn.getTelemetryClient();
+    this.recordService = new RecordService(this.telemetryService);
     this.topic2TableMap = new HashMap<>();
 
     // Setting the default value in constructor

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -121,8 +121,8 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
     this.recordNum = StreamingUtils.STREAMING_BUFFER_COUNT_RECORDS_DEFAULT;
     this.flushTimeSeconds = StreamingUtils.STREAMING_BUFFER_FLUSH_TIME_DEFAULT_SEC;
     this.conn = conn;
-    this.recordService = new RecordService();
     this.telemetryService = conn.getTelemetryClient();
+    this.recordService = new RecordService(this.telemetryService);
     this.topicToTableMap = new HashMap<>();
 
     // Setting the default value in constructor
@@ -181,7 +181,8 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
             this.connectorConfig,
             this.kafkaRecordErrorReporter,
             this.sinkTaskContext,
-            this.conn));
+            this.conn,
+            this.recordService));
   }
 
   /**
@@ -521,7 +522,8 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
         if (this.conn.isTableCompatible(tableName)) {
           LOGGER.info("Using existing table {}.", tableName);
         } else {
-          throw SnowflakeErrors.ERROR_5003.getException("table name: " + tableName);
+          throw SnowflakeErrors.ERROR_5003.getException(
+              "table name: " + tableName, this.telemetryService);
         }
       } else {
         this.conn.appendMetaColIfNotExist(tableName);

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
@@ -201,7 +201,8 @@ public class TopicPartitionChannel {
         sfConnectorConfig,
         kafkaRecordErrorReporter,
         sinkTaskContext,
-        null);
+        null, /* Null Connection */
+        new RecordService(null /* Null Telemetry Service*/));
   }
 
   /**
@@ -215,6 +216,7 @@ public class TopicPartitionChannel {
    * @param kafkaRecordErrorReporter kafka errpr reporter for sending records to DLQ
    * @param sinkTaskContext context on Kafka Connect's runtime
    * @param conn the snowflake connection service
+   * @param recordService record service for processing incoming offsets from Kafka
    */
   public TopicPartitionChannel(
       SnowflakeStreamingIngestClient streamingIngestClient,
@@ -225,7 +227,8 @@ public class TopicPartitionChannel {
       final Map<String, String> sfConnectorConfig,
       KafkaRecordErrorReporter kafkaRecordErrorReporter,
       SinkTaskContext sinkTaskContext,
-      SnowflakeConnectionService conn) {
+      SnowflakeConnectionService conn,
+      RecordService recordService) {
     this.streamingIngestClient = Preconditions.checkNotNull(streamingIngestClient);
     Preconditions.checkState(!streamingIngestClient.isClosed());
     this.topicPartition = Preconditions.checkNotNull(topicPartition);
@@ -238,7 +241,7 @@ public class TopicPartitionChannel {
     this.sinkTaskContext = Preconditions.checkNotNull(sinkTaskContext);
     this.conn = conn;
 
-    this.recordService = new RecordService();
+    this.recordService = recordService;
 
     this.previousFlushTimeStampMs = System.currentTimeMillis();
 

--- a/src/main/java/com/snowflake/kafka/connector/records/RecordService.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/RecordService.java
@@ -23,6 +23,7 @@ import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
 import com.snowflake.kafka.connector.internal.EnableLogging;
 import com.snowflake.kafka.connector.internal.LoggerHandler;
 import com.snowflake.kafka.connector.internal.SnowflakeErrors;
+import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryService;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.text.SimpleDateFormat;
@@ -90,13 +91,26 @@ public class RecordService extends EnableLogging {
   // This class is designed to work with empty metadata config map
   private SnowflakeMetadataConfig metadataConfig = new SnowflakeMetadataConfig();
 
+  /** Send Telemetry Data to Snowflake */
+  private final SnowflakeTelemetryService telemetryService;
+
   /**
    * process records output JSON format: { "meta": { "offset": 123, "topic": "topic name",
    * "partition": 123, "key":"key name" } "content": "record content" }
    *
    * <p>create a JsonRecordService instance
+   *
+   * @param telemetryService Telemetry Service Instance. Can be null.
    */
-  public RecordService() {}
+  public RecordService(SnowflakeTelemetryService telemetryService) {
+    this.telemetryService = telemetryService;
+  }
+
+  /** Record service with null telemetry Service, only use it for testing. */
+  @VisibleForTesting
+  public RecordService() {
+    this.telemetryService = null;
+  }
 
   public void setMetadataConfig(SnowflakeMetadataConfig metadataConfigIn) {
     metadataConfig = metadataConfigIn;

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelTest.java
@@ -13,6 +13,7 @@ import com.snowflake.kafka.connector.dlq.KafkaRecordErrorReporter;
 import com.snowflake.kafka.connector.internal.BufferThreshold;
 import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
 import com.snowflake.kafka.connector.internal.TestUtils;
+import com.snowflake.kafka.connector.records.RecordService;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
@@ -481,7 +482,8 @@ public class TopicPartitionChannelTest {
               sfConnectorConfigWithErrors,
               kafkaRecordErrorReporter,
               mockSinkTaskContext,
-              conn);
+              conn,
+              new RecordService());
 
       final int noOfRecords = 3;
       List<SinkRecord> records =


### PR DESCRIPTION
- Why as possible
  - It is possible we dont have connection object everywhere, so in that case, we will not be able to send telemetry to Snowflake

Part 1:
- Use telemetry Service wherever possible to send exceptions to Snowflake

Future PRs:
- We will annotate whether Snowpipe Streaming is used or Snowpipe to distinguish. 
- Channel usage telemetry - For example send data for channel open/close.
- Add alerts later on Snowflake Side. 