### PR TITLE
SNOW-760171 Use pom_confluent.xml in running confluent tests

### DIFF
--- a/.github/workflows/End2EndFullTest.yml
+++ b/.github/workflows/End2EndFullTest.yml
@@ -55,7 +55,7 @@ jobs:
         SHELL: "/bin/bash"
       run: |
         cd test
-        ./build_apache.sh ../../snowflake-kafka-connector
+        ./build_runtime_jar.sh ../../snowflake-kafka-connector
 
     - name: End to End Test of Confluent Platform 5.2.0
       env:

--- a/.github/workflows/End2EndFullTestAzure.yml
+++ b/.github/workflows/End2EndFullTestAzure.yml
@@ -55,7 +55,7 @@ jobs:
         SHELL: "/bin/bash"
       run: |
         cd test
-        ./build_apache.sh ../../snowflake-kafka-connector
+        ./build_runtime_jar.sh ../../snowflake-kafka-connector
 
     - name: End to End Test of Confluent Platform 5.2.0
       env:

--- a/.github/workflows/End2EndFullTestGCS.yml
+++ b/.github/workflows/End2EndFullTestGCS.yml
@@ -55,7 +55,7 @@ jobs:
           SHELL: "/bin/bash"
         run: |
           cd test
-          ./build_apache.sh ../../snowflake-kafka-connector
+          ./build_runtime_jar.sh ../../snowflake-kafka-connector
 
       - name: End to End Test of Confluent Platform 5.2.0
         env:

--- a/.github/workflows/End2EndTestApache.yml
+++ b/.github/workflows/End2EndTestApache.yml
@@ -56,14 +56,14 @@ jobs:
         sudo mv .github/scripts/squid.conf /etc/squid/squid.conf
         sudo service squid start
     
-    - name: Build with Unit Test
+    - name: Build with Unit Test for Apache
       env:
         JACOCO_COVERAGE: true
         SNOWFLAKE_CREDENTIAL_FILE: "../profile.json"
         SHELL: "/bin/bash"
       run: |
         cd test
-        ./build_apache.sh ../../snowflake-kafka-connector package
+        ./build_runtime_jar.sh ../../snowflake-kafka-connector package
 
     - name: End to End Test of Apache Platform ${{ matrix.apache_kafka_version }} against Snowflake in ${{ matrix.snowflake_cloud }}
       env:

--- a/.github/workflows/End2EndTestConfluent.yml
+++ b/.github/workflows/End2EndTestConfluent.yml
@@ -56,14 +56,14 @@ jobs:
         sudo mv .github/scripts/squid.conf /etc/squid/squid.conf
         sudo service squid start
 
-    - name: Build with Unit Test
+    - name: Build with Unit Test For Confluent
       env:
         JACOCO_COVERAGE: true
         SNOWFLAKE_CREDENTIAL_FILE: "../profile.json"
         SHELL: "/bin/bash"
       run: |
         cd test
-        ./build_apache.sh ../../snowflake-kafka-connector package
+        ./build_runtime_jar.sh ../../snowflake-kafka-connector package confluent
 
     - name: End to End Test of Confluent Platform Version ${{ matrix.confluent_version }} against Snowflake in ${{ matrix.snowflake_cloud }}
       env:

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -61,7 +61,7 @@ jobs:
         SHELL: "/bin/bash"
       run: |
         cd test
-        ./build_apache.sh ../../snowflake-kafka-connector
+        ./build_runtime_jar.sh ../../snowflake-kafka-connector
       
     - name: Code Coverage
       uses: codecov/codecov-action@v1

--- a/.github/workflows/StressTest.yml
+++ b/.github/workflows/StressTest.yml
@@ -63,7 +63,7 @@ jobs:
         SHELL: "/bin/bash"
       run: |
         cd test
-        ./build_apache.sh ../../snowflake-kafka-connector package
+        ./build_runtime_jar.sh ../../snowflake-kafka-connector package confluent
 
     - name: Stress Tests of Confluent Platform Version ${{ matrix.confluent_version }} against Snowflake in ${{ matrix.snowflake_cloud }}
       env:

--- a/README-TEST.md
+++ b/README-TEST.md
@@ -41,11 +41,11 @@ Integration test can be run by `mvn verify -Dgpg.skip=true`. Integration test wi
 End to end test spin up an actual Kafka cluster, then send records to Kafka and verify records shows up in Snowflake. To run the test, first make sure evironment variable`SNOWFLAKE_CREDENTIAL_FILE` is set `export SNOWFLAKE_CREDENTIAL_FILE="path/to/profile.json"`. **Then `cd test` to enter the test folder.** End to end test is splited into two steps - building jar file and executing.
 
 ```
-./build_apache.sh <path/to/snowflake-git-repo> <package/verify>
+./build_runtime_jar.sh <path/to/snowflake-git-repo> <package/verify>
 Build the current repo and only run unit test:
-	./build_apache.sh ../../snowflake-kafka-connector package
+	./build_runtime_jar.sh ../../snowflake-kafka-connector package
 Checkout from GitHub master and run integration test:
-	./build_apache.sh
+	./build_runtime_jar.sh
 ```
 
 The above command build a jar file and put it at `/usr/local/share/kafka/plugins`. Then the following command will spin up Kafka and Kafka Connect cluster and execute the test suits. 
@@ -184,7 +184,7 @@ Folders and files in directory test/
 - rest_request_template/: Connector configuration file for end to end test.
 - test_data/: Avro/Profobuf data for end to end test.
 - test_suit/: End to end test cases.
-- build_apache.sh: Build connector jar file.
+- build_runtime_jar.sh: Build connector jar file.
 - build_image.sh: Build a container with the connector jar file and push that to local Docker repo.
 - generate_ssl_key.sh: Generate SSL key on the fly for testing with SSL enabled.
 - run_test_apache.sh: Run end to end test on Apache Kafka.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
 # Snowflake-kafka-connector
 
-[![Build Status](https://github.com/snowflakedb/snowflake-kafka-connector/workflows/Kafka%20Connector%20End2End%20Test/badge.svg)](https://github.com/snowflakedb/snowflake-kafka-connector/actions?query=workflow%3A%22Kafka+Connector+End2End+Test%22)
+![Build Status](https://github.com/snowflakedb/snowflake-kafka-connector/actions/workflows/IntegrationTest.yml/badge.svg?branch=master)
+
+![Build Status](https://github.com/snowflakedb/snowflake-kafka-connector/actions/workflows/End2EndTestApache.yml/badge.svg?branch=master)
+
+![Build Status](https://github.com/snowflakedb/snowflake-kafka-connector/actions/workflows/End2EndTestConfluent.yml/badge.svg?branch=master)
+
 [![codecov](https://codecov.io/gh/snowflakedb/snowflake-kafka-connector/branch/master/graph/badge.svg)](https://codecov.io/gh/snowflakedb/snowflake-kafka-connector)
+
 [![License](http://img.shields.io/:license-Apache%202-brightgreen.svg)](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-Snowflake-kafka-connector is a plugin of Apache Kafka Connect.
+Snowflake-kafka-connector is a plugin of Apache Kafka Connect - Used to Ingest data from Kafka Topic to Snowflake Table.

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
@@ -739,7 +739,7 @@ public class SnowflakeConnectionServiceV1 extends EnableLogging
       try {
         file = sfconn.downloadStream(stageName, name, true);
       } catch (Exception e) {
-        throw SnowflakeErrors.ERROR_2002.getException(e);
+        throw SnowflakeErrors.ERROR_2002.getException(e, this.telemetry);
       }
       // put
       try {
@@ -750,7 +750,7 @@ public class SnowflakeConnectionServiceV1 extends EnableLogging
             FileNameUtils.removePrefixAndGZFromFileName(name),
             true);
       } catch (SQLException e) {
-        throw SnowflakeErrors.ERROR_2003.getException(e);
+        throw SnowflakeErrors.ERROR_2003.getException(e, this.telemetry);
       }
       LOG_INFO_MSG("moved file: {} from stage: {} to table stage: {}", name, stageName, tableName);
       // remove
@@ -792,7 +792,7 @@ public class SnowflakeConnectionServiceV1 extends EnableLogging
       stmt.close();
       resultSet.close();
     } catch (SQLException e) {
-      throw SnowflakeErrors.ERROR_2001.getException(e);
+      throw SnowflakeErrors.ERROR_2001.getException(e, this.telemetry);
     }
     LOG_INFO_MSG("list stage {} retrieved {} file names", stageName, result.size());
     return result;
@@ -850,7 +850,7 @@ public class SnowflakeConnectionServiceV1 extends EnableLogging
           stageName,
           stageType,
           fileName);
-      throw SnowflakeErrors.ERROR_2011.getException(e);
+      throw SnowflakeErrors.ERROR_2011.getException(e, this.telemetry);
     }
   }
 
@@ -874,7 +874,7 @@ public class SnowflakeConnectionServiceV1 extends EnableLogging
             return true;
           });
     } catch (Exception e) {
-      throw SnowflakeErrors.ERROR_2003.getException(e);
+      throw SnowflakeErrors.ERROR_2003.getException(e, this.telemetry);
     }
     LOG_INFO_MSG("put file: {} to table stage: {}", fileName, tableName);
   }
@@ -889,7 +889,7 @@ public class SnowflakeConnectionServiceV1 extends EnableLogging
     try {
       conn.close();
     } catch (SQLException e) {
-      throw SnowflakeErrors.ERROR_2005.getException(e);
+      throw SnowflakeErrors.ERROR_2005.getException(e, this.telemetry);
     }
 
     LOG_INFO_MSG("snowflake connection closed");
@@ -900,7 +900,7 @@ public class SnowflakeConnectionServiceV1 extends EnableLogging
     try {
       return conn.isClosed();
     } catch (SQLException e) {
-      throw SnowflakeErrors.ERROR_2006.getException(e);
+      throw SnowflakeErrors.ERROR_2006.getException(e, this.telemetry);
     }
   }
 
@@ -947,7 +947,7 @@ public class SnowflakeConnectionServiceV1 extends EnableLogging
         throw SnowflakeErrors.ERROR_1003.getException();
       }
     } catch (SQLException e) {
-      throw SnowflakeErrors.ERROR_1003.getException(e);
+      throw SnowflakeErrors.ERROR_1003.getException(e, this.telemetry);
     }
   }
 
@@ -988,7 +988,7 @@ public class SnowflakeConnectionServiceV1 extends EnableLogging
             return true;
           });
     } catch (Exception e) {
-      throw SnowflakeErrors.ERROR_2001.getException(e);
+      throw SnowflakeErrors.ERROR_2001.getException(e, this.telemetry);
     }
     LOG_DEBUG_MSG("deleted {} from stage {}", fileName, stageName);
   }

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeErrors.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeErrors.java
@@ -306,6 +306,16 @@ public enum SnowflakeErrors {
     return getException("", telemetryService);
   }
 
+  /**
+   * Convert a given message into SnowflakeKafkaConnectorException.
+   *
+   * <p>If message is null, we use Enum's toString() method to wrap inside
+   * SnowflakeKafkaConnectorException
+   *
+   * @param msg Message to send to Telemetry Service. Remember, we Strip the message
+   * @param telemetryService can be null
+   * @return Exception wrapped in Snowflake Connector Exception
+   */
   public SnowflakeKafkaConnectorException getException(
       String msg, SnowflakeTelemetryService telemetryService) {
     if (telemetryService != null) {

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeIngestionServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeIngestionServiceV1.java
@@ -59,7 +59,7 @@ public class SnowflakeIngestionServiceV1 extends EnableLogging
               port,
               userAgentSuffix);
     } catch (Exception e) {
-      throw SnowflakeErrors.ERROR_0002.getException(e);
+      throw SnowflakeErrors.ERROR_0002.getException(e, this.telemetry);
     }
     LOG_INFO_MSG("initialized the pipe connector for pipe {}", pipeName);
   }
@@ -77,7 +77,7 @@ public class SnowflakeIngestionServiceV1 extends EnableLogging
           SnowflakeInternalOperations.INSERT_FILES_SNOWPIPE_API,
           () -> ingestManager.ingestFile(new StagedFileWrapper(fileName), null));
     } catch (Exception e) {
-      throw SnowflakeErrors.ERROR_3001.getException(e);
+      throw SnowflakeErrors.ERROR_3001.getException(e, this.telemetry);
     }
     LOG_DEBUG_MSG("ingest file: {}", fileName);
   }
@@ -105,7 +105,7 @@ public class SnowflakeIngestionServiceV1 extends EnableLogging
             return true;
           });
     } catch (Exception e) {
-      throw SnowflakeErrors.ERROR_3001.getException(e);
+      throw SnowflakeErrors.ERROR_3001.getException(e, this.telemetry);
     }
   }
 
@@ -131,7 +131,7 @@ public class SnowflakeIngestionServiceV1 extends EnableLogging
                   SnowflakeInternalOperations.INSERT_REPORT_SNOWPIPE_API,
                   () -> ingestManager.getHistory(null, null, beginMark));
     } catch (Exception e) {
-      throw SnowflakeErrors.ERROR_3002.getException(e);
+      throw SnowflakeErrors.ERROR_3002.getException(e, this.telemetry);
     }
 
     int numOfRecords = 0;
@@ -209,13 +209,14 @@ public class SnowflakeIngestionServiceV1 extends EnableLogging
                         ingestManager.getHistoryRange(
                             null, (String) startTimeInclusiveFinal, endTimeExclusive));
       } catch (Exception e) {
-        throw SnowflakeErrors.ERROR_1002.getException(e);
+        throw SnowflakeErrors.ERROR_1002.getException(e, this.telemetry);
       }
       if (response != null && response.files != null) {
         response.files.forEach(
             entry -> result.put(entry.getPath(), convertIngestStatus(entry.getStatus())));
       } else {
-        throw SnowflakeErrors.ERROR_4001.getException("the response of load " + "history is null");
+        throw SnowflakeErrors.ERROR_4001.getException(
+            "the response of load history is null", this.telemetry);
       }
 
       LOG_INFO_MSG(

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
@@ -94,9 +94,9 @@ class SnowflakeSinkServiceV1 extends EnableLogging implements SnowflakeSinkServi
     this.flushTime = SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC_DEFAULT;
     this.pipes = new HashMap<>();
     this.conn = conn;
-    this.recordService = new RecordService();
     isStopped = false;
     this.telemetryService = conn.getTelemetryClient();
+    this.recordService = new RecordService(this.telemetryService);
     this.topic2TableMap = new HashMap<>();
 
     // Setting the default value in constructor

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -121,8 +121,8 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
     this.recordNum = StreamingUtils.STREAMING_BUFFER_COUNT_RECORDS_DEFAULT;
     this.flushTimeSeconds = StreamingUtils.STREAMING_BUFFER_FLUSH_TIME_DEFAULT_SEC;
     this.conn = conn;
-    this.recordService = new RecordService();
     this.telemetryService = conn.getTelemetryClient();
+    this.recordService = new RecordService(this.telemetryService);
     this.topicToTableMap = new HashMap<>();
 
     // Setting the default value in constructor
@@ -181,7 +181,8 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
             this.connectorConfig,
             this.kafkaRecordErrorReporter,
             this.sinkTaskContext,
-            this.conn));
+            this.conn,
+            this.recordService));
   }
 
   /**
@@ -521,7 +522,8 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
         if (this.conn.isTableCompatible(tableName)) {
           LOGGER.info("Using existing table {}.", tableName);
         } else {
-          throw SnowflakeErrors.ERROR_5003.getException("table name: " + tableName);
+          throw SnowflakeErrors.ERROR_5003.getException(
+              "table name: " + tableName, this.telemetryService);
         }
       } else {
         this.conn.appendMetaColIfNotExist(tableName);

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
@@ -201,7 +201,8 @@ public class TopicPartitionChannel {
         sfConnectorConfig,
         kafkaRecordErrorReporter,
         sinkTaskContext,
-        null);
+        null, /* Null Connection */
+        new RecordService(null /* Null Telemetry Service*/));
   }
 
   /**
@@ -215,6 +216,7 @@ public class TopicPartitionChannel {
    * @param kafkaRecordErrorReporter kafka errpr reporter for sending records to DLQ
    * @param sinkTaskContext context on Kafka Connect's runtime
    * @param conn the snowflake connection service
+   * @param recordService record service for processing incoming offsets from Kafka
    */
   public TopicPartitionChannel(
       SnowflakeStreamingIngestClient streamingIngestClient,
@@ -225,7 +227,8 @@ public class TopicPartitionChannel {
       final Map<String, String> sfConnectorConfig,
       KafkaRecordErrorReporter kafkaRecordErrorReporter,
       SinkTaskContext sinkTaskContext,
-      SnowflakeConnectionService conn) {
+      SnowflakeConnectionService conn,
+      RecordService recordService) {
     this.streamingIngestClient = Preconditions.checkNotNull(streamingIngestClient);
     Preconditions.checkState(!streamingIngestClient.isClosed());
     this.topicPartition = Preconditions.checkNotNull(topicPartition);
@@ -238,7 +241,7 @@ public class TopicPartitionChannel {
     this.sinkTaskContext = Preconditions.checkNotNull(sinkTaskContext);
     this.conn = conn;
 
-    this.recordService = new RecordService();
+    this.recordService = recordService;
 
     this.previousFlushTimeStampMs = System.currentTimeMillis();
 

--- a/src/main/java/com/snowflake/kafka/connector/records/RecordService.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/RecordService.java
@@ -23,6 +23,7 @@ import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
 import com.snowflake.kafka.connector.internal.EnableLogging;
 import com.snowflake.kafka.connector.internal.LoggerHandler;
 import com.snowflake.kafka.connector.internal.SnowflakeErrors;
+import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryService;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.text.SimpleDateFormat;
@@ -90,13 +91,26 @@ public class RecordService extends EnableLogging {
   // This class is designed to work with empty metadata config map
   private SnowflakeMetadataConfig metadataConfig = new SnowflakeMetadataConfig();
 
+  /** Send Telemetry Data to Snowflake */
+  private final SnowflakeTelemetryService telemetryService;
+
   /**
    * process records output JSON format: { "meta": { "offset": 123, "topic": "topic name",
    * "partition": 123, "key":"key name" } "content": "record content" }
    *
    * <p>create a JsonRecordService instance
+   *
+   * @param telemetryService Telemetry Service Instance. Can be null.
    */
-  public RecordService() {}
+  public RecordService(SnowflakeTelemetryService telemetryService) {
+    this.telemetryService = telemetryService;
+  }
+
+  /** Record service with null telemetry Service, only use it for testing. */
+  @VisibleForTesting
+  public RecordService() {
+    this.telemetryService = null;
+  }
 
   public void setMetadataConfig(SnowflakeMetadataConfig metadataConfigIn) {
     metadataConfig = metadataConfigIn;

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelTest.java
@@ -13,6 +13,7 @@ import com.snowflake.kafka.connector.dlq.KafkaRecordErrorReporter;
 import com.snowflake.kafka.connector.internal.BufferThreshold;
 import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
 import com.snowflake.kafka.connector.internal.TestUtils;
+import com.snowflake.kafka.connector.records.RecordService;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
@@ -481,7 +482,8 @@ public class TopicPartitionChannelTest {
               sfConnectorConfigWithErrors,
               kafkaRecordErrorReporter,
               mockSinkTaskContext,
-              conn);
+              conn,
+              new RecordService());
 
       final int noOfRecords = 3;
       List<SinkRecord> records =

--- a/test/build_runtime_jar.sh
+++ b/test/build_runtime_jar.sh
@@ -110,12 +110,9 @@ cp $SNOWFLAKE_PLUGIN_PATH/$SNOWFLAKE_PLUGIN_NAME $KAFKA_CONNECT_PLUGIN_PATH || t
 echo -e "copied SF Plugin Connector to $KAFKA_CONNECT_PLUGIN_PATH"
 
 if [[ $BUILD_FOR_RUNTIME == "confluent" ]]; then
-    echo "For confluent RUNTIME: Copying Lib directory of the Confluent Generated Zip package to $KAFKA_CONNECT_PLUGIN_PATH"
-    ls $SNOWFLAKE_PLUGIN_PATH/components/packages/*/*/lib/*
-    echo "list KAFKA_CONNECT_PLUGIN_PATH"
-    ls $KAFKA_CONNECT_PLUGIN_PATH
-    echo "Performing Recursive Copy"
-    cp -R $SNOWFLAKE_PLUGIN_PATH/components/packages/*/*/lib/* $KAFKA_CONNECT_PLUGIN_PATH
+    echo "For confluent RUNTIME: Copying Kafka Connect Maven Generated Zip file to a temporary location"
+    cp $SNOWFLAKE_PLUGIN_PATH/components/packages/snowflakeinc-snowflake-kafka-connector-*.zip /tmp/sf-kafka-connect-plugin.zip
+    ls /tmp/sf-kafka-connect-plugin*
 fi
 
 KAFKA_CONNECT_DOCKER_JAR_PATH="$SNOWFLAKE_CONNECTOR_PATH/docker-setup/snowflake-kafka-docker/jars"

--- a/test/build_runtime_jar.sh
+++ b/test/build_runtime_jar.sh
@@ -107,11 +107,15 @@ echo -e "\nbuilt connector name: $SNOWFLAKE_PLUGIN_NAME"
 mkdir -m 777 -p $KAFKA_CONNECT_PLUGIN_PATH || \
 sudo mkdir -m 777 -p $KAFKA_CONNECT_PLUGIN_PATH 
 cp $SNOWFLAKE_PLUGIN_PATH/$SNOWFLAKE_PLUGIN_NAME $KAFKA_CONNECT_PLUGIN_PATH || true
-echo -e "copied connector to $KAFKA_CONNECT_PLUGIN_PATH"
+echo -e "copied SF Plugin Connector to $KAFKA_CONNECT_PLUGIN_PATH"
 
 if [[ $BUILD_FOR_RUNTIME == "confluent" ]]; then
     echo "For confluent RUNTIME: Copying Lib directory of the Confluent Generated Zip package to $KAFKA_CONNECT_PLUGIN_PATH"
-    cp -R $SNOWFLAKE_PLUGIN_PATH/components/packages/*/*/lib/ $KAFKA_CONNECT_PLUGIN_PATH
+    ls $SNOWFLAKE_PLUGIN_PATH/components/packages/*/*/lib/*
+    echo "list KAFKA_CONNECT_PLUGIN_PATH"
+    ls $KAFKA_CONNECT_PLUGIN_PATH
+    echo "Performing Recursive Copy"
+    cp -R $SNOWFLAKE_PLUGIN_PATH/components/packages/*/*/lib/* $KAFKA_CONNECT_PLUGIN_PATH
 fi
 
 KAFKA_CONNECT_DOCKER_JAR_PATH="$SNOWFLAKE_CONNECTOR_PATH/docker-setup/snowflake-kafka-docker/jars"

--- a/test/build_runtime_jar.sh
+++ b/test/build_runtime_jar.sh
@@ -11,15 +11,28 @@ function error_exit() {
 
 # check argument number is 1 or 2 or 3
 if [ $# -gt 3 ] || [ $# -lt 1 ]; then
-    error_exit "Usage: ./build_image.sh [<path to snowflake repo>] [verify/package/none] .  Aborting."
+    error_exit "Usage: ./build_runtime_jar.sh [<path to snowflake repo>] [verify/package/none] [apache/confluent].
+    Default for Second argument is verify and third argument is apache. Exiting script"
 fi
 
 SNOWFLAKE_CONNECTOR_PATH=$1
 BUILD_METHOD=$2
+BUILD_FOR_RUNTIME=$3
 
 if [[ -z "${BUILD_METHOD}" ]]; then
     # Default build method verify
     BUILD_METHOD="verify"
+fi
+
+# Set POM file name based on target kafka runtime environment
+if [[ -z "${BUILD_FOR_RUNTIME}" ]]; then
+    # Default build target is for Apache
+    BUILD_FOR_RUNTIME="apache"
+    POM_FILE_NAME="pom.xml"
+fi
+
+if [[ $BUILD_FOR_RUNTIME == "confluent" ]]; then
+    POM_FILE_NAME="pom_confluent.xml"
 fi
 
 # check if connector path is set or checkout from github master
@@ -59,16 +72,23 @@ KAFKA_CONNECT_PLUGIN_PATH="/usr/local/share/kafka/plugins"
 # copy credential to SNOWFLAKE_CONNECTOR_PATH
 cp -rf $SNOWFLAKE_CREDENTIAL_FILE $SNOWFLAKE_CONNECTOR_PATH || true
 
+echo "Building Jar for Runtime: $BUILD_FOR_RUNTIME"
+
 # build and test the local repo
 pushd $SNOWFLAKE_CONNECTOR_PATH
 case $BUILD_METHOD in
 	verify)
+	  # mvn clean should clean the target directory, hence using default pom.xml
 	  mvn clean
-    mvn verify -Dgpg.skip=true -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+	  # mvn verify runs the integration test
+    mvn -f $POM_FILE_NAME verify -Dgpg.skip=true -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
 		;;
 	package)
+	  # mvn clean should clean the target directory, hence using default pom.xml
 	  mvn clean
-    mvn package -Dgpg.skip=true -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+	  # mvn package with pom_confluent runs the kafka-connect-maven-plugin which creates a zip file
+	  # More information: https://docs.confluent.io/platform/current/connect/kafka-connect-maven-plugin/site/plugin-info.html
+    mvn -f $POM_FILE_NAME package -Dgpg.skip=true -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
 		;;
 	none)
 		echo -e "\n=== skip building, please make sure built connector exist ==="
@@ -89,11 +109,12 @@ sudo mkdir -m 777 -p $KAFKA_CONNECT_PLUGIN_PATH
 cp $SNOWFLAKE_PLUGIN_PATH/$SNOWFLAKE_PLUGIN_NAME $KAFKA_CONNECT_PLUGIN_PATH || true
 echo -e "copied connector to $KAFKA_CONNECT_PLUGIN_PATH"
 
+if [[ $BUILD_FOR_RUNTIME == "confluent" ]]; then
+    echo "For confluent RUNTIME: Copying Lib directory of the Confluent Generated Zip package to $KAFKA_CONNECT_PLUGIN_PATH"
+    cp -R $SNOWFLAKE_PLUGIN_PATH/components/packages/*/*/lib/ $KAFKA_CONNECT_PLUGIN_PATH
+fi
+
 KAFKA_CONNECT_DOCKER_JAR_PATH="$SNOWFLAKE_CONNECTOR_PATH/docker-setup/snowflake-kafka-docker/jars"
 mkdir -m 777 -p $KAFKA_CONNECT_DOCKER_JAR_PATH
 cp $SNOWFLAKE_PLUGIN_PATH/$SNOWFLAKE_PLUGIN_NAME $KAFKA_CONNECT_DOCKER_JAR_PATH || true
 echo -e "copied connector to $KAFKA_CONNECT_DOCKER_JAR_PATH for docker"
-
-echo -e "\n===================================== WARNING ====================================="
-echo -e "not recommended to share this jar with customer unless necessary (PrPr feature, etc)"
-echo -e "absolutely do not let the customer run this jar on their production environment\n"

--- a/test/run_test_confluent.sh
+++ b/test/run_test_confluent.sh
@@ -106,26 +106,15 @@ rm $APACHE_LOG_PATH/zookeeper.log $APACHE_LOG_PATH/kafka.log || true
 rm $APACHE_LOG_PATH/kc.log || true
 rm -rf /tmp/kafka-logs /tmp/zookeeper || true
 
-# Fips Jar installation, required for encrypted private key
-fipsInstallDirectory=$CONFLUENT_FOLDER_NAME/"share/java/kafka"
+# Fips jars are required for encrypted private key
+# But installation is not required for Confluent.
+# Maven plugin: kafka-connect-maven-plugin creates a zip file https://docs.confluent.io/platform/current/connect/kafka-connect-maven-plugin/site/plugin-info.html
+# which includes all jars necessary to run Snowflake Kafka Connector plugin in Confluent Runtime
+# This jar is built using pom_confluent.xml file
 KAFKA_CONNECT_PLUGIN_PATH="/usr/local/share/kafka/plugins"
-echo $fipsInstallDirectory
-lsCommand=$(ls $fipsInstallDirectory | grep fips | wc -l)
-echo $lsCommand
 
-if [ $lsCommand == 0 ]; then
-    echo "Installing fips Jars in:"$fipsInstallDirectory
-    wget -P $fipsInstallDirectory https://repo1.maven.org/maven2/org/bouncycastle/bcpkix-fips/1.0.3/bcpkix-fips-1.0.3.jar
-    wget -P $fipsInstallDirectory https://repo1.maven.org/maven2/org/bouncycastle/bc-fips/1.0.2/bc-fips-1.0.2.jar
-    cp $fipsInstallDirectory/bcpkix-fips-1.0.3.jar $KAFKA_CONNECT_PLUGIN_PATH
-    cp $fipsInstallDirectory/bc-fips-1.0.2.jar $KAFKA_CONNECT_PLUGIN_PATH
-    echo "list KAFKA_CONNECT_PLUGIN_PATH: $KAFKA_CONNECT_PLUGIN_PATH"
-    ls $KAFKA_CONNECT_PLUGIN_PATH
-    echo "list confluent test share directory: $fipsInstallDirectory"
-    ls $fipsInstallDirectory
-else
-    echo "No need to download Fips Libraries"
-fi
+echo "list KAFKA_CONNECT_PLUGIN_PATH: $KAFKA_CONNECT_PLUGIN_PATH"
+ls $KAFKA_CONNECT_PLUGIN_PATH
 
 # Copy the sample connect log4j properties file to appropriate directory
 echo "Copying connect-log4j.properties file to confluent folder"

--- a/test/run_test_confluent.sh
+++ b/test/run_test_confluent.sh
@@ -132,7 +132,7 @@ ls $KAFKA_CONNECT_PLUGIN_PATH
 # this is the built jar
 echo "Built zip file:"
 ls /tmp/sf-kafka-connect-plugin*
-tar -xvzf /tmp/sf-kafka-connect-plugin* --directory $KAFKA_CONNECT_PLUGIN_PATH
+tar -xvzf /tmp/sf-kafka-connect-plugin.zip --directory $KAFKA_CONNECT_PLUGIN_PATH
 echo "list KAFKA_CONNECT_PLUGIN_PATH: $KAFKA_CONNECT_PLUGIN_PATH"
 ls $KAFKA_CONNECT_PLUGIN_PATH
 

--- a/test/run_test_confluent.sh
+++ b/test/run_test_confluent.sh
@@ -108,30 +108,10 @@ rm -rf /tmp/kafka-logs /tmp/zookeeper || true
 
 KAFKA_CONNECT_PLUGIN_PATH="/usr/local/share/kafka/plugins"
 
-echo "list KAFKA_CONNECT_PLUGIN_PATH: $KAFKA_CONNECT_PLUGIN_PATH"
-ls $KAFKA_CONNECT_PLUGIN_PATH
-
-# Fips Jar installation for version 5.x.x and 6.x.x, required for encrypted private key
-#if [[ ( $CONFLUENT_VERSION == *"5."* ) || ( $CONFLUENT_VERSION == *"6."* ) ]]; then
-#    fipsInstallDirectory=$CONFLUENT_FOLDER_NAME/"share/java/kafka"
-#    lsCommand=$(ls $fipsInstallDirectory | grep fips | wc -l)
-#    echo "Jars count with fips Libraries $lsCommand"
-#
-#    if [ $lsCommand == 0 ]; then
-#        echo "Installing fips Jars in:"$fipsInstallDirectory
-#        wget -P $fipsInstallDirectory https://repo1.maven.org/maven2/org/bouncycastle/bcpkix-fips/1.0.3/bcpkix-fips-1.0.3.jar
-#        wget -P $fipsInstallDirectory https://repo1.maven.org/maven2/org/bouncycastle/bc-fips/1.0.2/bc-fips-1.0.2.jar
-#        cp $fipsInstallDirectory/bcpkix-fips-1.0.3.jar $KAFKA_CONNECT_PLUGIN_PATH
-#        cp $fipsInstallDirectory/bc-fips-1.0.2.jar $KAFKA_CONNECT_PLUGIN_PATH
-#        echo "list KAFKA_CONNECT_PLUGIN_PATH: $KAFKA_CONNECT_PLUGIN_PATH"
-#        ls $KAFKA_CONNECT_PLUGIN_PATH
-#    else
-#        echo "No need to download Fips Libraries"
-#    fi
-#fi
 # this is the built jar
-echo "Built zip file:"
+echo "Built zip file using kafka connect maven plugin:"
 ls /tmp/sf-kafka-connect-plugin*
+# Plugin path is used by kafka connect to install plugin, in our case, SF Kafka Connector
 unzip /tmp/sf-kafka-connect-plugin.zip -d $KAFKA_CONNECT_PLUGIN_PATH
 echo "list KAFKA_CONNECT_PLUGIN_PATH: $KAFKA_CONNECT_PLUGIN_PATH"
 ls $KAFKA_CONNECT_PLUGIN_PATH
@@ -162,25 +142,6 @@ sleep 10
 echo -e "\n=== Start Kafka Connect ==="
 KAFKA_HEAP_OPTS="-Xms512m -Xmx6g" $CONFLUENT_FOLDER_NAME/bin/connect-distributed $SNOWFLAKE_APACHE_CONFIG_PATH/$SNOWFLAKE_KAFKA_CONNECT_CONFIG > $APACHE_LOG_PATH/kc.log 2>&1 &
 sleep 10
-#if [[ $CONFLUENT_VERSION == *"7."* ]]; then
-#    # Fips jars are required for encrypted private key
-#    # But No specific installation is required for Confluent.
-#    # Just Install using confluent-hub executable
-#    # Maven plugin: kafka-connect-maven-plugin creates a zip file https://docs.confluent.io/platform/current/connect/kafka-connect-maven-plugin/site/plugin-info.html
-#    # which includes all jars necessary to run Snowflake Kafka Connector plugin in Confluent Runtime
-#    # This jar is built using pom_confluent.xml file
-#    echo "\n=== Confluent Version is: $CONFLUENT_VERSION ==="
-#    confluentHubFile=$CONFLUENT_FOLDER_NAME/bin/confluent-hub
-#    if [ -e "$confluentHubFile" ]; then
-#        echo "\n=== Confluent-hub file exists $confluentHubFile ==="
-#        echo -e "\n=== Installing Snowflake Kafka Connect through Confluent hub==="
-#        $confluentHubFile install --no-prompt /tmp/sf-kafka-connect-plugin.zip
-#    else
-#        echo "File $confluentHubFile doesnt exist"
-#        ls $CONFLUENT_FOLDER_NAME/bin/
-#    fi
-#
-#fi
 echo -e "\n=== Start Schema Registry ==="
 $CONFLUENT_FOLDER_NAME/bin/schema-registry-start $SNOWFLAKE_APACHE_CONFIG_PATH/$SNOWFLAKE_SCHEMA_REGISTRY_CONFIG > $APACHE_LOG_PATH/sc.log 2>&1 &
 sleep 30

--- a/test/run_test_confluent.sh
+++ b/test/run_test_confluent.sh
@@ -155,6 +155,7 @@ $CONFLUENT_FOLDER_NAME/bin/kafka-server-start $SNOWFLAKE_APACHE_CONFIG_PATH/$SNO
 sleep 10
 echo -e "\n=== Start Kafka Connect ==="
 KAFKA_HEAP_OPTS="-Xms512m -Xmx6g" $CONFLUENT_FOLDER_NAME/bin/connect-distributed $SNOWFLAKE_APACHE_CONFIG_PATH/$SNOWFLAKE_KAFKA_CONNECT_CONFIG > $APACHE_LOG_PATH/kc.log 2>&1 &
+sleep 10
 if [[ $CONFLUENT_VERSION == *"7."* ]]; then
     # Fips jars are required for encrypted private key
     # But No specific installation is required for Confluent.
@@ -162,10 +163,11 @@ if [[ $CONFLUENT_VERSION == *"7."* ]]; then
     # Maven plugin: kafka-connect-maven-plugin creates a zip file https://docs.confluent.io/platform/current/connect/kafka-connect-maven-plugin/site/plugin-info.html
     # which includes all jars necessary to run Snowflake Kafka Connector plugin in Confluent Runtime
     # This jar is built using pom_confluent.xml file
+    echo "\n=== Confluent Version is: $CONFLUENT_VERSION ==="
     confluentHubFile=$CONFLUENT_FOLDER_NAME/bin/confluent-hub
-    if [ -f "$confluentHubFile" ]; then
-        echo "\n=== Confluent Version is: $CONFLUENT_VERSION and confluent-hub file exists ==="
-        echo -e "\n=== Installing Snowflake Kafka Connect ==="
+    if [[ -f "$confluentHubFile" ]]; then
+        echo "\n=== Confluent-hub file exists $confluentHubFile ==="
+        echo -e "\n=== Installing Snowflake Kafka Connect through Confluent hub==="
         $confluentHubFile install --no-prompt /tmp/sf-kafka-connect-plugin.zip
     fi
 fi

--- a/test/run_test_confluent.sh
+++ b/test/run_test_confluent.sh
@@ -132,7 +132,7 @@ ls $KAFKA_CONNECT_PLUGIN_PATH
 # this is the built jar
 echo "Built zip file:"
 ls /tmp/sf-kafka-connect-plugin*
-tar -xvzf /tmp/sf-kafka-connect-plugin.zip --directory $KAFKA_CONNECT_PLUGIN_PATH
+unzip /tmp/sf-kafka-connect-plugin.zip -d $KAFKA_CONNECT_PLUGIN_PATH
 echo "list KAFKA_CONNECT_PLUGIN_PATH: $KAFKA_CONNECT_PLUGIN_PATH"
 ls $KAFKA_CONNECT_PLUGIN_PATH
 

--- a/test/run_test_confluent.sh
+++ b/test/run_test_confluent.sh
@@ -165,11 +165,15 @@ if [[ $CONFLUENT_VERSION == *"7."* ]]; then
     # This jar is built using pom_confluent.xml file
     echo "\n=== Confluent Version is: $CONFLUENT_VERSION ==="
     confluentHubFile=$CONFLUENT_FOLDER_NAME/bin/confluent-hub
-    if [[ -f "$confluentHubFile" ]]; then
+    if [ -e "$confluentHubFile" ]; then
         echo "\n=== Confluent-hub file exists $confluentHubFile ==="
         echo -e "\n=== Installing Snowflake Kafka Connect through Confluent hub==="
         $confluentHubFile install --no-prompt /tmp/sf-kafka-connect-plugin.zip
+    else
+        echo "File $confluentHubFile doesnt exist"
+        ls $CONFLUENT_FOLDER_NAME/bin/
     fi
+
 fi
 sleep 10
 echo -e "\n=== Start Schema Registry ==="

--- a/test/run_test_confluent.sh
+++ b/test/run_test_confluent.sh
@@ -222,5 +222,7 @@ if [ $testError -ne 0 ]; then
     NC='\033[0m' # No Color
     echo -e "${RED} There is error above this line ${NC}"
     cat $APACHE_LOG_PATH/kc.log
+    echo "Output kafka logs for debugging"
+    cat $APACHE_LOG_PATH/kafka.log
     error_exit "=== test_verify.py failed ==="
 fi

--- a/test/run_test_confluent.sh
+++ b/test/run_test_confluent.sh
@@ -112,23 +112,29 @@ echo "list KAFKA_CONNECT_PLUGIN_PATH: $KAFKA_CONNECT_PLUGIN_PATH"
 ls $KAFKA_CONNECT_PLUGIN_PATH
 
 # Fips Jar installation for version 5.x.x and 6.x.x, required for encrypted private key
-if [[ ( $CONFLUENT_VERSION == *"5."* ) || ( $CONFLUENT_VERSION == *"6."* ) ]]; then
-    fipsInstallDirectory=$CONFLUENT_FOLDER_NAME/"share/java/kafka"
-    lsCommand=$(ls $fipsInstallDirectory | grep fips | wc -l)
-    echo "Jars count with fips Libraries $lsCommand"
-
-    if [ $lsCommand == 0 ]; then
-        echo "Installing fips Jars in:"$fipsInstallDirectory
-        wget -P $fipsInstallDirectory https://repo1.maven.org/maven2/org/bouncycastle/bcpkix-fips/1.0.3/bcpkix-fips-1.0.3.jar
-        wget -P $fipsInstallDirectory https://repo1.maven.org/maven2/org/bouncycastle/bc-fips/1.0.2/bc-fips-1.0.2.jar
-        cp $fipsInstallDirectory/bcpkix-fips-1.0.3.jar $KAFKA_CONNECT_PLUGIN_PATH
-        cp $fipsInstallDirectory/bc-fips-1.0.2.jar $KAFKA_CONNECT_PLUGIN_PATH
-        echo "list KAFKA_CONNECT_PLUGIN_PATH: $KAFKA_CONNECT_PLUGIN_PATH"
-        ls $KAFKA_CONNECT_PLUGIN_PATH
-    else
-        echo "No need to download Fips Libraries"
-    fi
-fi
+#if [[ ( $CONFLUENT_VERSION == *"5."* ) || ( $CONFLUENT_VERSION == *"6."* ) ]]; then
+#    fipsInstallDirectory=$CONFLUENT_FOLDER_NAME/"share/java/kafka"
+#    lsCommand=$(ls $fipsInstallDirectory | grep fips | wc -l)
+#    echo "Jars count with fips Libraries $lsCommand"
+#
+#    if [ $lsCommand == 0 ]; then
+#        echo "Installing fips Jars in:"$fipsInstallDirectory
+#        wget -P $fipsInstallDirectory https://repo1.maven.org/maven2/org/bouncycastle/bcpkix-fips/1.0.3/bcpkix-fips-1.0.3.jar
+#        wget -P $fipsInstallDirectory https://repo1.maven.org/maven2/org/bouncycastle/bc-fips/1.0.2/bc-fips-1.0.2.jar
+#        cp $fipsInstallDirectory/bcpkix-fips-1.0.3.jar $KAFKA_CONNECT_PLUGIN_PATH
+#        cp $fipsInstallDirectory/bc-fips-1.0.2.jar $KAFKA_CONNECT_PLUGIN_PATH
+#        echo "list KAFKA_CONNECT_PLUGIN_PATH: $KAFKA_CONNECT_PLUGIN_PATH"
+#        ls $KAFKA_CONNECT_PLUGIN_PATH
+#    else
+#        echo "No need to download Fips Libraries"
+#    fi
+#fi
+# this is the built jar
+echo "Built zip file:"
+ls /tmp/sf-kafka-connect-plugin*
+tar -xvzf /tmp/sf-kafka-connect-plugin* --directory $KAFKA_CONNECT_PLUGIN_PATH
+echo "list KAFKA_CONNECT_PLUGIN_PATH: $KAFKA_CONNECT_PLUGIN_PATH"
+ls $KAFKA_CONNECT_PLUGIN_PATH
 
 # Copy the sample connect log4j properties file to appropriate directory
 echo "Copying connect-log4j.properties file to confluent folder"
@@ -156,26 +162,25 @@ sleep 10
 echo -e "\n=== Start Kafka Connect ==="
 KAFKA_HEAP_OPTS="-Xms512m -Xmx6g" $CONFLUENT_FOLDER_NAME/bin/connect-distributed $SNOWFLAKE_APACHE_CONFIG_PATH/$SNOWFLAKE_KAFKA_CONNECT_CONFIG > $APACHE_LOG_PATH/kc.log 2>&1 &
 sleep 10
-if [[ $CONFLUENT_VERSION == *"7."* ]]; then
-    # Fips jars are required for encrypted private key
-    # But No specific installation is required for Confluent.
-    # Just Install using confluent-hub executable
-    # Maven plugin: kafka-connect-maven-plugin creates a zip file https://docs.confluent.io/platform/current/connect/kafka-connect-maven-plugin/site/plugin-info.html
-    # which includes all jars necessary to run Snowflake Kafka Connector plugin in Confluent Runtime
-    # This jar is built using pom_confluent.xml file
-    echo "\n=== Confluent Version is: $CONFLUENT_VERSION ==="
-    confluentHubFile=$CONFLUENT_FOLDER_NAME/bin/confluent-hub
-    if [ -e "$confluentHubFile" ]; then
-        echo "\n=== Confluent-hub file exists $confluentHubFile ==="
-        echo -e "\n=== Installing Snowflake Kafka Connect through Confluent hub==="
-        $confluentHubFile install --no-prompt /tmp/sf-kafka-connect-plugin.zip
-    else
-        echo "File $confluentHubFile doesnt exist"
-        ls $CONFLUENT_FOLDER_NAME/bin/
-    fi
-
-fi
-sleep 10
+#if [[ $CONFLUENT_VERSION == *"7."* ]]; then
+#    # Fips jars are required for encrypted private key
+#    # But No specific installation is required for Confluent.
+#    # Just Install using confluent-hub executable
+#    # Maven plugin: kafka-connect-maven-plugin creates a zip file https://docs.confluent.io/platform/current/connect/kafka-connect-maven-plugin/site/plugin-info.html
+#    # which includes all jars necessary to run Snowflake Kafka Connector plugin in Confluent Runtime
+#    # This jar is built using pom_confluent.xml file
+#    echo "\n=== Confluent Version is: $CONFLUENT_VERSION ==="
+#    confluentHubFile=$CONFLUENT_FOLDER_NAME/bin/confluent-hub
+#    if [ -e "$confluentHubFile" ]; then
+#        echo "\n=== Confluent-hub file exists $confluentHubFile ==="
+#        echo -e "\n=== Installing Snowflake Kafka Connect through Confluent hub==="
+#        $confluentHubFile install --no-prompt /tmp/sf-kafka-connect-plugin.zip
+#    else
+#        echo "File $confluentHubFile doesnt exist"
+#        ls $CONFLUENT_FOLDER_NAME/bin/
+#    fi
+#
+#fi
 echo -e "\n=== Start Schema Registry ==="
 $CONFLUENT_FOLDER_NAME/bin/schema-registry-start $SNOWFLAKE_APACHE_CONFIG_PATH/$SNOWFLAKE_SCHEMA_REGISTRY_CONFIG > $APACHE_LOG_PATH/sc.log 2>&1 &
 sleep 30

--- a/test/test_verify.py
+++ b/test/test_verify.py
@@ -703,6 +703,6 @@ if __name__ == "__main__":
                           testVersion,
                           enableSSL,
                           snowflakeCloudPlatform,
-                          False) # Disable delivery guarantee tests
+                          False)
 
     runTestSet(kafkaTest, testSet, nameSalt, pressure)

--- a/test/test_verify.py
+++ b/test/test_verify.py
@@ -703,6 +703,6 @@ if __name__ == "__main__":
                           testVersion,
                           enableSSL,
                           snowflakeCloudPlatform,
-                          enableDeliveryGuaranteeTests)
+                          False) # Disable delivery guarantee tests
 
     runTestSet(kafkaTest, testSet, nameSalt, pressure)


### PR DESCRIPTION
### Benefits:
- Catch issues before releasing a zip in Confluent Hub
- Use pom_confluent.xml in our tests. We only used pom.xml until now and no way to check the diff between those two. 
- For private key which are encrypted, we have to deploy fips jar to confluen setup, this test would have caught that. 

### Details
- Rename build_apache.jar with build_runtime_jar
- Use pom_confluent.xml in Running End to end test against Confluent
- Pass in confluent argument when we want to use confluent as kafka runtime. 
- Add description in sh script. 
- pom_confluent uses https://docs.confluent.io/platform/current/connect/kafka-connect-maven-plugin/site/plugin-info.html plugin to create a zip file which gets released to Confluent Hub. 

Update: [For confluent tests]
- For all versions, we point plugin path to the zip file we extract after running build_runtime_jar.sh which runs the connect maven plugin. 

### Next:
- Some of the End2EndFullTest runs both Apache and Confluent on a weekly basis in the same workflow and is also running older version. 
- I will fix those tests to run apache and confluent only. 