### PR TITLE
Disable delivery guarantee tests

### DIFF
--- a/test/test_verify.py
+++ b/test/test_verify.py
@@ -703,6 +703,6 @@ if __name__ == "__main__":
                           testVersion,
                           enableSSL,
                           snowflakeCloudPlatform,
-                          enableDeliveryGuaranteeTests)
+                          False)
 
     runTestSet(kafkaTest, testSet, nameSalt, pressure)


### PR DESCRIPTION
- Revi will push her change but these delivery tests are getting very flaky. 
- End2End tests are running under 15 mins. Down from 45 mins in each suite. 
  - https://github.com/snowflakedb/snowflake-kafka-connector/actions/runs/4439592229/jobs/7792262057?pr=577 
- Helps reducing the noise https://github.com/snowflakedb/snowflake-kafka-connector/pull/573