### PR TITLE
NO-SNOW Best practice: Use fail-safe plugin for IT tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,9 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <skipTests>false</skipTests>
+        <skipUnitTests>${skipTests}</skipUnitTests>
+        <skipIntegrationTests>${skipTests}</skipIntegrationTests>
     </properties>
 
 
@@ -152,25 +155,29 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.0</version>
                 <configuration>
+                    <skipTests>${skipUnitTests}</skipTests>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.22.2</version>
+                <configuration>
+                    <includes>
+                        <include>**/*IT.java</include>
+                    </includes>
                     <excludes>
-                        <exclude>**/*IT.java</exclude>
+                        <exclude>none</exclude>
                     </excludes>
+                    <skipTests>${skipIntegrationTests}</skipTests>
                 </configuration>
                 <executions>
                     <execution>
-                        <id>integration-test</id>
                         <goals>
-                            <goal>test</goal>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
                         </goals>
-                        <phase>integration-test</phase>
-                        <configuration>
-                            <excludes>
-                                <exclude>none</exclude>
-                            </excludes>
-                            <includes>
-                                <include>**/*IT.java</include>
-                            </includes>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -46,6 +46,9 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <skipTests>false</skipTests>
+        <skipUnitTests>${skipTests}</skipUnitTests>
+        <skipIntegrationTests>${skipTests}</skipIntegrationTests>
     </properties>
 
 
@@ -212,25 +215,29 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.0</version>
                 <configuration>
+                    <skipTests>${skipUnitTests}</skipTests>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.22.2</version>
+                <configuration>
+                    <includes>
+                        <include>**/*IT.java</include>
+                    </includes>
                     <excludes>
-                        <exclude>**/*IT.java</exclude>
+                        <exclude>none</exclude>
                     </excludes>
+                    <skipTests>${skipIntegrationTests}</skipTests>
                 </configuration>
                 <executions>
                     <execution>
-                        <id>integration-test</id>
                         <goals>
-                            <goal>test</goal>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
                         </goals>
-                        <phase>integration-test</phase>
-                        <configuration>
-                            <excludes>
-                                <exclude>none</exclude>
-                            </excludes>
-                            <includes>
-                                <include>**/*IT.java</include>
-                            </includes>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
### Background
- I was struggling to run only integration test with our setup from a host machine against preprod12
- I researched about how this is running from our KC. 
- From https://maven.apache.org/surefire/maven-failsafe-plugin/ it is mentioned that failsafe should be used for Integration Test and surefire is only used for unit testing. 

This change will help in following way:
- Run below to execute only Unit Tests
`mvn clean test`
- You can execute below command to run the tests (both unit and integration)
`mvn clean verify`
- In order to run only Integration Tests, follow
`mvn failsafe:integration-test`
- Or skip unit tests
`mvn clean install -DskipUnitTests`
- Run single test IT test
`mvn -Dit.test=TopicPartitionChannelIT verify`
- Skip bunch of tests which are failing and requires some extra setup
`mvn '-Dit.test =*IT,!SinkServiceIT#testFileDiscardWithExactlyOnceSemantics,!SinkServiceIT#testIngestionWithExactlyOnceSemanticsHappyCase,SinkServiceIT#testRecordDiscardWithExactlyOnceSemantics,!SinkTaskProxyIT#testSinkTaskProxyConfig,!IngestionServiceIT#ingestFileWithClientInfoTestSuccessful,!IngestionServiceIT#ingestMultipleFilesWithClientInfoTest,!ConnectionServiceIT,!InternalStageIT#testInternalStageWithProxy' verify`

