### PR TITLE
[SNOW-659469] List all invalid parameters 

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnector.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnector.java
@@ -204,7 +204,7 @@ public class SnowflakeSinkConnector extends SinkConnector {
     }
 
     // Verify proxy config is valid
-    Map<String, String> invalidProxyParams = Utils.validateProxySetting(connectorConfigs);
+    Map<String, String> invalidProxyParams = Utils.validateProxySettings(connectorConfigs);
 
     for (String invalidKey : invalidProxyParams.keySet()) {
       Utils.updateConfigErrorMessage(result, invalidKey, invalidProxyParams.get(invalidKey));

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnector.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnector.java
@@ -204,31 +204,12 @@ public class SnowflakeSinkConnector extends SinkConnector {
     }
 
     // Verify proxy config is valid
-    try {
-      Utils.validateProxySetting(connectorConfigs);
-    } catch (SnowflakeKafkaConnectorException e) {
-      LOGGER.error("Error validating proxy parameters:{}", e.getMessage());
-      switch (e.getCode()) {
-        case "0022":
-          Utils.updateConfigErrorMessage(
-              result,
-              SnowflakeSinkConnectorConfig.JVM_PROXY_HOST,
-              ": proxy host and port must be provided together");
-          Utils.updateConfigErrorMessage(
-              result,
-              SnowflakeSinkConnectorConfig.JVM_PROXY_PORT,
-              ": proxy host and port must be provided together");
-        case "0023":
-          Utils.updateConfigErrorMessage(
-              result,
-              SnowflakeSinkConnectorConfig.JVM_PROXY_USERNAME,
-              ": proxy username and password must be provided together");
-          Utils.updateConfigErrorMessage(
-              result,
-              SnowflakeSinkConnectorConfig.JVM_PROXY_PASSWORD,
-              ": proxy username and password must be provided together");
-      }
+    Map<String, String> invalidProxyParams = Utils.validateProxySetting(connectorConfigs);
+
+    for (String invalidKey : invalidProxyParams.keySet()) {
+      Utils.updateConfigErrorMessage(result, invalidKey, invalidProxyParams.get(invalidKey));
     }
+
     // If private key or private key passphrase is provided through file, skip validation
     if (connectorConfigs.getOrDefault(Utils.SF_PRIVATE_KEY, "").contains("${file:")
         || connectorConfigs.getOrDefault(Utils.PRIVATE_KEY_PASSPHRASE, "").contains("${file:"))

--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -492,9 +492,9 @@ public class Utils {
             Utils.formatString(
                 "Config value '{}' is invalid. Error message: '{}'", invalidKey, invalidValue);
         invalidParamsMessage += errorMessage + "\n";
-        LOGGER.error(errorMessage);
       }
 
+      LOGGER.error("Invalid config: " + invalidParamsMessage);
       throw SnowflakeErrors.ERROR_0001.getException(invalidParamsMessage);
     }
 

--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -339,9 +339,11 @@ public class Utils {
     // unique name of this connector instance
     String connectorName = config.getOrDefault(SnowflakeSinkConnectorConfig.NAME, "");
     if (connectorName.isEmpty() || !isValidSnowflakeApplicationName(connectorName)) {
-      invalidConfigParams.put(SnowflakeSinkConnectorConfig.NAME, Utils.formatString(
-              "{} is empty or invalid. It should match Snowflake object identifier syntax. Please see "
-                      + "the documentation.",
+      invalidConfigParams.put(
+          SnowflakeSinkConnectorConfig.NAME,
+          Utils.formatString(
+              "{} is empty or invalid. It should match Snowflake object identifier syntax. Please"
+                  + " see the documentation.",
               SnowflakeSinkConnectorConfig.NAME));
     }
 
@@ -352,17 +354,22 @@ public class Utils {
         || config
             .get(INGESTION_METHOD_OPT)
             .equalsIgnoreCase(IngestionMethodConfig.SNOWPIPE.toString())) {
-      invalidConfigParams.putAll(BufferThreshold.validateBufferThreshold(config, IngestionMethodConfig.SNOWPIPE));
+      invalidConfigParams.putAll(
+          BufferThreshold.validateBufferThreshold(config, IngestionMethodConfig.SNOWPIPE));
 
       if (config.containsKey(SnowflakeSinkConnectorConfig.ENABLE_SCHEMATIZATION_CONFIG)
           && Boolean.parseBoolean(
               config.get(SnowflakeSinkConnectorConfig.ENABLE_SCHEMATIZATION_CONFIG))) {
-        invalidConfigParams.put(IngestionMethodConfig.SNOWPIPE_STREAMING.toString(), Utils.formatString(
+        invalidConfigParams.put(
+            IngestionMethodConfig.SNOWPIPE_STREAMING.toString(),
+            Utils.formatString(
                 "Schematization is only available with {}.",
                 IngestionMethodConfig.SNOWPIPE_STREAMING.toString()));
       }
       if (config.containsKey(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_FILE_VERSION)) {
-        invalidConfigParams.put(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_FILE_VERSION, Utils.formatString(
+        invalidConfigParams.put(
+            SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_FILE_VERSION,
+            Utils.formatString(
                 "{} is only available with ingestion type: {}.",
                 SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_FILE_VERSION,
                 IngestionMethodConfig.SNOWPIPE_STREAMING.toString()));
@@ -372,35 +379,53 @@ public class Utils {
     if (config.containsKey(SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP)
         && parseTopicToTableMap(config.get(SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP))
             == null) {
-      invalidConfigParams.put(SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP, Utils.formatString("Invalid {} config format: {}", SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP, config.get(SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP)));
+      invalidConfigParams.put(
+          SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP,
+          Utils.formatString(
+              "Invalid {} config format: {}",
+              SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP,
+              config.get(SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP)));
     }
 
     // sanity check
     if (!config.containsKey(SnowflakeSinkConnectorConfig.SNOWFLAKE_DATABASE)) {
-      invalidConfigParams.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_DATABASE, Utils.formatString("{} cannot be empty.", SnowflakeSinkConnectorConfig.SNOWFLAKE_DATABASE));
+      invalidConfigParams.put(
+          SnowflakeSinkConnectorConfig.SNOWFLAKE_DATABASE,
+          Utils.formatString(
+              "{} cannot be empty.", SnowflakeSinkConnectorConfig.SNOWFLAKE_DATABASE));
     }
 
     // sanity check
     if (!config.containsKey(SnowflakeSinkConnectorConfig.SNOWFLAKE_SCHEMA)) {
-      invalidConfigParams.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_SCHEMA, Utils.formatString("{} cannot be empty.", SnowflakeSinkConnectorConfig.SNOWFLAKE_SCHEMA));
+      invalidConfigParams.put(
+          SnowflakeSinkConnectorConfig.SNOWFLAKE_SCHEMA,
+          Utils.formatString("{} cannot be empty.", SnowflakeSinkConnectorConfig.SNOWFLAKE_SCHEMA));
     }
 
     if (!config.containsKey(SnowflakeSinkConnectorConfig.SNOWFLAKE_PRIVATE_KEY)) {
-      invalidConfigParams.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_PRIVATE_KEY, Utils.formatString("{} cannot be empty.", SnowflakeSinkConnectorConfig.SNOWFLAKE_PRIVATE_KEY));
+      invalidConfigParams.put(
+          SnowflakeSinkConnectorConfig.SNOWFLAKE_PRIVATE_KEY,
+          Utils.formatString(
+              "{} cannot be empty.", SnowflakeSinkConnectorConfig.SNOWFLAKE_PRIVATE_KEY));
     }
 
     if (!config.containsKey(SnowflakeSinkConnectorConfig.SNOWFLAKE_USER)) {
-      invalidConfigParams.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_USER, Utils.formatString("{} cannot be empty.", SnowflakeSinkConnectorConfig.SNOWFLAKE_USER));
+      invalidConfigParams.put(
+          SnowflakeSinkConnectorConfig.SNOWFLAKE_USER,
+          Utils.formatString("{} cannot be empty.", SnowflakeSinkConnectorConfig.SNOWFLAKE_USER));
     }
 
     if (!config.containsKey(SnowflakeSinkConnectorConfig.SNOWFLAKE_URL)) {
-      invalidConfigParams.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_URL, Utils.formatString("{} cannot be empty.", SnowflakeSinkConnectorConfig.SNOWFLAKE_URL));
+      invalidConfigParams.put(
+          SnowflakeSinkConnectorConfig.SNOWFLAKE_URL,
+          Utils.formatString("{} cannot be empty.", SnowflakeSinkConnectorConfig.SNOWFLAKE_URL));
     }
     // jvm proxy settings
     try {
       validateProxySetting(config);
     } catch (SnowflakeKafkaConnectorException e) {
-      invalidConfigParams.put("Proxy info", Utils.formatString("Proxy settings error: ", e.getMessage()));
+      invalidConfigParams.put(
+          "Proxy info", Utils.formatString("Proxy settings error: ", e.getMessage()));
     }
 
     // set jdbc logging directory
@@ -412,7 +437,9 @@ public class Utils {
         SnowflakeSinkConnectorConfig.KafkaProvider.of(
             config.get(SnowflakeSinkConnectorConfig.PROVIDER_CONFIG));
       } catch (IllegalArgumentException exception) {
-        invalidConfigParams.put(SnowflakeSinkConnectorConfig.PROVIDER_CONFIG, Utils.formatString("Kafka provider config error:{}", exception.getMessage()));
+        invalidConfigParams.put(
+            SnowflakeSinkConnectorConfig.PROVIDER_CONFIG,
+            Utils.formatString("Kafka provider config error:{}", exception.getMessage()));
       }
     }
 
@@ -422,14 +449,20 @@ public class Utils {
         VALIDATOR.ensureValid(
             BEHAVIOR_ON_NULL_VALUES_CONFIG, config.get(BEHAVIOR_ON_NULL_VALUES_CONFIG));
       } catch (ConfigException exception) {
-        invalidConfigParams.put(BEHAVIOR_ON_NULL_VALUES_CONFIG, Utils.formatString("Kafka config:{} error:{}", BEHAVIOR_ON_NULL_VALUES_CONFIG, exception.getMessage()));
+        invalidConfigParams.put(
+            BEHAVIOR_ON_NULL_VALUES_CONFIG,
+            Utils.formatString(
+                "Kafka config:{} error:{}",
+                BEHAVIOR_ON_NULL_VALUES_CONFIG,
+                exception.getMessage()));
       }
     }
 
     if (config.containsKey(JMX_OPT)) {
       if (!(config.get(JMX_OPT).equalsIgnoreCase("true")
           || config.get(JMX_OPT).equalsIgnoreCase("false"))) {
-        invalidConfigParams.put(JMX_OPT, Utils.formatString("Kafka config:{} should either be true or false", JMX_OPT));
+        invalidConfigParams.put(
+            JMX_OPT, Utils.formatString("Kafka config:{} should either be true or false", JMX_OPT));
       }
     }
 
@@ -439,7 +472,10 @@ public class Utils {
               DELIVERY_GUARANTEE,
               SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee.AT_LEAST_ONCE.name()));
     } catch (IllegalArgumentException exception) {
-      invalidConfigParams.put(DELIVERY_GUARANTEE, Utils.formatString("Delivery Guarantee config:{} error:{}", DELIVERY_GUARANTEE, exception.getMessage()));
+      invalidConfigParams.put(
+          DELIVERY_GUARANTEE,
+          Utils.formatString(
+              "Delivery Guarantee config:{} error:{}", DELIVERY_GUARANTEE, exception.getMessage()));
     }
 
     // Check all config values for ingestion method == IngestionMethodConfig.SNOWPIPE_STREAMING
@@ -451,7 +487,9 @@ public class Utils {
 
       for (String invalidKey : invalidConfigParams.keySet()) {
         String invalidValue = invalidConfigParams.get(invalidKey);
-        String errorMessage = Utils.formatString("Config value '{}' is invalid. Error message: '{}'", invalidKey, invalidValue);
+        String errorMessage =
+            Utils.formatString(
+                "Config value '{}' is invalid. Error message: '{}'", invalidKey, invalidValue);
         invalidParamsMessage += errorMessage + "\n";
         LOGGER.error(errorMessage);
       }

--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -673,8 +673,8 @@ public class Utils {
       for (String invalidKey : invalidConfigParams.keySet()) {
         String invalidValue = invalidConfigParams.get(invalidKey);
         String errorMessage =
-                Utils.formatString(
-                        "Config value '{}' is invalid. Error message: '{}'", invalidKey, invalidValue);
+            Utils.formatString(
+                "Config value '{}' is invalid. Error message: '{}'", invalidKey, invalidValue);
         invalidParamsMessage += errorMessage + "\n";
       }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/BufferThreshold.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/BufferThreshold.java
@@ -7,7 +7,6 @@ import com.google.common.base.MoreObjects;
 import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
 import com.snowflake.kafka.connector.Utils;
 import com.snowflake.kafka.connector.internal.streaming.IngestionMethodConfig;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -129,7 +128,8 @@ public abstract class BufferThreshold {
   public static Map<String, String> validateBufferThreshold(
       Map<String, String> providedSFConnectorConfig, IngestionMethodConfig ingestionMethodConfig) {
     Map<String, String> invalidConfigParams = new HashMap<>();
-    invalidConfigParams.putAll(verifyBufferFlushTimeThreshold(providedSFConnectorConfig, ingestionMethodConfig));
+    invalidConfigParams.putAll(
+        verifyBufferFlushTimeThreshold(providedSFConnectorConfig, ingestionMethodConfig));
     invalidConfigParams.putAll(verifyBufferCountThreshold(providedSFConnectorConfig));
     invalidConfigParams.putAll(verifyBufferBytesThreshold(providedSFConnectorConfig));
     return invalidConfigParams;
@@ -141,7 +141,10 @@ public abstract class BufferThreshold {
 
     if (!providedSFConnectorConfig.containsKey(
         SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC)) {
-      invalidConfigParams.put(SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC, Utils.formatString("Config {} is empty", SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC));
+      invalidConfigParams.put(
+          SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC,
+          Utils.formatString(
+              "Config {} is empty", SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC));
     } else {
       String providedFlushTimeSecondsInStr =
           providedSFConnectorConfig.get(SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC);
@@ -154,14 +157,18 @@ public abstract class BufferThreshold {
                 ? BUFFER_FLUSH_TIME_SEC_MIN
                 : STREAMING_BUFFER_FLUSH_TIME_MINIMUM_SEC;
         if (providedFlushTimeSecondsInConfig < thresholdTimeToCompare) {
-          invalidConfigParams.put(SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC, Utils.formatString(
+          invalidConfigParams.put(
+              SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC,
+              Utils.formatString(
                   "{} is {}, it should be greater than {}",
                   SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC,
                   providedFlushTimeSecondsInConfig,
                   thresholdTimeToCompare));
         }
       } catch (NumberFormatException e) {
-        invalidConfigParams.put(SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC, Utils.formatString(
+        invalidConfigParams.put(
+            SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC,
+            Utils.formatString(
                 "{} should be an integer. Invalid integer was provided:{}",
                 SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC,
                 providedFlushTimeSecondsInStr));
@@ -171,12 +178,15 @@ public abstract class BufferThreshold {
     return invalidConfigParams;
   }
 
-  private static Map<String, String> verifyBufferBytesThreshold(Map<String, String> providedSFConnectorConfig) {
+  private static Map<String, String> verifyBufferBytesThreshold(
+      Map<String, String> providedSFConnectorConfig) {
     Map<String, String> invalidConfigParams = new HashMap();
 
     // verify buffer.size.bytes
     if (!providedSFConnectorConfig.containsKey(SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES)) {
-      invalidConfigParams.put(SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES, Utils.formatString("Config {} is empty", SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES));
+      invalidConfigParams.put(
+          SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES,
+          Utils.formatString("Config {} is empty", SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES));
     } else {
       final String providedBufferSizeBytesStr =
           providedSFConnectorConfig.get(SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES);
@@ -185,14 +195,18 @@ public abstract class BufferThreshold {
         if (providedBufferSizeBytesConfig
             < SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES_MIN) // 1 byte
         {
-          invalidConfigParams.put(SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES, Utils.formatString(
+          invalidConfigParams.put(
+              SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES,
+              Utils.formatString(
                   "{} is too low at {}. It must be {} or greater.",
                   SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES,
                   providedBufferSizeBytesConfig,
                   SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES_MIN));
         }
       } catch (NumberFormatException e) {
-        invalidConfigParams.put(SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES, Utils.formatString(
+        invalidConfigParams.put(
+            SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES,
+            Utils.formatString(
                 "Config {} should be an integer. Provided:{}",
                 SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES,
                 providedBufferSizeBytesStr));
@@ -201,25 +215,33 @@ public abstract class BufferThreshold {
     return invalidConfigParams;
   }
 
-  private static Map<String, String> verifyBufferCountThreshold(Map<String, String> providedSFConnectorConfig) {
+  private static Map<String, String> verifyBufferCountThreshold(
+      Map<String, String> providedSFConnectorConfig) {
     Map<String, String> invalidConfigParams = new HashMap();
 
     // verify buffer.count.records
     if (!providedSFConnectorConfig.containsKey(SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS)) {
-      invalidConfigParams.put(SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS, Utils.formatString("Config {} is empty", SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS));
+      invalidConfigParams.put(
+          SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS,
+          Utils.formatString(
+              "Config {} is empty", SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS));
     } else {
       final String providedBufferCountRecordsStr =
           providedSFConnectorConfig.get(SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS);
       try {
         long providedBufferCountRecords = Long.parseLong(providedBufferCountRecordsStr);
         if (providedBufferCountRecords <= 0) {
-          invalidConfigParams.put(SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS, Utils.formatString(
+          invalidConfigParams.put(
+              SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS,
+              Utils.formatString(
                   "Config {} is {}, it should at least 1",
                   SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS,
                   providedBufferCountRecords));
         }
       } catch (NumberFormatException e) {
-        invalidConfigParams.put(SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS, Utils.formatString(
+        invalidConfigParams.put(
+            SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS,
+            Utils.formatString(
                 "Config {} should be a positive integer. Provided:{}",
                 SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS,
                 providedBufferCountRecordsStr));

--- a/src/main/java/com/snowflake/kafka/connector/internal/BufferThreshold.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/BufferThreshold.java
@@ -4,6 +4,7 @@ import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BUFFER_
 import static com.snowflake.kafka.connector.internal.streaming.StreamingUtils.STREAMING_BUFFER_FLUSH_TIME_MINIMUM_SEC;
 
 import com.google.common.base.MoreObjects;
+import com.google.common.collect.ImmutableMap;
 import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
 import com.snowflake.kafka.connector.Utils;
 import com.snowflake.kafka.connector.internal.streaming.IngestionMethodConfig;
@@ -123,19 +124,19 @@ public abstract class BufferThreshold {
    *
    * @param providedSFConnectorConfig provided by customer
    * @param ingestionMethodConfig ingestion method used. Check {@link IngestionMethodConfig}
-   * @return true if all thresholds are valid.
+   * @return invalid config parameters, if exists
    */
-  public static Map<String, String> validateBufferThreshold(
+  public static ImmutableMap<String, String> validateBufferThreshold(
       Map<String, String> providedSFConnectorConfig, IngestionMethodConfig ingestionMethodConfig) {
     Map<String, String> invalidConfigParams = new HashMap<>();
     invalidConfigParams.putAll(
         verifyBufferFlushTimeThreshold(providedSFConnectorConfig, ingestionMethodConfig));
     invalidConfigParams.putAll(verifyBufferCountThreshold(providedSFConnectorConfig));
     invalidConfigParams.putAll(verifyBufferBytesThreshold(providedSFConnectorConfig));
-    return invalidConfigParams;
+    return ImmutableMap.copyOf(invalidConfigParams);
   }
 
-  private static Map<String, String> verifyBufferFlushTimeThreshold(
+  private static ImmutableMap<String, String> verifyBufferFlushTimeThreshold(
       Map<String, String> providedSFConnectorConfig, IngestionMethodConfig ingestionMethodConfig) {
     Map<String, String> invalidConfigParams = new HashMap();
 
@@ -175,10 +176,10 @@ public abstract class BufferThreshold {
       }
     }
 
-    return invalidConfigParams;
+    return ImmutableMap.copyOf(invalidConfigParams);
   }
 
-  private static Map<String, String> verifyBufferBytesThreshold(
+  private static ImmutableMap<String, String> verifyBufferBytesThreshold(
       Map<String, String> providedSFConnectorConfig) {
     Map<String, String> invalidConfigParams = new HashMap();
 
@@ -212,10 +213,11 @@ public abstract class BufferThreshold {
                 providedBufferSizeBytesStr));
       }
     }
-    return invalidConfigParams;
+
+    return ImmutableMap.copyOf(invalidConfigParams);
   }
 
-  private static Map<String, String> verifyBufferCountThreshold(
+  private static ImmutableMap<String, String> verifyBufferCountThreshold(
       Map<String, String> providedSFConnectorConfig) {
     Map<String, String> invalidConfigParams = new HashMap();
 
@@ -247,7 +249,8 @@ public abstract class BufferThreshold {
                 providedBufferCountRecordsStr));
       }
     }
-    return invalidConfigParams;
+
+    return ImmutableMap.copyOf(invalidConfigParams);
   }
 
   @Override

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeErrors.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeErrors.java
@@ -27,7 +27,7 @@ public enum SnowflakeErrors {
       "0001",
       "Invalid input connector configuration",
       "input kafka connector configuration is null, missing required values, "
-          + "or wrong input value"),
+          + "or wrong input value. Check logs for list of invalid parameters."),
   ERROR_0002("0002", "Invalid private key", "private key should be a valid PEM RSA private key"),
   ERROR_0003(
       "0003",

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeErrors.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeErrors.java
@@ -27,7 +27,7 @@ public enum SnowflakeErrors {
       "0001",
       "Invalid input connector configuration",
       "input kafka connector configuration is null, missing required values, "
-          + "or wrong input value. Check logs for list of invalid parameters."),
+          + "or is invalid. Check logs for list of invalid parameters."),
   ERROR_0002("0002", "Invalid private key", "private key should be a valid PEM RSA private key"),
   ERROR_0003(
       "0003",

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
@@ -12,6 +12,7 @@ import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.KEY_CON
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.VALUE_CONVERTER_CONFIG_FIELD;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
 import com.snowflake.kafka.connector.Utils;
@@ -132,7 +133,7 @@ public class StreamingUtils {
    * @param inputConfig given in connector json file
    * @return map of invalid parameters
    */
-  public static Map<String, String> validateStreamingSnowpipeConfig(
+  public static ImmutableMap<String, String> validateStreamingSnowpipeConfig(
       final Map<String, String> inputConfig) {
     Map<String, String> invalidParams = new HashMap<>();
 
@@ -207,7 +208,8 @@ public class StreamingUtils {
                 "Kafka config:{} error:{}", INGESTION_METHOD_OPT, exception.getMessage()));
       }
     }
-    return invalidParams;
+
+    return ImmutableMap.copyOf(invalidParams);
   }
 
   /**

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
@@ -132,7 +132,8 @@ public class StreamingUtils {
    * @param inputConfig given in connector json file
    * @return map of invalid parameters
    */
-  public static Map<String, String> validateStreamingSnowpipeConfig(final Map<String, String> inputConfig) {
+  public static Map<String, String> validateStreamingSnowpipeConfig(
+      final Map<String, String> inputConfig) {
     Map<String, String> invalidParams = new HashMap<>();
 
     // For snowpipe_streaming, role should be non empty and delivery guarantee should be exactly
@@ -147,8 +148,9 @@ public class StreamingUtils {
             .equalsIgnoreCase(IngestionMethodConfig.SNOWPIPE_STREAMING.toString())) {
 
           // check if buffer thresholds are within permissible range
-          invalidParams.putAll(BufferThreshold.validateBufferThreshold(
-              inputConfig, IngestionMethodConfig.SNOWPIPE_STREAMING));
+          invalidParams.putAll(
+              BufferThreshold.validateBufferThreshold(
+                  inputConfig, IngestionMethodConfig.SNOWPIPE_STREAMING));
 
           invalidParams.putAll(validateConfigConverters(KEY_CONVERTER_CONFIG_FIELD, inputConfig));
           invalidParams.putAll(validateConfigConverters(VALUE_CONVERTER_CONFIG_FIELD, inputConfig));
@@ -156,10 +158,12 @@ public class StreamingUtils {
           // Validate if snowflake role is present
           if (!inputConfig.containsKey(Utils.SF_ROLE)
               || Strings.isNullOrEmpty(inputConfig.get(Utils.SF_ROLE))) {
-            invalidParams.put(Utils.SF_ROLE, Utils.formatString(
-                "Config:{} should be present if ingestionMethod is:{}",
+            invalidParams.put(
                 Utils.SF_ROLE,
-                inputConfig.get(INGESTION_METHOD_OPT)));
+                Utils.formatString(
+                    "Config:{} should be present if ingestionMethod is:{}",
+                    Utils.SF_ROLE,
+                    inputConfig.get(INGESTION_METHOD_OPT)));
           }
           // setting delivery guarantee to EOS.
           // It is fine for customer to not set this value if Streaming SNOWPIPE is used.
@@ -171,11 +175,13 @@ public class StreamingUtils {
 
           if (deliveryGuarantee.equals(
               SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee.AT_LEAST_ONCE)) {
-            invalidParams.put(SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee.AT_LEAST_ONCE.toString(), Utils.formatString(
-                "Config:{} should be:{} if ingestion method is:{}",
-                DELIVERY_GUARANTEE,
-                SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee.EXACTLY_ONCE.toString(),
-                IngestionMethodConfig.SNOWPIPE_STREAMING.toString()));
+            invalidParams.put(
+                SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee.AT_LEAST_ONCE.toString(),
+                Utils.formatString(
+                    "Config:{} should be:{} if ingestion method is:{}",
+                    DELIVERY_GUARANTEE,
+                    SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee.EXACTLY_ONCE.toString(),
+                    IngestionMethodConfig.SNOWPIPE_STREAMING.toString()));
           }
 
           /**
@@ -195,7 +201,10 @@ public class StreamingUtils {
           invalidParams.putAll(validateSchematizationConfig(inputConfig));
         }
       } catch (ConfigException exception) {
-        invalidParams.put(INGESTION_METHOD_OPT, Utils.formatString("Kafka config:{} error:{}", INGESTION_METHOD_OPT, exception.getMessage()));
+        invalidParams.put(
+            INGESTION_METHOD_OPT,
+            Utils.formatString(
+                "Kafka config:{} error:{}", INGESTION_METHOD_OPT, exception.getMessage()));
       }
     }
     return invalidParams;
@@ -211,17 +220,19 @@ public class StreamingUtils {
       final String inputConfigConverterField, Map<String, String> inputConfig) {
     Map<String, String> invalidParams = new HashMap<>();
 
-    if (inputConfig.containsKey(inputConfigConverterField) && DISALLOWED_CONVERTERS_STREAMING.contains(inputConfig.get(inputConfigConverterField))) {
-        invalidParams.put(inputConfigConverterField, Utils.formatString(
-            "Config:{} has provided value:{}. If ingestionMethod is:{}, Snowflake Custom"
-                + " Converters are not allowed. \n"
-                + "Invalid Converters:{}",
-            inputConfigConverterField,
-            inputConfig.get(inputConfigConverterField),
-            IngestionMethodConfig.SNOWPIPE_STREAMING,
-            Iterables.toString(DISALLOWED_CONVERTERS_STREAMING)));
-      }
-
+    if (inputConfig.containsKey(inputConfigConverterField)
+        && DISALLOWED_CONVERTERS_STREAMING.contains(inputConfig.get(inputConfigConverterField))) {
+      invalidParams.put(
+          inputConfigConverterField,
+          Utils.formatString(
+              "Config:{} has provided value:{}. If ingestionMethod is:{}, Snowflake Custom"
+                  + " Converters are not allowed. \n"
+                  + "Invalid Converters:{}",
+              inputConfigConverterField,
+              inputConfig.get(inputConfigConverterField),
+              IngestionMethodConfig.SNOWPIPE_STREAMING,
+              Iterables.toString(DISALLOWED_CONVERTERS_STREAMING)));
+    }
 
     return invalidParams;
   }
@@ -246,9 +257,11 @@ public class StreamingUtils {
               || inputConfig
                   .get(VALUE_CONVERTER_CONFIG_FIELD)
                   .contains(BYTE_ARRAY_CONVERTER_KEYWORD))) {
-        invalidParams.put(inputConfig.get(VALUE_CONVERTER_CONFIG_FIELD), Utils.formatString(
-            "The value converter:{} is not supported with schematization.",
-            inputConfig.get(VALUE_CONVERTER_CONFIG_FIELD)));
+        invalidParams.put(
+            inputConfig.get(VALUE_CONVERTER_CONFIG_FIELD),
+            Utils.formatString(
+                "The value converter:{} is not supported with schematization.",
+                inputConfig.get(VALUE_CONVERTER_CONFIG_FIELD)));
       }
     }
 

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
@@ -5,10 +5,10 @@ import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.NAME;
 import static com.snowflake.kafka.connector.internal.TestUtils.getConfig;
 
+import com.snowflake.kafka.connector.internal.SnowflakeErrors;
 import com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException;
 import com.snowflake.kafka.connector.internal.streaming.IngestionMethodConfig;
 import com.snowflake.kafka.connector.internal.streaming.StreamingUtils;
-import java.util.Locale;
 import java.util.Map;
 import org.junit.Test;
 
@@ -30,69 +30,104 @@ public class ConnectorConfigTest {
     Utils.validateConfig(config);
   }
 
-  @Test(expected = SnowflakeKafkaConnectorException.class)
+  @Test
   public void testEmptyFlushTime() {
-    Map<String, String> config = getConfig();
-    config.remove(SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC);
-    Utils.validateConfig(config);
+    try {
+      Map<String, String> config = getConfig();
+      config.remove(SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC);
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception.getMessage().contains(SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC);
+    }
   }
 
-  @Test(expected = SnowflakeKafkaConnectorException.class)
+  @Test
   public void testFlushTimeSmall() {
-    Map<String, String> config = getConfig();
-    config.put(
-        SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC,
-        (SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC_MIN - 1) + "");
-    Utils.validateConfig(config);
+    try {
+      Map<String, String> config = getConfig();
+      config.put(
+          SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC,
+          (SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC_MIN - 1) + "");
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception.getMessage().contains(SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC);
+    }
   }
 
-  @Test(expected = SnowflakeKafkaConnectorException.class)
+  @Test
   public void testFlushTimeNotNumber() {
-    Map<String, String> config = getConfig();
-    config.put(SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC, "fdas");
-    Utils.validateConfig(config);
+    try {
+      Map<String, String> config = getConfig();
+      config.put(SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC, "fdas");
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception.getMessage().contains(SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC);
+    }
   }
 
-  @Test(expected = SnowflakeKafkaConnectorException.class)
+  @Test
   public void testEmptyName() {
-    Map<String, String> config = getConfig();
-    config.remove(SnowflakeSinkConnectorConfig.NAME);
-    Utils.validateConfig(config);
+    try {
+      Map<String, String> config = getConfig();
+      config.remove(SnowflakeSinkConnectorConfig.NAME);
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception.getMessage().contains(SnowflakeSinkConnectorConfig.NAME);
+    }
   }
 
-  @Test(expected = SnowflakeKafkaConnectorException.class)
   public void testURL() {
-    Map<String, String> config = getConfig();
-    config.remove(SnowflakeSinkConnectorConfig.SNOWFLAKE_URL);
-    Utils.validateConfig(config);
+    try {
+      Map<String, String> config = getConfig();
+      config.remove(SnowflakeSinkConnectorConfig.SNOWFLAKE_URL);
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception.getMessage().contains(SnowflakeSinkConnectorConfig.SNOWFLAKE_URL);
+    }
   }
 
-  @Test(expected = SnowflakeKafkaConnectorException.class)
+  @Test
   public void testEmptyUser() {
-    Map<String, String> config = getConfig();
-    config.remove(SnowflakeSinkConnectorConfig.SNOWFLAKE_USER);
-    Utils.validateConfig(config);
+    try {
+      Map<String, String> config = getConfig();
+      config.remove(SnowflakeSinkConnectorConfig.SNOWFLAKE_USER);
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception.getMessage().contains(SnowflakeSinkConnectorConfig.SNOWFLAKE_USER);
+    }
   }
 
-  @Test(expected = SnowflakeKafkaConnectorException.class)
+  @Test
   public void testEmptyDatabase() {
-    Map<String, String> config = getConfig();
-    config.remove(SnowflakeSinkConnectorConfig.SNOWFLAKE_DATABASE);
-    Utils.validateConfig(config);
+    try {
+      Map<String, String> config = getConfig();
+      config.remove(SnowflakeSinkConnectorConfig.SNOWFLAKE_DATABASE);
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception.getMessage().contains(SnowflakeSinkConnectorConfig.SNOWFLAKE_DATABASE);
+    }
   }
 
-  @Test(expected = SnowflakeKafkaConnectorException.class)
+  @Test
   public void testEmptySchema() {
-    Map<String, String> config = getConfig();
-    config.remove(SnowflakeSinkConnectorConfig.SNOWFLAKE_SCHEMA);
-    Utils.validateConfig(config);
+    try {
+      Map<String, String> config = getConfig();
+      config.remove(SnowflakeSinkConnectorConfig.SNOWFLAKE_SCHEMA);
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception.getMessage().contains(SnowflakeSinkConnectorConfig.SNOWFLAKE_SCHEMA);
+    }
   }
 
-  @Test(expected = SnowflakeKafkaConnectorException.class)
+  @Test
   public void testEmptyPrivateKey() {
-    Map<String, String> config = getConfig();
-    config.remove(SnowflakeSinkConnectorConfig.SNOWFLAKE_PRIVATE_KEY);
-    Utils.validateConfig(config);
+    try {
+      Map<String, String> config = getConfig();
+      config.remove(SnowflakeSinkConnectorConfig.SNOWFLAKE_PRIVATE_KEY);
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception.getMessage().contains(SnowflakeSinkConnectorConfig.SNOWFLAKE_PRIVATE_KEY);
+    }
   }
 
   @Test
@@ -103,39 +138,59 @@ public class ConnectorConfigTest {
     Utils.validateConfig(config);
   }
 
-  @Test(expected = SnowflakeKafkaConnectorException.class)
+  @Test
   public void testEmptyPort() {
-    Map<String, String> config = getConfig();
-    config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_HOST, "127.0.0.1");
-    Utils.validateConfig(config);
+    try {
+      Map<String, String> config = getConfig();
+      config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_HOST, "127.0.0.1");
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception.getMessage().contains(SnowflakeSinkConnectorConfig.JVM_PROXY_HOST);
+    }
   }
 
-  @Test(expected = SnowflakeKafkaConnectorException.class)
+  @Test
   public void testEmptyHost() {
-    Map<String, String> config = getConfig();
-    config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_PORT, "3128");
-    Utils.validateConfig(config);
+    try {
+      Map<String, String> config = getConfig();
+      config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_PORT, "3128");
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception.getMessage().contains(SnowflakeSinkConnectorConfig.JVM_PROXY_PORT);
+    }
   }
 
-  @Test(expected = SnowflakeKafkaConnectorException.class)
+  @Test
   public void testIllegalTopicMap() {
-    Map<String, String> config = getConfig();
-    config.put(SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP, "$@#$#@%^$12312");
-    Utils.validateConfig(config);
+    try {
+      Map<String, String> config = getConfig();
+      config.put(SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP, "$@#$#@%^$12312");
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception.getMessage().contains(SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP);
+    }
   }
 
-  @Test(expected = SnowflakeKafkaConnectorException.class)
+  @Test
   public void testIllegalTableName() {
-    Map<String, String> config = getConfig();
-    config.put(SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP, "topic1:!@#@!#!@");
-    Utils.validateConfig(config);
+    try {
+      Map<String, String> config = getConfig();
+      config.put(SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP, "topic1:!@#@!#!@");
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception.getCode().equals(SnowflakeErrors.ERROR_0021.getCode());
+    }
   }
 
-  @Test(expected = SnowflakeKafkaConnectorException.class)
+  @Test
   public void testDuplicatedTopic() {
-    Map<String, String> config = getConfig();
-    config.put(SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP, "topic1:table1,topic1:table2");
-    Utils.validateConfig(config);
+    try {
+      Map<String, String> config = getConfig();
+      config.put(SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP, "topic1:table1,topic1:table2");
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception.getCode().equals(SnowflakeErrors.ERROR_0021.getCode());
+    }
   }
 
   @Test
@@ -153,48 +208,72 @@ public class ConnectorConfigTest {
     Utils.validateConfig(config);
   }
 
-  @Test(expected = SnowflakeKafkaConnectorException.class)
+  @Test
   public void testBufferSizeRange() {
-    Map<String, String> config = getConfig();
-    config.put(
-        SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES,
-        SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES_MIN - 1 + "");
-    Utils.validateConfig(config);
+    try {
+      Map<String, String> config = getConfig();
+      config.put(
+          SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES,
+          SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES_MIN - 1 + "");
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception.getMessage().contains(SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES);
+    }
   }
 
-  @Test(expected = SnowflakeKafkaConnectorException.class)
+  @Test
   public void testBufferSizeValue() {
-    Map<String, String> config = getConfig();
-    config.put(SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES, "afdsa");
-    Utils.validateConfig(config);
+    try {
+      Map<String, String> config = getConfig();
+      config.put(SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES, "afdsa");
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception.getMessage().contains(SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES);
+    }
   }
 
-  @Test(expected = SnowflakeKafkaConnectorException.class)
+  @Test
   public void testEmptyBufferSize() {
-    Map<String, String> config = getConfig();
-    config.remove(SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES);
-    Utils.validateConfig(config);
+    try {
+      Map<String, String> config = getConfig();
+      config.remove(SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES);
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception.getMessage().contains(SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES);
+    }
   }
 
-  @Test(expected = SnowflakeKafkaConnectorException.class)
+  @Test
   public void testEmptyBufferCount() {
-    Map<String, String> config = getConfig();
-    config.remove(SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS);
-    Utils.validateConfig(config);
+    try {
+      Map<String, String> config = getConfig();
+      config.remove(SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS);
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception.getMessage().contains(SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS);
+    }
   }
 
-  @Test(expected = SnowflakeKafkaConnectorException.class)
+  @Test
   public void testEmptyBufferCountNegative() {
-    Map<String, String> config = getConfig();
-    config.put(SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS, "-1");
-    Utils.validateConfig(config);
+    try {
+      Map<String, String> config = getConfig();
+      config.put(SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS, "-1");
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception.getMessage().contains(SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS);
+    }
   }
 
-  @Test(expected = SnowflakeKafkaConnectorException.class)
+  @Test
   public void testBufferCountValue() {
-    Map<String, String> config = getConfig();
-    config.put(SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS, "adssadsa");
-    Utils.validateConfig(config);
+    try {
+      Map<String, String> config = getConfig();
+      config.put(SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS, "adssadsa");
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception.getMessage().contains(SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS);
+    }
   }
 
   @Test
@@ -224,11 +303,15 @@ public class ConnectorConfigTest {
     Utils.validateConfig(config);
   }
 
-  @Test(expected = SnowflakeKafkaConnectorException.class)
+  @Test
   public void testKafkaProviderConfigValue_invalid_value() {
-    Map<String, String> config = getConfig();
-    config.put(SnowflakeSinkConnectorConfig.PROVIDER_CONFIG, "Something_which_is_not_supported");
-    Utils.validateConfig(config);
+    try {
+      Map<String, String> config = getConfig();
+      config.put(SnowflakeSinkConnectorConfig.PROVIDER_CONFIG, "Something_which_is_not_supported");
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception.getMessage().contains(SnowflakeSinkConnectorConfig.PROVIDER_CONFIG);
+    }
   }
 
   @Test
@@ -241,11 +324,17 @@ public class ConnectorConfigTest {
     Utils.validateConfig(config);
   }
 
-  @Test(expected = SnowflakeKafkaConnectorException.class)
+  @Test
   public void testBehaviorOnNullValuesConfig_invalid_value() {
-    Map<String, String> config = getConfig();
-    config.put(SnowflakeSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG, "INVALID");
-    Utils.validateConfig(config);
+    try {
+      Map<String, String> config = getConfig();
+      config.put(SnowflakeSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG, "INVALID");
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception
+          .getMessage()
+          .contains(SnowflakeSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG);
+    }
   }
 
   @Test
@@ -258,11 +347,15 @@ public class ConnectorConfigTest {
     Utils.validateConfig(config);
   }
 
-  @Test(expected = SnowflakeKafkaConnectorException.class)
+  @Test
   public void testJMX_invalid_value() {
-    Map<String, String> config = getConfig();
-    config.put(SnowflakeSinkConnectorConfig.JMX_OPT, "INVALID");
-    Utils.validateConfig(config);
+    try {
+      Map<String, String> config = getConfig();
+      config.put(SnowflakeSinkConnectorConfig.JMX_OPT, "INVALID");
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception.getMessage().contains(SnowflakeSinkConnectorConfig.JMX_OPT);
+    }
   }
 
   @Test
@@ -281,11 +374,15 @@ public class ConnectorConfigTest {
     Utils.validateConfig(config);
   }
 
-  @Test(expected = SnowflakeKafkaConnectorException.class)
+  @Test
   public void testDeliveryGuarantee_invalid_value() {
-    Map<String, String> config = getConfig();
-    config.put(SnowflakeSinkConnectorConfig.DELIVERY_GUARANTEE, "INVALID");
-    Utils.validateConfig(config);
+    try {
+      Map<String, String> config = getConfig();
+      config.put(SnowflakeSinkConnectorConfig.DELIVERY_GUARANTEE, "INVALID");
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception.getMessage().contains(SnowflakeSinkConnectorConfig.DELIVERY_GUARANTEE);
+    }
   }
 
   @Test
@@ -308,58 +405,30 @@ public class ConnectorConfigTest {
     Utils.validateConfig(config);
   }
 
-  @Test(expected = SnowflakeKafkaConnectorException.class)
+  @Test
   public void testIngestionTypeConfig_invalid_snowpipe_streaming() {
-    Map<String, String> config = getConfig();
+    try {
+      Map<String, String> config = getConfig();
 
-    config.put(
-        SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
-        IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
-    config.put(Utils.SF_ROLE, "");
-    Utils.validateConfig(config);
+      config.put(
+          SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
+          IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
+      config.put(Utils.SF_ROLE, "");
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception.getMessage().contains(Utils.SF_ROLE);
+    }
   }
 
-  @Test(expected = SnowflakeKafkaConnectorException.class)
+  @Test
   public void testIngestionTypeConfig_invalid_value() {
-    Map<String, String> config = getConfig();
-    config.put(SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT, "INVALID_VALUE");
-    Utils.validateConfig(config);
-  }
-
-  @Test(expected = SnowflakeKafkaConnectorException.class)
-  public void testIngestionTypeConfig_streaming_invalid_delivery_guarantee() {
-    Map<String, String> config = getConfig();
-    config.put(
-        SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
-        IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
-    config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
-    config.put(
-        SnowflakeSinkConnectorConfig.DELIVERY_GUARANTEE,
-        SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee.AT_LEAST_ONCE.name());
-    Utils.validateConfig(config);
-  }
-
-  @Test
-  public void testIngestionTypeConfig_streaming_valid_delivery_guarantee() {
-    Map<String, String> config = getConfig();
-    config.put(
-        SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
-        IngestionMethodConfig.SNOWPIPE_STREAMING.toString().toUpperCase(Locale.ROOT));
-    config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
-    config.put(
-        SnowflakeSinkConnectorConfig.DELIVERY_GUARANTEE,
-        SnowflakeSinkConnectorConfig.IngestionDeliveryGuarantee.EXACTLY_ONCE.name());
-    Utils.validateConfig(config);
-  }
-
-  @Test
-  public void testIngestionTypeConfig_streaming_default_delivery_guarantee() {
-    Map<String, String> config = getConfig();
-    config.put(
-        SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
-        IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
-    config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
-    Utils.validateConfig(config);
+    try {
+      Map<String, String> config = getConfig();
+      config.put(SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT, "INVALID_VALUE");
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception.getMessage().contains(SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT);
+    }
   }
 
   /** These error tests are not going to enforce errors if they are not passed as configs. */
@@ -381,15 +450,19 @@ public class ConnectorConfigTest {
     Utils.validateConfig(config);
   }
 
-  @Test(expected = SnowflakeKafkaConnectorException.class)
+  @Test
   public void testErrorTolerance_DisallowedValues() {
-    Map<String, String> config = getConfig();
-    config.put(ERRORS_TOLERANCE_CONFIG, "INVALID");
-    config.put(
-        SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
-        IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
-    config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
-    Utils.validateConfig(config);
+    try {
+      Map<String, String> config = getConfig();
+      config.put(ERRORS_TOLERANCE_CONFIG, "INVALID");
+      config.put(
+          SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
+          IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
+      config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception.getMessage().contains(SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT);
+    }
   }
 
   @Test
@@ -409,51 +482,66 @@ public class ConnectorConfigTest {
     Utils.validateConfig(config);
   }
 
-  @Test(expected = SnowflakeKafkaConnectorException.class)
+  @Test
   public void testErrorLog_DisallowedValues() {
-    Map<String, String> config = getConfig();
-    config.put(ERRORS_LOG_ENABLE_CONFIG, "INVALID");
-    config.put(
-        SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
-        IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
-    config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
-    Utils.validateConfig(config);
+    try {
+      Map<String, String> config = getConfig();
+      config.put(ERRORS_LOG_ENABLE_CONFIG, "INVALID");
+      config.put(
+          SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
+          IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
+      config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception.getMessage().contains(SnowflakeSinkConnectorConfig.ERRORS_LOG_ENABLE_CONFIG);
+    }
   }
 
   // ---------- Streaming Buffer tests ---------- //
-  @Test(expected = SnowflakeKafkaConnectorException.class)
+  @Test
   public void testStreamingEmptyFlushTime() {
-    Map<String, String> config = getConfig();
-    config.put(
-        SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
-        IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
-    config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
-    config.remove(SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC);
-    Utils.validateConfig(config);
+    try {
+      Map<String, String> config = getConfig();
+      config.put(
+          SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
+          IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
+      config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
+      config.remove(SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC);
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception.getMessage().contains(SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC);
+    }
   }
 
-  @Test(expected = SnowflakeKafkaConnectorException.class)
+  @Test
   public void testStreamingFlushTimeSmall() {
-    Map<String, String> config = getConfig();
-    config.put(
-        SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
-        IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
-    config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
-    config.put(
-        SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC,
-        (StreamingUtils.STREAMING_BUFFER_FLUSH_TIME_MINIMUM_SEC - 1) + "");
-    Utils.validateConfig(config);
+    try {
+      Map<String, String> config = getConfig();
+      config.put(
+          SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
+          IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
+      config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
+      config.put(
+          SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC,
+          (StreamingUtils.STREAMING_BUFFER_FLUSH_TIME_MINIMUM_SEC - 1) + "");
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception.getMessage().contains(SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC);
+    }
   }
 
-  @Test(expected = SnowflakeKafkaConnectorException.class)
   public void testStreamingFlushTimeNotNumber() {
-    Map<String, String> config = getConfig();
-    config.put(
-        SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
-        IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
-    config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
-    config.put(SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC, "fdas");
-    Utils.validateConfig(config);
+    try {
+      Map<String, String> config = getConfig();
+      config.put(
+          SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
+          IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
+      config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
+      config.put(SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC, "fdas");
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception.getMessage().contains(SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC);
+    }
   }
 
   @Test
@@ -471,37 +559,46 @@ public class ConnectorConfigTest {
     }
   }
 
-  @Test(expected = SnowflakeKafkaConnectorException.class)
   public void testStreamingEmptyBufferCount() {
-    Map<String, String> config = getConfig();
-    config.put(
-        SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
-        IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
-    config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
-    config.remove(SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS);
-    Utils.validateConfig(config);
+    try {
+      Map<String, String> config = getConfig();
+      config.put(
+          SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
+          IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
+      config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
+      config.remove(SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS);
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception.getMessage().contains(SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS);
+    }
   }
 
-  @Test(expected = SnowflakeKafkaConnectorException.class)
   public void testStreamingBufferCountNegative() {
-    Map<String, String> config = getConfig();
-    config.put(
-        SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
-        IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
-    config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
-    config.put(SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS, "-1");
-    Utils.validateConfig(config);
+    try {
+      Map<String, String> config = getConfig();
+      config.put(
+          SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
+          IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
+      config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
+      config.put(SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS, "-1");
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception.getMessage().contains(SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS);
+    }
   }
 
-  @Test(expected = SnowflakeKafkaConnectorException.class)
   public void testStreamingBufferCountValue() {
-    Map<String, String> config = getConfig();
-    config.put(
-        SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
-        IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
-    config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
-    config.put(SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS, "adssadsa");
-    Utils.validateConfig(config);
+    try {
+      Map<String, String> config = getConfig();
+      config.put(
+          SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
+          IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
+      config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
+      config.put(SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS, "adssadsa");
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception.getMessage().contains(SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS);
+    }
   }
 
   @Test
@@ -542,45 +639,61 @@ public class ConnectorConfigTest {
     Utils.validateConfig(config);
   }
 
-  @Test(expected = SnowflakeKafkaConnectorException.class)
   public void testInvalidKeyConvertersForStreamingSnowpipe() {
-    Map<String, String> config = getConfig();
-    config.put(
-        SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
-        IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
-    config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
-    config.put(
-        SnowflakeSinkConnectorConfig.KEY_CONVERTER_CONFIG_FIELD,
-        "com.snowflake.kafka.connector.records.SnowflakeJsonConverter");
+    try {
+      Map<String, String> config = getConfig();
+      config.put(
+          SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
+          IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
+      config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
+      config.put(
+          SnowflakeSinkConnectorConfig.KEY_CONVERTER_CONFIG_FIELD,
+          "com.snowflake.kafka.connector.records.SnowflakeJsonConverter");
 
-    config.put(
-        SnowflakeSinkConnectorConfig.VALUE_CONVERTER_CONFIG_FIELD,
-        "org.apache.kafka.connect.storage.StringConverter");
-    Utils.validateConfig(config);
+      config.put(
+          SnowflakeSinkConnectorConfig.VALUE_CONVERTER_CONFIG_FIELD,
+          "org.apache.kafka.connect.storage.StringConverter");
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception
+          .getMessage()
+          .contains(SnowflakeSinkConnectorConfig.KEY_CONVERTER_CONFIG_FIELD);
+    }
   }
 
-  @Test(expected = SnowflakeKafkaConnectorException.class)
   public void testInvalidValueConvertersForStreamingSnowpipe() {
-    Map<String, String> config = getConfig();
-    config.put(
-        SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
-        IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
-    config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
-    config.put(
-        SnowflakeSinkConnectorConfig.VALUE_CONVERTER_CONFIG_FIELD,
-        "com.snowflake.kafka.connector.records.SnowflakeJsonConverter");
+    try {
+      Map<String, String> config = getConfig();
+      config.put(
+          SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
+          IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
+      config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
+      config.put(
+          SnowflakeSinkConnectorConfig.VALUE_CONVERTER_CONFIG_FIELD,
+          "com.snowflake.kafka.connector.records.SnowflakeJsonConverter");
 
-    config.put(
-        SnowflakeSinkConnectorConfig.KEY_CONVERTER_CONFIG_FIELD,
-        "org.apache.kafka.connect.storage.StringConverter");
-    Utils.validateConfig(config);
+      config.put(
+          SnowflakeSinkConnectorConfig.KEY_CONVERTER_CONFIG_FIELD,
+          "org.apache.kafka.connect.storage.StringConverter");
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception
+          .getMessage()
+          .contains(SnowflakeSinkConnectorConfig.KEY_CONVERTER_CONFIG_FIELD);
+    }
   }
 
-  @Test(expected = SnowflakeKafkaConnectorException.class)
+  @Test
   public void testInValidConfigFileTypeForSnowpipe() {
-    Map<String, String> config = getConfig();
-    config.put(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_FILE_VERSION, "3");
-    Utils.validateConfig(config);
+    try {
+      Map<String, String> config = getConfig();
+      config.put(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_FILE_VERSION, "3");
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception
+          .getMessage()
+          .contains(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_FILE_VERSION);
+    }
   }
 
   @Test
@@ -602,15 +715,19 @@ public class ConnectorConfigTest {
     Utils.validateConfig(config);
   }
 
-  @Test(expected = SnowflakeKafkaConnectorException.class)
+  @Test
   public void testInvalidSchematizationForSnowpipe() {
-    Map<String, String> config = getConfig();
-    config.put(
-        SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
-        IngestionMethodConfig.SNOWPIPE.toString());
-    config.put(SnowflakeSinkConnectorConfig.ENABLE_SCHEMATIZATION_CONFIG, "true");
-    config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
-    Utils.validateConfig(config);
+    try {
+      Map<String, String> config = getConfig();
+      config.put(
+          SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
+          IngestionMethodConfig.SNOWPIPE.toString());
+      config.put(SnowflakeSinkConnectorConfig.ENABLE_SCHEMATIZATION_CONFIG, "true");
+      config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception.getMessage().contains(IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
+    }
   }
 
   @Test
@@ -624,31 +741,41 @@ public class ConnectorConfigTest {
     Utils.validateConfig(config);
   }
 
-  @Test(expected = SnowflakeKafkaConnectorException.class)
+  @Test
   public void testSchematizationWithUnsupportedConverter() {
-    Map<String, String> config = getConfig();
-    config.put(
-        SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
-        IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
-    config.put(SnowflakeSinkConnectorConfig.ENABLE_SCHEMATIZATION_CONFIG, "true");
-    config.put(
-        SnowflakeSinkConnectorConfig.VALUE_CONVERTER_CONFIG_FIELD,
-        "org.apache.kafka.connect.storage.StringConverter");
-    config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
-    Utils.validateConfig(config);
+    try {
+      Map<String, String> config = getConfig();
+      config.put(
+          SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
+          IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
+      config.put(SnowflakeSinkConnectorConfig.ENABLE_SCHEMATIZATION_CONFIG, "true");
+      config.put(
+          SnowflakeSinkConnectorConfig.VALUE_CONVERTER_CONFIG_FIELD,
+          "org.apache.kafka.connect.storage.StringConverter");
+      config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception.getMessage().contains("org.apache.kafka.connect.storage.StringConverter");
+    }
   }
 
   @Test
   public void testDisabledSchematizationWithUnsupportedConverter() {
-    Map<String, String> config = getConfig();
-    config.put(
-        SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
-        IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
-    config.put(SnowflakeSinkConnectorConfig.ENABLE_SCHEMATIZATION_CONFIG, "false");
-    config.put(
-        SnowflakeSinkConnectorConfig.VALUE_CONVERTER_CONFIG_FIELD,
-        "org.apache.kafka.connect.storage.StringConverter");
-    config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
-    Utils.validateConfig(config);
+    try {
+      Map<String, String> config = getConfig();
+      config.put(
+          SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
+          IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
+      config.put(SnowflakeSinkConnectorConfig.ENABLE_SCHEMATIZATION_CONFIG, "false");
+      config.put(
+          SnowflakeSinkConnectorConfig.VALUE_CONVERTER_CONFIG_FIELD,
+          "org.apache.kafka.connect.storage.StringConverter");
+      config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception
+          .getMessage()
+          .contains(SnowflakeSinkConnectorConfig.ENABLE_SCHEMATIZATION_CONFIG);
+    }
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
@@ -801,6 +801,7 @@ public class ConnectorConfigTest {
     }
   }
 
+  // removes each of the following params iteratively to test if the log/exception has all the expected removed params
   @Test
   public void testMultipleInvalidConfigs() {
     List<String> emptyParams =

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
@@ -9,7 +9,6 @@ import com.snowflake.kafka.connector.internal.SnowflakeErrors;
 import com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException;
 import com.snowflake.kafka.connector.internal.streaming.IngestionMethodConfig;
 import com.snowflake.kafka.connector.internal.streaming.StreamingUtils;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -790,53 +789,36 @@ public class ConnectorConfigTest {
       Map<String, String> config = new HashMap<>();
       Utils.validateConfig(config);
     } catch (SnowflakeKafkaConnectorException exception) {
-      assert exception
-              .getMessage()
-              .contains(SnowflakeSinkConnectorConfig.SNOWFLAKE_DATABASE);
-      assert exception
-              .getMessage()
-              .contains(SnowflakeSinkConnectorConfig.SNOWFLAKE_SCHEMA);
-      assert exception
-              .getMessage()
-              .contains(SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS);
-      assert exception
-              .getMessage()
-              .contains(SnowflakeSinkConnectorConfig.SNOWFLAKE_PRIVATE_KEY);
-      assert exception
-              .getMessage()
-              .contains(SnowflakeSinkConnectorConfig.SNOWFLAKE_USER);
-      assert exception
-              .getMessage()
-              .contains(SnowflakeSinkConnectorConfig.NAME);
-      assert exception
-              .getMessage()
-              .contains(SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC);
-      assert exception
-              .getMessage()
-              .contains(SnowflakeSinkConnectorConfig.SNOWFLAKE_URL);
-      assert exception
-              .getMessage()
-              .contains(SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES);
+      assert exception.getMessage().contains(SnowflakeSinkConnectorConfig.SNOWFLAKE_DATABASE);
+      assert exception.getMessage().contains(SnowflakeSinkConnectorConfig.SNOWFLAKE_SCHEMA);
+      assert exception.getMessage().contains(SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS);
+      assert exception.getMessage().contains(SnowflakeSinkConnectorConfig.SNOWFLAKE_PRIVATE_KEY);
+      assert exception.getMessage().contains(SnowflakeSinkConnectorConfig.SNOWFLAKE_USER);
+      assert exception.getMessage().contains(SnowflakeSinkConnectorConfig.NAME);
+      assert exception.getMessage().contains(SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC);
+      assert exception.getMessage().contains(SnowflakeSinkConnectorConfig.SNOWFLAKE_URL);
+      assert exception.getMessage().contains(SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES);
     }
   }
 
-    @Test
-    public void testMultipleInvalidConfigs() {
-      List<String> emptyParams = Arrays.asList(
-              SnowflakeSinkConnectorConfig.SNOWFLAKE_DATABASE,
-              SnowflakeSinkConnectorConfig.SNOWFLAKE_SCHEMA,
-              SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS,
-              SnowflakeSinkConnectorConfig.SNOWFLAKE_PRIVATE_KEY,
-              SnowflakeSinkConnectorConfig.SNOWFLAKE_USER,
-              SnowflakeSinkConnectorConfig.NAME,
-              SnowflakeSinkConnectorConfig.SNOWFLAKE_URL,
-              SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES);
-      List<String> paramsToRemove = new ArrayList<String>();
+  @Test
+  public void testMultipleInvalidConfigs() {
+    List<String> emptyParams =
+        Arrays.asList(
+            SnowflakeSinkConnectorConfig.SNOWFLAKE_DATABASE,
+            SnowflakeSinkConnectorConfig.SNOWFLAKE_SCHEMA,
+            SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS,
+            SnowflakeSinkConnectorConfig.SNOWFLAKE_PRIVATE_KEY,
+            SnowflakeSinkConnectorConfig.SNOWFLAKE_USER,
+            SnowflakeSinkConnectorConfig.NAME,
+            SnowflakeSinkConnectorConfig.SNOWFLAKE_URL,
+            SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES);
+    List<String> paramsToRemove = new ArrayList<String>();
 
-      for (String param : emptyParams) {
-        paramsToRemove.add(param);
-        this.invalidConfigRunner(paramsToRemove);
-      }
+    for (String param : emptyParams) {
+      paramsToRemove.add(param);
+      this.invalidConfigRunner(paramsToRemove);
+    }
   }
 
   private void invalidConfigRunner(List<String> paramsToRemove) {
@@ -849,9 +831,7 @@ public class ConnectorConfigTest {
       Utils.validateConfig(config);
     } catch (SnowflakeKafkaConnectorException exception) {
       for (String configParam : paramsToRemove) {
-        assert exception
-                .getMessage()
-                .contains(configParam);
+        assert exception.getMessage().contains(configParam);
       }
     }
   }

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
@@ -461,8 +461,8 @@ public class ConnectorConfigTest {
     try {
       Map<String, String> config = getConfig();
       config.put(
-              SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
-              IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
+          SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
+          IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
       config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
       config.remove(SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES);
       Utils.validateConfig(config);

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
@@ -801,7 +801,8 @@ public class ConnectorConfigTest {
     }
   }
 
-  // removes each of the following params iteratively to test if the log/exception has all the expected removed params
+  // removes each of the following params iteratively to test if the log/exception has all the
+  // expected removed params
   @Test
   public void testMultipleInvalidConfigs() {
     List<String> emptyParams =

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
@@ -9,6 +9,11 @@ import com.snowflake.kafka.connector.internal.SnowflakeErrors;
 import com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException;
 import com.snowflake.kafka.connector.internal.streaming.IngestionMethodConfig;
 import com.snowflake.kafka.connector.internal.streaming.StreamingUtils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.Test;
 
@@ -776,6 +781,78 @@ public class ConnectorConfigTest {
       assert exception
           .getMessage()
           .contains(SnowflakeSinkConnectorConfig.ENABLE_SCHEMATIZATION_CONFIG);
+    }
+  }
+
+  @Test
+  public void testInvalidEmptyConfig() {
+    try {
+      Map<String, String> config = new HashMap<>();
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception
+              .getMessage()
+              .contains(SnowflakeSinkConnectorConfig.SNOWFLAKE_DATABASE);
+      assert exception
+              .getMessage()
+              .contains(SnowflakeSinkConnectorConfig.SNOWFLAKE_SCHEMA);
+      assert exception
+              .getMessage()
+              .contains(SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS);
+      assert exception
+              .getMessage()
+              .contains(SnowflakeSinkConnectorConfig.SNOWFLAKE_PRIVATE_KEY);
+      assert exception
+              .getMessage()
+              .contains(SnowflakeSinkConnectorConfig.SNOWFLAKE_USER);
+      assert exception
+              .getMessage()
+              .contains(SnowflakeSinkConnectorConfig.NAME);
+      assert exception
+              .getMessage()
+              .contains(SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC);
+      assert exception
+              .getMessage()
+              .contains(SnowflakeSinkConnectorConfig.SNOWFLAKE_URL);
+      assert exception
+              .getMessage()
+              .contains(SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES);
+    }
+  }
+
+    @Test
+    public void testMultipleInvalidConfigs() {
+      List<String> emptyParams = Arrays.asList(
+              SnowflakeSinkConnectorConfig.SNOWFLAKE_DATABASE,
+              SnowflakeSinkConnectorConfig.SNOWFLAKE_SCHEMA,
+              SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS,
+              SnowflakeSinkConnectorConfig.SNOWFLAKE_PRIVATE_KEY,
+              SnowflakeSinkConnectorConfig.SNOWFLAKE_USER,
+              SnowflakeSinkConnectorConfig.NAME,
+              SnowflakeSinkConnectorConfig.SNOWFLAKE_URL,
+              SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES);
+      List<String> paramsToRemove = new ArrayList<String>();
+
+      for (String param : emptyParams) {
+        paramsToRemove.add(param);
+        this.invalidConfigRunner(paramsToRemove);
+      }
+  }
+
+  private void invalidConfigRunner(List<String> paramsToRemove) {
+    Map<String, String> config = getConfig();
+    for (String configParam : paramsToRemove) {
+      config.remove(configParam);
+    }
+
+    try {
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      for (String configParam : paramsToRemove) {
+        assert exception
+                .getMessage()
+                .contains(configParam);
+      }
     }
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
@@ -456,15 +456,19 @@ public class ConnectorConfigTest {
     Utils.validateConfig(config);
   }
 
-  @Test(expected = SnowflakeKafkaConnectorException.class)
+  @Test
   public void testStreamingEmptyBufferSize() {
-    Map<String, String> config = getConfig();
-    config.put(
-        SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
-        IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
-    config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
-    config.remove(SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES);
-    Utils.validateConfig(config);
+    try {
+      Map<String, String> config = getConfig();
+      config.put(
+              SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
+              IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
+      config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
+      config.remove(SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES);
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception.getMessage().contains(SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES);
+    }
   }
 
   @Test(expected = SnowflakeKafkaConnectorException.class)

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorIT.java
@@ -5,13 +5,11 @@ import static com.snowflake.kafka.connector.Utils.TASK_ID;
 import static com.snowflake.kafka.connector.internal.TestUtils.TEST_CONNECTOR_NAME;
 import static com.snowflake.kafka.connector.internal.TestUtils.getConf;
 
-import com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException;
 import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigValue;
-import org.junit.Assert;
 import org.junit.Test;
 
 public class ConnectorIT {

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorIT.java
@@ -269,7 +269,7 @@ public class ConnectorIT {
     Map<String, String> config = getCorrectConfig();
     config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_HOST, "localhost");
     config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_PORT, "8080");
-    Utils.validateProxySetting(config);
+    Utils.validateProxySettings(config);
   }
 
   @Test
@@ -279,7 +279,7 @@ public class ConnectorIT {
     config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_PORT, "8080");
     config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_USERNAME, "user");
     try {
-      Utils.validateProxySetting(config);
+      Utils.validateProxySettings(config);
     } catch (SnowflakeKafkaConnectorException e) {
       Assert.assertEquals("0023", e.getCode());
       return;
@@ -294,7 +294,7 @@ public class ConnectorIT {
     config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_PORT, "8080");
     config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_PASSWORD, "pass");
     try {
-      Utils.validateProxySetting(config);
+      Utils.validateProxySettings(config);
     } catch (SnowflakeKafkaConnectorException e) {
       Assert.assertEquals("0023", e.getCode());
       return;
@@ -309,7 +309,7 @@ public class ConnectorIT {
     config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_PORT, "3128");
     config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_USERNAME, "admin");
     config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_PASSWORD, "test");
-    Utils.validateProxySetting(config);
+    Utils.validateProxySettings(config);
   }
 
   @Test

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorIT.java
@@ -278,13 +278,9 @@ public class ConnectorIT {
     config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_HOST, "localhost");
     config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_PORT, "8080");
     config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_USERNAME, "user");
-    try {
-      Utils.validateProxySettings(config);
-    } catch (SnowflakeKafkaConnectorException e) {
-      Assert.assertEquals("0023", e.getCode());
-      return;
-    }
-    Assert.fail();
+
+    Map<String, String> invalidConfigs = Utils.validateProxySettings(config);
+    assert invalidConfigs.containsKey(SnowflakeSinkConnectorConfig.JVM_PROXY_USERNAME);
   }
 
   @Test
@@ -293,13 +289,9 @@ public class ConnectorIT {
     config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_HOST, "localhost");
     config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_PORT, "8080");
     config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_PASSWORD, "pass");
-    try {
-      Utils.validateProxySettings(config);
-    } catch (SnowflakeKafkaConnectorException e) {
-      Assert.assertEquals("0023", e.getCode());
-      return;
-    }
-    Assert.fail();
+
+    Map<String, String> invalidConfigs = Utils.validateProxySettings(config);
+    assert invalidConfigs.containsKey(SnowflakeSinkConnectorConfig.JVM_PROXY_PASSWORD);
   }
 
   @Test


### PR DESCRIPTION
Collect all invalid parameters and error messages to log and throw an exception at the end

Changes: 
- Replaced isConfigValid boolean with invalidConfigParam hashmap
- Changed most of the 'validateX' methods to return the list of invalid params and messages
- Added additional assert to config tests to check for the required invalid params