### PR TITLE
Reenable accidentally disabled config tests from PR 586

### DIFF
--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
@@ -80,6 +80,7 @@ public class ConnectorConfigTest {
     }
   }
 
+  @Test
   public void testURL() {
     try {
       Map<String, String> config = getConfig();
@@ -534,6 +535,7 @@ public class ConnectorConfigTest {
     }
   }
 
+  @Test
   public void testStreamingFlushTimeNotNumber() {
     try {
       Map<String, String> config = getConfig();
@@ -563,6 +565,7 @@ public class ConnectorConfigTest {
     }
   }
 
+  @Test
   public void testStreamingEmptyBufferCount() {
     try {
       Map<String, String> config = getConfig();
@@ -577,6 +580,7 @@ public class ConnectorConfigTest {
     }
   }
 
+  @Test
   public void testStreamingBufferCountNegative() {
     try {
       Map<String, String> config = getConfig();
@@ -591,6 +595,7 @@ public class ConnectorConfigTest {
     }
   }
 
+  @Test
   public void testStreamingBufferCountValue() {
     try {
       Map<String, String> config = getConfig();
@@ -643,6 +648,7 @@ public class ConnectorConfigTest {
     Utils.validateConfig(config);
   }
 
+  @Test
   public void testInvalidKeyConvertersForStreamingSnowpipe() {
     try {
       Map<String, String> config = getConfig();
@@ -665,6 +671,7 @@ public class ConnectorConfigTest {
     }
   }
 
+  @Test
   public void testInvalidValueConvertersForStreamingSnowpipe() {
     try {
       Map<String, String> config = getConfig();
@@ -683,7 +690,7 @@ public class ConnectorConfigTest {
     } catch (SnowflakeKafkaConnectorException exception) {
       assert exception
           .getMessage()
-          .contains(SnowflakeSinkConnectorConfig.KEY_CONVERTER_CONFIG_FIELD);
+          .contains(SnowflakeSinkConnectorConfig.VALUE_CONVERTER_CONFIG_FIELD);
     }
   }
 


### PR DESCRIPTION
Apologies, I accidentally deleted the `@Test` in this previous PR https://github.com/snowflakedb/snowflake-kafka-connector/pull/586. Reenable these tests