### PR TITLE
One client change 1/3: add parameter to enable one client optimization

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -161,7 +161,7 @@ public class SnowflakeSinkConnectorConfig {
       "Enable streaming client optimization";
   public static final boolean ENABLE_STREAMING_CLIENT_OPTIMIZATION_DEFAULT = false;
   public static final String ENABLE_STREAMING_CLIENT_OPTIMIZATION_DOC =
-      "Whether to reduce optimize the streaming client to reduce cost. Note that this may affect"
+      "Whether to optimize the streaming client to reduce cost. Note that this may affect"
           + " throughput or latency and can only be set if Streaming Snowpipe is enabled";
 
   /**

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -155,6 +155,11 @@ public class SnowflakeSinkConnectorConfig {
           + "By default messages are not sent to the dead letter queue. "
           + "Requires property `errors.tolerance=all`.";
 
+  public static final String ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG = "enable.streaming.client.optimization";
+  public static final String ENABLE_STREAMING_CLIENT_OPTIMIZATION_DISPLAY = "Enable streaming client optimization";
+  public static final boolean ENABLE_STREAMING_CLIENT_OPTIMIZATION_DEFAULT = false;
+  public static final String ENABLE_STREAMING_CLIENT_OPTIMIZATION_DOC = "Whether to reduce optimize the streaming client to reduce cost. Note that this may affect throughput or latency and can only be set if Streaming Snowpipe is enabled";
+
   /**
    * Used to serialize the incoming records to kafka connector. Note: Converter code is invoked
    * before actually sending records to Kafka connector.
@@ -508,7 +513,17 @@ public class SnowflakeSinkConnectorConfig {
             ERROR_GROUP,
             2,
             ConfigDef.Width.NONE,
-            ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_DISPLAY);
+            ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_DISPLAY)
+        .define(
+            ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG,
+            Type.BOOLEAN,
+            ENABLE_STREAMING_CLIENT_OPTIMIZATION_DEFAULT,
+            Importance.LOW,
+            ENABLE_STREAMING_CLIENT_OPTIMIZATION_DOC,
+            CONNECTOR_CONFIG,
+            7,
+            ConfigDef.Width.NONE,
+            ENABLE_STREAMING_CLIENT_OPTIMIZATION_DISPLAY);
   }
 
   public static class TopicToTableValidator implements ConfigDef.Validator {

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -155,10 +155,14 @@ public class SnowflakeSinkConnectorConfig {
           + "By default messages are not sent to the dead letter queue. "
           + "Requires property `errors.tolerance=all`.";
 
-  public static final String ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG = "enable.streaming.client.optimization";
-  public static final String ENABLE_STREAMING_CLIENT_OPTIMIZATION_DISPLAY = "Enable streaming client optimization";
+  public static final String ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG =
+      "enable.streaming.client.optimization";
+  public static final String ENABLE_STREAMING_CLIENT_OPTIMIZATION_DISPLAY =
+      "Enable streaming client optimization";
   public static final boolean ENABLE_STREAMING_CLIENT_OPTIMIZATION_DEFAULT = false;
-  public static final String ENABLE_STREAMING_CLIENT_OPTIMIZATION_DOC = "Whether to reduce optimize the streaming client to reduce cost. Note that this may affect throughput or latency and can only be set if Streaming Snowpipe is enabled";
+  public static final String ENABLE_STREAMING_CLIENT_OPTIMIZATION_DOC =
+      "Whether to reduce optimize the streaming client to reduce cost. Note that this may affect"
+          + " throughput or latency and can only be set if Streaming Snowpipe is enabled";
 
   /**
    * Used to serialize the incoming records to kafka connector. Note: Converter code is invoked

--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -384,12 +384,13 @@ public class Utils {
       }
       if (config.containsKey(ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG)
           && Boolean.parseBoolean(
-              config.get(SnowflakeSinkConnectorConfig.ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG))) {
+              config.get(
+                  SnowflakeSinkConnectorConfig.ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG))) {
         invalidConfigParams.put(
-                SnowflakeSinkConnectorConfig.ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG,
-                Utils.formatString(
-                        "Streaming client optimization is only available with {}.",
-                        IngestionMethodConfig.SNOWPIPE_STREAMING.toString()));
+            SnowflakeSinkConnectorConfig.ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG,
+            Utils.formatString(
+                "Streaming client optimization is only available with {}.",
+                IngestionMethodConfig.SNOWPIPE_STREAMING.toString()));
       }
     }
 

--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -369,7 +369,7 @@ public class Utils {
           && Boolean.parseBoolean(
               config.get(SnowflakeSinkConnectorConfig.ENABLE_SCHEMATIZATION_CONFIG))) {
         invalidConfigParams.put(
-            IngestionMethodConfig.SNOWPIPE_STREAMING.toString(),
+            SnowflakeSinkConnectorConfig.ENABLE_SCHEMATIZATION_CONFIG,
             Utils.formatString(
                 "Schematization is only available with {}.",
                 IngestionMethodConfig.SNOWPIPE_STREAMING.toString()));
@@ -381,6 +381,15 @@ public class Utils {
                 "{} is only available with ingestion type: {}.",
                 SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_FILE_VERSION,
                 IngestionMethodConfig.SNOWPIPE_STREAMING.toString()));
+      }
+      if (config.containsKey(ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG)
+          && Boolean.parseBoolean(
+              config.get(SnowflakeSinkConnectorConfig.ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG))) {
+        invalidConfigParams.put(
+                SnowflakeSinkConnectorConfig.ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG,
+                Utils.formatString(
+                        "Streaming client optimization is only available with {}.",
+                        IngestionMethodConfig.SNOWPIPE_STREAMING.toString()));
       }
     }
 
@@ -479,10 +488,6 @@ public class Utils {
           DELIVERY_GUARANTEE,
           Utils.formatString(
               "Delivery Guarantee config:{} error:{}", DELIVERY_GUARANTEE, exception.getMessage()));
-    }
-
-    if (config.containsKey(ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG)) {
-
     }
 
     // Check all config values for ingestion method == IngestionMethodConfig.SNOWPIPE_STREAMING

--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -19,6 +19,7 @@ package com.snowflake.kafka.connector;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BehaviorOnNullValues.VALIDATOR;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.DELIVERY_GUARANTEE;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.JMX_OPT;
 
@@ -478,6 +479,10 @@ public class Utils {
           DELIVERY_GUARANTEE,
           Utils.formatString(
               "Delivery Guarantee config:{} error:{}", DELIVERY_GUARANTEE, exception.getMessage()));
+    }
+
+    if (config.containsKey(ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG)) {
+
     }
 
     // Check all config values for ingestion method == IngestionMethodConfig.SNOWPIPE_STREAMING

--- a/src/main/java/com/snowflake/kafka/connector/internal/telemetry/SnowflakeTelemetryService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/telemetry/SnowflakeTelemetryService.java
@@ -8,7 +8,6 @@ import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_SCHEMATIZATION_DEFAULT;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_STREAMING_CLIENT_OPTIMIZATION_DEFAULT;
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_STREAMING_CLIENT_OPTIMIZATION_DOC;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.INGESTION_METHOD_DEFAULT_SNOWPIPE;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.KEY_CONVERTER_CONFIG_FIELD;
@@ -261,7 +260,11 @@ public abstract class SnowflakeTelemetryService {
             ENABLE_SCHEMATIZATION_CONFIG, ENABLE_SCHEMATIZATION_DEFAULT));
 
     // Record whether streaming client optimization is enabled
-    dataObjectNode.put(ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG, userProvidedConfig.getOrDefault(ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG, ENABLE_STREAMING_CLIENT_OPTIMIZATION_DEFAULT + ""));
+    dataObjectNode.put(
+        ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG,
+        userProvidedConfig.getOrDefault(
+            ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG,
+            ENABLE_STREAMING_CLIENT_OPTIMIZATION_DEFAULT + ""));
   }
 
   enum TelemetryType {

--- a/src/main/java/com/snowflake/kafka/connector/internal/telemetry/SnowflakeTelemetryService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/telemetry/SnowflakeTelemetryService.java
@@ -6,6 +6,9 @@ import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BUFFER_
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.DELIVERY_GUARANTEE;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_SCHEMATIZATION_CONFIG;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_SCHEMATIZATION_DEFAULT;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_STREAMING_CLIENT_OPTIMIZATION_DEFAULT;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_STREAMING_CLIENT_OPTIMIZATION_DOC;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.INGESTION_METHOD_DEFAULT_SNOWPIPE;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.KEY_CONVERTER_CONFIG_FIELD;
@@ -256,6 +259,9 @@ public abstract class SnowflakeTelemetryService {
         ENABLE_SCHEMATIZATION_CONFIG,
         userProvidedConfig.getOrDefault(
             ENABLE_SCHEMATIZATION_CONFIG, ENABLE_SCHEMATIZATION_DEFAULT));
+
+    // Record whether streaming client optimization is enabled
+    dataObjectNode.put(ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG, userProvidedConfig.getOrDefault(ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG, ENABLE_STREAMING_CLIENT_OPTIMIZATION_DEFAULT + ""));
   }
 
   enum TelemetryType {

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
@@ -787,12 +787,10 @@ public class ConnectorConfigTest {
   public void testEnableOptimizeStreamingClientConfig() {
     Map<String, String> config = getConfig();
     config.put(
-            SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
-            IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
+        SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
+        IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
     config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
-    config.put(
-            SnowflakeSinkConnectorConfig.ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG,
-            "true");
+    config.put(SnowflakeSinkConnectorConfig.ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG, "true");
 
     Utils.validateConfig(config);
   }
@@ -802,15 +800,15 @@ public class ConnectorConfigTest {
     try {
       Map<String, String> config = getConfig();
       config.put(
-              SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
-              IngestionMethodConfig.SNOWPIPE.toString());
-      config.put(
-              SnowflakeSinkConnectorConfig.ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG,
-              "true");
+          SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
+          IngestionMethodConfig.SNOWPIPE.toString());
+      config.put(SnowflakeSinkConnectorConfig.ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG, "true");
 
       Utils.validateConfig(config);
     } catch (SnowflakeKafkaConnectorException exception) {
-      assert exception.getMessage().contains(SnowflakeSinkConnectorConfig.ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG);
+      assert exception
+          .getMessage()
+          .contains(SnowflakeSinkConnectorConfig.ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG);
     }
   }
 

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
@@ -784,6 +784,37 @@ public class ConnectorConfigTest {
   }
 
   @Test
+  public void testEnableOptimizeStreamingClientConfig() {
+    Map<String, String> config = getConfig();
+    config.put(
+            SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
+            IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
+    config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
+    config.put(
+            SnowflakeSinkConnectorConfig.ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG,
+            "true");
+
+    Utils.validateConfig(config);
+  }
+
+  @Test
+  public void testInvalidEnableOptimizeStreamingClientConfig() {
+    try {
+      Map<String, String> config = getConfig();
+      config.put(
+              SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
+              IngestionMethodConfig.SNOWPIPE.toString());
+      config.put(
+              SnowflakeSinkConnectorConfig.ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG,
+              "true");
+
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception.getMessage().contains(SnowflakeSinkConnectorConfig.ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG);
+    }
+  }
+
+  @Test
   public void testInvalidEmptyConfig() {
     try {
       Map<String, String> config = new HashMap<>();


### PR DESCRIPTION
Adds a parameter to enable one client optimization (all partitions and tasks pointing to one client). This param is currently unused, but will be used in later PRs.