### PR TITLE
Add telemetry for fatal errors in TopicPartitionChannel

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceFactory.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceFactory.java
@@ -2,6 +2,7 @@ package com.snowflake.kafka.connector.internal;
 
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.PROVIDER_CONFIG;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
 import com.snowflake.kafka.connector.Utils;
 import com.snowflake.kafka.connector.internal.streaming.IngestionMethodConfig;
@@ -25,11 +26,13 @@ public class SnowflakeConnectionServiceFactory {
     // This property will be appeneded to user agent while calling snowpipe API in http request
     private String kafkaProvider = null;
 
+    /** Underlying implementation - Check Enum {@link IngestionMethodConfig} */
     private IngestionMethodConfig ingestionMethodConfig;
 
-    // For testing only
+    @VisibleForTesting
     public SnowflakeConnectionServiceBuilder setProperties(Properties prop) {
       this.prop = prop;
+      this.ingestionMethodConfig = IngestionMethodConfig.SNOWPIPE;
       return this;
     }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceFactory.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceFactory.java
@@ -4,6 +4,7 @@ import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.PROVIDE
 
 import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
 import com.snowflake.kafka.connector.Utils;
+import com.snowflake.kafka.connector.internal.streaming.IngestionMethodConfig;
 import java.util.Map;
 import java.util.Properties;
 
@@ -23,6 +24,8 @@ public class SnowflakeConnectionServiceFactory {
     // This info is provided in the connector configuration
     // This property will be appeneded to user agent while calling snowpipe API in http request
     private String kafkaProvider = null;
+
+    private IngestionMethodConfig ingestionMethodConfig;
 
     // For testing only
     public SnowflakeConnectionServiceBuilder setProperties(Properties prop) {
@@ -65,6 +68,7 @@ public class SnowflakeConnectionServiceFactory {
       // be decoupled
       this.proxyProperties = InternalUtils.generateProxyParametersIfRequired(conf);
       this.connectorName = conf.get(Utils.NAME);
+      this.ingestionMethodConfig = IngestionMethodConfig.determineIngestionMethod(conf);
       return this;
     }
 
@@ -73,7 +77,7 @@ public class SnowflakeConnectionServiceFactory {
       InternalUtils.assertNotEmpty("url", url);
       InternalUtils.assertNotEmpty("connectorName", connectorName);
       return new SnowflakeConnectionServiceV1(
-          prop, url, connectorName, taskID, proxyProperties, kafkaProvider);
+          prop, url, connectorName, taskID, proxyProperties, kafkaProvider, ingestionMethodConfig);
     }
   }
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
@@ -4,6 +4,7 @@ import static com.snowflake.kafka.connector.Utils.TABLE_COLUMN_CONTENT;
 import static com.snowflake.kafka.connector.Utils.TABLE_COLUMN_METADATA;
 
 import com.snowflake.kafka.connector.Utils;
+import com.snowflake.kafka.connector.internal.streaming.IngestionMethodConfig;
 import com.snowflake.kafka.connector.internal.streaming.SchematizationUtils;
 import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryService;
 import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryServiceFactory;
@@ -61,7 +62,8 @@ public class SnowflakeConnectionServiceV1 implements SnowflakeConnectionService 
       String connectorName,
       String taskID,
       Properties proxyProperties,
-      String kafkaProvider) {
+      String kafkaProvider,
+      IngestionMethodConfig ingestionMethodConfig) {
     this.connectorName = connectorName;
     this.taskID = taskID;
     this.url = url;
@@ -87,7 +89,7 @@ public class SnowflakeConnectionServiceV1 implements SnowflakeConnectionService 
         new SnowflakeInternalStage(
             (SnowflakeConnectionV1) this.conn, credentialExpireTimeMillis, proxyProperties);
     this.telemetry =
-        SnowflakeTelemetryServiceFactory.builder(conn)
+        SnowflakeTelemetryServiceFactory.builder(conn, ingestionMethodConfig)
             .setAppName(this.connectorName)
             .setTaskID(this.taskID)
             .build();

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/IngestionMethodConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/IngestionMethodConfig.java
@@ -55,7 +55,8 @@ public enum IngestionMethodConfig {
   /**
    * Returns the Ingestion Method found in User Configuration for Snowflake Kafka Connector.
    *
-   * <p>Default is always {@link IngestionMethodConfig#SNOWPIPE}.
+   * <p>Default is always {@link IngestionMethodConfig#SNOWPIPE} unless an invalid value is passed
+   * which results in exception.
    */
   public static IngestionMethodConfig determineIngestionMethod(Map<String, String> inputConf) {
     if (inputConf == null
@@ -69,7 +70,7 @@ public enum IngestionMethodConfig {
                 .get(SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT)
                 .toUpperCase(Locale.ROOT));
       } catch (IllegalArgumentException ex) {
-        return IngestionMethodConfig.SNOWPIPE;
+        throw ex;
       }
     }
   }

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/IngestionMethodConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/IngestionMethodConfig.java
@@ -53,15 +53,16 @@ public enum IngestionMethodConfig {
   }
 
   /**
-   * Returns the Ingestion Method found in User Configuration for Snowflake Kafka Connector. Default
-   * is always {@link IngestionMethodConfig#SNOWPIPE}.
+   * Returns the Ingestion Method found in User Configuration for Snowflake Kafka Connector.
+   *
+   * <p>Default is always {@link IngestionMethodConfig#SNOWPIPE}.
    */
   public static IngestionMethodConfig determineIngestionMethod(Map<String, String> inputConf) {
     if (inputConf == null
         || inputConf.isEmpty()
-        || !inputConf.containsKey(SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT))
+        || !inputConf.containsKey(SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT)) {
       return IngestionMethodConfig.SNOWPIPE;
-    else {
+    } else {
       try {
         return IngestionMethodConfig.valueOf(
             inputConf

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/IngestionMethodConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/IngestionMethodConfig.java
@@ -1,11 +1,15 @@
 package com.snowflake.kafka.connector.internal.streaming;
 
+import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
 import java.util.Locale;
+import java.util.Map;
 import org.apache.kafka.common.config.ConfigDef;
 
 /**
  * Enum representing the allowed values for config {@link
  * com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig#INGESTION_METHOD_OPT}
+ *
+ * <p>NOTE: Please do not change ordering of this Enums, please append to the end.
  */
 public enum IngestionMethodConfig {
 
@@ -46,6 +50,27 @@ public enum IngestionMethodConfig {
     }
 
     return result;
+  }
+
+  /**
+   * Returns the Ingestion Method found in User Configuration for Snowflake Kafka Connector. Default
+   * is always {@link IngestionMethodConfig#SNOWPIPE}.
+   */
+  public static IngestionMethodConfig determineIngestionMethod(Map<String, String> inputConf) {
+    if (inputConf == null
+        || inputConf.isEmpty()
+        || !inputConf.containsKey(SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT))
+      return IngestionMethodConfig.SNOWPIPE;
+    else {
+      try {
+        return IngestionMethodConfig.valueOf(
+            inputConf
+                .get(SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT)
+                .toUpperCase(Locale.ROOT));
+      } catch (IllegalArgumentException ex) {
+        return IngestionMethodConfig.SNOWPIPE;
+      }
+    }
   }
 
   @Override

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -178,7 +178,8 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
             this.kafkaRecordErrorReporter,
             this.sinkTaskContext,
             this.conn,
-            this.recordService));
+            this.recordService,
+            this.conn.getTelemetryClient()));
   }
 
   /**

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeTelemetryServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeTelemetryServiceV2.java
@@ -19,10 +19,9 @@ package com.snowflake.kafka.connector.internal.streaming;
 
 import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryBasicInfo;
 import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryService;
+import java.sql.Connection;
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.node.ObjectNode;
 import net.snowflake.client.jdbc.telemetry.TelemetryClient;
-
-import java.sql.Connection;
 
 /**
  * This is the implementation of Telemetry Service for Snowpipe Streaming. Sends data related to
@@ -30,14 +29,20 @@ import java.sql.Connection;
  */
 public class SnowflakeTelemetryServiceV2 extends SnowflakeTelemetryService {
 
+  /**
+   * Constructor for TelemetryService which is used by Snowpipe Streaming.
+   *
+   * @param conn Connection Object which gives the Telemetry Instance.
+   */
   public SnowflakeTelemetryServiceV2(Connection conn) {
     this.telemetry = TelemetryClient.createTelemetry(conn);
   }
 
-
   @Override
   public void reportKafkaPartitionUsage(
-      SnowflakeTelemetryBasicInfo partitionStatus, boolean isClosing) {throw new IllegalStateException("Snowpipe Streaming Doesnt Have Pipe Usage")}
+      SnowflakeTelemetryBasicInfo partitionStatus, boolean isClosing) {
+    throw new IllegalStateException("Snowpipe Streaming Doesnt Have Pipe Usage");
+  }
 
   @Override
   public ObjectNode getObjectNode() {

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeTelemetryServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeTelemetryServiceV2.java
@@ -19,13 +19,29 @@ package com.snowflake.kafka.connector.internal.streaming;
 
 import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryBasicInfo;
 import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryService;
+import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.node.ObjectNode;
+import net.snowflake.client.jdbc.telemetry.TelemetryClient;
+
+import java.sql.Connection;
 
 /**
  * This is the implementation of Telemetry Service for Snowpipe Streaming. Sends data related to
  * Snowpipe Streaming to Snowflake for additional debugging purposes.
  */
 public class SnowflakeTelemetryServiceV2 extends SnowflakeTelemetryService {
+
+  public SnowflakeTelemetryServiceV2(Connection conn) {
+    this.telemetry = TelemetryClient.createTelemetry(conn);
+  }
+
+
   @Override
   public void reportKafkaPartitionUsage(
-      SnowflakeTelemetryBasicInfo partitionStatus, boolean isClosing) {}
+      SnowflakeTelemetryBasicInfo partitionStatus, boolean isClosing) {throw new IllegalStateException("Snowpipe Streaming Doesnt Have Pipe Usage")}
+
+  @Override
+  public ObjectNode getObjectNode() {
+    ObjectNode objectNode = getDefaultObjectNode(IngestionMethodConfig.SNOWPIPE_STREAMING);
+    return objectNode;
+  }
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
@@ -18,6 +18,7 @@ import com.snowflake.kafka.connector.internal.BufferThreshold;
 import com.snowflake.kafka.connector.internal.KCLogger;
 import com.snowflake.kafka.connector.internal.PartitionBuffer;
 import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
+import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryService;
 import com.snowflake.kafka.connector.records.RecordService;
 import com.snowflake.kafka.connector.records.SnowflakeJsonSchema;
 import com.snowflake.kafka.connector.records.SnowflakeRecordContent;
@@ -143,7 +144,12 @@ public class TopicPartitionChannel {
   // Reference to the Snowflake connection service
   private final SnowflakeConnectionService conn;
 
+  // Used to send telemetry to Snowflake. (Currently uses a client which is created from connection,
+  // i.e. not a session-less client)
+  private final SnowflakeTelemetryService telemetryServiceV2;
+
   /** Testing only, initialize TopicPartitionChannel without the connection service */
+  @VisibleForTesting
   public TopicPartitionChannel(
       SnowflakeStreamingIngestClient streamingIngestClient,
       TopicPartition topicPartition,
@@ -202,6 +208,7 @@ public class TopicPartitionChannel {
     this.conn = conn;
 
     this.recordService = recordService;
+    this.telemetryServiceV2 = conn.getTelemetryClient();
 
     this.previousFlushTimeStampMs = System.currentTimeMillis();
 
@@ -661,8 +668,12 @@ public class TopicPartitionChannel {
         }
       }
     } else {
-      throw new DataException(
-          "Error inserting Records using Streaming API", insertErrors.get(0).getException());
+      final String errMsg =
+          String.format(
+              "Error inserting Records using Streaming API with msg:%s",
+              insertErrors.get(0).getException().getMessage());
+      this.telemetryServiceV2.reportKafkaConnectFatalError(errMsg);
+      throw new DataException(errMsg, insertErrors.get(0).getException());
     }
   }
 
@@ -946,11 +957,12 @@ public class TopicPartitionChannel {
     try {
       this.channel.close().get();
     } catch (InterruptedException | ExecutionException e) {
-      LOGGER.error(
-          "Failure closing Streaming Channel name:{} msg:{}",
-          this.getChannelName(),
-          e.getMessage(),
-          e);
+      final String errMsg =
+          String.format(
+              "Failure closing Streaming Channel name:%s msg:%s",
+              this.getChannelName(), e.getMessage());
+      this.telemetryServiceV2.reportKafkaConnectFatalError(errMsg);
+      LOGGER.error(errMsg, e);
     }
   }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/telemetry/SnowflakeTelemetryBasicInfo.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/telemetry/SnowflakeTelemetryBasicInfo.java
@@ -6,11 +6,14 @@ import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.node.Object
 /** Minimum information needed to sent to Snowflake through Telemetry API */
 public abstract class SnowflakeTelemetryBasicInfo {
   final String tableName;
+
+  // User created or user visible stage name
+  // It is null for Snowpipe Streaming Telemetry.
   final String stageName;
 
   static final KCLogger LOGGER = new KCLogger(SnowflakeTelemetryBasicInfo.class.getName());
 
-  SnowflakeTelemetryBasicInfo(final String tableName, final String stageName) {
+  public SnowflakeTelemetryBasicInfo(final String tableName, final String stageName) {
     this.tableName = tableName;
     this.stageName = stageName;
   }
@@ -21,12 +24,12 @@ public abstract class SnowflakeTelemetryBasicInfo {
    *
    * @param msg ObjectNode in which extra fields needs to be added.
    */
-  abstract void dumpTo(ObjectNode msg);
+  public abstract void dumpTo(ObjectNode msg);
 
   /**
    * @return true if it would suggest that their was no update to corresponding implementation's
    *     member variables. Or, in other words, the corresponding partition didnt receive any
    *     records, in which case we would not call telemetry API.
    */
-  abstract boolean isEmpty();
+  public abstract boolean isEmpty();
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/telemetry/SnowflakeTelemetryBasicInfo.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/telemetry/SnowflakeTelemetryBasicInfo.java
@@ -1,5 +1,7 @@
 package com.snowflake.kafka.connector.internal.telemetry;
 
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import com.snowflake.kafka.connector.internal.KCLogger;
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.node.ObjectNode;
 
@@ -7,13 +9,25 @@ import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.node.Object
 public abstract class SnowflakeTelemetryBasicInfo {
   final String tableName;
 
-  // User created or user visible stage name
-  // It is null for Snowpipe Streaming Telemetry.
+  /**
+   * User created or user visible stage name.
+   *
+   * <p>It is null for Snowpipe Streaming Telemetry.
+   */
   final String stageName;
 
   static final KCLogger LOGGER = new KCLogger(SnowflakeTelemetryBasicInfo.class.getName());
 
+  /**
+   * Base Constructor. Accepts a tableName and StageName.
+   *
+   * @param tableName Checks for Nullability
+   * @param stageName Can be null (In case of Snowpipe Streaming since there is no user visible
+   *     Snowflake Stage)
+   */
   public SnowflakeTelemetryBasicInfo(final String tableName, final String stageName) {
+    Preconditions.checkArgument(
+        !Strings.isNullOrEmpty(tableName), "tableName cannot be null or empty");
     this.tableName = tableName;
     this.stageName = stageName;
   }

--- a/src/main/java/com/snowflake/kafka/connector/internal/telemetry/SnowflakeTelemetryPipeCreation.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/telemetry/SnowflakeTelemetryPipeCreation.java
@@ -34,7 +34,7 @@ public class SnowflakeTelemetryPipeCreation extends SnowflakeTelemetryBasicInfo 
   }
 
   @Override
-  void dumpTo(ObjectNode msg) {
+  public void dumpTo(ObjectNode msg) {
     msg.put(TABLE_NAME, tableName);
     msg.put(STAGE_NAME, stageName);
     msg.put(PIPE_NAME, pipeName);

--- a/src/main/java/com/snowflake/kafka/connector/internal/telemetry/SnowflakeTelemetryPipeStatus.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/telemetry/SnowflakeTelemetryPipeStatus.java
@@ -261,7 +261,7 @@ public class SnowflakeTelemetryPipeStatus extends SnowflakeTelemetryBasicInfo {
   }
 
   @Override
-  void dumpTo(ObjectNode msg) {
+  public void dumpTo(ObjectNode msg) {
     msg.put(TABLE_NAME, tableName);
     msg.put(STAGE_NAME, stageName);
     msg.put(PIPE_NAME, pipeName);

--- a/src/main/java/com/snowflake/kafka/connector/internal/telemetry/SnowflakeTelemetryService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/telemetry/SnowflakeTelemetryService.java
@@ -12,8 +12,10 @@ import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.INGESTI
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.KEY_CONVERTER_CONFIG_FIELD;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.VALUE_CONVERTER_CONFIG_FIELD;
 
+import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
 import com.snowflake.kafka.connector.Utils;
 import com.snowflake.kafka.connector.internal.KCLogger;
+import com.snowflake.kafka.connector.internal.streaming.IngestionMethodConfig;
 import java.util.Map;
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.JsonNode;
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.ObjectMapper;
@@ -132,6 +134,14 @@ public abstract class SnowflakeTelemetryService {
       final SnowflakeTelemetryBasicInfo partitionStatus, boolean isClosing);
 
   /**
+   * Get default object Node which will be part of every telemetry being sent to snowflake. Based on
+   * the underlying implementation, node fields might change.
+   *
+   * @return ObjectNode in Json Format
+   */
+  public abstract ObjectNode getObjectNode();
+
+  /**
    * report connector partition start
    *
    * @param pipeCreation SnowflakeTelemetryBasicInfor object
@@ -151,15 +161,17 @@ public abstract class SnowflakeTelemetryService {
    * {
    *  "app_name": "<connector_app_name>",
    *  "task_id": 1,
+   *  "snowflake.ingestion.method": "<Enum Ordinal>" for {@link IngestionMethodConfig}
    * }
    * </pre>
    *
    * @return An ObjectNode which is by default always created with certain defined properties in it.
    */
-  protected ObjectNode getObjectNode() {
+  protected ObjectNode getDefaultObjectNode(IngestionMethodConfig ingestionMethodConfig) {
     ObjectNode msg = MAPPER.createObjectNode();
     msg.put(APP_NAME, getAppName());
     msg.put(TASK_ID, getTaskID());
+    msg.put(SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT, ingestionMethodConfig.ordinal());
     return msg;
   }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/telemetry/SnowflakeTelemetryServiceFactory.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/telemetry/SnowflakeTelemetryServiceFactory.java
@@ -1,5 +1,7 @@
 package com.snowflake.kafka.connector.internal.telemetry;
 
+import com.snowflake.kafka.connector.internal.streaming.IngestionMethodConfig;
+import com.snowflake.kafka.connector.internal.streaming.SnowflakeTelemetryServiceV2;
 import java.sql.Connection;
 
 /**
@@ -8,17 +10,26 @@ import java.sql.Connection;
  */
 public class SnowflakeTelemetryServiceFactory {
 
-  public static SnowflakeTelemetryServiceBuilder builder(Connection conn) {
-    return new SnowflakeTelemetryServiceBuilder(conn);
+  public static SnowflakeTelemetryServiceBuilder builder(
+      Connection conn, IngestionMethodConfig ingestionMethodConfig) {
+    return new SnowflakeTelemetryServiceBuilder(conn, ingestionMethodConfig);
   }
 
   /** Builder for TelemetryService */
   public static class SnowflakeTelemetryServiceBuilder {
     private final SnowflakeTelemetryService service;
 
-    /** @param conn snowflake connection is required for telemetry service */
-    public SnowflakeTelemetryServiceBuilder(Connection conn) {
-      this.service = new SnowflakeTelemetryServiceV1(conn);
+    /**
+     * @param conn snowflake connection is required for telemetry service
+     * @param ingestionMethodConfig Snowpipe or Snowpipe Streaming
+     */
+    public SnowflakeTelemetryServiceBuilder(
+        Connection conn, IngestionMethodConfig ingestionMethodConfig) {
+      if (ingestionMethodConfig.equals(IngestionMethodConfig.SNOWPIPE)) {
+        this.service = new SnowflakeTelemetryServiceV1(conn);
+      } else {
+        this.service = new SnowflakeTelemetryServiceV2(conn);
+      }
     }
 
     /**

--- a/src/main/java/com/snowflake/kafka/connector/internal/telemetry/SnowflakeTelemetryServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/telemetry/SnowflakeTelemetryServiceV1.java
@@ -1,6 +1,7 @@
 package com.snowflake.kafka.connector.internal.telemetry;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.snowflake.kafka.connector.internal.streaming.IngestionMethodConfig;
 import java.sql.Connection;
 import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.node.ObjectNode;
 import net.snowflake.client.jdbc.telemetry.Telemetry;
@@ -30,5 +31,11 @@ public class SnowflakeTelemetryServiceV1 extends SnowflakeTelemetryService {
     msg.put(IS_PIPE_CLOSING, isClosing);
 
     send(TelemetryType.KAFKA_PIPE_USAGE, msg);
+  }
+
+  @Override
+  public ObjectNode getObjectNode() {
+    ObjectNode objectNode = getDefaultObjectNode(IngestionMethodConfig.SNOWPIPE);
+    return objectNode;
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
@@ -420,12 +420,12 @@ public class ConnectorConfigTest {
         IngestionMethodConfig.SNOWPIPE, IngestionMethodConfig.determineIngestionMethod(null));
   }
 
-  @Test
+  @Test(expected = IllegalArgumentException.class)
   public void testDetermineIngestionMethod_invalidIngestionMethod() {
     Map<String, String> config = getConfig();
     config.put(SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT, "INVALID_VALUE");
-    assertEquals(
-        IngestionMethodConfig.SNOWPIPE, IngestionMethodConfig.determineIngestionMethod(config));
+
+    IngestionMethodConfig.determineIngestionMethod(config);
   }
 
   @Test

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
@@ -4,6 +4,7 @@ import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_TOLERANCE_CONFIG;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.NAME;
 import static com.snowflake.kafka.connector.internal.TestUtils.getConfig;
+import static org.junit.Assert.assertEquals;
 
 import com.snowflake.kafka.connector.internal.SnowflakeErrors;
 import com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException;
@@ -407,6 +408,42 @@ public class ConnectorConfigTest {
     } catch (SnowflakeKafkaConnectorException exception) {
       assert exception.getMessage().contains(SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT);
     }
+  }
+
+  @Test
+  public void testDetermineIngestionMethod_nullOrEmptyInput() {
+    Map<String, String> config = getConfig();
+    assertEquals(
+        IngestionMethodConfig.SNOWPIPE, IngestionMethodConfig.determineIngestionMethod(config));
+
+    assertEquals(
+        IngestionMethodConfig.SNOWPIPE, IngestionMethodConfig.determineIngestionMethod(null));
+  }
+
+  @Test
+  public void testDetermineIngestionMethod_invalidIngestionMethod() {
+    Map<String, String> config = getConfig();
+    config.put(SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT, "INVALID_VALUE");
+    assertEquals(
+        IngestionMethodConfig.SNOWPIPE, IngestionMethodConfig.determineIngestionMethod(config));
+  }
+
+  @Test
+  public void testDetermineIngestionLoadMethod_validIngestionMethod() {
+    Map<String, String> config = getConfig();
+    config.put(SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT, "SNOWPIPE_STREAMING");
+    assertEquals(
+        IngestionMethodConfig.SNOWPIPE_STREAMING,
+        IngestionMethodConfig.determineIngestionMethod(config));
+  }
+
+  @Test
+  public void testDetermineIngestionLoadMethod_validIngestionMethod_lowercase() {
+    Map<String, String> config = getConfig();
+    config.put(SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT, "snowpipe_stREAMING");
+    assertEquals(
+        IngestionMethodConfig.SNOWPIPE_STREAMING,
+        IngestionMethodConfig.determineIngestionMethod(config));
   }
 
   /** These error tests are not going to enforce errors if they are not passed as configs. */

--- a/src/test/java/com/snowflake/kafka/connector/internal/ConnectionServiceIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/ConnectionServiceIT.java
@@ -1,9 +1,13 @@
 package com.snowflake.kafka.connector.internal;
 
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT;
 import static com.snowflake.kafka.connector.internal.SnowflakeConnectionServiceV1.USER_AGENT_SUFFIX_FORMAT;
 
 import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
 import com.snowflake.kafka.connector.Utils;
+import com.snowflake.kafka.connector.internal.streaming.IngestionMethodConfig;
+import com.snowflake.kafka.connector.internal.streaming.SnowflakeTelemetryServiceV2;
+import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryServiceV1;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -107,11 +111,21 @@ public class ConnectionServiceIT {
     Properties prop = InternalUtils.createProperties(TestUtils.getConf(), url.sslEnabled());
     String appName = TestUtils.TEST_CONNECTOR_NAME;
 
-    SnowflakeConnectionServiceFactory.builder()
-        .setProperties(prop)
-        .setURL(url)
-        .setConnectorName(appName)
-        .build();
+    service =
+        SnowflakeConnectionServiceFactory.builder()
+            .setProperties(prop)
+            .setURL(url)
+            .setConnectorName(appName)
+            .build();
+
+    assert service.getTelemetryClient() instanceof SnowflakeTelemetryServiceV1;
+
+    assert service
+        .getTelemetryClient()
+        .getObjectNode()
+        .get(SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT)
+        .toString()
+        .equals("0");
 
     assert TestUtils.assertError(
         SnowflakeErrors.ERROR_0003,
@@ -132,6 +146,29 @@ public class ConnectionServiceIT {
     assert TestUtils.assertError(
         SnowflakeErrors.ERROR_0003,
         () -> SnowflakeConnectionServiceFactory.builder().setURL(url).setProperties(prop).build());
+  }
+
+  @Test
+  public void createConnectionService_SnowpipeStreaming() {
+
+    Map<String, String> config = TestUtils.getConfForStreaming();
+    SnowflakeSinkConnectorConfig.setDefaultValues(config);
+
+    config.put(INGESTION_METHOD_OPT, IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
+
+    SnowflakeConnectionService service =
+        SnowflakeConnectionServiceFactory.builder().setProperties(config).build();
+
+    assert service.getConnectorName().equals(TestUtils.TEST_CONNECTOR_NAME);
+
+    assert service.getTelemetryClient() instanceof SnowflakeTelemetryServiceV2;
+
+    assert service
+        .getTelemetryClient()
+        .getObjectNode()
+        .get(SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT)
+        .toString()
+        .equals("1");
   }
 
   @After

--- a/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
@@ -35,6 +35,7 @@ import static com.snowflake.kafka.connector.Utils.SF_USER;
 import com.snowflake.client.jdbc.SnowflakeDriver;
 import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
 import com.snowflake.kafka.connector.Utils;
+import com.snowflake.kafka.connector.internal.streaming.IngestionMethodConfig;
 import com.snowflake.kafka.connector.internal.streaming.StreamingUtils;
 import com.snowflake.kafka.connector.records.SnowflakeJsonSchema;
 import com.snowflake.kafka.connector.records.SnowflakeRecordContent;
@@ -253,6 +254,9 @@ public class TestUtils {
     // On top of existing configurations, add
     configuration.put(Utils.SF_ROLE, getProfile(PROFILE_PATH).get(ROLE).asText());
     configuration.put(Utils.TASK_ID, "0");
+    configuration.put(
+        SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
+        IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
 
     return configuration;
   }
@@ -375,6 +379,10 @@ public class TestUtils {
   /** @return snowflake connection for test */
   public static SnowflakeConnectionService getConnectionService() {
     return SnowflakeConnectionServiceFactory.builder().setProperties(getConf()).build();
+  }
+
+  public static SnowflakeConnectionService getConnectionServiceForStreaming() {
+    return SnowflakeConnectionServiceFactory.builder().setProperties(getConfForStreaming()).build();
   }
 
   /**

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelIT.java
@@ -23,7 +23,7 @@ import org.junit.Test;
 
 public class TopicPartitionChannelIT {
 
-  private SnowflakeConnectionService conn = TestUtils.getConnectionService();
+  private SnowflakeConnectionService conn = TestUtils.getConnectionServiceForStreaming();
   private String testTableName;
 
   private static int PARTITION = 0, PARTITION_2 = 1;
@@ -202,6 +202,9 @@ public class TopicPartitionChannelIT {
         snowflakeSinkServiceV2.getTopicPartitionChannelFromCacheKey(testChannelName).get();
 
     Assert.assertNotNull(topicPartitionChannel);
+
+    Assert.assertTrue(
+        topicPartitionChannel.getTelemetryServiceV2() instanceof SnowflakeTelemetryServiceV2);
 
     // close channel
     topicPartitionChannel.closeChannel();


### PR DESCRIPTION
- Also add default ingestion method in all msg in telemetry. Using ordinal to save some bytes. 
- Sending fatal errors in TopicPartitionChannel. 
  - Not sending all channel reopen events since that data is already present in Snowflake EventLogger. 
