### PR TITLE
SNOW-774533 Fix DLQ bug, re-enable test

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
@@ -204,7 +204,7 @@ public class SnowflakeSinkTask extends SinkTask {
     enableRebalancing =
         Boolean.parseBoolean(parsedConfig.get(SnowflakeSinkConnectorConfig.REBALANCING));
 
-    KafkaRecordErrorReporter kafkaRecordErrorReporter = noOpKafkaRecordErrorReporter();
+    KafkaRecordErrorReporter kafkaRecordErrorReporter = createKafkaRecordErrorReporter();
 
     // default to snowpipe
     IngestionMethodConfig ingestionType = IngestionMethodConfig.SNOWPIPE;
@@ -450,6 +450,10 @@ public class SnowflakeSinkTask extends SinkTask {
               (record, error) -> {
                 try {
                   // Blocking this until record is delivered to DLQ
+                  DYNAMIC_LOGGER.debug(
+                      "Sending Sink Record to DLQ with recordOffset:{}, partition:{}",
+                      record.kafkaOffset(),
+                      record.kafkaPartition());
                   errantRecordReporter.report(record, error).get();
                 } catch (InterruptedException | ExecutionException e) {
                   final String errMsg = "ERROR reporting records to ErrantRecordReporter";
@@ -465,6 +469,8 @@ public class SnowflakeSinkTask extends SinkTask {
         this.DYNAMIC_LOGGER.info(
             "Kafka versions prior to 2.6 do not support the errant record reporter.");
       }
+    } else {
+      DYNAMIC_LOGGER.warn("SinkTaskContext is not set");
     }
     return result;
   }
@@ -491,6 +497,9 @@ public class SnowflakeSinkTask extends SinkTask {
    */
   @VisibleForTesting
   static KafkaRecordErrorReporter noOpKafkaRecordErrorReporter() {
-    return (record, e) -> {};
+    return (record, e) -> {
+      STATIC_LOGGER.warn(
+          "DLQ Kafka Record Error Reporter is not set, requires Kafka Version to be >= 2.6");
+    };
   }
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
@@ -642,7 +642,7 @@ public class TopicPartitionChannel {
       List<SinkRecord> insertedRecordsToBuffer) {
     if (logErrors) {
       for (InsertValidationResponse.InsertError insertError : insertErrors) {
-        LOGGER.error("Insert Row Error message", insertError.getException());
+        LOGGER.error("Insert Row Error message:{}", insertError.getException().getMessage());
       }
     }
     if (errorTolerance) {

--- a/test/test_suit/test_snowpipe_streaming_string_json_dlq.py
+++ b/test/test_suit/test_snowpipe_streaming_string_json_dlq.py
@@ -4,6 +4,10 @@ from test_suit.test_utils import RetryableError, NonRetryableError
 import json
 from time import sleep
 
+'''
+Testing this doesnt require a custom DLQ api to be invoked since this is happening at connect level. 
+i.e the bad message being to Kafka is not being serialized at Converter level. 
+'''
 class TestSnowpipeStreamingStringJsonDLQ:
     def __init__(self, driver, nameSalt):
         self.driver = driver

--- a/test/test_suites.py
+++ b/test/test_suites.py
@@ -1,6 +1,5 @@
 from collections import OrderedDict
 from test_suit.test_string_json import TestStringJson
-from test_suit.test_string_json_proxy import TestStringJsonProxy
 from test_suit.test_json_json import TestJsonJson
 from test_suit.test_string_avro import TestStringAvro
 from test_suit.test_avro_avro import TestAvroAvro
@@ -133,9 +132,8 @@ def create_end_to_end_test_suites(driver, nameSalt, schemaRegistryAddress, testS
         ("TestSchemaMapping", EndToEndTestSuite(
             test_instance=TestSchemaMapping(driver, nameSalt), clean=True, run_in_confluent=True,run_in_apache=True
         )),
-        # Disable failing test for Confluent and Apache because no data in DLQ, Re-enable SNOW-774533
         ("TestSnowpipeStreamingSchemaMappingDLQ", EndToEndTestSuite(
-            test_instance=TestSnowpipeStreamingSchemaMappingDLQ(driver, nameSalt), clean=True, run_in_confluent=False, run_in_apache=False
+            test_instance=TestSnowpipeStreamingSchemaMappingDLQ(driver, nameSalt), clean=True, run_in_confluent=True, run_in_apache=True
         )),
         ("TestAutoTableCreation", EndToEndTestSuite(
             test_instance=TestAutoTableCreation(driver, nameSalt, schemaRegistryAddress, testSet), clean=True, run_in_confluent=True, run_in_apache=False


### PR DESCRIPTION
- Well, well, well, guess DLQ was not working. (When we manually try to insert it from Kafka Connect)
- Works if serialization/deserialization issue. 
- Fixing the bug and re-enabling the test. 

- Was working un-expectedly because the test was disabled in the previous refactoring of confluent and apache runs. 
 - Now we know which tests are running and disabled/enabled. Less noise, less flaky. 