### PR TITLE
SNOW-774533 Enable Json & Proxy Test - Bug in setting up Confluent Tests

### DIFF
--- a/test/build_runtime_jar.sh
+++ b/test/build_runtime_jar.sh
@@ -103,16 +103,19 @@ popd
 SNOWFLAKE_PLUGIN_NAME=$(ls $SNOWFLAKE_PLUGIN_PATH | grep "$SNOWFLAKE_PLUGIN_NAME_REGEX" | head -n 1)
 echo -e "\nbuilt connector name: $SNOWFLAKE_PLUGIN_NAME"
 
-# copy built connector to plugin path
 mkdir -m 777 -p $KAFKA_CONNECT_PLUGIN_PATH || \
-sudo mkdir -m 777 -p $KAFKA_CONNECT_PLUGIN_PATH 
-cp $SNOWFLAKE_PLUGIN_PATH/$SNOWFLAKE_PLUGIN_NAME $KAFKA_CONNECT_PLUGIN_PATH || true
-echo -e "copied SF Plugin Connector to $KAFKA_CONNECT_PLUGIN_PATH"
+sudo mkdir -m 777 -p $KAFKA_CONNECT_PLUGIN_PATH
 
 if [[ $BUILD_FOR_RUNTIME == "confluent" ]]; then
+    # For confluent, copy the zip file and unzip it later
     echo "For confluent RUNTIME: Copying Kafka Connect Maven Generated Zip file to a temporary location"
     cp $SNOWFLAKE_PLUGIN_PATH/components/packages/snowflakeinc-snowflake-kafka-connector-*.zip /tmp/sf-kafka-connect-plugin.zip
     ls /tmp/sf-kafka-connect-plugin*
+else
+    # Apache Kafka
+    # Only copy built connector to plugin path
+    cp $SNOWFLAKE_PLUGIN_PATH/$SNOWFLAKE_PLUGIN_NAME $KAFKA_CONNECT_PLUGIN_PATH || true
+    echo -e "copied SF Plugin Connector to $KAFKA_CONNECT_PLUGIN_PATH"
 fi
 
 KAFKA_CONNECT_DOCKER_JAR_PATH="$SNOWFLAKE_CONNECTOR_PATH/docker-setup/snowflake-kafka-docker/jars"

--- a/test/test_suites.py
+++ b/test/test_suites.py
@@ -83,7 +83,7 @@ def create_end_to_end_test_suites(driver, nameSalt, schemaRegistryAddress, testS
     test_suites = OrderedDict([
         # Disable Failing tests only in confluent because of fips error, re-enable: SNOW-774533
         ("TestStringJson", EndToEndTestSuite(
-            test_instance=TestStringJson(driver, nameSalt), clean=True, run_in_confluent=False, run_in_apache=True
+            test_instance=TestStringJson(driver, nameSalt), clean=True, run_in_confluent=True, run_in_apache=True
         )),
         ("TestJsonJson", EndToEndTestSuite(
             test_instance=TestJsonJson(driver, nameSalt), clean=True, run_in_confluent=True, run_in_apache=True

--- a/test/test_suites.py
+++ b/test/test_suites.py
@@ -81,7 +81,6 @@ def create_end_to_end_test_suites(driver, nameSalt, schemaRegistryAddress, testS
     :return:
     '''
     test_suites = OrderedDict([
-        # Disable Failing tests only in confluent because of fips error, re-enable: SNOW-774533
         ("TestStringJson", EndToEndTestSuite(
             test_instance=TestStringJson(driver, nameSalt), clean=True, run_in_confluent=True, run_in_apache=True
         )),

--- a/test/test_verify.py
+++ b/test/test_verify.py
@@ -501,7 +501,7 @@ def runTestSet(driver, testSet, nameSalt, enable_stress_test):
             test_instance=TestStringJsonProxy(driver, nameSalt), clean=True, run_in_confluent=False, run_in_apache=False
         )]
 
-        proxy_suite_clean_enable_list = [single_end_to_end_test.clean for single_end_to_end_test in proxy_tests_suite]
+        proxy_suite_clean_enable_list = [single_end_to_end_test.test_instance for single_end_to_end_test in proxy_tests_suite]
 
         proxy_suite_runner = []
 

--- a/test/test_verify.py
+++ b/test/test_verify.py
@@ -492,16 +492,17 @@ def runTestSet(driver, testSet, nameSalt, enable_stress_test):
 
         from test_suit.test_string_json_proxy import TestStringJsonProxy
         from test_suites import EndToEndTestSuite
-        from collections import OrderedDict
 
         print(datetime.now().strftime("\n%H:%M:%S "), "=== Last Round: Proxy E2E Test ===")
         print("Proxy Test should be the last test, since it modifies the JVM values")
 
         proxy_tests_suite = [EndToEndTestSuite(
-            test_instance=TestStringJsonProxy(driver, nameSalt), clean=True, run_in_confluent=False, run_in_apache=False
+            test_instance=TestStringJsonProxy(driver, nameSalt), clean=True, run_in_confluent=True, run_in_apache=True
         )]
 
-        proxy_suite_clean_enable_list = [single_end_to_end_test.test_instance for single_end_to_end_test in proxy_tests_suite]
+        end_to_end_proxy_tests_suite = [single_end_to_end_test.test_instance for single_end_to_end_test in proxy_tests_suite]
+
+        proxy_suite_clean_enable_list = [single_end_to_end_test.clean for single_end_to_end_test in proxy_tests_suite]
 
         proxy_suite_runner = []
 
@@ -512,7 +513,7 @@ def runTestSet(driver, testSet, nameSalt, enable_stress_test):
         elif testSet != "clean":
             errorExit("Unknown testSet option {}, please input confluent, apache or clean".format(testSet))
 
-        execution(testSet, proxy_tests_suite, proxy_suite_clean_enable_list, proxy_suite_runner, driver, nameSalt)
+        execution(testSet, end_to_end_proxy_tests_suite, proxy_suite_clean_enable_list, proxy_suite_runner, driver, nameSalt)
         ############################ Proxy End To End Test End ############################
 
 


### PR DESCRIPTION
- Currently, the plugin path has Snowflake jar and zip built from confluent maven. For confluent runtime, we only need zip created by build_runtime_jar deployed to plugin path. (Unzipped)
- There is a fips exception caused by two different versions of fips identified by JVM since fips does sha256 on every fips associated jar available on classpath. 

Simply have different runtime jars deployed for apache kafka and confluent kafka. 
- Apache kafka will have plugin jar + fips installed from maven. 
- Confluent Kafka will have every needed jar in the zip file. (Try it out by downloading zip from confluent hub and checking lib directory)