### PR TITLE
SNOW-480523 Fix breaking change in upgrade to JDBC 3.13.25

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
@@ -162,6 +162,14 @@ class InternalUtils {
     // put values for optional parameters
     properties.put(JDBC_SESSION_KEEP_ALIVE, "true");
 
+    /**
+     * Behavior change in JDBC release 3.13.25
+     *
+     * @see <a href="https://community.snowflake.com/s/article/JDBC-Driver-Release-Notes">Snowflake
+     *     Documentation Release Notes </a>
+     */
+    properties.put(SFSessionProperty.ALLOW_UNDERSCORES_IN_HOST.getPropertyKey(), "true");
+
     // required parameter check
     if (!properties.containsKey(JDBC_PRIVATE_KEY)) {
       throw SnowflakeErrors.ERROR_0013.getException();


### PR DESCRIPTION
- No test, relying on JDBC tests. https://community.snowflake.com/s/article/JDBC-Driver-Release-Notes
- We will test later on our privatelink setup which is broken right now since qa3 is decomissioned. 