### PR TITLE
NO-SNOW Add caching layer for maven to speed up Github action

### DIFF
--- a/.github/workflows/End2EndTestApache.yml
+++ b/.github/workflows/End2EndTestApache.yml
@@ -21,6 +21,13 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
+    - name: "Cache local Maven repository"
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
     - name: Install Python
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/End2EndTestConfluent.yml
+++ b/.github/workflows/End2EndTestConfluent.yml
@@ -21,6 +21,13 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
+    - name: "Cache local Maven repository"
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom_confluent.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
     - name: Install Python
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -20,6 +20,13 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
+    - name: "Cache local Maven repository"
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
     - name: Install Python
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/PerfTest.yml
+++ b/.github/workflows/PerfTest.yml
@@ -14,6 +14,13 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
+    - name: "Cache local Maven repository"
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
     - name: Install Python
       uses: actions/setup-python@v1
       with:


### PR DESCRIPTION
- Readd this since this was not the bottleneck, bug was found in setup of the tests. 
- This will help speed up the runtime of github actions. 

You will start noticing cache uploaded to Actions tab in the repo. It is at a PR/branch level so you can always delete some caches if you feel this is the issue. 