### PR TITLE
[SNOW-726924] Add New jvm.nonProxy.hosts Parameter - Undo Revert 

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -78,6 +78,7 @@ public class SnowflakeSinkConnectorConfig {
   private static final String PROXY_INFO = "Proxy Info";
   public static final String JVM_PROXY_HOST = "jvm.proxy.host";
   public static final String JVM_PROXY_PORT = "jvm.proxy.port";
+  public static final String JVM_NON_PROXY_HOSTS = "jvm.nonProxy.hosts";
   public static final String JVM_PROXY_USERNAME = "jvm.proxy.username";
   public static final String JVM_PROXY_PASSWORD = "jvm.proxy.password";
 
@@ -311,13 +312,23 @@ public class SnowflakeSinkConnectorConfig {
             ConfigDef.Width.NONE,
             JVM_PROXY_PORT)
         .define(
+            JVM_NON_PROXY_HOSTS,
+            Type.STRING,
+            "",
+            Importance.LOW,
+            "JVM option: http.nonProxyHosts",
+            PROXY_INFO,
+            2,
+            ConfigDef.Width.NONE,
+            JVM_NON_PROXY_HOSTS)
+        .define(
             JVM_PROXY_USERNAME,
             Type.STRING,
             "",
             Importance.LOW,
             "JVM proxy username",
             PROXY_INFO,
-            2,
+            3,
             ConfigDef.Width.NONE,
             JVM_PROXY_USERNAME)
         .define(
@@ -327,7 +338,7 @@ public class SnowflakeSinkConnectorConfig {
             Importance.LOW,
             "JVM proxy password",
             PROXY_INFO,
-            3,
+            4,
             ConfigDef.Width.NONE,
             JVM_PROXY_PASSWORD)
         // Connector Config

--- a/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
@@ -210,6 +210,13 @@ class InternalUtils {
           SFSessionProperty.PROXY_PORT.getPropertyKey(),
           conf.get(SnowflakeSinkConnectorConfig.JVM_PROXY_PORT));
 
+      // nonProxyHosts parameter is not required. Check if it was set or not.
+      if (conf.get(SnowflakeSinkConnectorConfig.JVM_NON_PROXY_HOSTS) != null) {
+        proxyProperties.put(
+            SFSessionProperty.NON_PROXY_HOSTS.getPropertyKey(),
+            conf.get(SnowflakeSinkConnectorConfig.JVM_NON_PROXY_HOSTS));
+      }
+
       // For username and password, check if host and port are given.
       // If they are given, check if username and password are non null
       String username = conf.get(SnowflakeSinkConnectorConfig.JVM_PROXY_USERNAME);

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
@@ -3,6 +3,7 @@ package com.snowflake.kafka.connector;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_LOG_ENABLE_CONFIG;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_TOLERANCE_CONFIG;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.NAME;
+import static com.snowflake.kafka.connector.Utils.HTTP_NON_PROXY_HOSTS;
 import static com.snowflake.kafka.connector.internal.TestUtils.getConfig;
 import static org.junit.Assert.assertEquals;
 
@@ -15,6 +16,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class ConnectorConfigTest {
@@ -163,6 +165,33 @@ public class ConnectorConfigTest {
       Utils.validateConfig(config);
     } catch (SnowflakeKafkaConnectorException exception) {
       assert exception.getMessage().contains(SnowflakeSinkConnectorConfig.JVM_PROXY_PORT);
+    }
+  }
+
+  @Test
+  public void testNonProxyHosts() {
+    String oldNonProxyHosts =
+        (System.getProperty(HTTP_NON_PROXY_HOSTS) != null)
+            ? System.getProperty(HTTP_NON_PROXY_HOSTS)
+            : null;
+
+    System.setProperty(HTTP_NON_PROXY_HOSTS, "host1.com|host2.com|localhost");
+    Map<String, String> config = getConfig();
+    config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_HOST, "127.0.0.1");
+    config.put(SnowflakeSinkConnectorConfig.JVM_PROXY_PORT, "3128");
+    config.put(
+        SnowflakeSinkConnectorConfig.JVM_NON_PROXY_HOSTS,
+        "*.snowflakecomputing.com|*.amazonaws.com");
+    Utils.enableJVMProxy(config);
+    String mergedNonProxyHosts = System.getProperty(HTTP_NON_PROXY_HOSTS);
+    Assert.assertTrue(
+        mergedNonProxyHosts.equals(
+            "host1.com|host2.com|localhost|*.snowflakecomputing.com|*.amazonaws.com"));
+
+    if (oldNonProxyHosts != null) {
+      System.setProperty(HTTP_NON_PROXY_HOSTS, oldNonProxyHosts);
+    } else {
+      System.clearProperty(HTTP_NON_PROXY_HOSTS);
     }
   }
 


### PR DESCRIPTION
Readding #533 

The jvm.nonProxy.hosts parameter can be added to the connector's configuration file and is the equivalent to the JVM argument -Dhttp.nonProxyHosts. If a user provides that parameter and the connector runs in a JVM where -Dhttp.nonProxyHosts was set, then we will merge the two lists of hosts. In the future, we'll want another method of adding proxy configurations without resorting to System.setProperty() calls

- Jay - Rebasing master, picking 3.13.25 and other changes. 