### PR TITLE
Revert kafka put and precommit log message to info

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
@@ -406,11 +406,11 @@ public class SnowflakeSinkTask extends SinkTask {
           size,
           executionTime);
     } else {
-      this.DYNAMIC_LOGGER.debug(
+      this.DYNAMIC_LOGGER.info(
           "successfully called {} with {} records, execution time: {} seconds",
           apiName,
           size,
-          getExecutionTimeSec(startTime, System.currentTimeMillis()));
+          executionTime);
     }
   }
 

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
@@ -395,23 +395,22 @@ public class SnowflakeSinkTask extends SinkTask {
 
   void logWarningForPutAndPrecommit(long startTime, int size, String apiName) {
     long executionTimeMs = getDurationFromStartMs(startTime);
-    long executionTimeSec = executionTimeMs / 1000;
-    if (executionTimeSec > 300) {
+    if (executionTimeMs > 300000) {
       // This won't be frequently printed. It is vary rare to have execution greater than 300
       // seconds.
       // But having this warning helps customer to debug their Kafka Connect config.
       this.DYNAMIC_LOGGER.warn(
-          "{} {}. Time: {} milliseconds = {} seconds > 300 seconds. If there is"
+          "{} {}. Time: {} ms = {} seconds > 300 seconds. If there is"
               + " CommitFailedException in the log or there is duplicated records, refer to this"
               + " link for solution: "
               + "https://docs.snowflake.com/en/user-guide/kafka-connector-ts.html#resolving-specific-issues",
           apiName,
           size,
           executionTimeMs,
-          executionTimeSec);
+          executionTimeMs / 1000);
     } else {
       this.DYNAMIC_LOGGER.info(
-          "successfully called {} with {} records, execution time: {} milliseconds",
+          "successfully called {} with {} records, execution time: {} ms",
           apiName,
           size,
           executionTimeMs);

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
@@ -400,9 +400,8 @@ public class SnowflakeSinkTask extends SinkTask {
       // seconds.
       // But having this warning helps customer to debug their Kafka Connect config.
       this.DYNAMIC_LOGGER.warn(
-          "{} {}. Time: {} ms = {} seconds > 300 seconds. If there is"
-              + " CommitFailedException in the log or there is duplicated records, refer to this"
-              + " link for solution: "
+          "{} {}. Time: {} ms = {} seconds > 300 seconds. If there is CommitFailedException in the"
+              + " log or there is duplicated records, refer to this link for solution: "
               + "https://docs.snowflake.com/en/user-guide/kafka-connector-ts.html#resolving-specific-issues",
           apiName,
           size,

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
@@ -301,7 +301,8 @@ public class SnowflakeSinkTask extends SinkTask {
 
     getSink().insert(records);
 
-    logWarningForPutAndPrecommit(startTime, Utils.formatString("called PUT with {} records", recordSize));
+    logWarningForPutAndPrecommit(
+        startTime, Utils.formatString("called PUT with {} records", recordSize));
   }
 
   /**
@@ -345,7 +346,12 @@ public class SnowflakeSinkTask extends SinkTask {
       this.DYNAMIC_LOGGER.error("PreCommit error: {} ", e.getMessage());
     }
 
-    logWarningForPutAndPrecommit(startTime, Utils.formatString("called PRECOMMIT on all {} partitions, safe to commit {} partitions", offsets.size(), committedOffsets.size()));
+    logWarningForPutAndPrecommit(
+        startTime,
+        Utils.formatString(
+            "called PRECOMMIT on all {} partitions, safe to commit {} partitions",
+            offsets.size(),
+            committedOffsets.size()));
     return committedOffsets;
   }
 
@@ -396,15 +402,16 @@ public class SnowflakeSinkTask extends SinkTask {
 
   void logWarningForPutAndPrecommit(long startTime, String logContent) {
     final long executionTimeMs = getDurationFromStartMs(startTime);
-    String logExecutionContent = Utils.formatString("{}, executionTime: {} ms", logContent, executionTimeMs);
+    String logExecutionContent =
+        Utils.formatString("{}, executionTime: {} ms", logContent, executionTimeMs);
 
     if (executionTimeMs > 300000) {
       // This won't be frequently printed. It is vary rare to have execution greater than 300
       // seconds.
       // But having this warning helps customer to debug their Kafka Connect config.
       this.DYNAMIC_LOGGER.warn(
-          "{}. Expected call to be under {} ms. If there is CommitFailedException in the"
-              + " log or there is duplicated records, refer to this link for solution: "
+          "{}. Expected call to be under {} ms. If there is CommitFailedException in the log or"
+              + " there is duplicated records, refer to this link for solution: "
               + "https://docs.snowflake.com/en/user-guide/kafka-connector-ts.html#resolving-specific-issues",
           logExecutionContent,
           executionTimeMs);

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
@@ -401,8 +401,9 @@ public class SnowflakeSinkTask extends SinkTask {
       // seconds.
       // But having this warning helps customer to debug their Kafka Connect config.
       this.DYNAMIC_LOGGER.warn(
-          "{} {}. Time: {} milliseconds = {} seconds > 300 seconds. If there is CommitFailedException in the log or"
-              + " there is duplicated records, refer to this link for solution: "
+          "{} {}. Time: {} milliseconds = {} seconds > 300 seconds. If there is"
+              + " CommitFailedException in the log or there is duplicated records, refer to this"
+              + " link for solution: "
               + "https://docs.snowflake.com/en/user-guide/kafka-connector-ts.html#resolving-specific-issues",
           apiName,
           size,

--- a/src/test/java/com/snowflake/kafka/connector/SinkTaskIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/SinkTaskIT.java
@@ -188,8 +188,6 @@ public class SinkTaskIT {
 
     sinkTask.close(topicPartitions);
     sinkTask.stop();
-
-    sinkTask.logWarningForPutAndPrecommit(System.currentTimeMillis() - 400 * 1000, 1, "put");
   }
 
   @Test
@@ -217,7 +215,7 @@ public class SinkTaskIT {
     task1.start(task1Config);
 
     // verify task1 start logs
-    Mockito.verify(logger, Mockito.times(2)).debug(Mockito.contains("start"));
+    Mockito.verify(logger, Mockito.times(2)).info(Mockito.contains("start"));
 
     // open tasks
     ArrayList<TopicPartition> topicPartitions0 = new ArrayList<>();
@@ -229,7 +227,7 @@ public class SinkTaskIT {
     task1.open(topicPartitions1);
 
     // verify task1 open logs
-    Mockito.verify(logger, Mockito.times(1)).debug(Mockito.contains("open"));
+    Mockito.verify(logger, Mockito.times(1)).info(Mockito.contains("open"));
 
     // put regular data to tasks
     ArrayList<SinkRecord> records = new ArrayList<>();
@@ -255,7 +253,7 @@ public class SinkTaskIT {
     task1.put(records);
 
     // verify task1 put logs
-    Mockito.verify(logger, Mockito.times(1)).debug(Mockito.contains("put"));
+    Mockito.verify(logger, Mockito.times(1)).info(Mockito.contains("PUT"));
 
     // send broken data to task1
     String brokenJson = "{ broken json";
@@ -275,7 +273,7 @@ public class SinkTaskIT {
     task1.put(records);
 
     // verify task1 broken put logs, 4 bc in addition to last call
-    Mockito.verify(logger, Mockito.times(2)).debug(Mockito.contains("put"));
+    Mockito.verify(logger, Mockito.times(2)).info(Mockito.contains("PUT"));
 
     // commit offset
     Map<TopicPartition, OffsetAndMetadata> offsetMap0 = new HashMap<>();
@@ -287,20 +285,20 @@ public class SinkTaskIT {
     offsetMap1 = task1.preCommit(offsetMap1);
 
     // verify task1 precommit logs
-    Mockito.verify(logger, Mockito.times(1)).debug(Mockito.contains("precommit"));
+    Mockito.verify(logger, Mockito.times(1)).info(Mockito.contains("PRECOMMIT"));
 
     // close tasks
     task0.close(topicPartitions0);
     task1.close(topicPartitions1);
 
     // verify task1 close logs
-    Mockito.verify(logger, Mockito.times(1)).debug(Mockito.contains("closed"));
+    Mockito.verify(logger, Mockito.times(1)).info(Mockito.contains("closed"));
     // stop tasks
     task0.stop();
     task1.stop();
 
     // verify task1 stop logs
-    Mockito.verify(logger, Mockito.times(1)).debug(Mockito.contains("stop"));
+    Mockito.verify(logger, Mockito.times(1)).info(Mockito.contains("stop"));
 
     assert offsetMap1.get(topicPartitions0.get(0)).offset() == BUFFER_COUNT_RECORDS_DEFAULT;
     assert offsetMap0.get(topicPartitions1.get(0)).offset() == BUFFER_COUNT_RECORDS_DEFAULT;


### PR DESCRIPTION
Most SnowflakeSinkTask from debug to info for debugging purposes. Also update the precommit log to include the number of partitions instead of record count. Note that this may increase log size, however they are very nice to have for debugging.

Example log:
`[SF_KAFKA_CONNECTOR] Successfully called PUT with 10000 records, executionTime: 1643 ms`
`[SF_KAFKA_CONNECTOR] Successfully called PRECOMMIT on all 1 partitions, safe to commit 1 partitions, executionTime: 744 ms`