### PR TITLE
[Buffer Refactor 2/2] Add buffer flush reason to pull out duplicate buffer validation and flush code

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -45,20 +45,23 @@ public class SnowflakeSinkConnectorConfig {
 
   // Connector config
   private static final String CONNECTOR_CONFIG = "Connector Config";
-  public static final String BUFFER_COUNT_RECORDS = "buffer.count.records";
-  public static final long BUFFER_COUNT_RECORDS_DEFAULT = 10000;
-  public static final String BUFFER_SIZE_BYTES = "buffer.size.bytes";
-  public static final long BUFFER_SIZE_BYTES_DEFAULT = 5000000;
-  public static final long BUFFER_SIZE_BYTES_MIN = 1;
   static final String TOPICS_TABLES_MAP = "snowflake.topic2table.map";
 
   // For tombstone records
   public static final String BEHAVIOR_ON_NULL_VALUES_CONFIG = "behavior.on.null.values";
 
-  // Time in seconds
-  public static final long BUFFER_FLUSH_TIME_SEC_MIN = 10;
-  public static final long BUFFER_FLUSH_TIME_SEC_DEFAULT = 120;
+  // Buffer thresholds
   public static final String BUFFER_FLUSH_TIME_SEC = "buffer.flush.time";
+  public static final long BUFFER_FLUSH_TIME_SEC_DEFAULT = 120;
+  public static final long BUFFER_FLUSH_TIME_SEC_MIN = 10;
+
+  public static final String BUFFER_SIZE_BYTES = "buffer.size.bytes";
+  public static final long BUFFER_SIZE_BYTES_DEFAULT = 5000000;
+  public static final long BUFFER_SIZE_BYTES_MIN = 1;
+
+  public static final String BUFFER_COUNT_RECORDS = "buffer.count.records";
+  public static final long BUFFER_COUNT_RECORDS_DEFAULT = 10000;
+  public static final long BUFFER_COUNT_RECORDS_MIN = 1;
 
   // Snowflake connection and database config
   private static final String SNOWFLAKE_LOGIN_INFO = "Snowflake Login Info";

--- a/src/main/java/com/snowflake/kafka/connector/internal/BufferThreshold.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/BufferThreshold.java
@@ -52,6 +52,7 @@ public abstract class BufferThreshold {
 
   private final long SECOND_TO_MILLIS = TimeUnit.SECONDS.toMillis(1);
 
+  // ideally this would be in the streamingBuffer object, however java doesn't allow enums to be added to a protected inner class
   public enum FlushReason {
     NONE("NONE"),
     BUFFER_FLUSH_TIME(SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC),

--- a/src/main/java/com/snowflake/kafka/connector/internal/BufferThreshold.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/BufferThreshold.java
@@ -52,7 +52,8 @@ public abstract class BufferThreshold {
 
   private final long SECOND_TO_MILLIS = TimeUnit.SECONDS.toMillis(1);
 
-  // ideally this would be in the streamingBuffer object, however java doesn't allow enums to be added to a protected inner class
+  // ideally this would be in the streamingBuffer object, however java doesn't allow enums to be
+  // added to a protected inner class
   public enum FlushReason {
     NONE("NONE"),
     BUFFER_FLUSH_TIME(SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC),
@@ -134,9 +135,7 @@ public abstract class BufferThreshold {
         >= (this.bufferFlushTimeThreshold * SECOND_TO_MILLIS);
   }
 
-  /**
-   * Returns the buffer flush time threshold
-   */
+  /** Returns the buffer flush time threshold */
   public long getBufferFlushTimeThreshold() {
     return this.bufferFlushTimeThreshold;
   }

--- a/src/main/java/com/snowflake/kafka/connector/internal/BufferThreshold.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/BufferThreshold.java
@@ -135,6 +135,13 @@ public abstract class BufferThreshold {
   }
 
   /**
+   * Returns the buffer flush time threshold
+   */
+  public long getBufferFlushTimeThreshold() {
+    return this.bufferFlushTimeThreshold;
+  }
+
+  /**
    * Check if provided snowflake kafka connector buffer properties are within permissible values.
    *
    * <p>This method invokes three verifiers - Time based threshold, buffer size and buffer count

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -232,7 +232,7 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
     // check all partitions to see if they need to be flushed based on time
     for (TopicPartitionChannel partitionChannel : partitionsToChannel.values()) {
       // Time based flushing
-      partitionChannel.insertBufferedRecordsIfFlushTimeThresholdReached();
+      partitionChannel.tryFlushCurrentStreamingBuffer();
     }
   }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingBufferThreshold.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingBufferThreshold.java
@@ -1,6 +1,5 @@
 package com.snowflake.kafka.connector.internal.streaming;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.snowflake.kafka.connector.internal.BufferThreshold;
 
 /**

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingBufferThreshold.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingBufferThreshold.java
@@ -12,13 +12,13 @@ import com.snowflake.kafka.connector.internal.BufferThreshold;
  */
 public class StreamingBufferThreshold extends BufferThreshold {
   public StreamingBufferThreshold(
-      long flushTimeThresholdSeconds,
-      long bufferSizeThresholdBytes,
-      long bufferKafkaRecordCountThreshold) {
+      long bufferFlushTimeThreshold,
+      long bufferByteSizeThreshold,
+      long bufferRecordCountThreshold) {
     super(
         IngestionMethodConfig.SNOWPIPE_STREAMING,
-        flushTimeThresholdSeconds,
-        bufferSizeThresholdBytes,
-        bufferKafkaRecordCountThreshold);
+        bufferFlushTimeThreshold,
+        bufferByteSizeThreshold,
+        bufferRecordCountThreshold);
   }
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingBufferThreshold.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingBufferThreshold.java
@@ -1,5 +1,6 @@
 package com.snowflake.kafka.connector.internal.streaming;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.snowflake.kafka.connector.internal.BufferThreshold;
 
 /**

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
@@ -296,9 +296,9 @@ public class TopicPartitionChannel {
         this.streamingBuffer.insert(kafkaSinkRecord);
         this.processedOffset.set(kafkaSinkRecord.kafkaOffset());
         // # of records or size based flushing
-        if (this.streamingBufferThreshold.isFlushBufferedBytesBased(
+        if (this.streamingBufferThreshold.shouldFlushOnBufferByteSize(
                 streamingBuffer.getBufferSizeBytes())
-            || this.streamingBufferThreshold.isFlushBufferedRecordCountBased(
+            || this.streamingBufferThreshold.shouldFlushOnBufferRecordCount(
                 streamingBuffer.getNumOfRecords())) {
           copiedStreamingBuffer = streamingBuffer;
           this.streamingBuffer = new StreamingBuffer();
@@ -441,14 +441,14 @@ public class TopicPartitionChannel {
    * <p>Previous flush time here means last time we called insertRows API with rows present in
    */
   protected void insertBufferedRecordsIfFlushTimeThresholdReached() {
-    if (this.streamingBufferThreshold.isFlushTimeBased(this.previousFlushTimeStampMs)) {
+    if (this.streamingBufferThreshold.shouldFlushOnBufferTime(this.previousFlushTimeStampMs)) {
       LOGGER.debug(
           "Time based flush for channel:{}, CurrentTimeMs:{}, previousFlushTimeMs:{},"
               + " bufferThresholdSeconds:{}",
           this.getChannelName(),
           System.currentTimeMillis(),
           this.previousFlushTimeStampMs,
-          this.streamingBufferThreshold.getFlushTimeThresholdSeconds());
+          this.streamingBufferThreshold.getBufferFlushTimeThreshold());
       StreamingBuffer copiedStreamingBuffer;
       bufferLock.lock();
       try {

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
@@ -463,8 +463,19 @@ public class TopicPartitionChannel {
 //    }
 
   protected void tryGetFlushableStreamingBuffer(BufferThreshold.FlushReason flushReason, StreamingBuffer streamingBuffer) {
-    if (this.streamingBufferThreshold.shouldFlushBuffer(flushReason)) {
+    boolean shouldFlush;
 
+    switch (flushReason) {
+      case BUFFER_FLUSH_TIME:
+        shouldFlush = this.streamingBufferThreshold.shouldFlushOnBufferTime(this.previousFlushTimeStampMs);
+        break;
+      case BUFFER_BYTE_SIZE:
+        break;
+      case BUFFER_RECORD_COUNT:
+        break;
+      default:
+        // TODO default error
+        break;
     }
   }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
@@ -415,10 +415,12 @@ public class TopicPartitionChannel {
       if (this.streamingBufferThreshold.shouldFlushOnBufferTime(this.previousFlushTimeStampMs)) {
         shouldFlush = true;
         this.streamingBuffer.setFlushReason(BufferThreshold.FlushReason.BUFFER_FLUSH_TIME);
-      } else if (this.streamingBufferThreshold.shouldFlushOnBufferByteSize(streamingBuffer.getBufferSizeBytes())) {
+      } else if (this.streamingBufferThreshold.shouldFlushOnBufferByteSize(
+          streamingBuffer.getBufferSizeBytes())) {
         shouldFlush = true;
         this.streamingBuffer.setFlushReason(BufferThreshold.FlushReason.BUFFER_BYTE_SIZE);
-      } else if (this.streamingBufferThreshold.shouldFlushOnBufferRecordCount(streamingBuffer.getNumOfRecords())) {
+      } else if (this.streamingBufferThreshold.shouldFlushOnBufferRecordCount(
+          streamingBuffer.getNumOfRecords())) {
         shouldFlush = true;
         this.streamingBuffer.setFlushReason(BufferThreshold.FlushReason.BUFFER_RECORD_COUNT);
       }
@@ -429,7 +431,9 @@ public class TopicPartitionChannel {
         this.streamingBuffer = new StreamingBuffer();
 
         LOGGER.debug(
-            "Flushable buffer based on {} for channel:{}. previousFlushTime:{} currentBufferByteSize:{}, currentBufferRecordCount:{}, connectorBufferThresholds:{}",
+            "Flushable buffer based on {} for channel:{}. previousFlushTime:{}"
+                + " currentBufferByteSize:{}, currentBufferRecordCount:{},"
+                + " connectorBufferThresholds:{}",
             flushableStreamingBuffer.flushReason.toString(),
             this.getChannelName(),
             this.previousFlushTimeStampMs,

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
@@ -428,6 +428,45 @@ public class TopicPartitionChannel {
   }
 
   // --------------- BUFFER FLUSHING LOGIC --------------- //
+//   if (currentProcessedOffset == NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE
+//        || kafkaSinkRecord.kafkaOffset() >= currentProcessedOffset + 1) {
+//    StreamingBuffer copiedStreamingBuffer = null;
+//    bufferLock.lock();
+//    try {
+//      this.streamingBuffer.insert(kafkaSinkRecord);
+//      this.processedOffset.set(kafkaSinkRecord.kafkaOffset());
+
+//      // # of records or size based flushing
+//      if (this.streamingBufferThreshold.shouldFlushOnBufferByteSize(
+//          streamingBuffer.getBufferSizeBytes())
+//          || this.streamingBufferThreshold.shouldFlushOnBufferRecordCount(
+//          streamingBuffer.getNumOfRecords())) {
+//        copiedStreamingBuffer = streamingBuffer;
+//        this.streamingBuffer = new StreamingBuffer();
+//        LOGGER.debug(
+//            "Flush based on buffered bytes or buffered number of records for"
+//                + " channel:{},currentBufferSizeInBytes:{}, currentBufferedRecordCount:{},"
+//                + " connectorBufferThresholds:{}",
+//            this.getChannelName(),
+//            copiedStreamingBuffer.getBufferSizeBytes(),
+//            copiedStreamingBuffer.getSinkRecords().size(),
+//            this.streamingBufferThreshold);
+//      }
+//    } finally {
+//      bufferLock.unlock();
+//    }
+//
+//    // If we found reaching buffer size threshold or count based threshold, we will immediately
+//    // flush (Insert them)
+//    if (copiedStreamingBuffer != null) {
+//      insertBufferedRecords(copiedStreamingBuffer);
+//    }
+
+  protected void tryGetFlushableStreamingBuffer(BufferThreshold.FlushReason flushReason, StreamingBuffer streamingBuffer) {
+    if (this.streamingBufferThreshold.shouldFlushBuffer(flushReason)) {
+
+    }
+  }
 
   /**
    * If difference between current time and previous flush time is more than threshold, insert the
@@ -442,13 +481,13 @@ public class TopicPartitionChannel {
    */
   protected void insertBufferedRecordsIfFlushTimeThresholdReached() {
     if (this.streamingBufferThreshold.shouldFlushOnBufferTime(this.previousFlushTimeStampMs)) {
-      LOGGER.debug(
-          "Time based flush for channel:{}, CurrentTimeMs:{}, previousFlushTimeMs:{},"
-              + " bufferThresholdSeconds:{}",
-          this.getChannelName(),
-          System.currentTimeMillis(),
-          this.previousFlushTimeStampMs,
-          this.streamingBufferThreshold.getBufferFlushTimeThreshold());
+//      LOGGER.debug(
+//          "Time based flush for channel:{}, CurrentTimeMs:{}, previousFlushTimeMs:{},"
+//              + " bufferThresholdSeconds:{}",
+//          this.getChannelName(),
+//          System.currentTimeMillis(),
+//          this.previousFlushTimeStampMs,
+//          this.streamingBufferThreshold.getBufferFlushTimeThreshold());
       StreamingBuffer copiedStreamingBuffer;
       bufferLock.lock();
       try {

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
@@ -413,8 +413,7 @@ public class TopicPartitionChannel {
       // check if buffer can flush
       if (this.streamingBufferThreshold.shouldFlushOnBufferTime(this.previousFlushTimeStampMs)) {
         this.streamingBuffer.setFlushReason(BufferThreshold.FlushReason.BUFFER_FLUSH_TIME);
-      } else if (this.streamingBufferThreshold.shouldFlushOnBufferByteSize(
-          currBufferByteSize)) {
+      } else if (this.streamingBufferThreshold.shouldFlushOnBufferByteSize(currBufferByteSize)) {
         this.streamingBuffer.setFlushReason(BufferThreshold.FlushReason.BUFFER_BYTE_SIZE);
       } else if (this.streamingBufferThreshold.shouldFlushOnBufferRecordCount(
           currBufferRecordCount)) {

--- a/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
@@ -261,9 +261,14 @@ public class TestUtils {
         IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
 
     // set default buffer thresholds
-    configuration.put(SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC, String.valueOf(STREAMING_BUFFER_FLUSH_TIME_DEFAULT_SEC));
-    configuration.put(SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES, String.valueOf(BUFFER_SIZE_BYTES_DEFAULT));
-    configuration.put(SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS, String.valueOf(BUFFER_COUNT_RECORDS_DEFAULT));
+    configuration.put(
+        SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC,
+        String.valueOf(STREAMING_BUFFER_FLUSH_TIME_DEFAULT_SEC));
+    configuration.put(
+        SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES, String.valueOf(BUFFER_SIZE_BYTES_DEFAULT));
+    configuration.put(
+        SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS,
+        String.valueOf(BUFFER_COUNT_RECORDS_DEFAULT));
 
     return configuration;
   }
@@ -634,11 +639,8 @@ public class TestUtils {
     config.put(SF_SCHEMA, "testSchema");
     config.put(SF_DATABASE, "testDatabase");
     config.put(
-        SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS,
-        BUFFER_COUNT_RECORDS_DEFAULT + "");
-    config.put(
-        SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES,
-        BUFFER_SIZE_BYTES_DEFAULT + "");
+        SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS, BUFFER_COUNT_RECORDS_DEFAULT + "");
+    config.put(SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES, BUFFER_SIZE_BYTES_DEFAULT + "");
     config.put(
         SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC,
         SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC_DEFAULT + "");

--- a/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
@@ -16,6 +16,8 @@
  */
 package com.snowflake.kafka.connector.internal;
 
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS_DEFAULT;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES_DEFAULT;
 import static com.snowflake.kafka.connector.Utils.HTTPS_PROXY_HOST;
 import static com.snowflake.kafka.connector.Utils.HTTPS_PROXY_PASSWORD;
 import static com.snowflake.kafka.connector.Utils.HTTPS_PROXY_PORT;
@@ -30,6 +32,7 @@ import static com.snowflake.kafka.connector.Utils.SF_DATABASE;
 import static com.snowflake.kafka.connector.Utils.SF_SCHEMA;
 import static com.snowflake.kafka.connector.Utils.SF_URL;
 import static com.snowflake.kafka.connector.Utils.SF_USER;
+import static com.snowflake.kafka.connector.internal.streaming.StreamingUtils.STREAMING_BUFFER_FLUSH_TIME_DEFAULT_SEC;
 
 import com.snowflake.client.jdbc.SnowflakeDriver;
 import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
@@ -256,6 +259,11 @@ public class TestUtils {
     configuration.put(
         SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
         IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
+
+    // set default buffer thresholds
+    configuration.put(SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC, String.valueOf(STREAMING_BUFFER_FLUSH_TIME_DEFAULT_SEC));
+    configuration.put(SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES, String.valueOf(BUFFER_SIZE_BYTES_DEFAULT));
+    configuration.put(SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS, String.valueOf(BUFFER_COUNT_RECORDS_DEFAULT));
 
     return configuration;
   }
@@ -627,10 +635,10 @@ public class TestUtils {
     config.put(SF_DATABASE, "testDatabase");
     config.put(
         SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS,
-        SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS_DEFAULT + "");
+        BUFFER_COUNT_RECORDS_DEFAULT + "");
     config.put(
         SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES,
-        SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES_DEFAULT + "");
+        BUFFER_SIZE_BYTES_DEFAULT + "");
     config.put(
         SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC,
         SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC_DEFAULT + "");

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingBufferThresholdTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingBufferThresholdTest.java
@@ -13,13 +13,14 @@ public class StreamingBufferThresholdTest {
     BufferThreshold streamingBufferThreshold =
         new StreamingBufferThreshold(10, bytesThresholdForBuffer, 100);
 
-    Assert.assertTrue(streamingBufferThreshold.isFlushBufferedBytesBased(bytesThresholdForBuffer));
+    Assert.assertTrue(
+        streamingBufferThreshold.shouldFlushOnBufferByteSize(bytesThresholdForBuffer));
 
     Assert.assertTrue(
-        streamingBufferThreshold.isFlushBufferedBytesBased(bytesThresholdForBuffer + 1));
+        streamingBufferThreshold.shouldFlushOnBufferByteSize(bytesThresholdForBuffer + 1));
 
     Assert.assertFalse(
-        streamingBufferThreshold.isFlushBufferedBytesBased(bytesThresholdForBuffer - 1));
+        streamingBufferThreshold.shouldFlushOnBufferByteSize(bytesThresholdForBuffer - 1));
   }
 
   @Test
@@ -31,15 +32,15 @@ public class StreamingBufferThresholdTest {
         new StreamingBufferThreshold(10, 10_000, bufferThresholdRecordCount);
 
     Assert.assertTrue(
-        streamingBufferThreshold.isFlushBufferedRecordCountBased(bufferThresholdRecordCount));
+        streamingBufferThreshold.shouldFlushOnBufferRecordCount(bufferThresholdRecordCount));
 
     Assert.assertTrue(
-        streamingBufferThreshold.isFlushBufferedRecordCountBased(bufferThresholdRecordCount + 1));
+        streamingBufferThreshold.shouldFlushOnBufferRecordCount(bufferThresholdRecordCount + 1));
 
     Assert.assertFalse(
-        streamingBufferThreshold.isFlushBufferedRecordCountBased(bufferThresholdRecordCount - 1));
+        streamingBufferThreshold.shouldFlushOnBufferRecordCount(bufferThresholdRecordCount - 1));
 
-    Assert.assertFalse(streamingBufferThreshold.isFlushBufferedRecordCountBased(0));
+    Assert.assertFalse(streamingBufferThreshold.shouldFlushOnBufferRecordCount(0));
   }
 
   @Test
@@ -53,16 +54,16 @@ public class StreamingBufferThresholdTest {
     StreamingBufferThreshold streamingBufferThreshold =
         new StreamingBufferThreshold(flushTimeThresholdSeconds, 10_0000, 100);
 
-    Assert.assertTrue(streamingBufferThreshold.isFlushTimeBased(previousFlushTimeStampMs));
+    Assert.assertTrue(streamingBufferThreshold.shouldFlushOnBufferTime(previousFlushTimeStampMs));
 
     // setting flush time to right now..
     previousFlushTimeStampMs = System.currentTimeMillis();
 
-    Assert.assertFalse(streamingBufferThreshold.isFlushTimeBased(previousFlushTimeStampMs));
+    Assert.assertFalse(streamingBufferThreshold.shouldFlushOnBufferTime(previousFlushTimeStampMs));
 
     // Subtracting 10 seconds
     previousFlushTimeStampMs = System.currentTimeMillis() - (10 * 1000);
 
-    Assert.assertTrue(streamingBufferThreshold.isFlushTimeBased(previousFlushTimeStampMs));
+    Assert.assertTrue(streamingBufferThreshold.shouldFlushOnBufferTime(previousFlushTimeStampMs));
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingBufferThresholdTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingBufferThresholdTest.java
@@ -70,20 +70,33 @@ public class StreamingBufferThresholdTest {
   @Test
   public void testValidBufferThreshold() {
     Map<String, String> config = TestUtils.getConfForStreaming();
-    config.put(SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC, String.valueOf(STREAMING_BUFFER_FLUSH_TIME_DEFAULT_SEC));
-    config.put(SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES, String.valueOf(BUFFER_SIZE_BYTES_DEFAULT));
-    config.put(SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS, String.valueOf(BUFFER_COUNT_RECORDS_DEFAULT));
 
-    IngestionMethodConfig ingestionMethodConfig = IngestionMethodConfig.SNOWPIPE_STREAMING;
-
-    Map<String, String> invalidConfigs = StreamingBufferThreshold.validateBufferThreshold(config, ingestionMethodConfig);
+    // test for invalid configs
+    Map<String, String> invalidConfigs = StreamingBufferThreshold.validateBufferThreshold(config, IngestionMethodConfig.SNOWPIPE_STREAMING);
 
     // verify no invalid configs
     assert invalidConfigs.size() == 0;
   }
 
   @Test
-  public void testInvalidBufferThreshold() {
+  public void testInvalidBufferThresholds() {
+    String invalidFlushTime = "-1";
+    String invalidByteSize = "0.4";
+    String invalidRecordCount = "0";
 
+    this.testInvalidBufferThresholdRunner(SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC, invalidFlushTime, BufferThreshold.FlushReason.BUFFER_FLUSH_TIME.toString());
+    this.testInvalidBufferThresholdRunner(SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES, invalidFlushTime, BufferThreshold.FlushReason.BUFFER_BYTE_SIZE.toString());
+    this.testInvalidBufferThresholdRunner(SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS, invalidFlushTime, BufferThreshold.FlushReason.BUFFER_RECORD_COUNT.toString());
+  }
+
+  private void testInvalidBufferThresholdRunner(String configParam, String configVal, String invalidConfigParam) {
+    Map<String, String> config = TestUtils.getConfForStreaming();
+
+    // test invalid flush time
+    config.put(configParam, configVal);
+
+    Map<String, String> invalidConfigs = StreamingBufferThreshold.validateBufferThreshold(config, IngestionMethodConfig.SNOWPIPE_STREAMING);
+    assert invalidConfigs.size() == 1;
+    assert invalidConfigs.containsKey(invalidConfigParam);
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingBufferThresholdTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingBufferThresholdTest.java
@@ -3,15 +3,9 @@ package com.snowflake.kafka.connector.internal.streaming;
 import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
 import com.snowflake.kafka.connector.internal.BufferThreshold;
 import com.snowflake.kafka.connector.internal.TestUtils;
+import java.util.Map;
 import org.junit.Assert;
 import org.junit.Test;
-
-import java.nio.Buffer;
-import java.util.Map;
-
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS_DEFAULT;
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES_DEFAULT;
-import static com.snowflake.kafka.connector.internal.streaming.StreamingUtils.STREAMING_BUFFER_FLUSH_TIME_DEFAULT_SEC;
 
 public class StreamingBufferThresholdTest {
   @Test
@@ -72,7 +66,9 @@ public class StreamingBufferThresholdTest {
     Map<String, String> config = TestUtils.getConfForStreaming();
 
     // test for invalid configs
-    Map<String, String> invalidConfigs = StreamingBufferThreshold.validateBufferThreshold(config, IngestionMethodConfig.SNOWPIPE_STREAMING);
+    Map<String, String> invalidConfigs =
+        StreamingBufferThreshold.validateBufferThreshold(
+            config, IngestionMethodConfig.SNOWPIPE_STREAMING);
 
     // verify no invalid configs
     assert invalidConfigs.size() == 0;
@@ -84,18 +80,30 @@ public class StreamingBufferThresholdTest {
     String invalidByteSize = "0.4";
     String invalidRecordCount = "0";
 
-    this.testInvalidBufferThresholdRunner(SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC, invalidFlushTime, BufferThreshold.FlushReason.BUFFER_FLUSH_TIME.toString());
-    this.testInvalidBufferThresholdRunner(SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES, invalidFlushTime, BufferThreshold.FlushReason.BUFFER_BYTE_SIZE.toString());
-    this.testInvalidBufferThresholdRunner(SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS, invalidFlushTime, BufferThreshold.FlushReason.BUFFER_RECORD_COUNT.toString());
+    this.testInvalidBufferThresholdRunner(
+        SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC,
+        invalidFlushTime,
+        BufferThreshold.FlushReason.BUFFER_FLUSH_TIME.toString());
+    this.testInvalidBufferThresholdRunner(
+        SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES,
+        invalidFlushTime,
+        BufferThreshold.FlushReason.BUFFER_BYTE_SIZE.toString());
+    this.testInvalidBufferThresholdRunner(
+        SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS,
+        invalidFlushTime,
+        BufferThreshold.FlushReason.BUFFER_RECORD_COUNT.toString());
   }
 
-  private void testInvalidBufferThresholdRunner(String configParam, String configVal, String invalidConfigParam) {
+  private void testInvalidBufferThresholdRunner(
+      String configParam, String configVal, String invalidConfigParam) {
     Map<String, String> config = TestUtils.getConfForStreaming();
 
     // test invalid flush time
     config.put(configParam, configVal);
 
-    Map<String, String> invalidConfigs = StreamingBufferThreshold.validateBufferThreshold(config, IngestionMethodConfig.SNOWPIPE_STREAMING);
+    Map<String, String> invalidConfigs =
+        StreamingBufferThreshold.validateBufferThreshold(
+            config, IngestionMethodConfig.SNOWPIPE_STREAMING);
     assert invalidConfigs.size() == 1;
     assert invalidConfigs.containsKey(invalidConfigParam);
   }

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingBufferThresholdTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingBufferThresholdTest.java
@@ -1,13 +1,21 @@
 package com.snowflake.kafka.connector.internal.streaming;
 
+import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
 import com.snowflake.kafka.connector.internal.BufferThreshold;
+import com.snowflake.kafka.connector.internal.TestUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.nio.Buffer;
+import java.util.Map;
+
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS_DEFAULT;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES_DEFAULT;
+import static com.snowflake.kafka.connector.internal.streaming.StreamingUtils.STREAMING_BUFFER_FLUSH_TIME_DEFAULT_SEC;
+
 public class StreamingBufferThresholdTest {
   @Test
-  public void testFlushBufferedBytesBased() {
-
+  public void testShouldFlushOnBufferByteSize() {
     final long bytesThresholdForBuffer = 10_000;
 
     BufferThreshold streamingBufferThreshold =
@@ -15,17 +23,14 @@ public class StreamingBufferThresholdTest {
 
     Assert.assertTrue(
         streamingBufferThreshold.shouldFlushOnBufferByteSize(bytesThresholdForBuffer));
-
     Assert.assertTrue(
         streamingBufferThreshold.shouldFlushOnBufferByteSize(bytesThresholdForBuffer + 1));
-
     Assert.assertFalse(
         streamingBufferThreshold.shouldFlushOnBufferByteSize(bytesThresholdForBuffer - 1));
   }
 
   @Test
-  public void testFlushBufferedRecordCountBased() {
-
+  public void testShouldFlushOnBufferRecordCount() {
     final long bufferThresholdRecordCount = 100;
 
     StreamingBufferThreshold streamingBufferThreshold =
@@ -33,13 +38,10 @@ public class StreamingBufferThresholdTest {
 
     Assert.assertTrue(
         streamingBufferThreshold.shouldFlushOnBufferRecordCount(bufferThresholdRecordCount));
-
     Assert.assertTrue(
         streamingBufferThreshold.shouldFlushOnBufferRecordCount(bufferThresholdRecordCount + 1));
-
     Assert.assertFalse(
         streamingBufferThreshold.shouldFlushOnBufferRecordCount(bufferThresholdRecordCount - 1));
-
     Assert.assertFalse(streamingBufferThreshold.shouldFlushOnBufferRecordCount(0));
   }
 
@@ -58,12 +60,30 @@ public class StreamingBufferThresholdTest {
 
     // setting flush time to right now..
     previousFlushTimeStampMs = System.currentTimeMillis();
-
     Assert.assertFalse(streamingBufferThreshold.shouldFlushOnBufferTime(previousFlushTimeStampMs));
 
     // Subtracting 10 seconds
     previousFlushTimeStampMs = System.currentTimeMillis() - (10 * 1000);
-
     Assert.assertTrue(streamingBufferThreshold.shouldFlushOnBufferTime(previousFlushTimeStampMs));
+  }
+
+  @Test
+  public void testValidBufferThreshold() {
+    Map<String, String> config = TestUtils.getConfForStreaming();
+    config.put(SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC, String.valueOf(STREAMING_BUFFER_FLUSH_TIME_DEFAULT_SEC));
+    config.put(SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES, String.valueOf(BUFFER_SIZE_BYTES_DEFAULT));
+    config.put(SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS, String.valueOf(BUFFER_COUNT_RECORDS_DEFAULT));
+
+    IngestionMethodConfig ingestionMethodConfig = IngestionMethodConfig.SNOWPIPE_STREAMING;
+
+    Map<String, String> invalidConfigs = StreamingBufferThreshold.validateBufferThreshold(config, ingestionMethodConfig);
+
+    // verify no invalid configs
+    assert invalidConfigs.size() == 0;
+  }
+
+  @Test
+  public void testInvalidBufferThreshold() {
+
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelTest.java
@@ -502,7 +502,7 @@ public class TopicPartitionChannelTest {
       // Will wait for 10 seconds.
       Thread.sleep(bufferFlushTimeSeconds * 1000 + 10);
 
-      topicPartitionChannel.insertBufferedRecordsIfFlushTimeThresholdReached();
+      topicPartitionChannel.tryFlushCurrentStreamingBuffer();
 
       // Verify that the buffer is cleaned up and one record is in the DLQ
       Assert.assertTrue(topicPartitionChannel.isPartitionBufferEmpty());
@@ -752,7 +752,7 @@ public class TopicPartitionChannelTest {
     // Will wait for 10 seconds.
     Thread.sleep(bufferFlushTimeSeconds * 1000 + 10);
 
-    topicPartitionChannel.insertBufferedRecordsIfFlushTimeThresholdReached();
+    topicPartitionChannel.tryFlushCurrentStreamingBuffer();
 
     Assert.assertTrue(topicPartitionChannel.isPartitionBufferEmpty());
     Mockito.verify(mockStreamingChannel, Mockito.times(2))
@@ -798,7 +798,7 @@ public class TopicPartitionChannelTest {
     // reached. We are mimicking that call. Will wait for 10 seconds.
     Thread.sleep(bufferFlushTimeSeconds * 1000 + 10);
 
-    topicPartitionChannel.insertBufferedRecordsIfFlushTimeThresholdReached();
+    topicPartitionChannel.tryFlushCurrentStreamingBuffer();
 
     Assert.assertTrue(topicPartitionChannel.isPartitionBufferEmpty());
     Mockito.verify(mockStreamingChannel, Mockito.times(2))

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelTest.java
@@ -22,9 +22,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-
 import net.snowflake.ingest.streaming.InsertValidationResponse;
 import net.snowflake.ingest.streaming.OpenChannelRequest;
 import net.snowflake.ingest.streaming.SnowflakeStreamingIngestChannel;
@@ -726,33 +724,39 @@ public class TopicPartitionChannelTest {
 
     // flush thresholds to be hit
     long recordCount = 5;
-    long byteSize = recordCount * (this.enableSchematization ? JSON_BYTE_RATIO_SCHEMATIZATION : JSON_BYTE_RATIO);
+    long byteSize =
+        recordCount
+            * (this.enableSchematization ? JSON_BYTE_RATIO_SCHEMATIZATION : JSON_BYTE_RATIO);
     long flushTime = 5L;
     List<SinkRecord> records = createNativeJsonSinkRecords(0, recordCount, "test", 0);
 
     // test byte size flush
     this.testTryFlushValidStreamingBufferRunner(
-        new StreamingBufferThreshold(bufferFlushTimeThreshold, byteSize, bufferRecordCountThreshold),
+        new StreamingBufferThreshold(
+            bufferFlushTimeThreshold, byteSize, bufferRecordCountThreshold),
         records,
-        false
-    );
+        false);
 
     // test record count flush
     this.testTryFlushValidStreamingBufferRunner(
-        new StreamingBufferThreshold(bufferFlushTimeThreshold, bufferByteSizeThreshold, recordCount + 1),
+        new StreamingBufferThreshold(
+            bufferFlushTimeThreshold, bufferByteSizeThreshold, recordCount + 1),
         records,
-        false
-    );
+        false);
 
     // test time flush
     this.testTryFlushValidStreamingBufferRunner(
-        new StreamingBufferThreshold(flushTime, bufferByteSizeThreshold, bufferRecordCountThreshold),
+        new StreamingBufferThreshold(
+            flushTime, bufferByteSizeThreshold, bufferRecordCountThreshold),
         records,
-        true
-    );
+        true);
   }
 
-  private void testTryFlushValidStreamingBufferRunner(StreamingBufferThreshold streamingBufferThreshold, List<SinkRecord> records, boolean isTimeBasedFlush) throws Exception {
+  private void testTryFlushValidStreamingBufferRunner(
+      StreamingBufferThreshold streamingBufferThreshold,
+      List<SinkRecord> records,
+      boolean isTimeBasedFlush)
+      throws Exception {
     // mocks
     Mockito.when(
             mockStreamingChannel.insertRows(
@@ -769,8 +773,7 @@ public class TopicPartitionChannelTest {
             streamingBufferThreshold,
             sfConnectorConfig,
             mockKafkaRecordErrorReporter,
-            mockSinkTaskContext
-            );
+            mockSinkTaskContext);
 
     // should hit threshold on the last record or time flush
     records.forEach(topicPartitionChannel::insertRecordToBuffer);


### PR DESCRIPTION
Add a buffer flush reason enum to the buffer threshold. Ideally it would be in the streamingBuffer class, however Java doesn't allow for enums in protected inner classes. 

The flush reason allows us to refactor the buffer validate and the buffer flush logic into one call each and remove duplicate code.
