### PR TITLE
SNOW-826772 Unification of Snowflake role and user for Snowpipe Streaming

### DIFF
--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -136,7 +136,7 @@
                             </confluentControlCenterIntegration>
                             <singleMessageTransforms>false
                             </singleMessageTransforms>
-                            <supportedEncodings>UTF-8</supportedEncodings>
+                            <supportedEncodings>any</supportedEncodings>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
@@ -109,7 +109,7 @@ class InternalUtils {
 
   /**
    * Use this function if you want to create properties from user provided Snowflake kafka connector
-   * config.
+   * config. It assumes the caller wants to use this Property for Snowpipe based Kafka Connector.
    *
    * @param conf User provided kafka connector config
    * @param sslEnabled is sslEnabled?

--- a/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
@@ -108,10 +108,10 @@ class InternalUtils {
   }
 
   /**
-   * Use this function if you want to create properties from user provide Snowflake kafka connector
+   * Use this function if you want to create properties from user provided Snowflake kafka connector
    * config.
    *
-   * @param conf User provided kafka connector configu
+   * @param conf User provided kafka connector config
    * @param sslEnabled is sslEnabled?
    * @return Properties object which will be passed down to JDBC connection
    */
@@ -189,11 +189,11 @@ class InternalUtils {
     if (ingestionMethodConfig == IngestionMethodConfig.SNOWPIPE_STREAMING) {
       final String providedSFRoleInConfig = conf.get(Utils.SF_ROLE);
       if (!Strings.isNullOrEmpty(providedSFRoleInConfig)) {
-        LOGGER.debug("Using provided role {} for JDBC connection.", providedSFRoleInConfig);
+        LOGGER.info("Using provided role {} for JDBC connection.", providedSFRoleInConfig);
         properties.put(SFSessionProperty.ROLE, providedSFRoleInConfig);
       } else {
-        LOGGER.debug(
-            "No role is provided, default role for the user will be used for JDBC connection.");
+        LOGGER.info(
+            "Snowflake role is not provided, user's default role will be used for JDBC connection");
       }
     }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
@@ -20,7 +20,6 @@ import net.snowflake.client.core.SFSessionProperty;
 import net.snowflake.client.jdbc.internal.apache.commons.codec.binary.Base64;
 import net.snowflake.client.jdbc.internal.org.bouncycastle.jce.provider.BouncyCastleProvider;
 import net.snowflake.ingest.connection.IngestStatus;
-import org.graalvm.compiler.core.common.util.Util;
 
 class InternalUtils {
   // JDBC parameter list
@@ -108,6 +107,14 @@ class InternalUtils {
     return date;
   }
 
+  /**
+   * Use this function if you want to create properties from user provide Snowflake kafka connector
+   * config.
+   *
+   * @param conf User provided kafka connector configu
+   * @param sslEnabled is sslEnabled?
+   * @return Properties object which will be passed down to JDBC connection
+   */
   static Properties createProperties(Map<String, String> conf, boolean sslEnabled) {
     return createProperties(conf, sslEnabled, IngestionMethodConfig.SNOWPIPE);
   }
@@ -184,9 +191,9 @@ class InternalUtils {
       if (!Strings.isNullOrEmpty(providedSFRoleInConfig)) {
         LOGGER.debug("Using provided role {} for JDBC connection.", providedSFRoleInConfig);
         properties.put(SFSessionProperty.ROLE, providedSFRoleInConfig);
-      }
-      else {
-        LOGGER.debug("No role is provided, default role for the user will be used for JDBC connection.");
+      } else {
+        LOGGER.debug(
+            "No role is provided, default role for the user will be used for JDBC connection.");
       }
     }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceFactory.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceFactory.java
@@ -61,7 +61,6 @@ public class SnowflakeConnectionServiceFactory {
         throw SnowflakeErrors.ERROR_0017.getException();
       }
       this.url = new SnowflakeURL(conf.get(Utils.SF_URL));
-      this.prop = InternalUtils.createProperties(conf, this.url.sslEnabled());
       this.kafkaProvider =
           SnowflakeSinkConnectorConfig.KafkaProvider.of(conf.get(PROVIDER_CONFIG)).name();
       // TODO: Ideally only one property is required, but because we dont pass it around in JDBC and
@@ -72,6 +71,8 @@ public class SnowflakeConnectionServiceFactory {
       this.proxyProperties = InternalUtils.generateProxyParametersIfRequired(conf);
       this.connectorName = conf.get(Utils.NAME);
       this.ingestionMethodConfig = IngestionMethodConfig.determineIngestionMethod(conf);
+      this.prop =
+          InternalUtils.createProperties(conf, this.url.sslEnabled(), ingestionMethodConfig);
       return this;
     }
 

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2IT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2IT.java
@@ -42,7 +42,7 @@ import org.junit.Test;
 
 public class SnowflakeSinkServiceV2IT {
 
-  private SnowflakeConnectionService conn = TestUtils.getConnectionService();
+  private SnowflakeConnectionService conn = TestUtils.getConnectionServiceForStreaming();
   private String table = TestUtils.randomTableName();
   private int partition = 0;
   private int partition2 = 1;


### PR DESCRIPTION
- Here is what the connection object is used for: [Only for Snowpipe Streaming]
  - DB existence checker. 
  - Schema existence checker.
  - CreateTable
  - Alter table 


Do you need test for this change?
- Existing tests uses a user and a uses a default role. [Check profile.json]
  - Verifying existing tests passes is enough. 
  - ConnectionServiceIT is one test which verifies this code path. 
- It's not worth adding the another profile.json and modifying the existing tests to use a new user/role. 
- Manual tests: Ran a manual test in sfctest0 account with a new role and a new user. Also ran a test which revoked an insert privilege from this role and it resulted into channel open error. 


Can anything go wrong with this change?
- Yes, if the default role of the user has more privileges than the role supplied. The role being used for Snowpipe Streaming needs atleast an insert privilege. But most of the times, an insert priv is accompanied by usage priv as well.
  - We will be adding this change in a new 2.0.0 version of Kafka Connector, so this will be advertised/documented. 
  - Only affects Snowpipe Streaming.

