### PR TITLE
SNOW-811265 Do not close channel on rebalance

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -302,14 +302,15 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
   /**
    * This function is called during rebalance.
    *
-   * <p>All the channels are closed. The client is still active. Upon rebalance, (inside {@link
-   * com.snowflake.kafka.connector.SnowflakeSinkTask#open(Collection)} we will reopen the channel.
+   * <p>We don't close the channels. Upon rebalance, (inside {@link
+   * com.snowflake.kafka.connector.SnowflakeSinkTask#open(Collection)} we will reopen the channel
+   * anyways. [Check c'tor of {@link TopicPartitionChannel}]
    *
    * <p>We will wipe the cache partitionsToChannel so that in {@link
    * com.snowflake.kafka.connector.SnowflakeSinkTask#open(Collection)} we reinstantiate and fetch
    * offsetToken
    *
-   * @param partitions a list of topic partition
+   * @param partitions a list of topic partitions to close/shutdown
    */
   @Override
   public void close(Collection<TopicPartition> partitions) {
@@ -321,15 +322,16 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
               partitionsToChannel.get(partitionChannelKey);
           // Check for null since it's possible that the something goes wrong even before the
           // channels are created
-          if (topicPartitionChannel != null) {
-            topicPartitionChannel.closeChannel();
-          }
           LOGGER.info(
-              "Closing partitionChannel:{}, partition:{}, topic:{}",
+              "Removing partitionChannel:{}, partition:{}, topic:{} from map(partitionsToChannel)",
               topicPartitionChannel == null ? null : topicPartitionChannel.getChannelName(),
               topicPartition.topic(),
               topicPartition.partition());
         });
+    LOGGER.info(
+        "Closing {} partitions and Clearing partitionsToChannel Map of size:{}",
+        partitions.size(),
+        partitionsToChannel.size());
     partitionsToChannel.clear();
   }
 


### PR DESCRIPTION
Benefits:
- Performance improvement since we will not be waiting for channels to get closed. Currently, channel.close().get() is a blocking call. 
- We anyways reopen the channel during open partition. 
- I have seen significant improvements in closing of partitions in terms of latency. This will be visible when more partitions are assigned to a task. (Happens when customers uses a lot of topics in their connector)
- Less number of exceptions in close API call if previous call to insert rows resulted in failure. 


Tests:
- Existing tests are enough. 

Here are few examples of what we gain:
- Test setup: Create a single snowflake connector starting with one topic and 4 tasks. Keep on adding 10 datagen connector adding data to 10 topics and also modify the existing snowflake connector with the newly added topic. 
- In the end we will have 11 connectors - 10 Datagen and 1 SF connector with 10 topics. 

- As you can see from below image, partitions get reassigned when you add more topics (with 4 partitions each)
- The time taken to close the channel grows. 
- Removing the close call has no affect on behavior. 
- During open partitions, we reopen channel, fetch the offsetToken and reset a non-null offset to kafka. 


<img width="1487" alt="Screenshot 2023-06-23 at 10 12 25 AM" src="https://github.com/snowflakedb/snowflake-kafka-connector/assets/57274584/81c8dc75-6fe4-4a73-8fe3-1e72c306a82a">

<img width="1164" alt="Screenshot 2023-06-23 at 10 09 11 AM" src="https://github.com/snowflakedb/snowflake-kafka-connector/assets/57274584/096b440f-185d-4d22-822a-14c31b84e8f2">

