### PR TITLE
[SNOW-840882] Disable flakey streaming client test

### DIFF
--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientConcurrencyTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientConcurrencyTest.java
@@ -34,7 +34,9 @@ import net.snowflake.ingest.streaming.SnowflakeStreamingIngestClient;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.mockito.Mockito;
@@ -90,7 +92,8 @@ public class StreamingClientConcurrencyTest {
     }
   }
 
-  @Test
+  @Ignore
+  // SNOW-840882 flakey test
   public void testMultipleGetAndClose() throws Exception {
     // setup configs for 3 clients
     Map<String, String> clientConfig1 = new HashMap<>(this.clientConfig);

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientConcurrencyTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientConcurrencyTest.java
@@ -36,7 +36,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.jupiter.api.Disabled;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.mockito.Mockito;


### PR DESCRIPTION
testMultipleGetAndClose() passes locally however fails on aws and azure. Most likely some concurrency issue