### PR TITLE
no-snow update Google guava

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -434,7 +434,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>31.0.1-jre</version>
+            <version>32.0.1-jre</version>
         </dependency>
 
         <!-- https://github.com/failsafe-lib/failsafe-->

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -486,7 +486,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>31.0.1-jre</version>
+            <version>32.0.1-jre</version>
         </dependency>
 
         <!-- https://github.com/failsafe-lib/failsafe-->


### PR DESCRIPTION
- Update google guava for CVE: https://avd.aquasec.com/nvd/2023/cve-2023-2976/
- It says 32.0.1 is better suited than 32.0.0
- Also requested from confluent. 