### PR TITLE
[SNOW-843760] Upgrade bc-fips in response to CVE vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -289,7 +289,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-fips</artifactId>
-            <version>1.0.3</version>
+            <version>1.0.7</version>
             <scope>provided</scope>
         </dependency>
 

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -342,7 +342,7 @@
             <!-- This dependency won't be present in the kafka connect runtime, hence we are packaging this in an uber jar -->
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-fips</artifactId>
-            <version>1.0.3</version>
+            <version>1.0.7</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.apache.kafka/connect-api -->


### PR DESCRIPTION
There is no fix for the corresponding CVE vulnerability, however it is not exploitable as it only affects java 13+. Regardless lets update to the latest version. 

Note that our bcpkix-fips references bc-fips as a dependency. 
https://mvnrepository.com/artifact/org.bouncycastle/bc-fips/1.0.2.3