### PR TITLE
SNOW-811265 Not clearing entire map of partitionToChannel, only remove

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -19,10 +19,8 @@ import com.snowflake.kafka.connector.records.RecordService;
 import com.snowflake.kafka.connector.records.SnowflakeMetadataConfig;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import net.snowflake.ingest.streaming.SnowflakeStreamingIngestClient;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.sink.SinkRecord;
@@ -335,18 +333,11 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
               topicPartition.partition());
           partitionsToChannel.remove(partitionChannelKey);
         });
-    List<String> partitionsNotClosed =
-        partitionsToChannel.keySet().stream()
-            .filter(
-                key ->
-                    partitions.stream()
-                        .noneMatch(
-                            tp -> key.equals(partitionChannelKey(tp.topic(), tp.partition()))))
-            .collect(Collectors.toList());
     LOGGER.info(
-        "Closing {} partitions and remaining partitions which are not closed are:{}",
+        "Closing {} partitions and remaining partitions which are not closed are:{}, with size:{}",
         partitions.size(),
-        partitionsNotClosed.toString());
+        partitionsToChannel.keySet().toString(),
+        partitionsToChannel.size());
   }
 
   @Override


### PR DESCRIPTION
those which are part of close API

Added test with comments which fails in previous versions. 

TLDR:
- We have observed close API from kafka connect only closing certain partitions assigned to a task. 
- Until now, we clear entire map which can have data in its buffer. Even though we reopen the channel and reset offset in kafka, the in memory variables are advanced and if Kafka connect send those offsets again we ignore and skip adding it in buffer. 
- Clearing entire map also affects the put latency in which it reopens the channels. Kafka connect adheres to the contract that if a partition is closed, it will not send data for that partition, but since we are clearing entire map, we are not sticking to that protocol. 
- The IT test mimicks/mocks this behavior. 
- Here are the triggering points for this fix. (Closely look at partitions to close and map of partitionsToChannel)

![Screenshot 2023-08-09 at 10 54 55 AM](https://github.com/snowflakedb/snowflake-kafka-connector/assets/57274584/dfac828a-e24a-4222-9125-d12e0e0afecb)

