### PR TITLE
GH actions tests upgrade python from 3.6 to 3.9

### DIFF
--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -28,9 +28,9 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-maven-
     - name: Install Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
-        python-version: '3.6'
+        python-version: '3.9'
         architecture: 'x64'
     - name: Decrypt profile.json in Snowflake Cloud ${{ matrix.snowflake_cloud }}
       run: ./.github/scripts/decrypt_secret.sh ${{ matrix.snowflake_cloud }}

--- a/.github/workflows/PerfTest.yml
+++ b/.github/workflows/PerfTest.yml
@@ -22,9 +22,9 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-maven-
     - name: Install Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
-        python-version: '3.6'
+        python-version: '3.9'
         architecture: 'x64'
     - name: Decrypt snowflake.json
       run: ./.github/scripts/perf_test_decrypt_secret.sh


### PR DESCRIPTION
Python 3.6 is end of life and causing integration test github action runs to fail. Upgrade to 3.9 (similar to other [tests](https://github.com/search?q=repo%3Asnowflakedb%2Fsnowflake-kafka-connector%20setup-python&type=code))