### PR TITLE
Use .equals() to compare schemas

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/records/RecordService.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/RecordService.java
@@ -523,7 +523,7 @@ public class RecordService {
         case STRUCT:
           {
             Struct struct = (Struct) value;
-            if (struct.schema() != schema)
+            if (!struct.schema().equals(schema))
               throw SnowflakeErrors.ERROR_5015.getException("Mismatching schema.");
             ObjectNode obj = JsonNodeFactory.instance.objectNode();
             for (Field field : schema.fields()) {


### PR DESCRIPTION
If SMT clones the schema of the object for any reason, it does not have the same "hash" as original schema but structurally it's the same. Using `!.equals()` instead of `!=` will allow SMTs to properly clone the schemas.