### PR TITLE
[SNOW-934984] Update Avro version for security vulnerability

### DIFF
--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -398,7 +398,7 @@
         <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
-            <version>1.11.1</version>
+            <version>1.11.3</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>

--- a/src/test/java/com/snowflake/kafka/connector/internal/TombstoneRecordIngestionIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/TombstoneRecordIngestionIT.java
@@ -214,8 +214,8 @@ public class TombstoneRecordIngestionIT {
         this.behavior == SnowflakeSinkConnectorConfig.BehaviorOnNullValues.DEFAULT
             ? sinkRecords.size()
             : 1;
-    TestUtils.assertWithRetry(() -> TestUtils.tableSize(table) == expectedOffset, 10, 5);
+    TestUtils.assertWithRetry(() -> TestUtils.tableSize(table) == expectedOffset, 10, 20);
     TestUtils.assertWithRetry(
-        () -> service.getOffset(new TopicPartition(topic, partition)) == expectedOffset, 10, 5);
+        () -> service.getOffset(new TopicPartition(topic, partition)) == expectedOffset, 10, 20);
   }
 }

--- a/test/perf_test/pom.xml
+++ b/test/perf_test/pom.xml
@@ -54,7 +54,7 @@
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
-      <version>1.11.1</version>
+      <version>1.11.3</version>
     </dependency>
   </dependencies>
 
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.avro</groupId>
         <artifactId>avro-maven-plugin</artifactId>
-        <version>1.11.1</version>
+        <version>1.11.3</version>
         <executions>
           <execution>
             <phase>generate-sources</phase>


### PR DESCRIPTION
Received email about https://nvd.nist.gov/vuln/detail/CVE-2023-39410 so update our pom.xml accordingly

Snyk [updated our main pom](https://github.com/snowflakedb/snowflake-kafka-connector/commit/3021c2b1ccd315c0b59aa40fb7d3821c7fcc299a), but not our confluent or perf test pom. Will follow up to see if we can get snyk to scan all the poms