### PR TITLE
Fix array of objects serialization

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/records/RecordService.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/RecordService.java
@@ -287,14 +287,7 @@ public class RecordService {
       String columnName = columnNames.next();
       JsonNode columnNode = node.get(columnName);
       Object columnValue;
-      if (columnNode.isArray()) {
-        List<String> itemList = new ArrayList<>();
-        ArrayNode arrayNode = (ArrayNode) columnNode;
-        for (JsonNode e : arrayNode) {
-          itemList.add(e.isTextual() ? e.textValue() : MAPPER.writeValueAsString(e));
-        }
-        columnValue = itemList;
-      } else if (columnNode.isTextual()) {
+      if (columnNode.isTextual()) {
         columnValue = columnNode.textValue();
       } else if (columnNode.isNull()) {
         columnValue = null;

--- a/src/test/java/com/snowflake/kafka/connector/records/RecordContentTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/records/RecordContentTest.java
@@ -259,6 +259,24 @@ public class RecordContentTest {
   }
 
   @Test
+  public void testSchematizationArrayOfObject() throws JsonProcessingException {
+    RecordService service = new RecordService();
+    SnowflakeJsonConverter jsonConverter = new SnowflakeJsonConverter();
+
+    service.setEnableSchematization(true);
+    String value = "{\"players\":[{\"name\":\"John Doe\",\"age\":30},{\"name\":\"Jane Doe\",\"age\":30}]}";
+    byte[] valueContents = (value).getBytes(StandardCharsets.UTF_8);
+    SchemaAndValue sv = jsonConverter.toConnectData(topic, valueContents);
+
+    SinkRecord record =
+            new SinkRecord(
+                    topic, partition, Schema.STRING_SCHEMA, "string", sv.schema(), sv.value(), partition);
+
+    Map<String, Object> got = service.getProcessedRecordForStreamingIngest(record);
+    assert got.get("\"PLAYERS\"").equals("[{\"name\":\"John Doe\",\"age\":30},{\"name\":\"Jane Doe\",\"age\":30}]");
+  }
+
+  @Test
   public void testColumnNameFormatting() throws JsonProcessingException {
     RecordService service = new RecordService();
     SnowflakeJsonConverter jsonConverter = new SnowflakeJsonConverter();


### PR DESCRIPTION
Currently, array of structs/objects are being written as an array of stringified json objects.

Here's a quick comparison:
Expected value in ARRAY column:
```json
[
  null,
  {
    "xCategory": null,
    "xEntityId": null,
    "xEntityName": null,
    "xId": "89asda9s0a"
  }
]
```

Actual value:
```json
[
  "null",
  "{\"xCategory\":null,\"xEntityId\":null,\"xId\":\"89asda9s0a\",\"xEntityName\":null}"
]
```


 I think it's happening because those objects/structs are getting serialized twice. A simple fix here would be to serialize an entire ArrayNode as is instead of creating a `List<String>` out of it. This way, the value (Stringified array) is a valid JSON that is accepted by `net.snowflake.ingest.streaming.SnowflakeStreamingIngestChannel.insertRow()`

Issue: https://github.com/snowflakedb/snowflake-kafka-connector/issues/724 