### PR TITLE
PROD-39429 Add parameter for connector name in channel name:

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -168,6 +168,18 @@ public class SnowflakeSinkConnectorConfig {
       "Whether to optimize the streaming client to reduce cost. Note that this may affect"
           + " throughput or latency and can only be set if Streaming Snowpipe is enabled";
 
+  public static final String ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME =
+      "enable.connector_name.in.streaming_channel_name";
+  public static final boolean ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME_DEFAULT = false;
+
+  public static final String ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME_DISPLAY =
+      "Enable Connector Name in Snowpipe Streaming Channel Name";
+
+  public static final String ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME_DOC =
+      "Whether to use connector name in streaming channels. If it is set to false, we will not use"
+          + " connector name in channel name. Note: Please use this config cautiously and it is not"
+          + " advised to use this if you are coming from old Snowflake Kafka Connector Version. ";
+
   // MDC logging header
   public static final String ENABLE_MDC_LOGGING_CONFIG = "enable.mdc.logging";
   public static final String ENABLE_MDC_LOGGING_DISPLAY = "Enable MDC logging";
@@ -591,7 +603,17 @@ public class SnowflakeSinkConnectorConfig {
             CONNECTOR_CONFIG,
             8,
             ConfigDef.Width.NONE,
-            ENABLE_MDC_LOGGING_DISPLAY);
+            ENABLE_MDC_LOGGING_DISPLAY)
+        .define(
+            ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME,
+            Type.BOOLEAN,
+            ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME_DEFAULT,
+            Importance.LOW,
+            ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME_DOC,
+            CONNECTOR_CONFIG,
+            9,
+            ConfigDef.Width.NONE,
+            ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME_DISPLAY);
   }
 
   public static class TopicToTableValidator implements ConfigDef.Validator {

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -168,17 +168,19 @@ public class SnowflakeSinkConnectorConfig {
       "Whether to optimize the streaming client to reduce cost. Note that this may affect"
           + " throughput or latency and can only be set if Streaming Snowpipe is enabled";
 
-  public static final String ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME =
-      "enable.connector_name.in.streaming_channel_name";
-  public static final boolean ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME_DEFAULT = false;
+  public static final String SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2 =
+      "snowflake.enable.streaming.channel.format.v2";
+  public static final boolean SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2_DEFAULT = false;
 
-  public static final String ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME_DISPLAY =
-      "Enable Connector Name in Snowpipe Streaming Channel Name";
+  public static final String SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2_DISPLAY =
+      "Enable Connector Name in Snowpipe Streaming Channel Name - V2 of Channel Name";
 
-  public static final String ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME_DOC =
+  public static final String SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2_DOC =
       "Whether to use connector name in streaming channels. If it is set to false, we will not use"
-          + " connector name in channel name. Note: Please use this config cautiously and it is not"
-          + " advised to use this if you are coming from old Snowflake Kafka Connector Version. ";
+          + " connector name in channel name(Which is version 2 of Channel Name). Note: Please use"
+          + " this config cautiously and it is not advised to use this if you are coming from old"
+          + " Snowflake Kafka Connector Version where Default Channel Name doesnt contain Connector"
+          + " Name, contains Topic Name and Partition # only.";
 
   // MDC logging header
   public static final String ENABLE_MDC_LOGGING_CONFIG = "enable.mdc.logging";
@@ -605,15 +607,15 @@ public class SnowflakeSinkConnectorConfig {
             ConfigDef.Width.NONE,
             ENABLE_MDC_LOGGING_DISPLAY)
         .define(
-            ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME,
+            SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2,
             Type.BOOLEAN,
-            ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME_DEFAULT,
+            SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2_DEFAULT,
             Importance.LOW,
-            ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME_DOC,
+            SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2_DOC,
             CONNECTOR_CONFIG,
             9,
             ConfigDef.Width.NONE,
-            ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME_DISPLAY);
+            SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2_DISPLAY);
   }
 
   public static class TopicToTableValidator implements ConfigDef.Validator {

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -168,19 +168,19 @@ public class SnowflakeSinkConnectorConfig {
       "Whether to optimize the streaming client to reduce cost. Note that this may affect"
           + " throughput or latency and can only be set if Streaming Snowpipe is enabled";
 
-  public static final String SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2 =
-      "snowflake.enable.streaming.channel.format.v2";
-  public static final boolean SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2_DEFAULT = false;
+  public static final String SNOWFLAKE_ENABLE_NEW_CHANNEL_NAME_FORMAT =
+      "snowflake.enable.new.channel.name.format";
+  public static final boolean SNOWFLAKE_ENABLE_NEW_CHANNEL_NAME_FORMAT_DEFAULT = false;
 
-  public static final String SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2_DISPLAY =
-      "Enable Connector Name in Snowpipe Streaming Channel Name - V2 of Channel Name";
+  public static final String SNOWFLAKE_ENABLE_NEW_CHANNEL_NAME_FORMAT_DISPLAY =
+      "Enable Connector Name in Snowpipe Streaming Channel Name";
 
-  public static final String SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2_DOC =
+  public static final String SNOWFLAKE_ENABLE_NEW_CHANNEL_NAME_FORMAT_DOC =
       "Whether to use connector name in streaming channels. If it is set to false, we will not use"
-          + " connector name in channel name(Which is version 2 of Channel Name). Note: Please use"
-          + " this config cautiously and it is not advised to use this if you are coming from old"
-          + " Snowflake Kafka Connector Version where Default Channel Name doesnt contain Connector"
-          + " Name, contains Topic Name and Partition # only.";
+          + " connector name in channel name(Which is new version of Channel Name). Note: Please"
+          + " use this config cautiously and it is not advised to use this if you are coming from"
+          + " old Snowflake Kafka Connector Version where Default Channel Name doesnt contain"
+          + " Connector Name, contains Topic Name and Partition # only.";
 
   // MDC logging header
   public static final String ENABLE_MDC_LOGGING_CONFIG = "enable.mdc.logging";
@@ -607,15 +607,15 @@ public class SnowflakeSinkConnectorConfig {
             ConfigDef.Width.NONE,
             ENABLE_MDC_LOGGING_DISPLAY)
         .define(
-            SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2,
+            SNOWFLAKE_ENABLE_NEW_CHANNEL_NAME_FORMAT,
             Type.BOOLEAN,
-            SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2_DEFAULT,
+            SNOWFLAKE_ENABLE_NEW_CHANNEL_NAME_FORMAT_DEFAULT,
             Importance.LOW,
-            SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2_DOC,
+            SNOWFLAKE_ENABLE_NEW_CHANNEL_NAME_FORMAT_DOC,
             CONNECTOR_CONFIG,
             9,
             ConfigDef.Width.NONE,
-            SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2_DISPLAY);
+            SNOWFLAKE_ENABLE_NEW_CHANNEL_NAME_FORMAT_DISPLAY);
   }
 
   public static class TopicToTableValidator implements ConfigDef.Validator {

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -1,8 +1,8 @@
 package com.snowflake.kafka.connector.internal.streaming;
 
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES_DEFAULT;
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2;
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2_DEFAULT;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWFLAKE_ENABLE_NEW_CHANNEL_NAME_FORMAT;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWFLAKE_ENABLE_NEW_CHANNEL_NAME_FORMAT_DEFAULT;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWFLAKE_ROLE;
 import static com.snowflake.kafka.connector.internal.streaming.StreamingUtils.STREAMING_BUFFER_COUNT_RECORDS_DEFAULT;
 import static com.snowflake.kafka.connector.internal.streaming.StreamingUtils.STREAMING_BUFFER_FLUSH_TIME_DEFAULT_SEC;
@@ -94,7 +94,7 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
   private boolean enableSchematization;
 
   /**
-   * Key is formulated in {@link #partitionChannelKey(String, String, int)} }
+   * Key is formulated in {@link #partitionChannelKey(String, String, int, boolean)}
    *
    * <p>value is the Streaming Ingest Channel implementation (Wrapped around TopicPartitionChannel)
    */
@@ -103,8 +103,10 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
   // Cache for schema evolution
   private final Map<String, Boolean> tableName2SchemaEvolutionPermission;
 
-  // This is the V2 of channel Name creation. (This corresponds to the config
-  // SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2)
+  /**
+   * This is the new format for channel Names. (This corresponds to the config {@link
+   * SnowflakeSinkConnectorConfig#SNOWFLAKE_ENABLE_NEW_CHANNEL_NAME_FORMAT} )
+   */
   private final boolean shouldUseConnectorNameInChannelName;
 
   public SnowflakeSinkServiceV2(
@@ -147,8 +149,8 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
     this.shouldUseConnectorNameInChannelName =
         Boolean.parseBoolean(
             connectorConfig.getOrDefault(
-                SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2,
-                String.valueOf(SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2_DEFAULT)));
+                SNOWFLAKE_ENABLE_NEW_CHANNEL_NAME_FORMAT,
+                String.valueOf(SNOWFLAKE_ENABLE_NEW_CHANNEL_NAME_FORMAT_DEFAULT)));
   }
 
   @VisibleForTesting
@@ -197,8 +199,8 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
     this.shouldUseConnectorNameInChannelName =
         Boolean.parseBoolean(
             connectorConfig.getOrDefault(
-                SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2,
-                String.valueOf(SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2_DEFAULT)));
+                SNOWFLAKE_ENABLE_NEW_CHANNEL_NAME_FORMAT,
+                String.valueOf(SNOWFLAKE_ENABLE_NEW_CHANNEL_NAME_FORMAT_DEFAULT)));
   }
 
   /**

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -558,7 +558,8 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
    *     or PROD)
    * @param topic topic name
    * @param partition partition number
-   * @param shouldUseConnectorNameInChannelName If true, use connectorName, else not
+   * @param shouldUseConnectorNameInChannelName If true, use connectorName, else not. This is the
+   *     new format for channel Name.
    * @return combinartion of topic and partition
    */
   @VisibleForTesting
@@ -567,11 +568,9 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
       String topic,
       int partition,
       final boolean shouldUseConnectorNameInChannelName) {
-    if (shouldUseConnectorNameInChannelName) {
-      return connectorName + "_" + topic + "_" + partition;
-    } else {
-      return topic + "_" + partition;
-    }
+    return shouldUseConnectorNameInChannelName
+        ? connectorName + "_" + topic + "_" + partition
+        : topic + "_" + partition;
   }
 
   /* Used for testing */

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -1,6 +1,8 @@
 package com.snowflake.kafka.connector.internal.streaming;
 
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES_DEFAULT;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME_DEFAULT;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWFLAKE_ROLE;
 import static com.snowflake.kafka.connector.internal.streaming.StreamingUtils.STREAMING_BUFFER_COUNT_RECORDS_DEFAULT;
 import static com.snowflake.kafka.connector.internal.streaming.StreamingUtils.STREAMING_BUFFER_FLUSH_TIME_DEFAULT_SEC;
@@ -101,6 +103,9 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
   // Cache for schema evolution
   private final Map<String, Boolean> tableName2SchemaEvolutionPermission;
 
+  // Used to create a channel name.
+  private final boolean shouldUseConnectorNameInChannelName;
+
   public SnowflakeSinkServiceV2(
       SnowflakeConnectionService conn, Map<String, String> connectorConfig) {
     if (conn == null || conn.isClosed()) {
@@ -138,6 +143,11 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
             ? "default_connector"
             : this.conn.getConnectorName();
     this.metricsJmxReporter = new MetricsJmxReporter(new MetricRegistry(), connectorName);
+    this.shouldUseConnectorNameInChannelName =
+        Boolean.parseBoolean(
+            connectorConfig.getOrDefault(
+                ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME,
+                String.valueOf(ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME_DEFAULT)));
   }
 
   @VisibleForTesting
@@ -183,6 +193,11 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
             populateSchemaEvolutionPermissions(tableName);
           });
     }
+    this.shouldUseConnectorNameInChannelName =
+        Boolean.parseBoolean(
+            connectorConfig.getOrDefault(
+                ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME,
+                String.valueOf(ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME_DEFAULT)));
   }
 
   /**
@@ -236,7 +251,10 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
       boolean hasSchemaEvolutionPermission) {
     final String partitionChannelKey =
         partitionChannelKey(
-            conn.getConnectorName(), topicPartition.topic(), topicPartition.partition());
+            conn.getConnectorName(),
+            topicPartition.topic(),
+            topicPartition.partition(),
+            this.shouldUseConnectorNameInChannelName);
     // Create new instance of TopicPartitionChannel which will always open the channel.
     partitionsToChannel.put(
         partitionChannelKey,
@@ -296,7 +314,11 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
   @Override
   public void insert(SinkRecord record) {
     String partitionChannelKey =
-        partitionChannelKey(this.conn.getConnectorName(), record.topic(), record.kafkaPartition());
+        partitionChannelKey(
+            this.conn.getConnectorName(),
+            record.topic(),
+            record.kafkaPartition(),
+            this.shouldUseConnectorNameInChannelName);
     // init a new topic partition if it's not presented in cache or if channel is closed
     if (!partitionsToChannel.containsKey(partitionChannelKey)
         || partitionsToChannel.get(partitionChannelKey).isChannelClosed()) {
@@ -317,7 +339,10 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
   public long getOffset(TopicPartition topicPartition) {
     String partitionChannelKey =
         partitionChannelKey(
-            conn.getConnectorName(), topicPartition.topic(), topicPartition.partition());
+            conn.getConnectorName(),
+            topicPartition.topic(),
+            topicPartition.partition(),
+            this.shouldUseConnectorNameInChannelName);
     if (partitionsToChannel.containsKey(partitionChannelKey)) {
       long offset = partitionsToChannel.get(partitionChannelKey).getOffsetSafeToCommitToKafka();
       partitionsToChannel.get(partitionChannelKey).setLatestConsumerOffset(offset);
@@ -372,7 +397,10 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
         topicPartition -> {
           final String partitionChannelKey =
               partitionChannelKey(
-                  conn.getConnectorName(), topicPartition.topic(), topicPartition.partition());
+                  conn.getConnectorName(),
+                  topicPartition.topic(),
+                  topicPartition.partition(),
+                  this.shouldUseConnectorNameInChannelName);
           TopicPartitionChannel topicPartitionChannel =
               partitionsToChannel.get(partitionChannelKey);
           // Check for null since it's possible that the something goes wrong even before the
@@ -527,11 +555,20 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
    *     or PROD)
    * @param topic topic name
    * @param partition partition number
+   * @param shouldUseConnectorNameInChannelName If true, use connectorName, else not
    * @return combinartion of topic and partition
    */
   @VisibleForTesting
-  public static String partitionChannelKey(String connectorName, String topic, int partition) {
-    return connectorName + "_" + topic + "_" + partition;
+  public static String partitionChannelKey(
+      String connectorName,
+      String topic,
+      int partition,
+      final boolean shouldUseConnectorNameInChannelName) {
+    if (shouldUseConnectorNameInChannelName) {
+      return connectorName + "_" + topic + "_" + partition;
+    } else {
+      return topic + "_" + partition;
+    }
   }
 
   /* Used for testing */

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -1,8 +1,8 @@
 package com.snowflake.kafka.connector.internal.streaming;
 
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES_DEFAULT;
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME;
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME_DEFAULT;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2_DEFAULT;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWFLAKE_ROLE;
 import static com.snowflake.kafka.connector.internal.streaming.StreamingUtils.STREAMING_BUFFER_COUNT_RECORDS_DEFAULT;
 import static com.snowflake.kafka.connector.internal.streaming.StreamingUtils.STREAMING_BUFFER_FLUSH_TIME_DEFAULT_SEC;
@@ -103,7 +103,8 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
   // Cache for schema evolution
   private final Map<String, Boolean> tableName2SchemaEvolutionPermission;
 
-  // Used to create a channel name.
+  // This is the V2 of channel Name creation. (This corresponds to the config
+  // SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2)
   private final boolean shouldUseConnectorNameInChannelName;
 
   public SnowflakeSinkServiceV2(
@@ -146,8 +147,8 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
     this.shouldUseConnectorNameInChannelName =
         Boolean.parseBoolean(
             connectorConfig.getOrDefault(
-                ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME,
-                String.valueOf(ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME_DEFAULT)));
+                SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2,
+                String.valueOf(SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2_DEFAULT)));
   }
 
   @VisibleForTesting
@@ -196,8 +197,8 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
     this.shouldUseConnectorNameInChannelName =
         Boolean.parseBoolean(
             connectorConfig.getOrDefault(
-                ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME,
-                String.valueOf(ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME_DEFAULT)));
+                SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2,
+                String.valueOf(SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2_DEFAULT)));
   }
 
   /**

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
@@ -8,7 +8,7 @@ import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ErrorTolerance;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.KEY_CONVERTER_CONFIG_FIELD;
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWFLAKE_ENABLE_NEW_CHANNEL_NAME_FORMAT;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.VALUE_CONVERTER_CONFIG_FIELD;
 
 import com.google.common.base.Strings;
@@ -222,10 +222,10 @@ public class StreamingUtils {
             BOOLEAN_VALIDATOR.ensureValid(
                 ERRORS_LOG_ENABLE_CONFIG, inputConfig.get(ERRORS_LOG_ENABLE_CONFIG));
           }
-          if (inputConfig.containsKey(SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2)) {
+          if (inputConfig.containsKey(SNOWFLAKE_ENABLE_NEW_CHANNEL_NAME_FORMAT)) {
             BOOLEAN_VALIDATOR.ensureValid(
-                SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2,
-                inputConfig.get(SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2));
+                SNOWFLAKE_ENABLE_NEW_CHANNEL_NAME_FORMAT,
+                inputConfig.get(SNOWFLAKE_ENABLE_NEW_CHANNEL_NAME_FORMAT));
           }
 
           // Valid schematization for Snowpipe Streaming

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
@@ -1,6 +1,15 @@
 package com.snowflake.kafka.connector.internal.streaming;
 
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.*;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BOOLEAN_VALIDATOR;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.CUSTOM_SNOWFLAKE_CONVERTERS;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_LOG_ENABLE_CONFIG;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_TOLERANCE_CONFIG;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ErrorTolerance;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.KEY_CONVERTER_CONFIG_FIELD;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.VALUE_CONVERTER_CONFIG_FIELD;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
@@ -1,14 +1,6 @@
 package com.snowflake.kafka.connector.internal.streaming;
 
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BOOLEAN_VALIDATOR;
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.CUSTOM_SNOWFLAKE_CONVERTERS;
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG;
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_LOG_ENABLE_CONFIG;
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_TOLERANCE_CONFIG;
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ErrorTolerance;
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT;
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.KEY_CONVERTER_CONFIG_FIELD;
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.VALUE_CONVERTER_CONFIG_FIELD;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.*;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
@@ -220,6 +212,11 @@ public class StreamingUtils {
           if (inputConfig.containsKey(ERRORS_LOG_ENABLE_CONFIG)) {
             BOOLEAN_VALIDATOR.ensureValid(
                 ERRORS_LOG_ENABLE_CONFIG, inputConfig.get(ERRORS_LOG_ENABLE_CONFIG));
+          }
+          if (inputConfig.containsKey(SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2)) {
+            BOOLEAN_VALIDATOR.ensureValid(
+                SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2,
+                inputConfig.get(SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2));
           }
 
           // Valid schematization for Snowpipe Streaming

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
@@ -868,6 +868,34 @@ public class ConnectorConfigTest {
   }
 
   @Test
+  public void testEnableStreamingChannelFormatV2Config() {
+    Map<String, String> config = getConfig();
+    config.put(
+        SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
+        IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
+    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2, "true");
+    config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
+    Utils.validateConfig(config);
+  }
+
+  @Test
+  public void testInvalidEnableStreamingChannelFormatV2Config() {
+    try {
+      Map<String, String> config = getConfig();
+      config.put(
+          SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
+          IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
+      config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
+      config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2, "yes");
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception
+          .getMessage()
+          .contains(SnowflakeSinkConnectorConfig.SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2);
+    }
+  }
+
+  @Test
   public void testInvalidEmptyConfig() {
     try {
       Map<String, String> config = new HashMap<>();

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
@@ -873,7 +873,7 @@ public class ConnectorConfigTest {
     config.put(
         SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
         IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
-    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2, "true");
+    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_ENABLE_NEW_CHANNEL_NAME_FORMAT, "true");
     config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
     Utils.validateConfig(config);
   }
@@ -886,12 +886,12 @@ public class ConnectorConfigTest {
           SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
           IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
       config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
-      config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2, "yes");
+      config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_ENABLE_NEW_CHANNEL_NAME_FORMAT, "yes");
       Utils.validateConfig(config);
     } catch (SnowflakeKafkaConnectorException exception) {
       assert exception
           .getMessage()
-          .contains(SnowflakeSinkConnectorConfig.SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2);
+          .contains(SnowflakeSinkConnectorConfig.SNOWFLAKE_ENABLE_NEW_CHANNEL_NAME_FORMAT);
     }
   }
 

--- a/src/test/java/com/snowflake/kafka/connector/SnowflakeSinkTaskStreamingTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/SnowflakeSinkTaskStreamingTest.java
@@ -1,10 +1,10 @@
 package com.snowflake.kafka.connector;
 
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS;
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_TOLERANCE_CONFIG;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2;
 import static com.snowflake.kafka.connector.internal.TestUtils.TEST_CONNECTOR_NAME;
 import static com.snowflake.kafka.connector.internal.streaming.SnowflakeSinkServiceV2.partitionChannelKey;
 
@@ -77,7 +77,7 @@ public class SnowflakeSinkTaskStreamingTest {
     config.put(ERRORS_TOLERANCE_CONFIG, SnowflakeSinkConnectorConfig.ErrorTolerance.ALL.toString());
     config.put(ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG, "test_DLQ");
     config.put(
-        ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME,
+        SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2,
         String.valueOf(this.shouldUseConnectorNameInChannelName));
     InMemoryKafkaRecordErrorReporter errorReporter = new InMemoryKafkaRecordErrorReporter();
     SnowflakeConnectionService mockConnectionService =

--- a/src/test/java/com/snowflake/kafka/connector/SnowflakeSinkTaskStreamingTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/SnowflakeSinkTaskStreamingTest.java
@@ -4,7 +4,7 @@ import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BUFFER_
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_TOLERANCE_CONFIG;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT;
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWFLAKE_ENABLE_NEW_CHANNEL_NAME_FORMAT;
 import static com.snowflake.kafka.connector.internal.TestUtils.TEST_CONNECTOR_NAME;
 import static com.snowflake.kafka.connector.internal.streaming.SnowflakeSinkServiceV2.partitionChannelKey;
 
@@ -77,7 +77,7 @@ public class SnowflakeSinkTaskStreamingTest {
     config.put(ERRORS_TOLERANCE_CONFIG, SnowflakeSinkConnectorConfig.ErrorTolerance.ALL.toString());
     config.put(ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG, "test_DLQ");
     config.put(
-        SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2,
+        SNOWFLAKE_ENABLE_NEW_CHANNEL_NAME_FORMAT,
         String.valueOf(this.shouldUseConnectorNameInChannelName));
     InMemoryKafkaRecordErrorReporter errorReporter = new InMemoryKafkaRecordErrorReporter();
     SnowflakeConnectionService mockConnectionService =

--- a/src/test/java/com/snowflake/kafka/connector/SnowflakeSinkTaskStreamingTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/SnowflakeSinkTaskStreamingTest.java
@@ -1,6 +1,7 @@
 package com.snowflake.kafka.connector;
 
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_TOLERANCE_CONFIG;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT;
@@ -19,8 +20,10 @@ import com.snowflake.kafka.connector.internal.streaming.TopicPartitionChannel;
 import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryService;
 import com.snowflake.kafka.connector.records.RecordService;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import net.snowflake.ingest.streaming.InsertValidationResponse;
 import net.snowflake.ingest.streaming.OpenChannelRequest;
@@ -36,14 +39,28 @@ import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
 /** Unit test for testing Snowflake Sink Task Behavior with Snowpipe Streaming */
+@RunWith(Parameterized.class)
 public class SnowflakeSinkTaskStreamingTest {
   private String topicName;
   private static int partition = 0;
   private TopicPartition topicPartition;
+
+  private final boolean shouldUseConnectorNameInChannelName;
+
+  @Parameterized.Parameters
+  public static List<Boolean> input() {
+    return Arrays.asList(Boolean.TRUE, Boolean.FALSE);
+  }
+
+  public SnowflakeSinkTaskStreamingTest(boolean shouldUseConnectorNameInChannelName) {
+    this.shouldUseConnectorNameInChannelName = shouldUseConnectorNameInChannelName;
+  }
 
   @Before
   public void setup() {
@@ -59,6 +76,9 @@ public class SnowflakeSinkTaskStreamingTest {
     config.put(INGESTION_METHOD_OPT, IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
     config.put(ERRORS_TOLERANCE_CONFIG, SnowflakeSinkConnectorConfig.ErrorTolerance.ALL.toString());
     config.put(ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG, "test_DLQ");
+    config.put(
+        ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME,
+        String.valueOf(this.shouldUseConnectorNameInChannelName));
     InMemoryKafkaRecordErrorReporter errorReporter = new InMemoryKafkaRecordErrorReporter();
     SnowflakeConnectionService mockConnectionService =
         Mockito.mock(SnowflakeConnectionServiceV1.class);
@@ -88,7 +108,11 @@ public class SnowflakeSinkTaskStreamingTest {
         new TopicPartitionChannel(
             mockStreamingClient,
             topicPartition,
-            SnowflakeSinkServiceV2.partitionChannelKey(TEST_CONNECTOR_NAME, topicName, partition),
+            SnowflakeSinkServiceV2.partitionChannelKey(
+                TEST_CONNECTOR_NAME,
+                topicName,
+                partition,
+                this.shouldUseConnectorNameInChannelName),
             topicName,
             new StreamingBufferThreshold(10, 10_000, 1),
             config,
@@ -98,7 +122,12 @@ public class SnowflakeSinkTaskStreamingTest {
 
     Map topicPartitionChannelMap =
         Collections.singletonMap(
-            partitionChannelKey(TEST_CONNECTOR_NAME, topicName, partition), topicPartitionChannel);
+            partitionChannelKey(
+                TEST_CONNECTOR_NAME,
+                topicName,
+                partition,
+                this.shouldUseConnectorNameInChannelName),
+            topicPartitionChannel);
 
     SnowflakeSinkServiceV2 mockSinkService =
         new SnowflakeSinkServiceV2(

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2IT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2IT.java
@@ -1,5 +1,6 @@
 package com.snowflake.kafka.connector.internal.streaming;
 
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME;
 import static com.snowflake.kafka.connector.internal.TestUtils.TEST_CONNECTOR_NAME;
 import static com.snowflake.kafka.connector.internal.streaming.SnowflakeSinkServiceV2.partitionChannelKey;
 import static com.snowflake.kafka.connector.internal.streaming.TopicPartitionChannel.NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE;
@@ -62,14 +63,21 @@ public class SnowflakeSinkServiceV2IT {
   // use OAuth as authenticator or not
   private boolean useOAuth;
 
-  @Parameterized.Parameters(name = "useOAuth: {0}")
+  private final boolean shouldUseConnectorNameInChannelName;
+
+  @Parameterized.Parameters(name = "useOAuth: {0}, shouldUseConnectorNameInChannelName: {1}")
   public static Collection<Object[]> input() {
-    // TODO: Added {true} after SNOW-352846 is released
-    return Arrays.asList(new Object[][] {{false}});
+    // TODO: Add {true, false} and {true, true} after SNOW-352846 is released
+    return Arrays.asList(
+        new Object[][] {
+          {false, false},
+          {false, true}
+        });
   }
 
-  public SnowflakeSinkServiceV2IT(boolean useOAuth) {
+  public SnowflakeSinkServiceV2IT(boolean useOAuth, boolean shouldUseConnectorNameInChannelName) {
     this.useOAuth = useOAuth;
+    this.shouldUseConnectorNameInChannelName = shouldUseConnectorNameInChannelName;
     if (!useOAuth) {
       conn = TestUtils.getConnectionServiceForStreaming();
     } else {
@@ -120,6 +128,9 @@ public class SnowflakeSinkServiceV2IT {
   public void testChannelCloseIngestion() throws Exception {
     Map<String, String> config = getConfig();
     SnowflakeSinkConnectorConfig.setDefaultValues(config);
+    config.put(
+        ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME,
+        String.valueOf(this.shouldUseConnectorNameInChannelName));
     conn.createTable(table);
 
     // opens a channel for partition 0, table and topic
@@ -169,6 +180,9 @@ public class SnowflakeSinkServiceV2IT {
       throws Exception {
     Map<String, String> config = TestUtils.getConfForStreaming();
     SnowflakeSinkConnectorConfig.setDefaultValues(config);
+    config.put(
+        ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME,
+        String.valueOf(this.shouldUseConnectorNameInChannelName));
     conn.createTable(table);
     TopicPartition tp1 = new TopicPartition(table, partition);
     TopicPartition tp2 = new TopicPartition(table, partition2);
@@ -222,7 +236,11 @@ public class SnowflakeSinkServiceV2IT {
     Assert.assertTrue(
         snowflakeSinkServiceV2
             .getTopicPartitionChannelFromCacheKey(
-                partitionChannelKey(TEST_CONNECTOR_NAME, tp2.topic(), tp2.partition()))
+                partitionChannelKey(
+                    TEST_CONNECTOR_NAME,
+                    tp2.topic(),
+                    tp2.partition(),
+                    this.shouldUseConnectorNameInChannelName))
             .isPresent());
 
     List<SinkRecord> newRecordsPartition1 =
@@ -293,6 +311,9 @@ public class SnowflakeSinkServiceV2IT {
   public void testStreamingIngestion() throws Exception {
     Map<String, String> config = getConfig();
     SnowflakeSinkConnectorConfig.setDefaultValues(config);
+    config.put(
+        ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME,
+        String.valueOf(this.shouldUseConnectorNameInChannelName));
     conn.createTable(table);
 
     // opens a channel for partition 0, table and topic
@@ -357,6 +378,9 @@ public class SnowflakeSinkServiceV2IT {
   public void testStreamingIngest_multipleChannelPartitions_withMetrics() throws Exception {
     Map<String, String> config = getConfig();
     SnowflakeSinkConnectorConfig.setDefaultValues(config);
+    config.put(
+        ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME,
+        String.valueOf(this.shouldUseConnectorNameInChannelName));
 
     // set up telemetry service spy
     SnowflakeConnectionService connectionService = Mockito.spy(this.conn);
@@ -413,7 +437,11 @@ public class SnowflakeSinkServiceV2IT {
     Map<String, Gauge> metricRegistry =
         service
             .getMetricRegistry(
-                SnowflakeSinkServiceV2.partitionChannelKey(TEST_CONNECTOR_NAME, topic, partition))
+                SnowflakeSinkServiceV2.partitionChannelKey(
+                    TEST_CONNECTOR_NAME,
+                    topic,
+                    partition,
+                    this.shouldUseConnectorNameInChannelName))
             .get()
             .getGauges();
     assert metricRegistry.size()
@@ -422,7 +450,8 @@ public class SnowflakeSinkServiceV2IT {
     // partition 1
     this.verifyPartitionMetrics(
         metricRegistry,
-        partitionChannelKey(TEST_CONNECTOR_NAME, topic, partition),
+        partitionChannelKey(
+            TEST_CONNECTOR_NAME, topic, partition, this.shouldUseConnectorNameInChannelName),
         NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE,
         recordsInPartition1 - 1,
         recordsInPartition1,
@@ -430,7 +459,8 @@ public class SnowflakeSinkServiceV2IT {
         this.conn.getConnectorName());
     this.verifyPartitionMetrics(
         metricRegistry,
-        partitionChannelKey(TEST_CONNECTOR_NAME, topic, partition2),
+        partitionChannelKey(
+            TEST_CONNECTOR_NAME, topic, partition2, this.shouldUseConnectorNameInChannelName),
         NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE,
         recordsInPartition2 - 1,
         recordsInPartition2,
@@ -446,7 +476,8 @@ public class SnowflakeSinkServiceV2IT {
     // verify metrics closed
     assert !service
         .getMetricRegistry(
-            SnowflakeSinkServiceV2.partitionChannelKey(TEST_CONNECTOR_NAME, topic, partition))
+            SnowflakeSinkServiceV2.partitionChannelKey(
+                TEST_CONNECTOR_NAME, topic, partition, this.shouldUseConnectorNameInChannelName))
         .isPresent();
 
     Mockito.verify(telemetryService, Mockito.times(2))

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2IT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2IT.java
@@ -1,6 +1,6 @@
 package com.snowflake.kafka.connector.internal.streaming;
 
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWFLAKE_ENABLE_NEW_CHANNEL_NAME_FORMAT;
 import static com.snowflake.kafka.connector.internal.TestUtils.TEST_CONNECTOR_NAME;
 import static com.snowflake.kafka.connector.internal.streaming.SnowflakeSinkServiceV2.partitionChannelKey;
 import static com.snowflake.kafka.connector.internal.streaming.TopicPartitionChannel.NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE;
@@ -129,7 +129,7 @@ public class SnowflakeSinkServiceV2IT {
     Map<String, String> config = getConfig();
     SnowflakeSinkConnectorConfig.setDefaultValues(config);
     config.put(
-        SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2,
+        SNOWFLAKE_ENABLE_NEW_CHANNEL_NAME_FORMAT,
         String.valueOf(this.shouldUseConnectorNameInChannelName));
     conn.createTable(table);
 
@@ -181,7 +181,7 @@ public class SnowflakeSinkServiceV2IT {
     Map<String, String> config = TestUtils.getConfForStreaming();
     SnowflakeSinkConnectorConfig.setDefaultValues(config);
     config.put(
-        SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2,
+        SNOWFLAKE_ENABLE_NEW_CHANNEL_NAME_FORMAT,
         String.valueOf(this.shouldUseConnectorNameInChannelName));
     conn.createTable(table);
     TopicPartition tp1 = new TopicPartition(table, partition);
@@ -312,7 +312,7 @@ public class SnowflakeSinkServiceV2IT {
     Map<String, String> config = getConfig();
     SnowflakeSinkConnectorConfig.setDefaultValues(config);
     config.put(
-        SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2,
+        SNOWFLAKE_ENABLE_NEW_CHANNEL_NAME_FORMAT,
         String.valueOf(this.shouldUseConnectorNameInChannelName));
     conn.createTable(table);
 
@@ -379,7 +379,7 @@ public class SnowflakeSinkServiceV2IT {
     Map<String, String> config = getConfig();
     SnowflakeSinkConnectorConfig.setDefaultValues(config);
     config.put(
-        SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2,
+        SNOWFLAKE_ENABLE_NEW_CHANNEL_NAME_FORMAT,
         String.valueOf(this.shouldUseConnectorNameInChannelName));
 
     // set up telemetry service spy
@@ -1518,7 +1518,7 @@ public class SnowflakeSinkServiceV2IT {
     Map<String, String> overriddenConfig = new HashMap<>(config);
 
     config.put(
-        SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2,
+        SNOWFLAKE_ENABLE_NEW_CHANNEL_NAME_FORMAT,
         String.valueOf(this.shouldUseConnectorNameInChannelName));
 
     conn.createTable(table);

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelIT.java
@@ -1,6 +1,6 @@
 package com.snowflake.kafka.connector.internal.streaming;
 
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWFLAKE_ENABLE_NEW_CHANNEL_NAME_FORMAT;
 import static com.snowflake.kafka.connector.internal.TestUtils.TEST_CONNECTOR_NAME;
 
 import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
@@ -78,7 +78,7 @@ public class TopicPartitionChannelIT {
     Map<String, String> config = TestUtils.getConfForStreaming();
     SnowflakeSinkConnectorConfig.setDefaultValues(config);
     config.put(
-        SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2,
+        SNOWFLAKE_ENABLE_NEW_CHANNEL_NAME_FORMAT,
         String.valueOf(this.shouldUseConnectorNameInChannelName));
 
     InMemorySinkTaskContext inMemorySinkTaskContext =
@@ -139,7 +139,7 @@ public class TopicPartitionChannelIT {
     SnowflakeSinkConnectorConfig.setDefaultValues(config);
     SnowflakeSinkConnectorConfig.setDefaultValues(config);
     config.put(
-        SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2,
+        SNOWFLAKE_ENABLE_NEW_CHANNEL_NAME_FORMAT,
         String.valueOf(this.shouldUseConnectorNameInChannelName));
 
     InMemorySinkTaskContext inMemorySinkTaskContext =
@@ -207,7 +207,7 @@ public class TopicPartitionChannelIT {
     SnowflakeSinkConnectorConfig.setDefaultValues(config);
     SnowflakeSinkConnectorConfig.setDefaultValues(config);
     config.put(
-        SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2,
+        SNOWFLAKE_ENABLE_NEW_CHANNEL_NAME_FORMAT,
         String.valueOf(this.shouldUseConnectorNameInChannelName));
 
     InMemorySinkTaskContext inMemorySinkTaskContext =
@@ -299,7 +299,7 @@ public class TopicPartitionChannelIT {
     config.put(SnowflakeSinkConnectorConfig.ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG, "true");
     SnowflakeSinkConnectorConfig.setDefaultValues(config);
     config.put(
-        SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2,
+        SNOWFLAKE_ENABLE_NEW_CHANNEL_NAME_FORMAT,
         String.valueOf(this.shouldUseConnectorNameInChannelName));
 
     InMemorySinkTaskContext inMemorySinkTaskContext =
@@ -422,7 +422,7 @@ public class TopicPartitionChannelIT {
     config.put(SnowflakeSinkConnectorConfig.ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG, "true");
     SnowflakeSinkConnectorConfig.setDefaultValues(config);
     config.put(
-        SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2,
+        SNOWFLAKE_ENABLE_NEW_CHANNEL_NAME_FORMAT,
         String.valueOf(this.shouldUseConnectorNameInChannelName));
 
     InMemorySinkTaskContext inMemorySinkTaskContext =
@@ -501,7 +501,7 @@ public class TopicPartitionChannelIT {
     overriddenConfig.put(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_FILE_VERSION, "1");
     SnowflakeSinkConnectorConfig.setDefaultValues(overriddenConfig);
     overriddenConfig.put(
-        SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2,
+        SNOWFLAKE_ENABLE_NEW_CHANNEL_NAME_FORMAT,
         String.valueOf(this.shouldUseConnectorNameInChannelName));
 
     InMemorySinkTaskContext inMemorySinkTaskContext =

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelIT.java
@@ -1,6 +1,6 @@
 package com.snowflake.kafka.connector.internal.streaming;
 
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2;
 import static com.snowflake.kafka.connector.internal.TestUtils.TEST_CONNECTOR_NAME;
 
 import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
@@ -78,7 +78,7 @@ public class TopicPartitionChannelIT {
     Map<String, String> config = TestUtils.getConfForStreaming();
     SnowflakeSinkConnectorConfig.setDefaultValues(config);
     config.put(
-        ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME,
+        SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2,
         String.valueOf(this.shouldUseConnectorNameInChannelName));
 
     InMemorySinkTaskContext inMemorySinkTaskContext =
@@ -139,7 +139,7 @@ public class TopicPartitionChannelIT {
     SnowflakeSinkConnectorConfig.setDefaultValues(config);
     SnowflakeSinkConnectorConfig.setDefaultValues(config);
     config.put(
-        ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME,
+        SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2,
         String.valueOf(this.shouldUseConnectorNameInChannelName));
 
     InMemorySinkTaskContext inMemorySinkTaskContext =
@@ -207,7 +207,7 @@ public class TopicPartitionChannelIT {
     SnowflakeSinkConnectorConfig.setDefaultValues(config);
     SnowflakeSinkConnectorConfig.setDefaultValues(config);
     config.put(
-        ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME,
+        SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2,
         String.valueOf(this.shouldUseConnectorNameInChannelName));
 
     InMemorySinkTaskContext inMemorySinkTaskContext =
@@ -299,7 +299,7 @@ public class TopicPartitionChannelIT {
     config.put(SnowflakeSinkConnectorConfig.ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG, "true");
     SnowflakeSinkConnectorConfig.setDefaultValues(config);
     config.put(
-        ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME,
+        SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2,
         String.valueOf(this.shouldUseConnectorNameInChannelName));
 
     InMemorySinkTaskContext inMemorySinkTaskContext =
@@ -422,7 +422,7 @@ public class TopicPartitionChannelIT {
     config.put(SnowflakeSinkConnectorConfig.ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG, "true");
     SnowflakeSinkConnectorConfig.setDefaultValues(config);
     config.put(
-        ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME,
+        SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2,
         String.valueOf(this.shouldUseConnectorNameInChannelName));
 
     InMemorySinkTaskContext inMemorySinkTaskContext =
@@ -501,7 +501,7 @@ public class TopicPartitionChannelIT {
     overriddenConfig.put(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_FILE_VERSION, "1");
     SnowflakeSinkConnectorConfig.setDefaultValues(overriddenConfig);
     overriddenConfig.put(
-        ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME,
+        SNOWFLAKE_ENABLE_STREAMING_CHANNEL_FORMAT_V2,
         String.valueOf(this.shouldUseConnectorNameInChannelName));
 
     InMemorySinkTaskContext inMemorySinkTaskContext =

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelIT.java
@@ -1,5 +1,6 @@
 package com.snowflake.kafka.connector.internal.streaming;
 
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME;
 import static com.snowflake.kafka.connector.internal.TestUtils.TEST_CONNECTOR_NAME;
 
 import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
@@ -11,6 +12,8 @@ import com.snowflake.kafka.connector.internal.SnowflakeSinkServiceFactory;
 import com.snowflake.kafka.connector.internal.TestUtils;
 import com.snowflake.kafka.connector.internal.streaming.telemetry.SnowflakeTelemetryServiceV2;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -23,7 +26,10 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+@RunWith(Parameterized.class)
 public class TopicPartitionChannelIT {
 
   private SnowflakeConnectionService conn = TestUtils.getConnectionServiceForStreaming();
@@ -34,6 +40,17 @@ public class TopicPartitionChannelIT {
   private TopicPartition topicPartition, topicPartition2;
   private String testChannelName, testChannelName2;
 
+  private final boolean shouldUseConnectorNameInChannelName;
+
+  public TopicPartitionChannelIT(boolean shouldUseConnectorNameInChannelName) {
+    this.shouldUseConnectorNameInChannelName = shouldUseConnectorNameInChannelName;
+  }
+
+  @Parameterized.Parameters(name = "shouldUseConnectorNameInChannelName: {0}")
+  public static Collection<Object[]> input() {
+    return Arrays.asList(new Object[][] {{true}, {false}});
+  }
+
   @Before
   public void beforeEach() {
     testTableName = TestUtils.randomTableName();
@@ -43,10 +60,12 @@ public class TopicPartitionChannelIT {
     topicPartition2 = new TopicPartition(topic, PARTITION_2);
 
     testChannelName =
-        SnowflakeSinkServiceV2.partitionChannelKey(TEST_CONNECTOR_NAME, topic, PARTITION);
+        SnowflakeSinkServiceV2.partitionChannelKey(
+            TEST_CONNECTOR_NAME, topic, PARTITION, this.shouldUseConnectorNameInChannelName);
 
     testChannelName2 =
-        SnowflakeSinkServiceV2.partitionChannelKey(TEST_CONNECTOR_NAME, topic, PARTITION_2);
+        SnowflakeSinkServiceV2.partitionChannelKey(
+            TEST_CONNECTOR_NAME, topic, PARTITION_2, this.shouldUseConnectorNameInChannelName);
   }
 
   @After
@@ -58,6 +77,9 @@ public class TopicPartitionChannelIT {
   public void testAutoChannelReopenOn_OffsetTokenSFException() throws Exception {
     Map<String, String> config = TestUtils.getConfForStreaming();
     SnowflakeSinkConnectorConfig.setDefaultValues(config);
+    config.put(
+        ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME,
+        String.valueOf(this.shouldUseConnectorNameInChannelName));
 
     InMemorySinkTaskContext inMemorySinkTaskContext =
         new InMemorySinkTaskContext(Collections.singleton(topicPartition));
@@ -115,6 +137,10 @@ public class TopicPartitionChannelIT {
   public void testInsertRowsOnChannelClosed() throws Exception {
     Map<String, String> config = TestUtils.getConfForStreaming();
     SnowflakeSinkConnectorConfig.setDefaultValues(config);
+    SnowflakeSinkConnectorConfig.setDefaultValues(config);
+    config.put(
+        ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME,
+        String.valueOf(this.shouldUseConnectorNameInChannelName));
 
     InMemorySinkTaskContext inMemorySinkTaskContext =
         new InMemorySinkTaskContext(Collections.singleton(topicPartition));
@@ -179,6 +205,10 @@ public class TopicPartitionChannelIT {
   public void testAutoChannelReopen_InsertRowsSFException() throws Exception {
     Map<String, String> config = TestUtils.getConfForStreaming();
     SnowflakeSinkConnectorConfig.setDefaultValues(config);
+    SnowflakeSinkConnectorConfig.setDefaultValues(config);
+    config.put(
+        ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME,
+        String.valueOf(this.shouldUseConnectorNameInChannelName));
 
     InMemorySinkTaskContext inMemorySinkTaskContext =
         new InMemorySinkTaskContext(Collections.singleton(topicPartition));
@@ -267,6 +297,10 @@ public class TopicPartitionChannelIT {
     Map<String, String> config = TestUtils.getConfForStreaming();
     SnowflakeSinkConnectorConfig.setDefaultValues(config);
     config.put(SnowflakeSinkConnectorConfig.ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG, "true");
+    SnowflakeSinkConnectorConfig.setDefaultValues(config);
+    config.put(
+        ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME,
+        String.valueOf(this.shouldUseConnectorNameInChannelName));
 
     InMemorySinkTaskContext inMemorySinkTaskContext =
         new InMemorySinkTaskContext(Collections.singleton(topicPartition));
@@ -386,6 +420,10 @@ public class TopicPartitionChannelIT {
     Map<String, String> config = TestUtils.getConfForStreaming();
     SnowflakeSinkConnectorConfig.setDefaultValues(config);
     config.put(SnowflakeSinkConnectorConfig.ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG, "true");
+    SnowflakeSinkConnectorConfig.setDefaultValues(config);
+    config.put(
+        ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME,
+        String.valueOf(this.shouldUseConnectorNameInChannelName));
 
     InMemorySinkTaskContext inMemorySinkTaskContext =
         new InMemorySinkTaskContext(Collections.singleton(topicPartition));
@@ -461,6 +499,10 @@ public class TopicPartitionChannelIT {
     // add config which overrides the bdec file format
     Map<String, String> overriddenConfig = new HashMap<>(TestUtils.getConfForStreaming());
     overriddenConfig.put(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_FILE_VERSION, "1");
+    SnowflakeSinkConnectorConfig.setDefaultValues(overriddenConfig);
+    overriddenConfig.put(
+        ENABLE_CONNECTOR_NAME_IN_STREAMING_CHANNEL_NAME,
+        String.valueOf(this.shouldUseConnectorNameInChannelName));
 
     InMemorySinkTaskContext inMemorySinkTaskContext =
         new InMemorySinkTaskContext(Collections.singleton(topicPartition));

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelTest.java
@@ -72,7 +72,7 @@ public class TopicPartitionChannelTest {
   private static final int PARTITION = 0;
 
   private static final String TEST_CHANNEL_NAME =
-      SnowflakeSinkServiceV2.partitionChannelKey(TEST_CONNECTOR_NAME, TOPIC, PARTITION);
+      SnowflakeSinkServiceV2.partitionChannelKey(TEST_CONNECTOR_NAME, TOPIC, PARTITION, false);
   private static final String TEST_TABLE_NAME = "TEST_TABLE";
 
   private TopicPartition topicPartition;

--- a/test/rest_request_template/test_snowpipe_streaming_channel_format_v2.json
+++ b/test/rest_request_template/test_snowpipe_streaming_channel_format_v2.json
@@ -1,0 +1,23 @@
+{
+  "name": "SNOWFLAKE_CONNECTOR_NAME",
+  "config": {
+    "connector.class": "com.snowflake.kafka.connector.SnowflakeSinkConnector",
+    "topics": "SNOWFLAKE_TEST_TOPIC",
+    "tasks.max": "1",
+    "buffer.flush.time": "10",
+    "buffer.count.records": "100",
+    "buffer.size.bytes": "5000000",
+    "snowflake.url.name": "SNOWFLAKE_HOST",
+    "snowflake.user.name": "SNOWFLAKE_USER",
+    "snowflake.private.key": "SNOWFLAKE_PRIVATE_KEY",
+    "snowflake.database.name": "SNOWFLAKE_DATABASE",
+    "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
+    "snowflake.role.name": "SNOWFLAKE_ROLE",
+    "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
+    "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+    "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+    "value.converter.schemas.enable": "false",
+    "jmx": "true",
+    "snowflake.enable.streaming.channel.format.v2": "true"
+  }
+}

--- a/test/rest_request_template/test_snowpipe_streaming_channel_format_v2.json
+++ b/test/rest_request_template/test_snowpipe_streaming_channel_format_v2.json
@@ -18,6 +18,6 @@
     "value.converter": "org.apache.kafka.connect.json.JsonConverter",
     "value.converter.schemas.enable": "false",
     "jmx": "true",
-    "snowflake.enable.streaming.channel.format.v2": "true"
+    "snowflake.enable.new.channel.name.format": "true"
   }
 }

--- a/test/test_suit/test_snowpipe_streaming_channel_format_v2.py
+++ b/test/test_suit/test_snowpipe_streaming_channel_format_v2.py
@@ -1,0 +1,78 @@
+import datetime
+
+from test_suit.test_utils import RetryableError, NonRetryableError
+import json
+from time import sleep
+
+class TestSnowpipeStreamingChannelFormatV2:
+    def __init__(self, driver, nameSalt):
+        self.driver = driver
+        self.fileName = "test_snowpipe_streaming_channel_format_v2"
+        self.topic = self.fileName + nameSalt
+
+        self.topicNum = 1
+        self.partitionNum = 3
+        self.recordNum = 1000
+
+        # create topic and partitions in constructor since the post REST api will automatically create topic with only one partition
+        self.driver.createTopics(self.topic, partitionNum=self.partitionNum, replicationNum=1)
+
+    def getConfigFileName(self):
+        return self.fileName + ".json"
+
+    def send(self):
+        # create topic with n partitions and only one replication factor
+        print("Partition count:" + str(self.partitionNum))
+        print("Topic:", self.topic)
+
+        self.driver.describeTopic(self.topic)
+
+        for p in range(self.partitionNum):
+            print("Sending in Partition:" + str(p))
+            key = []
+            value = []
+
+            for e in range(self.recordNum):
+                value.append(json.dumps(
+                    {'numbernumbernumbernumbernumbernumbernumbernumbernumbernumbernumbernumber': str(e)}
+                ).encode('utf-8'))
+
+            self.driver.sendBytesData(self.topic, value, key, partition=p)
+            sleep(2)
+
+    def verify(self, round):
+        res = self.driver.snowflake_conn.cursor().execute(
+            "SELECT count(*) FROM {}".format(self.topic)).fetchone()[0]
+        print("Count records in table {}={}".format(self.topic, str(res)))
+        if res < (self.recordNum * self.partitionNum):
+            print("Topic:" + self.topic + " count is less, will retry")
+            raise RetryableError()
+        elif res > (self.recordNum * self.partitionNum):
+            print("Topic:" + self.topic + " count is more, duplicates detected")
+            raise NonRetryableError("Duplication occurred, number of record in table is larger than number of record sent")
+        else:
+            print("Table:" + self.topic + " count is exactly " + str(self.recordNum * self.partitionNum))
+
+        # for duplicates
+        res = self.driver.snowflake_conn.cursor().execute("Select record_metadata:\"offset\"::string as OFFSET_NO,record_metadata:\"partition\"::string as PARTITION_NO from {} group by OFFSET_NO, PARTITION_NO having count(*)>1".format(self.topic)).fetchone()
+        print("Duplicates:{}".format(res))
+        if res is not None:
+            raise NonRetryableError("Duplication detected")
+
+        # for uniqueness in offset numbers
+        rows = self.driver.snowflake_conn.cursor().execute("Select count(distinct record_metadata:\"offset\"::number) as UNIQUE_OFFSETS,record_metadata:\"partition\"::number as PARTITION_NO from {} group by PARTITION_NO order by PARTITION_NO".format(self.topic)).fetchall()
+
+        if rows is None:
+            raise NonRetryableError("Unique offsets for partitions not found")
+        else:
+            assert len(rows) == self.partitionNum
+
+            for p in range(self.partitionNum):
+                # unique offset count and partition no are two columns (returns tuple)
+                if rows[p][0] != self.recordNum or rows[p][1] != p:
+                    raise NonRetryableError("Unique offsets for partitions count doesnt match")
+
+    def clean(self):
+        # dropping of stage and pipe doesnt apply for snowpipe streaming. (It executes drop if exists)
+        self.driver.cleanTableStagePipe(self.topic)
+        return

--- a/test/test_suites.py
+++ b/test/test_suites.py
@@ -45,6 +45,7 @@ from test_suit.test_string_avro import TestStringAvro
 from test_suit.test_string_avrosr import TestStringAvrosr
 from test_suit.test_string_json import TestStringJson
 from test_suit.test_string_json_ignore_tombstone import TestStringJsonIgnoreTombstone
+from test_suit.test_snowpipe_streaming_channel_format_v2 import TestSnowpipeStreamingChannelFormatV2
 
 
 class EndToEndTestSuite:
@@ -237,6 +238,10 @@ def create_end_to_end_test_suites(driver, nameSalt, schemaRegistryAddress, testS
         )),
         ("TestSchemaEvolutionMultiTopicDropTable", EndToEndTestSuite(
             test_instance=TestSchemaEvolutionMultiTopicDropTable(driver, nameSalt), clean=True, run_in_confluent=True,
+            run_in_apache=True
+        )),
+        ("TestSnowpipeStreamingChannelFormatV2", EndToEndTestSuite(
+            test_instance=TestSnowpipeStreamingChannelFormatV2(driver, nameSalt), clean=True, run_in_confluent=True,
             run_in_apache=True
         )),
     ])


### PR DESCRIPTION
PROD-39429

## Description
This Commit is adding a parameter to https://github.com/snowflakedb/snowflake-kafka-connector/commit/3bf9106b22510c62068f7d2f7137b9e57989274c and is also reverting the behavior. 
i.e If this commit is pushed and is in release branch, the behavior of determining the `channelName` is reverted. (Contains only topic name and partition number)

Users will have to enable the parameter `snowflake.enable.new.channel.name.format` (set to true) to have connector name in their channel name. 

## Scenarios for users reading this commit:
1. For customers on 2.1.0 where [this](3bf9106b22510c62068f7d2f7137b9e57989274c) change was introduced, we are asking you all to be cautious and look for duplicates. Chances of duplicates are very slim but still possible. We would encourage you all to upgrade to next patch version which has this revert released and set parameter to true to continue with your 2.1.0's behavior. 
2. For users who are below 2.1.0, you dont have to do anything except not using 2.1.0 :)


## Why
TLDR:
Commit 3bf9106b22510c62068f7d2f7137b9e57989274c which was release in v2.1.0 is not compatible with old versions upgrading to 2.1.0 because it changes the channel name and we lose offset information in new channels.  
Longer Description:
```
Assumptions: TopicName = HALLOWEEN, partitions 2, connector_name = connector_name1
1. Channel name HALLOWEEN_1, HALLOWEEN_2 -> offset token 10, 12 respectively in snowflake but last committed offset in kafka is 8.10. 
3. We turned off connector. Upgraded jar and used 2.1.0 kc version. (One with the commit)
4. This new version will create  connector_name1_HALLOWEEN_1, connector_name1_HALLOWEEN_2. 
5. These two channels will have null offset token and since last committed in kafka is 8, 10, we accept that in kafka connector since channel offsets are null on snowflake. 
6. This has potential to have duplicates.

```

## Plan
- Patch release a new version with this commit. 
- Existing 2.1.0 users will have to enable param to true. (We will reach out to all those users)
- Default param is false. 
- Long term fix: Smooth transition between old version and new version to transfer offsets from old channelNames to new channelNames


## Tests
Added tests using ParameterizedTest feature. 

