### PR TITLE
PROD-39429 PART-2 Make REST API(/channels/status) call which acts as Channel Exi…

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
@@ -72,7 +72,7 @@ public class InternalUtils {
     }
   }
 
-  static PrivateKey parsePrivateKey(String key) {
+  public static PrivateKey parsePrivateKey(String key) {
     // remove header, footer, and line breaks
     key = key.replaceAll("-+[A-Za-z ]+-+", "");
     key = key.replaceAll("\\s", "");

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/ChannelExistenceCheckerRequest.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/ChannelExistenceCheckerRequest.java
@@ -1,0 +1,103 @@
+package com.snowflake.kafka.connector.internal.streaming;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+/** Class to deserialize a request from a channel status request */
+class ChannelExistenceCheckerRequest {
+
+  // Used to deserialize a channel request
+  static class ChannelStatusRequestDTO {
+    // Database name
+    private final String databaseName;
+
+    // Schema name
+    private final String schemaName;
+
+    // Table Name
+    private final String tableName;
+
+    // Channel Name
+    private final String channelName;
+
+    // Client Sequencer
+    private final Long clientSequencer;
+
+    public ChannelStatusRequestDTO(
+        String databaseName,
+        String schemaName,
+        String tableName,
+        String channelName,
+        Long clientSequencer) {
+      this.databaseName = databaseName;
+      this.schemaName = schemaName;
+      this.tableName = tableName;
+      this.channelName = channelName;
+      this.clientSequencer = clientSequencer;
+    }
+
+    @JsonProperty("table")
+    String getTableName() {
+      return tableName;
+    }
+
+    @JsonProperty("database")
+    String getDatabaseName() {
+      return databaseName;
+    }
+
+    @JsonProperty("schema")
+    String getSchemaName() {
+      return schemaName;
+    }
+
+    @JsonProperty("channel_name")
+    String getChannelName() {
+      return channelName;
+    }
+
+    @JsonProperty("client_sequencer")
+    Long getClientSequencer() {
+      return clientSequencer;
+    }
+  }
+
+  // Optional Request ID. Used for diagnostic purposes.
+  private String requestId;
+
+  // Channels in request
+  private List<ChannelStatusRequestDTO> channels;
+
+  // Snowflake role used by client
+  private String role;
+
+  @JsonProperty("request_id")
+  String getRequestId() {
+    return requestId;
+  }
+
+  @JsonProperty("role")
+  public String getRole() {
+    return role;
+  }
+
+  @JsonProperty("role")
+  public void setRole(String role) {
+    this.role = role;
+  }
+
+  @JsonProperty("request_id")
+  void setRequestId(String requestId) {
+    this.requestId = requestId;
+  }
+
+  @JsonProperty("channels")
+  void setChannels(List<ChannelStatusRequestDTO> channels) {
+    this.channels = channels;
+  }
+
+  @JsonProperty("channels")
+  List<ChannelStatusRequestDTO> getChannels() {
+    return channels;
+  }
+}

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/ChannelExistenceCheckerRequest.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/ChannelExistenceCheckerRequest.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
+ */
 package com.snowflake.kafka.connector.internal.streaming;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/ChannelExistenceCheckerRequest.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/ChannelExistenceCheckerRequest.java
@@ -3,7 +3,10 @@ package com.snowflake.kafka.connector.internal.streaming;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
-/** Class to deserialize a request from a channel status request */
+/**
+ * Class to deserialize a request from a channel status request Please keep this upto date with
+ * {@link net.snowflake.ingest.streaming.internal.ChannelsStatusRequest}
+ */
 class ChannelExistenceCheckerRequest {
 
   // Used to deserialize a channel request

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/ChannelExistenceCheckerResponse.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/ChannelExistenceCheckerResponse.java
@@ -1,0 +1,96 @@
+package com.snowflake.kafka.connector.internal.streaming;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+/** Class used to serialize a response for the channels status endpoint */
+public class ChannelExistenceCheckerResponse {
+  static class ChannelStatusResponseDTO {
+
+    private Long statusCode;
+
+    // Latest persisted offset token
+    private String persistedOffsetToken;
+
+    // Latest persisted client sequencer
+    private Long persistedClientSequencer;
+
+    // Latest persisted row sequencer
+    private Long persistedRowSequencer;
+
+    @JsonProperty("status_code")
+    Long getStatusCode() {
+      return statusCode;
+    }
+
+    @JsonProperty("status_code")
+    void setStatusCode(Long statusCode) {
+      this.statusCode = statusCode;
+    }
+
+    @JsonProperty("persisted_row_sequencer")
+    Long getPersistedRowSequencer() {
+      return persistedRowSequencer;
+    }
+
+    @JsonProperty("persisted_row_sequencer")
+    void setPersistedRowSequencer(Long persistedRowSequencer) {
+      this.persistedRowSequencer = persistedRowSequencer;
+    }
+
+    @JsonProperty("persisted_client_sequencer")
+    Long getPersistedClientSequencer() {
+      return persistedClientSequencer;
+    }
+
+    @JsonProperty("persisted_client_sequencer")
+    void setPersistedClientSequencer(Long persistedClientSequencer) {
+      this.persistedClientSequencer = persistedClientSequencer;
+    }
+
+    @JsonProperty("persisted_offset_token")
+    String getPersistedOffsetToken() {
+      return persistedOffsetToken;
+    }
+
+    @JsonProperty("persisted_offset_token")
+    void setPersistedOffsetToken(String persistedOffsetToken) {
+      this.persistedOffsetToken = persistedOffsetToken;
+    }
+  }
+
+  // Channel array to return
+  private List<ChannelStatusResponseDTO> channels;
+  private Long statusCode;
+  private String message;
+
+  @JsonProperty("status_code")
+  void setStatusCode(Long statusCode) {
+    this.statusCode = statusCode;
+  }
+
+  @JsonProperty("status_code")
+  Long getStatusCode() {
+    return this.statusCode;
+  }
+
+  @JsonProperty("message")
+  void setMessage(String message) {
+    this.message = message;
+  }
+
+  @JsonProperty("message")
+  String getMessage() {
+    return this.message;
+  }
+
+  @JsonProperty("channels")
+  void setChannels(List<ChannelStatusResponseDTO> channels) {
+    this.channels = channels;
+  }
+
+  @JsonProperty("channels")
+  List<ChannelStatusResponseDTO> getChannels() {
+    return channels;
+  }
+}

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/ChannelExistenceCheckerResponse.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/ChannelExistenceCheckerResponse.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
+ */
 package com.snowflake.kafka.connector.internal.streaming;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/ChannelExistenceCheckerResponse.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/ChannelExistenceCheckerResponse.java
@@ -3,7 +3,10 @@ package com.snowflake.kafka.connector.internal.streaming;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
-/** Class used to serialize a response for the channels status endpoint */
+/**
+ * Class used to serialize a response for the channels status endpoint. Please keep this upto date
+ * with {@link net.snowflake.ingest.streaming.internal.ChannelsStatusResponse}
+ */
 public class ChannelExistenceCheckerResponse {
   static class ChannelStatusResponseDTO {
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingChannelExistenceChecker.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingChannelExistenceChecker.java
@@ -1,3 +1,6 @@
+/*
+ * Copyright (c) 2023 Snowflake Computing Inc. All rights reserved.
+ */
 package com.snowflake.kafka.connector.internal.streaming;
 
 import static net.snowflake.ingest.streaming.internal.StreamingIngestResponseCode.ERR_CHANNEL_DOES_NOT_EXIST_OR_IS_NOT_AUTHORIZED;

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingChannelExistenceChecker.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingChannelExistenceChecker.java
@@ -1,0 +1,290 @@
+package com.snowflake.kafka.connector.internal.streaming;
+
+import static net.snowflake.ingest.streaming.internal.StreamingIngestResponseCode.ERR_CHANNEL_DOES_NOT_EXIST_OR_IS_NOT_AUTHORIZED;
+import static net.snowflake.ingest.streaming.internal.StreamingIngestResponseCode.ERR_CHANNEL_HAS_INVALID_CLIENT_SEQUENCER;
+import static net.snowflake.ingest.streaming.internal.StreamingIngestResponseCode.SUCCESS;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
+import com.snowflake.kafka.connector.Utils;
+import com.snowflake.kafka.connector.internal.KCLogger;
+import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.spec.InvalidKeySpecException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.UUID;
+import net.snowflake.client.core.SFSessionProperty;
+import net.snowflake.client.jdbc.internal.apache.http.HttpEntity;
+import net.snowflake.client.jdbc.internal.apache.http.HttpResponse;
+import net.snowflake.client.jdbc.internal.apache.http.HttpStatus;
+import net.snowflake.client.jdbc.internal.apache.http.StatusLine;
+import net.snowflake.client.jdbc.internal.apache.http.client.methods.CloseableHttpResponse;
+import net.snowflake.client.jdbc.internal.apache.http.client.methods.HttpUriRequest;
+import net.snowflake.client.jdbc.internal.apache.http.impl.client.CloseableHttpClient;
+import net.snowflake.client.jdbc.internal.apache.http.util.EntityUtils;
+import net.snowflake.ingest.connection.OAuthCredential;
+import net.snowflake.ingest.connection.RequestBuilder;
+import net.snowflake.ingest.connection.ServiceResponseHandler;
+import net.snowflake.ingest.streaming.SnowflakeStreamingIngestChannel;
+import net.snowflake.ingest.utils.BackOffException;
+import net.snowflake.ingest.utils.Constants;
+import net.snowflake.ingest.utils.ErrorCode;
+import net.snowflake.ingest.utils.HttpUtil;
+import net.snowflake.ingest.utils.SFException;
+import net.snowflake.ingest.utils.SnowflakeURL;
+
+/**
+ * Class which handles REST API call directly for a Streaming channel and obtains a response of its
+ * existence.
+ *
+ * <p>This is a bit different from what we are doing in {@link
+ * SnowflakeStreamingIngestChannel#getLatestCommittedOffsetToken()} wherein we first have to Open A
+ * Channel and then make another call for getOffsetToken.
+ *
+ * <p>A method (checkChannelExistence) in this class bypasses that open Channel call and directly
+ * creates the payload for Get Status {@link
+ * StreamingChannelExistenceChecker#CHANNEL_STATUS_ENDPOINT} API.
+ */
+public class StreamingChannelExistenceChecker {
+  private static final KCLogger LOGGER =
+      new KCLogger(StreamingChannelExistenceChecker.class.getName());
+
+  private static final String DEBUG_PREFIX = "Channel Existence Checker - Kafka Connector";
+
+  private static final String CHANNEL_STATUS_ENDPOINT = "/v1/streaming/channels/status/";
+
+  // This is just a placeholder String, it has no value since we are not making a call through a
+  // Client.
+  private static final String STREAMING_CUSTOM_REST_API_CLIENT = "KC_CHANNEL_EXISTENCE_CHECKER";
+  private final String tableName;
+  private final Map<String, String> connectorConfig;
+
+  // Using SnowflakeURL from IngestSDK
+  private final SnowflakeURL snowflakeURL;
+
+  // We always set clientSequencer to 0.
+  private final Long clientSequencer;
+
+  @VisibleForTesting
+  StreamingChannelExistenceChecker(
+      String tableName, Map<String, String> connectorConfig, final Long clientSequencer) {
+    this.tableName = tableName;
+    this.connectorConfig = connectorConfig;
+    this.snowflakeURL = new SnowflakeURL(this.connectorConfig.get(Utils.SF_URL));
+    this.clientSequencer = clientSequencer;
+  }
+
+  /**
+   * C'tor for StreamingChannelExistenceChecker
+   *
+   * @param tableName TableName for checking Channel Name in it.
+   * @param connectorConfig connectorConfig passed in SF Kafka Connect Configuration
+   */
+  public StreamingChannelExistenceChecker(String tableName, Map<String, String> connectorConfig) {
+    this(tableName, connectorConfig, 0L);
+  }
+
+  /**
+   * Determines if a Channel Exists or not for a table defined in this class's ctor.
+   *
+   * @param channelName Name of Channel to Check for Existence
+   * @return True if it exists, false if it doesn't.
+   */
+  public boolean checkChannelExistence(final String channelName) {
+    // Re-using client from IngestSDK since it handles lots of proxy props.
+    // Please don't close this client.
+    CloseableHttpClient httpClient = HttpUtil.getHttpClient(snowflakeURL.getAccount());
+    Object credential = generateCredentialObjectForStreamingRestApi();
+    RequestBuilder requestBuilder =
+        new RequestBuilder(
+            snowflakeURL,
+            connectorConfig.get(Utils.SF_USER),
+            credential,
+            httpClient,
+            /* This String is used for Telemetry */
+            String.format(
+                "%s_%s_%s",
+                STREAMING_CUSTOM_REST_API_CLIENT, channelName, System.currentTimeMillis()));
+
+    ChannelExistenceCheckerRequest channelExistenceCheckerRequest =
+        new ChannelExistenceCheckerRequest();
+    ChannelExistenceCheckerRequest.ChannelStatusRequestDTO requestDTO =
+        new ChannelExistenceCheckerRequest.ChannelStatusRequestDTO(
+            this.connectorConfig.get(Utils.SF_DATABASE),
+            this.connectorConfig.get(Utils.SF_SCHEMA),
+            tableName,
+            channelName,
+            this.clientSequencer);
+    channelExistenceCheckerRequest.setChannels(Collections.singletonList(requestDTO));
+    channelExistenceCheckerRequest.setRole(connectorConfig.get(Utils.SF_ROLE));
+    channelExistenceCheckerRequest.setRequestId(UUID.randomUUID().toString());
+
+    try {
+      ObjectMapper objectMapper = new ObjectMapper();
+      objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+      String requestPayload = objectMapper.writeValueAsString(channelExistenceCheckerRequest);
+
+      HttpUriRequest request =
+          requestBuilder.generateStreamingIngestPostRequest(
+              requestPayload,
+              CHANNEL_STATUS_ENDPOINT,
+              DEBUG_PREFIX /* Message passed on to Ingest SDK */);
+
+      ChannelExistenceCheckerResponse channelExistenceCheckerResponse;
+      try (CloseableHttpResponse closeableHttpResponse = httpClient.execute(request)) {
+
+        if (closeableHttpResponse == null) {
+          LOGGER.warn(
+              "Null response obtained in {} for channel:{}", CHANNEL_STATUS_ENDPOINT, channelName);
+          throw new SFException(ErrorCode.CHANNEL_STATUS_FAILURE);
+        }
+
+        // Handle the exceptional status code
+        HttpResponse httpResponse =
+            handleExceptionalStatus(
+                closeableHttpResponse,
+                null,
+                ServiceResponseHandler.ApiName.STREAMING_CHANNEL_STATUS,
+                httpClient,
+                request,
+                requestBuilder);
+
+        // Grab the string version of the response entity
+        String blob = consumeAndReturnResponseEntityAsString(httpResponse.getEntity());
+
+        // Read out our blob into a pojo
+        channelExistenceCheckerResponse =
+            objectMapper.readValue(blob, ChannelExistenceCheckerResponse.class);
+      }
+
+      if (channelExistenceCheckerResponse.getStatusCode() == SUCCESS.getStatusCode()) {
+        assert channelExistenceCheckerResponse.getChannels().size() == 1;
+        if (channelExistenceCheckerResponse
+            .getChannels()
+            .get(0)
+            .getStatusCode()
+            .equals(ERR_CHANNEL_DOES_NOT_EXIST_OR_IS_NOT_AUTHORIZED.getStatusCode())) {
+          LOGGER.debug(String.format("%s Channel:%s doesn't exist", DEBUG_PREFIX, channelName));
+          return false;
+        } else if (channelExistenceCheckerResponse
+                .getChannels()
+                .get(0)
+                .getStatusCode()
+                .equals(ERR_CHANNEL_HAS_INVALID_CLIENT_SEQUENCER.getStatusCode())
+            || channelExistenceCheckerResponse
+                .getChannels()
+                .get(0)
+                .getStatusCode()
+                .equals(SUCCESS.getStatusCode())) {
+          // We check two status codes, one for invalid client sequencers and one for a valid client
+          // Sequencer
+          LOGGER.debug(String.format("%s Channel:%s does exist", DEBUG_PREFIX, channelName));
+          return true;
+        }
+      }
+    } catch (Exception e) {
+      LOGGER.error(
+          "{} Error Getting a valid response for ChannelName:{} error:{}",
+          DEBUG_PREFIX,
+          channelName,
+          e.getMessage());
+    }
+    return false;
+  }
+
+  /** This implementation is copied over from Ingest SDK. */
+  private static HttpResponse handleExceptionalStatus(
+      HttpResponse response,
+      UUID requestId,
+      ServiceResponseHandler.ApiName apiName,
+      CloseableHttpClient httpClient,
+      HttpUriRequest request,
+      RequestBuilder requestBuilder)
+      throws IOException, BackOffException {
+    if (!isStatusOK(response.getStatusLine())) {
+      StatusLine statusLine = response.getStatusLine();
+      LOGGER.warn(
+          "{} Status hit from {}, requestId:{}",
+          statusLine.getStatusCode(),
+          apiName,
+          requestId == null ? "" : requestId.toString());
+
+      // if we have a 503 exception throw a backoff
+      switch (statusLine.getStatusCode()) {
+          // If we have a 503, BACKOFF
+        case HttpStatus.SC_SERVICE_UNAVAILABLE:
+          throw new BackOffException();
+        case HttpStatus.SC_UNAUTHORIZED:
+          LOGGER.warn("Authorization failed, refreshing Token succeeded, retry");
+          requestBuilder.refreshToken();
+          requestBuilder.addToken(request);
+          response = httpClient.execute(request);
+          if (!isStatusOK(response.getStatusLine())) {
+            throw new SecurityException("Authorization failed after retry");
+          }
+          break;
+        default:
+          String blob = consumeAndReturnResponseEntityAsString(response.getEntity());
+          final String errMsg =
+              String.format("Unknown Exception for:%s with body:%s", CHANNEL_STATUS_ENDPOINT, blob);
+          LOGGER.warn(errMsg);
+          throw new SFException(ErrorCode.CHANNEL_STATUS_FAILURE, errMsg);
+      }
+    }
+    return response;
+  }
+
+  /** This implementation is copied over from Ingest SDK. */
+  private static boolean isStatusOK(StatusLine statusLine) {
+    // If the status is 200 (OK) or greater but less than 300 (Multiple Choices) we're good
+    return statusLine.getStatusCode() >= HttpStatus.SC_OK
+        && statusLine.getStatusCode() < HttpStatus.SC_MULTIPLE_CHOICES;
+  }
+
+  /** This implementation is copied over from Ingest SDK. */
+  private static String consumeAndReturnResponseEntityAsString(HttpEntity httpResponseEntity)
+      throws IOException {
+    // grab the string version of the response entity
+    String responseEntityAsString = EntityUtils.toString(httpResponseEntity);
+
+    EntityUtils.consumeQuietly(httpResponseEntity);
+    return responseEntityAsString;
+  }
+
+  /** Handles JWT and Oauth token Both! */
+  private Object generateCredentialObjectForStreamingRestApi() {
+    Properties streamingClientProps = new Properties();
+    // These are the properties which Ingest SDK expected when it creates Streaming Client
+    streamingClientProps.putAll(
+        StreamingUtils.convertConfigForStreamingClient(new HashMap<>(this.connectorConfig)));
+    Properties convertedPropertiesFromIngestSDK =
+        net.snowflake.ingest.utils.Utils.createProperties(streamingClientProps);
+    Object credential;
+
+    if (convertedPropertiesFromIngestSDK
+        .getProperty(Constants.AUTHORIZATION_TYPE)
+        .equals(Constants.JWT)) {
+      try {
+        credential =
+            net.snowflake.ingest.utils.Utils.createKeyPairFromPrivateKey(
+                (PrivateKey)
+                    convertedPropertiesFromIngestSDK.get(
+                        SFSessionProperty.PRIVATE_KEY.getPropertyKey()));
+      } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+        throw new SFException(e, ErrorCode.KEYPAIR_CREATION_FAILURE);
+      }
+    } else {
+      credential =
+          new OAuthCredential(
+              convertedPropertiesFromIngestSDK.getProperty(Constants.OAUTH_CLIENT_ID),
+              convertedPropertiesFromIngestSDK.getProperty(Constants.OAUTH_CLIENT_SECRET),
+              convertedPropertiesFromIngestSDK.getProperty(Constants.OAUTH_REFRESH_TOKEN));
+    }
+    return credential;
+  }
+}

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingChannelExistenceCheckerTestIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingChannelExistenceCheckerTestIT.java
@@ -18,6 +18,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+/** IT test related to ChannelExistenceCheckerRequest which Makes server side Calls */
 public class StreamingChannelExistenceCheckerTestIT {
 
   private SnowflakeConnectionService conn = TestUtils.getConnectionServiceForStreaming();

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingChannelExistenceCheckerTestIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingChannelExistenceCheckerTestIT.java
@@ -1,0 +1,196 @@
+package com.snowflake.kafka.connector.internal.streaming;
+
+import static com.snowflake.kafka.connector.internal.TestUtils.TEST_CONNECTOR_NAME;
+
+import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
+import com.snowflake.kafka.connector.dlq.InMemoryKafkaRecordErrorReporter;
+import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
+import com.snowflake.kafka.connector.internal.SnowflakeSinkService;
+import com.snowflake.kafka.connector.internal.SnowflakeSinkServiceFactory;
+import com.snowflake.kafka.connector.internal.TestUtils;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class StreamingChannelExistenceCheckerTestIT {
+
+  private SnowflakeConnectionService conn = TestUtils.getConnectionServiceForStreaming();
+
+  private String testTableName;
+
+  private static int PARTITION = 0, PARTITION_2 = 1;
+  private String topic;
+  private TopicPartition topicPartition, topicPartition2;
+  private String testChannelName, testChannelName2;
+
+  @Before
+  public void beforeEach() {
+    testTableName = TestUtils.randomTableName();
+    topic = testTableName;
+    topicPartition = new TopicPartition(testTableName, PARTITION);
+
+    topicPartition2 = new TopicPartition(testTableName, PARTITION_2);
+
+    testChannelName =
+        SnowflakeSinkServiceV2.partitionChannelKey(TEST_CONNECTOR_NAME, testTableName, PARTITION);
+
+    testChannelName2 =
+        SnowflakeSinkServiceV2.partitionChannelKey(TEST_CONNECTOR_NAME, testTableName, PARTITION_2);
+  }
+
+  @After
+  public void afterEach() {
+    TestUtils.dropTable(testTableName);
+  }
+
+  @Test
+  public void testChannelExistenceChecker_validChannel_ClientSequencerMatch() throws Exception {
+    Map<String, String> config = TestUtils.getConfForStreaming();
+    SnowflakeSinkConnectorConfig.setDefaultValues(config);
+
+    InMemorySinkTaskContext inMemorySinkTaskContext =
+        new InMemorySinkTaskContext(Collections.singleton(topicPartition));
+
+    // This will automatically create a channel for topicPartition.
+    SnowflakeSinkService service =
+        SnowflakeSinkServiceFactory.builder(conn, IngestionMethodConfig.SNOWPIPE_STREAMING, config)
+            .setRecordNumber(1)
+            .setErrorReporter(new InMemoryKafkaRecordErrorReporter())
+            .setSinkTaskContext(inMemorySinkTaskContext)
+            .addTask(testTableName, topicPartition)
+            .build();
+
+    final long noOfRecords = 1;
+
+    // send regular data
+    List<SinkRecord> records =
+        TestUtils.createJsonStringSinkRecords(0, noOfRecords, topic, PARTITION);
+
+    service.insert(records);
+
+    TestUtils.assertWithRetry(() -> service.getOffset(topicPartition) == noOfRecords, 20, 5);
+    assert TestUtils.tableSize(testTableName) == noOfRecords
+        : "expected: " + noOfRecords + " actual: " + TestUtils.tableSize(testTableName);
+
+    // At this point we do have a channel.
+    // Check if we can get an existence without opening a channel
+    // This has default clientSequencer passed in API as 0
+    StreamingChannelExistenceChecker streamingChannelExistenceChecker =
+        new StreamingChannelExistenceChecker(testTableName, config);
+    Assert.assertTrue(
+        streamingChannelExistenceChecker.checkChannelExistence(
+            SnowflakeSinkServiceV2.partitionChannelKey(TEST_CONNECTOR_NAME, topic, PARTITION)));
+
+    streamingChannelExistenceChecker =
+        new StreamingChannelExistenceChecker(testTableName, config, 2L);
+    Assert.assertTrue(
+        streamingChannelExistenceChecker.checkChannelExistence(
+            SnowflakeSinkServiceV2.partitionChannelKey(TEST_CONNECTOR_NAME, topic, PARTITION)));
+
+    service.closeAll();
+  }
+
+  @Test
+  public void testChannelExistenceChecker_validChannel_ClientSequencerDoesntMatchOnServerSide()
+      throws Exception {
+    Map<String, String> config = TestUtils.getConfForStreaming();
+    SnowflakeSinkConnectorConfig.setDefaultValues(config);
+
+    InMemorySinkTaskContext inMemorySinkTaskContext =
+        new InMemorySinkTaskContext(Collections.singleton(topicPartition));
+
+    // This will automatically create a channel for topicPartition.
+    SnowflakeSinkService service =
+        SnowflakeSinkServiceFactory.builder(conn, IngestionMethodConfig.SNOWPIPE_STREAMING, config)
+            .setRecordNumber(1)
+            .setErrorReporter(new InMemoryKafkaRecordErrorReporter())
+            .setSinkTaskContext(inMemorySinkTaskContext)
+            .addTask(testTableName, topicPartition)
+            .build();
+
+    final long noOfRecords = 1;
+
+    // send regular data
+    List<SinkRecord> records =
+        TestUtils.createJsonStringSinkRecords(0, noOfRecords, topic, PARTITION);
+
+    service.insert(records);
+
+    TestUtils.assertWithRetry(() -> service.getOffset(topicPartition) == noOfRecords, 20, 5);
+    assert TestUtils.tableSize(testTableName) == noOfRecords
+        : "expected: " + noOfRecords + " actual: " + TestUtils.tableSize(testTableName);
+
+    SnowflakeSinkServiceV2 snowflakeSinkServiceV2 = (SnowflakeSinkServiceV2) service;
+    // Ctor of TopicPartitionChannel tries to open the channel. so clientSequencer == 1
+    TopicPartitionChannel channel =
+        new TopicPartitionChannel(
+            snowflakeSinkServiceV2.getStreamingIngestClient(),
+            topicPartition,
+            testChannelName,
+            testTableName,
+            new StreamingBufferThreshold(10, 10_000, 1),
+            config,
+            new InMemoryKafkaRecordErrorReporter(),
+            new InMemorySinkTaskContext(Collections.singleton(topicPartition)),
+            conn.getTelemetryClient());
+
+    assert service.getOffset(new TopicPartition(topic, PARTITION)) == noOfRecords;
+    assert inMemorySinkTaskContext.offsets().size() == 1;
+    assert inMemorySinkTaskContext.offsets().get(topicPartition) == 1;
+    assert TestUtils.tableSize(testTableName) == noOfRecords
+        : "expected: " + noOfRecords + " actual: " + TestUtils.tableSize(testTableName);
+
+    // At this point we do have a channel but channel sequencer is 1
+    // Check if we can get an existence without opening a channel
+    // This passes in clientSequencer = 0
+    StreamingChannelExistenceChecker streamingChannelExistenceChecker =
+        new StreamingChannelExistenceChecker(testTableName, config);
+    Assert.assertTrue(
+        streamingChannelExistenceChecker.checkChannelExistence(
+            SnowflakeSinkServiceV2.partitionChannelKey(TEST_CONNECTOR_NAME, topic, PARTITION)));
+
+    service.closeAll();
+  }
+
+  @Test
+  public void testChannelExistenceChecker_InvalidChannelName() throws Exception {
+    Map<String, String> config = TestUtils.getConfForStreaming();
+    SnowflakeSinkConnectorConfig.setDefaultValues(config);
+
+    InMemorySinkTaskContext inMemorySinkTaskContext =
+        new InMemorySinkTaskContext(Collections.singleton(topicPartition));
+
+    // This will automatically create a channel for topicPartition.
+    SnowflakeSinkService service =
+        SnowflakeSinkServiceFactory.builder(conn, IngestionMethodConfig.SNOWPIPE_STREAMING, config)
+            .setRecordNumber(1)
+            .setErrorReporter(new InMemoryKafkaRecordErrorReporter())
+            .setSinkTaskContext(inMemorySinkTaskContext)
+            .addTask(testTableName, topicPartition)
+            .build();
+
+    final long noOfRecords = 1;
+
+    // send regular data
+    List<SinkRecord> records =
+        TestUtils.createJsonStringSinkRecords(0, noOfRecords, topic, PARTITION);
+
+    service.insert(records);
+
+    // No need to assert insertion/count in table
+
+    StreamingChannelExistenceChecker streamingChannelExistenceChecker =
+        new StreamingChannelExistenceChecker(testTableName, config);
+    Assert.assertFalse(
+        streamingChannelExistenceChecker.checkChannelExistence(
+            SnowflakeSinkServiceV2.partitionChannelKey(TEST_CONNECTOR_NAME, topic, PARTITION_2)));
+
+    service.closeAll();
+  }
+}


### PR DESCRIPTION
…stence Checker

## What
- A skeleton code, to find out whether a Streaming Channel exists for a table. 
- This is a backdoor way to get Channel Status (If client sequencers match) and to find out if a channel exists without opening a channel or without needing to have a StreamingIngestChannel Object
- It has a lot of repeated code from Ingest SDK. 
- We would want to move away from KC code to ingest SDK. More on that will come later SNOW-951262

## Why
- We could have always opened a new Channel, find offsetToken and assign it to oldChannel. 
- But this has a risk of opening a new channel everytime and we would want to go away from that. This could also have a lot of channels on table and we could reach a limit. 
- Doing `show channels iliike '<channelName>' in table <tableName>` is an expensive operation and is not optimal and also doesnt get away from opening a channel. 
- This will also help us to have our future code (PR no 3, more on it later) backward compatible. 

If interested, take a look at this [algorithm](https://docs.google.com/document/d/1kXY_wXKoEYXu-fDP4whQzhYCKLuxXzIf0iw2AwMOvwo/edit#heading=h.ckf809ta3j2k):  (Internal employees only)

## Tests
Added tests. 