### PR TITLE
PROD-39429 PART-3 Implement System Function for Update Channel OffsetToken

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionService.java
@@ -282,4 +282,6 @@ public interface SnowflakeConnectionService {
    * @param tableName table name
    */
   void createTableWithOnlyMetadataColumn(String tableName);
+
+  void updateStreamingChannelOffsetToken(String channelName, String offsetToken);
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionService.java
@@ -283,5 +283,17 @@ public interface SnowflakeConnectionService {
    */
   void createTableWithOnlyMetadataColumn(String tableName);
 
-  void updateStreamingChannelOffsetToken(String channelName, String offsetToken);
+  /**
+   * Update Streaming Channel OffsetToken without Streaming Client and Streaming Channel
+   *
+   * @param tableName name of table. Otherwise throws exception
+   * @param channelName Channel Name, returns false if doesnt exist.
+   * @param offsetToken OffsetToken you want to set on channelName in associated tableName. This can
+   *     be NULL String, empty or any Valid String.
+   * @return true if Update was successful, false if channel doesnt exist, exception if table
+   *     doesn't exist.
+   */
+  boolean updateStreamingChannelOffsetToken(
+      String tableName, String channelName, String offsetToken)
+      throws SnowflakeKafkaConnectorException;
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
@@ -1005,4 +1005,9 @@ public class SnowflakeConnectionServiceV1 implements SnowflakeConnectionService 
   public SnowflakeInternalStage getInternalStage() {
     return this.internalStage;
   }
+
+  @Override
+  public void updateStreamingChannelOffsetToken(String channelName, String offsetToken) {
+
+  }
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeErrors.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeErrors.java
@@ -196,6 +196,11 @@ public enum SnowflakeErrors {
       "2017",
       "Failed to check schema evolution permission",
       "Failed to check schema evolution permission"),
+
+  ERROR_2018(
+      "2018",
+      "Failed to update Offset Token using System Function",
+      "Failed to update Offset Token using System Function"),
   // Snowpipe related issues 3---
   ERROR_3001("3001", "Failed to ingest file", "Exception reported by Ingest SDK"),
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeInternalOperations.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeInternalOperations.java
@@ -27,5 +27,7 @@ public enum SnowflakeInternalOperations {
 
   LOAD_HISTORY_SCAN_SNOWPIPE_API,
 
-  FETCH_OAUTH_TOKEN
+  FETCH_OAUTH_TOKEN,
+
+  UPDATE_OFFSET_TOKEN_SYS_FUNC,
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
@@ -73,6 +73,11 @@ public class StreamingUtils {
   public static final String STREAMING_CONSTANT_OAUTH_CLIENT_SECRET = "oauth_client_secret";
   public static final String STREAMING_CONSTANT_OAUTH_REFRESH_TOKEN = "oauth_refresh_token";
 
+  public static final String SUCCESSFUL_CHANNEL_UPDATE_RESPONSE_SYSTEM_FUNC_MSG =
+      "UPDATED %s.%s's offset token to %s";
+  public static final String CHANNEL_UPDATE_RESPONSE_CHANNEL_DOESNT_EXIST_SYSTEM_FUNC_MSG =
+      "%s.%s DOES NOT EXIST";
+
   /* Maps streaming client's property keys to what we got from snowflake KC config file. */
   public static Map<String, String> convertConfigForStreamingClient(
       Map<String, String> connectorConfig) {

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
@@ -1010,7 +1010,7 @@ public class TopicPartitionChannel {
       offsetToken = this.channel.getLatestCommittedOffsetToken();
       LOGGER.info(
           "Fetched offsetToken for channelName:{}, offset:{}", this.getChannelName(), offsetToken);
-      return offsetToken == null
+      return offsetToken == null || offsetToken.equalsIgnoreCase("NULL")
           ? NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE
           : Long.parseLong(offsetToken);
     } catch (NumberFormatException ex) {


### PR DESCRIPTION
## What
- A simple implementation of updating Channel with an OffsetToken
- fetchOffsetTokenWithRetry which calls the channel's getOffsetToken is now checking for an explicit `NULL` offsetToken. This is because, no matter what I set through system function (null, `NULL`) I always get NULL from channel API and not null string. 

 
## Why
- We will set NULL to new channels which were created by the commit 3bf9106b22510c62068f7d2f7137b9e57989274c after we have fetched the offsetToken from it and reset those to Kafka committed offset. 
- Idea behind it is next time we reopen channelV2 (new format) we see their offset NULL and hence we will continue to use old ones. 
- We ideally want to also drop this new channels but that is not possible today. 

## Tests
Added tests. 