### PR TITLE
SNOW-913746 upgrade JDBC to 3.14.3

### DIFF
--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -28,9 +28,9 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-maven-
     - name: Install Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
-        python-version: '3.6'
+        python-version: '3.9'
         architecture: 'x64'
     - name: Decrypt profile.json in Snowflake Cloud ${{ matrix.snowflake_cloud }}
       run: ./.github/scripts/decrypt_secret.sh ${{ matrix.snowflake_cloud }}

--- a/.github/workflows/PerfTest.yml
+++ b/.github/workflows/PerfTest.yml
@@ -22,9 +22,9 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-maven-
     - name: Install Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
-        python-version: '3.6'
+        python-version: '3.9'
         architecture: 'x64'
     - name: Decrypt snowflake.json
       run: ./.github/scripts/perf_test_decrypt_secret.sh

--- a/pom.xml
+++ b/pom.xml
@@ -327,7 +327,7 @@
         <dependency>
             <groupId>net.snowflake</groupId>
             <artifactId>snowflake-jdbc</artifactId>
-            <version>3.13.30</version>
+            <version>3.14.3</version>
         </dependency>
 
         <!-- Ingest SDK for copy staged file into snowflake table -->

--- a/pom.xml
+++ b/pom.xml
@@ -346,7 +346,7 @@
         <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
-            <version>1.11.1</version>
+            <version>1.11.3</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.snowflake</groupId>
     <artifactId>snowflake-kafka-connector</artifactId>
-    <version>2.0.1</version>
+    <version>2.0.2-rc</version>
     <packaging>jar</packaging>
     <name>Snowflake Kafka Connector</name>
     <description>Snowflake Kafka Connect Sink Connector</description>

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -398,7 +398,7 @@
         <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
-            <version>1.11.1</version>
+            <version>1.11.3</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -379,7 +379,7 @@
         <dependency>
             <groupId>net.snowflake</groupId>
             <artifactId>snowflake-jdbc</artifactId>
-            <version>3.13.30</version>
+            <version>3.14.3</version>
         </dependency>
 
         <!-- Ingest SDK for copy staged file into snowflake table -->

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.snowflake</groupId>
     <artifactId>snowflake-kafka-connector</artifactId>
-    <version>2.0.1</version>
+    <version>2.0.2-rc</version>
     <packaging>jar</packaging>
     <name>Snowflake Kafka Connector</name>
     <description>Snowflake Kafka Connect Sink Connector</description>

--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -50,7 +50,7 @@ import org.apache.kafka.common.config.ConfigValue;
 public class Utils {
 
   // Connector version, change every release
-  public static final String VERSION = "2.0.1";
+  public static final String VERSION = "2.0.2-rc";
 
   // connector parameter list
   public static final String NAME = "name";

--- a/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
@@ -253,6 +253,9 @@ class InternalUtils {
         proxyProperties.put(SFSessionProperty.PROXY_USER.getPropertyKey(), username);
         proxyProperties.put(SFSessionProperty.PROXY_PASSWORD.getPropertyKey(), password);
       }
+      // There is a change in JDBC version 3.13.31 which causes NPE if this is not added.
+      // https://github.com/snowflakedb/snowflake-jdbc/blob/master/src/main/java/net/snowflake/client/jdbc/SnowflakeUtil.java#L614
+      proxyProperties.put(SFSessionProperty.GZIP_DISABLED.getPropertyKey(), "false");
     }
     return proxyProperties;
   }

--- a/src/test/java/com/snowflake/kafka/connector/internal/InternalStageIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/InternalStageIT.java
@@ -140,6 +140,8 @@ public class InternalStageIT {
     proxyProperties.put(SFSessionProperty.PROXY_PORT.getPropertyKey(), "3128");
     proxyProperties.put(SFSessionProperty.PROXY_USER.getPropertyKey(), "admin");
     proxyProperties.put(SFSessionProperty.PROXY_PASSWORD.getPropertyKey(), "test");
+    // required otherwise JDBC version 3.13.31 throws NPE
+    proxyProperties.put(SFSessionProperty.GZIP_DISABLED.getPropertyKey(), "false");
 
     // Create new snowflake connection service
     Map<String, String> config = TestUtils.getConf();

--- a/test/perf_test/pom.xml
+++ b/test/perf_test/pom.xml
@@ -54,7 +54,7 @@
     <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
-      <version>1.11.1</version>
+      <version>1.11.3</version>
     </dependency>
   </dependencies>
 
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.avro</groupId>
         <artifactId>avro-maven-plugin</artifactId>
-        <version>1.11.1</version>
+        <version>1.11.3</version>
         <executions>
           <execution>
             <phase>generate-sources</phase>


### PR DESCRIPTION
We need this for a customer who wants to use s3 + regional URL. 

Here are supporting PRs which this change was originally dependent on:
1. Server side: https://github.com/snowflakedb/snowflake/commit/208702b0a6bdc3639c46f0c4b8ef4375824456b6
2. JDBC: https://github.com/snowflakedb/snowflake-jdbc/commit/14c13183df076cc55cf0ab0663756d43ab7be448

Originally, it was released in 3.14.2 but 3.14.2 is backward incompatible change which impacts telemetry constructor from IngestSDK. Hence using 3.14.3


TLDR;
- We use a response string from configure client API for snowpipe streaming. 
- We send this to get SnowflakeFileTransferMetadata Object. 
- JDBC needs to honor this variable and use the s3 regional URL. 
- This still needs the param set at an account level. (Please look at server side change for that)


We will push this to master as well as to a release branch for a requested customer. 