### PR TITLE
Support other configProviders than file in validation phase

### DIFF
--- a/src/test/java/com/snowflake/kafka/connector/ConnectorIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorIT.java
@@ -251,9 +251,25 @@ public class ConnectorIT {
   }
 
   @Test
+  public void testValidateConfigProviderPasswordConfig() {
+    Map<String, String> config = getCorrectConfig();
+    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_PRIVATE_KEY, " ${configProvider:/");
+    Map<String, ConfigValue> validateMap = toValidateMap(config);
+    assertPropHasError(validateMap, new String[] {});
+  }
+
+  @Test
   public void testValidateFilePassphraseConfig() {
     Map<String, String> config = getCorrectConfig();
     config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_PRIVATE_KEY_PASSPHRASE, " ${file:/");
+    Map<String, ConfigValue> validateMap = toValidateMap(config);
+    assertPropHasError(validateMap, new String[] {});
+  }
+
+  @Test
+  public void testValidateConfigProviderPassphraseConfig() {
+    Map<String, String> config = getCorrectConfig();
+    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_PRIVATE_KEY_PASSPHRASE, " ${configProvider:/");
     Map<String, ConfigValue> validateMap = toValidateMap(config);
     assertPropHasError(validateMap, new String[] {});
   }


### PR DESCRIPTION
I'm trying to use different config providers in my snowflake connector, but get an error during validation because the snowflake private key is not valid.
This is because validation seems to receive the raw config values (not running through configProviders which seems iffy).

In any case there was already a workaround to support `${file:` as a config provider value and to skip validation. I've extended it to include any configProvider with a different name.