### PR TITLE
PROD-39429 Implement migrate sys func from new channel(Format V2) to old channel (V1) - Push to Main

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -175,7 +175,9 @@ public class SnowflakeSinkConnectorConfig {
   public static final boolean ENABLE_CHANNEL_OFFSET_TOKEN_MIGRATION_DEFAULT = true;
   public static final String ENABLE_CHANNEL_OFFSET_TOKEN_MIGRATION_DOC =
       "This config is used to enable/disable streaming channel offset migration logic. If true, we"
-          + " will migrate offset token from channel name format V2 to name format v1.";
+          + " will migrate offset token from channel name format V2 to name format v1. V2 channel"
+          + " format is deprecated and V1 will be used always, disabling this config could have"
+          + " ramifications. Please consult Snowflake support before setting this to false.";
 
   // MDC logging header
   public static final String ENABLE_MDC_LOGGING_CONFIG = "enable.mdc.logging";

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -168,6 +168,15 @@ public class SnowflakeSinkConnectorConfig {
       "Whether to optimize the streaming client to reduce cost. Note that this may affect"
           + " throughput or latency and can only be set if Streaming Snowpipe is enabled";
 
+  public static final String ENABLE_CHANNEL_OFFSET_TOKEN_MIGRATION_CONFIG =
+      "enable.streaming.channel.offset.migration";
+  public static final String ENABLE_CHANNEL_OFFSET_TOKEN_MIGRATION_DISPLAY =
+      "Enable streaming Channel Offset Migration";
+  public static final boolean ENABLE_CHANNEL_OFFSET_TOKEN_MIGRATION_DEFAULT = true;
+  public static final String ENABLE_CHANNEL_OFFSET_TOKEN_MIGRATION_DOC =
+      "This config is used to enable/disable streaming channel offset migration logic. If true, we"
+          + " will migrate offset token from channel name format V2 to name format v1.";
+
   // MDC logging header
   public static final String ENABLE_MDC_LOGGING_CONFIG = "enable.mdc.logging";
   public static final String ENABLE_MDC_LOGGING_DISPLAY = "Enable MDC logging";
@@ -591,7 +600,17 @@ public class SnowflakeSinkConnectorConfig {
             CONNECTOR_CONFIG,
             8,
             ConfigDef.Width.NONE,
-            ENABLE_MDC_LOGGING_DISPLAY);
+            ENABLE_MDC_LOGGING_DISPLAY)
+        .define(
+            ENABLE_CHANNEL_OFFSET_TOKEN_MIGRATION_CONFIG,
+            Type.BOOLEAN,
+            ENABLE_CHANNEL_OFFSET_TOKEN_MIGRATION_DEFAULT,
+            Importance.LOW,
+            ENABLE_CHANNEL_OFFSET_TOKEN_MIGRATION_DOC,
+            CONNECTOR_CONFIG,
+            9,
+            ConfigDef.Width.NONE,
+            ENABLE_CHANNEL_OFFSET_TOKEN_MIGRATION_DISPLAY);
   }
 
   public static class TopicToTableValidator implements ConfigDef.Validator {

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -171,7 +171,7 @@ public class SnowflakeSinkConnectorConfig {
   public static final String ENABLE_CHANNEL_OFFSET_TOKEN_MIGRATION_CONFIG =
       "enable.streaming.channel.offset.migration";
   public static final String ENABLE_CHANNEL_OFFSET_TOKEN_MIGRATION_DISPLAY =
-      "Enable streaming Channel Offset Migration";
+      "Enable Streaming Channel Offset Migration";
   public static final boolean ENABLE_CHANNEL_OFFSET_TOKEN_MIGRATION_DEFAULT = true;
   public static final String ENABLE_CHANNEL_OFFSET_TOKEN_MIGRATION_DOC =
       "This config is used to enable/disable streaming channel offset migration logic. If true, we"

--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -454,6 +454,14 @@ public class Utils {
                 "Streaming client optimization is only available with {}.",
                 IngestionMethodConfig.SNOWPIPE_STREAMING.toString()));
       }
+      if (config.containsKey(
+          SnowflakeSinkConnectorConfig.ENABLE_CHANNEL_OFFSET_TOKEN_MIGRATION_CONFIG)) {
+        invalidConfigParams.put(
+            SnowflakeSinkConnectorConfig.ENABLE_CHANNEL_OFFSET_TOKEN_MIGRATION_CONFIG,
+            Utils.formatString(
+                "Streaming client Channel migration is only available with {}.",
+                IngestionMethodConfig.SNOWPIPE_STREAMING.toString()));
+      }
     }
 
     if (config.containsKey(SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP)

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionService.java
@@ -1,5 +1,6 @@
 package com.snowflake.kafka.connector.internal;
 
+import com.snowflake.kafka.connector.internal.streaming.ChannelMigrateOffsetTokenResponseDTO;
 import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryService;
 import java.sql.Connection;
 import java.util.List;
@@ -302,8 +303,8 @@ public interface SnowflakeConnectionService {
    *     Channel with this name will also be deleted.
    * @param destinationChannelName destinationChannel name to where the offsetToken will be copied
    *     over.
-   * @return Whether the migration was successful or a failure.
+   * @return The DTO serialized from the migration response.
    */
-  boolean migrateStreamingChannelOffsetToken(
+  ChannelMigrateOffsetTokenResponseDTO migrateStreamingChannelOffsetToken(
       String tableName, String sourceChannelName, String destinationChannelName);
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionService.java
@@ -282,4 +282,28 @@ public interface SnowflakeConnectionService {
    * @param tableName table name
    */
   void createTableWithOnlyMetadataColumn(String tableName);
+
+  /**
+   * Migrate Streaming Channel offsetToken from a source Channel to a destination channel.
+   *
+   * <p>Here, source channel is the new channel format we created here * @see <a
+   * href="https://github.com/snowflakedb/snowflake-kafka-connector/commit/3bf9106b22510c62068f7d2f7137b9e57989274c">Commit
+   * </a>
+   *
+   * <p>Destination channel is the original Format containing only topicName and partition number.
+   *
+   * <p>We catch SQLException and JsonProcessingException that might happen in this method. The
+   * caller should always open the Old Channel format. This old channel format will also be the key
+   * to many HashMaps we will create. (For instance {@link
+   * com.snowflake.kafka.connector.internal.streaming.SnowflakeSinkServiceV2#partitionsToChannel})
+   *
+   * @param tableName Name of the table
+   * @param sourceChannelName sourceChannel name from where the offset Token will be fetched.
+   *     Channel with this name will also be deleted.
+   * @param destinationChannelName destinationChannel name to where the offsetToken will be copied
+   *     over.
+   * @return Whether the migration was successful or a failure.
+   */
+  boolean migrateStreamingChannelOffsetToken(
+      String tableName, String sourceChannelName, String destinationChannelName);
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
@@ -1038,13 +1038,12 @@ public class SnowflakeConnectionServiceV1 implements SnowflakeConnectionService 
         migrateOffsetTokenResultFromSysFunc = resultSet.getString(1 /*Only one column*/);
       }
       if (migrateOffsetTokenResultFromSysFunc == null) {
-        LOGGER.warn(
-            "No result found in Migrating OffsetToken through System Function for tableName:{},"
-                + " sourceChannel:{}, destinationChannel:{}",
-            fullyQualifiedTableName,
-            sourceChannelName,
-            destinationChannelName);
-        return false;
+        final String errorMsg =
+            String.format(
+                "No result found in Migrating OffsetToken through System Function for tableName:%s,"
+                    + " sourceChannel:%s, destinationChannel:%s",
+                fullyQualifiedTableName, sourceChannelName, destinationChannelName);
+        throw SnowflakeErrors.ERROR_5023.getException(errorMsg, this.telemetry);
       }
 
       ChannelMigrateOffsetTokenResponseDTO channelMigrateOffsetTokenResponseDTO =
@@ -1059,12 +1058,15 @@ public class SnowflakeConnectionServiceV1 implements SnowflakeConnectionService 
           channelMigrateOffsetTokenResponseDTO);
       return true;
     } catch (SQLException | JsonProcessingException e) {
-      LOGGER.error(
-          "Migrating OffsetToken for a SourceChannel:{} in table:{} failed due to:{}",
-          sourceChannelName,
-          fullyQualifiedTableName,
-          e.getMessage());
-      return false;
+      final String errorMsg =
+          String.format(
+              "Migrating OffsetToken for a SourceChannel:%s in table:%s failed due to"
+                  + " exceptionMessage:%s and stackTrace:%s",
+              sourceChannelName,
+              fullyQualifiedTableName,
+              e.getMessage(),
+              Arrays.toString(e.getStackTrace()));
+      throw SnowflakeErrors.ERROR_5023.getException(errorMsg, this.telemetry);
     }
   }
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
@@ -3,7 +3,10 @@ package com.snowflake.kafka.connector.internal;
 import static com.snowflake.kafka.connector.Utils.TABLE_COLUMN_CONTENT;
 import static com.snowflake.kafka.connector.Utils.TABLE_COLUMN_METADATA;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.snowflake.kafka.connector.Utils;
+import com.snowflake.kafka.connector.internal.streaming.ChannelMigrateOffsetTokenResponseDTO;
 import com.snowflake.kafka.connector.internal.streaming.IngestionMethodConfig;
 import com.snowflake.kafka.connector.internal.streaming.SchematizationUtils;
 import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryService;
@@ -55,6 +58,8 @@ public class SnowflakeConnectionServiceV1 implements SnowflakeConnectionService 
 
   // User agent suffix we want to pass in to ingest service
   public static final String USER_AGENT_SUFFIX_FORMAT = "SFKafkaConnector/%s provider/%s";
+
+  private final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   SnowflakeConnectionServiceV1(
       Properties prop,
@@ -1005,5 +1010,61 @@ public class SnowflakeConnectionServiceV1 implements SnowflakeConnectionService 
 
   public SnowflakeInternalStage getInternalStage() {
     return this.internalStage;
+  }
+
+  @Override
+  public boolean migrateStreamingChannelOffsetToken(
+      String tableName, String sourceChannelName, String destinationChannelName) {
+    InternalUtils.assertNotEmpty("tableName", tableName);
+    InternalUtils.assertNotEmpty("sourceChannelName", sourceChannelName);
+    InternalUtils.assertNotEmpty("destinationChannelName", destinationChannelName);
+    String fullyQualifiedTableName =
+        prop.getProperty(InternalUtils.JDBC_DATABASE)
+            + "."
+            + prop.getProperty(InternalUtils.JDBC_SCHEMA)
+            + "."
+            + tableName;
+    String query = "select SYSTEM$SNOWPIPE_STREAMING_MIGRATE_CHANNEL_OFFSET_TOKEN((?), (?), (?));";
+
+    try {
+      PreparedStatement stmt = conn.prepareStatement(query);
+      stmt.setString(1, fullyQualifiedTableName);
+      stmt.setString(2, sourceChannelName);
+      stmt.setString(3, destinationChannelName);
+      ResultSet resultSet = stmt.executeQuery();
+
+      String migrateOffsetTokenResultFromSysFunc = null;
+      if (resultSet.next()) {
+        migrateOffsetTokenResultFromSysFunc = resultSet.getString(1 /*Only one column*/);
+      }
+      if (migrateOffsetTokenResultFromSysFunc == null) {
+        LOGGER.warn(
+            "No result found in Migrating OffsetToken through System Function for tableName:{},"
+                + " sourceChannel:{}, destinationChannel:{}",
+            fullyQualifiedTableName,
+            sourceChannelName,
+            destinationChannelName);
+        return false;
+      }
+
+      ChannelMigrateOffsetTokenResponseDTO channelMigrateOffsetTokenResponseDTO =
+          OBJECT_MAPPER.readValue(
+              migrateOffsetTokenResultFromSysFunc, ChannelMigrateOffsetTokenResponseDTO.class);
+      LOGGER.info(
+          "Migrate OffsetToken response for table:{}, sourceChannel:{}, destinationChannel:{}"
+              + " is:{}",
+          tableName,
+          sourceChannelName,
+          destinationChannelName,
+          channelMigrateOffsetTokenResponseDTO);
+      return true;
+    } catch (SQLException | JsonProcessingException e) {
+      LOGGER.error(
+          "Migrating OffsetToken for a SourceChannel:{} in table:{} failed due to:{}",
+          sourceChannelName,
+          fullyQualifiedTableName,
+          e.getMessage());
+      return false;
+    }
   }
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
@@ -5,6 +5,7 @@ import static com.snowflake.kafka.connector.Utils.TABLE_COLUMN_METADATA;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
 import com.snowflake.kafka.connector.Utils;
 import com.snowflake.kafka.connector.internal.streaming.ChannelMigrateOffsetTokenResponseDTO;
 import com.snowflake.kafka.connector.internal.streaming.ChannelMigrationResponseCode;
@@ -60,7 +61,7 @@ public class SnowflakeConnectionServiceV1 implements SnowflakeConnectionService 
   // User agent suffix we want to pass in to ingest service
   public static final String USER_AGENT_SUFFIX_FORMAT = "SFKafkaConnector/%s provider/%s";
 
-  private final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   SnowflakeConnectionServiceV1(
       Properties prop,
@@ -1048,8 +1049,8 @@ public class SnowflakeConnectionServiceV1 implements SnowflakeConnectionService 
       }
 
       ChannelMigrateOffsetTokenResponseDTO channelMigrateOffsetTokenResponseDTO =
-          OBJECT_MAPPER.readValue(
-              migrateOffsetTokenResultFromSysFunc, ChannelMigrateOffsetTokenResponseDTO.class);
+          getChannelMigrateOffsetTokenResponseDTO(migrateOffsetTokenResultFromSysFunc);
+
       LOGGER.info(
           "Migrate OffsetToken response for table:{}, sourceChannel:{}, destinationChannel:{}"
               + " is:{}",
@@ -1076,5 +1077,14 @@ public class SnowflakeConnectionServiceV1 implements SnowflakeConnectionService 
               Arrays.toString(e.getStackTrace()));
       throw SnowflakeErrors.ERROR_5023.getException(errorMsg, this.telemetry);
     }
+  }
+
+  @VisibleForTesting
+  protected ChannelMigrateOffsetTokenResponseDTO getChannelMigrateOffsetTokenResponseDTO(
+      String migrateOffsetTokenResultFromSysFunc) throws JsonProcessingException {
+    ChannelMigrateOffsetTokenResponseDTO channelMigrateOffsetTokenResponseDTO =
+        OBJECT_MAPPER.readValue(
+            migrateOffsetTokenResultFromSysFunc, ChannelMigrateOffsetTokenResponseDTO.class);
+    return channelMigrateOffsetTokenResponseDTO;
   }
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.snowflake.kafka.connector.Utils;
 import com.snowflake.kafka.connector.internal.streaming.ChannelMigrateOffsetTokenResponseDTO;
+import com.snowflake.kafka.connector.internal.streaming.ChannelMigrationResponseCode;
 import com.snowflake.kafka.connector.internal.streaming.IngestionMethodConfig;
 import com.snowflake.kafka.connector.internal.streaming.SchematizationUtils;
 import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryService;
@@ -1056,6 +1057,13 @@ public class SnowflakeConnectionServiceV1 implements SnowflakeConnectionService 
           sourceChannelName,
           destinationChannelName,
           channelMigrateOffsetTokenResponseDTO);
+      if (!ChannelMigrationResponseCode.isChannelMigrationResponseSuccessful(
+          channelMigrateOffsetTokenResponseDTO)) {
+        throw SnowflakeErrors.ERROR_5023.getException(
+            ChannelMigrationResponseCode.getMessageByCode(
+                channelMigrateOffsetTokenResponseDTO.getResponseCode()),
+            this.telemetry);
+      }
       return channelMigrateOffsetTokenResponseDTO;
     } catch (SQLException | JsonProcessingException e) {
       final String errorMsg =

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
@@ -1013,7 +1013,7 @@ public class SnowflakeConnectionServiceV1 implements SnowflakeConnectionService 
   }
 
   @Override
-  public boolean migrateStreamingChannelOffsetToken(
+  public ChannelMigrateOffsetTokenResponseDTO migrateStreamingChannelOffsetToken(
       String tableName, String sourceChannelName, String destinationChannelName) {
     InternalUtils.assertNotEmpty("tableName", tableName);
     InternalUtils.assertNotEmpty("sourceChannelName", sourceChannelName);
@@ -1056,7 +1056,7 @@ public class SnowflakeConnectionServiceV1 implements SnowflakeConnectionService 
           sourceChannelName,
           destinationChannelName,
           channelMigrateOffsetTokenResponseDTO);
-      return true;
+      return channelMigrateOffsetTokenResponseDTO;
     } catch (SQLException | JsonProcessingException e) {
       final String errorMsg =
           String.format(

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeErrors.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeErrors.java
@@ -297,7 +297,13 @@ public enum SnowflakeErrors {
       "5021",
       "Failed to get data schema",
       "Failed to get data schema. Unrecognizable data type in JSON object"),
-  ERROR_5022("5022", "Invalid column name", "Failed to find column in the schema");
+  ERROR_5022("5022", "Invalid column name", "Failed to find column in the schema"),
+
+  ERROR_5023(
+      "5023",
+      "Failure in Streaming Channel Offset Migration Response",
+      "Streaming Channel Offset Migration from Source to Destination Channel has no/invalid"
+          + " response, please contact Snowflake Support");
 
   // properties
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/ChannelMigrateOffsetTokenResponseDTO.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/ChannelMigrateOffsetTokenResponseDTO.java
@@ -1,0 +1,42 @@
+package com.snowflake.kafka.connector.internal.streaming;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * POJO used to serialize the System function response for migration offset from Source Channel to
+ * Destination.
+ */
+public class ChannelMigrateOffsetTokenResponseDTO {
+  private long responseCode;
+
+  private String responseMessage;
+
+  public ChannelMigrateOffsetTokenResponseDTO(long responseCode, String responseMessage) {
+    this.responseCode = responseCode;
+    this.responseMessage = responseMessage;
+  }
+
+  /** Default Ctor for Jackson */
+  public ChannelMigrateOffsetTokenResponseDTO() {}
+
+  @JsonProperty("responseCode")
+  public long getResponseCode() {
+    return responseCode;
+  }
+
+  @JsonProperty("responseMessage")
+  public String getResponseMessage() {
+    return responseMessage;
+  }
+
+  @Override
+  public String toString() {
+    return "ChannelMigrateOffsetTokenResponseDTO{"
+        + "responseCode="
+        + responseCode
+        + ", responseMessage='"
+        + responseMessage
+        + '\''
+        + '}';
+  }
+}

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/ChannelMigrateOffsetTokenResponseDTO.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/ChannelMigrateOffsetTokenResponseDTO.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2023 Snowflake Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.snowflake.kafka.connector.internal.streaming;
 
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/ChannelMigrationResponseCode.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/ChannelMigrationResponseCode.java
@@ -78,12 +78,9 @@ public enum ChannelMigrationResponseCode {
    * @param statusCodeToCheck response from JDBC system function call.
    * @return true or false
    */
-  public static boolean isStatusCodeSuccessful(final long statusCodeToCheck) {
-    if (statusCodeToCheck == SUCCESS.getStatusCode()
-        || statusCodeToCheck == OFFSET_MIGRATION_SOURCE_CHANNEL_DOES_NOT_EXIST.getStatusCode()) {
-      return true;
-    }
-    return false;
+  private static boolean isStatusCodeSuccessful(final long statusCodeToCheck) {
+    return statusCodeToCheck == SUCCESS.getStatusCode()
+        || statusCodeToCheck == OFFSET_MIGRATION_SOURCE_CHANNEL_DOES_NOT_EXIST.getStatusCode();
   }
 
   /**

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/ChannelMigrationResponseCode.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/ChannelMigrationResponseCode.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2023 Snowflake Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.snowflake.kafka.connector.internal.streaming;
+
+import com.google.common.annotations.VisibleForTesting;
+
+/**
+ * Response code sent from the system function to migrate offsets from Source to Destination
+ * Channel. Please keep this code(values) in sync with what the server side is assigned.
+ */
+public enum ChannelMigrationResponseCode {
+  ERR_TABLE_DOES_NOT_EXIST_NOT_AUTHORIZED(
+      4, "The supplied table does not exist or is not authorized"),
+
+  SUCCESS(50, "Success"),
+
+  OFFSET_MIGRATION_SOURCE_CHANNEL_DOES_NOT_EXIST(
+      51, "Source Channel does not exist for Offset Migration"),
+
+  CHANNEL_OFFSET_TOKEN_MIGRATION_GENERAL_EXCEPTION(
+      52, "Snowflake experienced a transient exception, please retry the migration request."),
+
+  OFFSET_MIGRATION_SOURCE_AND_DESTINATION_CHANNEL_SAME(
+      53, "Source and Destination Channel are same for Migration Offset Request"),
+  ;
+
+  private final long statusCode;
+
+  private final String message;
+
+  public static final String UNKNOWN_STATUS_MESSAGE =
+      "Unknown status message. Please contact Snowflake support for further assistance";
+
+  ChannelMigrationResponseCode(int statusCode, String message) {
+    this.statusCode = statusCode;
+    this.message = message;
+  }
+
+  @VisibleForTesting
+  public long getStatusCode() {
+    return statusCode;
+  }
+
+  @VisibleForTesting
+  public String getMessage() {
+    return message;
+  }
+
+  public static String getMessageByCode(Long statusCode) {
+    if (statusCode != null) {
+      for (ChannelMigrationResponseCode code : values()) {
+        if (code.statusCode == statusCode) {
+          return code.message;
+        }
+      }
+    }
+    return UNKNOWN_STATUS_MESSAGE;
+  }
+
+  /**
+   * Given a response code which was received from server side, check if it as successful migration
+   * or a failure.
+   *
+   * @param statusCodeToCheck response from JDBC system function call.
+   * @return true or false
+   */
+  public static boolean isStatusCodeSuccessful(final long statusCodeToCheck) {
+    if (statusCodeToCheck == SUCCESS.getStatusCode()
+        || statusCodeToCheck == OFFSET_MIGRATION_SOURCE_CHANNEL_DOES_NOT_EXIST.getStatusCode()) {
+      return true;
+    }
+    return false;
+  }
+}

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/ChannelMigrationResponseCode.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/ChannelMigrationResponseCode.java
@@ -85,4 +85,17 @@ public enum ChannelMigrationResponseCode {
     }
     return false;
   }
+
+  /**
+   * Given a Response DTO, which was received from server side and serialized, check if it as
+   * successful migration or a failure.
+   *
+   * @param channelMigrateOffsetTokenResponseDTO response from JDBC system function call serialized
+   *     into a DTO object.
+   * @return true or false
+   */
+  public static boolean isChannelMigrationResponseSuccessful(
+      final ChannelMigrateOffsetTokenResponseDTO channelMigrateOffsetTokenResponseDTO) {
+    return isStatusCodeSuccessful(channelMigrateOffsetTokenResponseDTO.getResponseCode());
+  }
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -92,7 +92,7 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
   private boolean enableSchematization;
 
   /**
-   * Key is formulated in {@link #partitionChannelKey(String, String, int)} }
+   * Key is formulated in {@link #partitionChannelKey(String, int)} }
    *
    * <p>value is the Streaming Ingest Channel implementation (Wrapped around TopicPartitionChannel)
    */
@@ -235,8 +235,7 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
       final TopicPartition topicPartition,
       boolean hasSchemaEvolutionPermission) {
     final String partitionChannelKey =
-        partitionChannelKey(
-            conn.getConnectorName(), topicPartition.topic(), topicPartition.partition());
+        partitionChannelKey(topicPartition.topic(), topicPartition.partition());
     // Create new instance of TopicPartitionChannel which will always open the channel.
     partitionsToChannel.put(
         partitionChannelKey,
@@ -295,8 +294,7 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
    */
   @Override
   public void insert(SinkRecord record) {
-    String partitionChannelKey =
-        partitionChannelKey(this.conn.getConnectorName(), record.topic(), record.kafkaPartition());
+    String partitionChannelKey = partitionChannelKey(record.topic(), record.kafkaPartition());
     // init a new topic partition if it's not presented in cache or if channel is closed
     if (!partitionsToChannel.containsKey(partitionChannelKey)
         || partitionsToChannel.get(partitionChannelKey).isChannelClosed()) {
@@ -316,8 +314,7 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
   @Override
   public long getOffset(TopicPartition topicPartition) {
     String partitionChannelKey =
-        partitionChannelKey(
-            conn.getConnectorName(), topicPartition.topic(), topicPartition.partition());
+        partitionChannelKey(topicPartition.topic(), topicPartition.partition());
     if (partitionsToChannel.containsKey(partitionChannelKey)) {
       long offset = partitionsToChannel.get(partitionChannelKey).getOffsetSafeToCommitToKafka();
       partitionsToChannel.get(partitionChannelKey).setLatestConsumerOffset(offset);
@@ -371,8 +368,7 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
     partitions.forEach(
         topicPartition -> {
           final String partitionChannelKey =
-              partitionChannelKey(
-                  conn.getConnectorName(), topicPartition.topic(), topicPartition.partition());
+              partitionChannelKey(topicPartition.topic(), topicPartition.partition());
           TopicPartitionChannel topicPartitionChannel =
               partitionsToChannel.get(partitionChannelKey);
           // Check for null since it's possible that the something goes wrong even before the
@@ -521,17 +517,13 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
   /**
    * Gets a unique identifier consisting of connector name, topic name and partition number.
    *
-   * @param connectorName Connector name is always unique. (Two connectors with same name won't be
-   *     allowed by Connector Framework)
-   *     <p>Note: Customers can have same named connector in different connector runtimes (Like DEV
-   *     or PROD)
    * @param topic topic name
    * @param partition partition number
    * @return combinartion of topic and partition
    */
   @VisibleForTesting
-  public static String partitionChannelKey(String connectorName, String topic, int partition) {
-    return connectorName + "_" + topic + "_" + partition;
+  public static String partitionChannelKey(String topic, int partition) {
+    return topic + "_" + partition;
   }
 
   /* Used for testing */

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -528,7 +528,7 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
 
   /* Used for testing */
   @VisibleForTesting
-  SnowflakeStreamingIngestClient getStreamingIngestClient() {
+  public SnowflakeStreamingIngestClient getStreamingIngestClient() {
     return StreamingClientProvider.getStreamingClientProviderInstance()
         .getClient(this.connectorConfig);
   }

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -378,7 +378,7 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
           }
           LOGGER.info(
               "Closing partitionChannel:{}, partition:{}, topic:{}",
-              topicPartitionChannel == null ? null : topicPartitionChannel.getChannelName(),
+              topicPartitionChannel == null ? null : topicPartitionChannel.getChannelNameFormatV1(),
               topicPartition.topic(),
               topicPartition.partition());
           partitionsToChannel.remove(partitionChannelKey);

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
@@ -1,6 +1,9 @@
 package com.snowflake.kafka.connector.internal.streaming;
 
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.*;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_CHANNEL_OFFSET_TOKEN_MIGRATION_CONFIG;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_CHANNEL_OFFSET_TOKEN_MIGRATION_DEFAULT;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_TOLERANCE_CONFIG;
 import static com.snowflake.kafka.connector.internal.streaming.StreamingUtils.DURATION_BETWEEN_GET_OFFSET_TOKEN_RETRY;
 import static com.snowflake.kafka.connector.internal.streaming.StreamingUtils.MAX_GET_OFFSET_TOKEN_RETRIES;
 import static java.time.temporal.ChronoUnit.SECONDS;
@@ -347,6 +350,17 @@ public class TopicPartitionChannel {
     return isEnableChannelOffsetMigration;
   }
 
+  /**
+   * This is the new channel Name format that was created. New channel name prefixes connector name
+   * in old format. Please note, we will not open channel with new format. We will run a migration
+   * function from this new channel format to old channel format and drop new channel format.
+   *
+   * @param channelNameFormatV1 Original format used.
+   * @param connectorName connector name used in SF config JSON.
+   * @return new channel name introduced as part of @see <a
+   *     href="https://github.com/snowflakedb/snowflake-kafka-connector/commit/3bf9106b22510c62068f7d2f7137b9e57989274c">
+   *     this change (released in version 2.1.0) </a>
+   */
   @VisibleForTesting
   protected String generateChannelNameFormatV2(String channelNameFormatV1, String connectorName) {
     return connectorName + "_" + channelNameFormatV1;

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
@@ -139,9 +139,6 @@ public class TopicPartitionChannel {
   /* Channel Name is computed from topic and partition */
   private final String channelNameFormatV1;
 
-  /* Channel Name format V2 is computed from connector name, topic and partition */
-  private final String channelNameFormatV2;
-
   /* table is required for opening the channel */
   private final String tableName;
 
@@ -285,12 +282,12 @@ public class TopicPartitionChannel {
 
     this.enableSchemaEvolution = this.enableSchematization && hasSchemaEvolutionPermission;
 
-    this.channelNameFormatV2 =
-        generateChannelNameFormatV2(this.channelNameFormatV1, this.conn.getConnectorName());
-
     if (isEnableChannelOffsetMigration(sfConnectorConfig)) {
+      /* Channel Name format V2 is computed from connector name, topic and partition */
+      final String channelNameFormatV2 =
+          generateChannelNameFormatV2(this.channelNameFormatV1, this.conn.getConnectorName());
       conn.migrateStreamingChannelOffsetToken(
-          this.tableName, this.channelNameFormatV2, this.channelNameFormatV1);
+          this.tableName, channelNameFormatV2, this.channelNameFormatV1);
     }
 
     // Open channel and reset the offset in kafka

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannel.java
@@ -366,7 +366,8 @@ public class TopicPartitionChannel {
    *     this change (released in version 2.1.0) </a>
    */
   @VisibleForTesting
-  protected String generateChannelNameFormatV2(String channelNameFormatV1, String connectorName) {
+  public static String generateChannelNameFormatV2(
+      String channelNameFormatV1, String connectorName) {
     return connectorName + "_" + channelNameFormatV1;
   }
 

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
@@ -868,6 +868,53 @@ public class ConnectorConfigTest {
   }
 
   @Test
+  public void testEnableStreamingChannelMigrationConfig() {
+    Map<String, String> config = getConfig();
+    config.put(
+        SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
+        IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
+    config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
+    config.put(SnowflakeSinkConnectorConfig.ENABLE_CHANNEL_OFFSET_TOKEN_MIGRATION_CONFIG, "true");
+
+    Utils.validateConfig(config);
+  }
+
+  @Test
+  public void testEnableStreamingChannelMigrationConfig_invalidWithSnowpipe() {
+    try {
+      Map<String, String> config = getConfig();
+      config.put(
+          SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
+          IngestionMethodConfig.SNOWPIPE.toString());
+      config.put(SnowflakeSinkConnectorConfig.ENABLE_CHANNEL_OFFSET_TOKEN_MIGRATION_CONFIG, "true");
+
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception
+          .getMessage()
+          .contains(SnowflakeSinkConnectorConfig.ENABLE_CHANNEL_OFFSET_TOKEN_MIGRATION_CONFIG);
+    }
+  }
+
+  @Test
+  public void testEnableStreamingChannelMigrationConfig_invalidWithSnowpipeStreaming() {
+    try {
+      Map<String, String> config = getConfig();
+      config.put(
+          SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
+          IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
+      config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
+      config.put(
+          SnowflakeSinkConnectorConfig.ENABLE_CHANNEL_OFFSET_TOKEN_MIGRATION_CONFIG, "INVALID");
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception
+          .getMessage()
+          .contains(SnowflakeSinkConnectorConfig.ENABLE_CHANNEL_OFFSET_TOKEN_MIGRATION_CONFIG);
+    }
+  }
+
+  @Test
   public void testInvalidEmptyConfig() {
     try {
       Map<String, String> config = new HashMap<>();

--- a/src/test/java/com/snowflake/kafka/connector/SnowflakeSinkTaskStreamingTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/SnowflakeSinkTaskStreamingTest.java
@@ -88,7 +88,7 @@ public class SnowflakeSinkTaskStreamingTest {
         new TopicPartitionChannel(
             mockStreamingClient,
             topicPartition,
-            SnowflakeSinkServiceV2.partitionChannelKey(TEST_CONNECTOR_NAME, topicName, partition),
+            SnowflakeSinkServiceV2.partitionChannelKey(topicName, partition),
             topicName,
             new StreamingBufferThreshold(10, 10_000, 1),
             config,
@@ -97,8 +97,7 @@ public class SnowflakeSinkTaskStreamingTest {
             mockTelemetryService);
 
     Map topicPartitionChannelMap =
-        Collections.singletonMap(
-            partitionChannelKey(TEST_CONNECTOR_NAME, topicName, partition), topicPartitionChannel);
+        Collections.singletonMap(partitionChannelKey(topicName, partition), topicPartitionChannel);
 
     SnowflakeSinkServiceV2 mockSinkService =
         new SnowflakeSinkServiceV2(

--- a/src/test/java/com/snowflake/kafka/connector/SnowflakeSinkTaskStreamingTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/SnowflakeSinkTaskStreamingTest.java
@@ -94,6 +94,7 @@ public class SnowflakeSinkTaskStreamingTest {
             config,
             errorReporter,
             inMemorySinkTaskContext,
+            mockConnectionService,
             mockTelemetryService);
 
     Map topicPartitionChannelMap =

--- a/src/test/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1Test.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1Test.java
@@ -1,0 +1,39 @@
+package com.snowflake.kafka.connector.internal;
+
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.snowflake.kafka.connector.internal.streaming.ChannelMigrateOffsetTokenResponseDTO;
+import org.junit.Test;
+
+public class SnowflakeConnectionServiceV1Test {
+  @Test
+  public void testChannelMigrationResponse_validResponse() throws Exception {
+    SnowflakeConnectionServiceV1 v1MockConnectionService = mock(SnowflakeConnectionServiceV1.class);
+    final String validMigrationResponse =
+        "{\"responseCode\": 51, \"responseMessage\": \"Source Channel does not exist for Offset"
+            + " Migration\"}";
+    when(v1MockConnectionService.getChannelMigrateOffsetTokenResponseDTO(anyString()))
+        .thenCallRealMethod();
+
+    ChannelMigrateOffsetTokenResponseDTO migrationDTO =
+        v1MockConnectionService.getChannelMigrateOffsetTokenResponseDTO(validMigrationResponse);
+    assert migrationDTO.getResponseCode() == 51;
+    assert migrationDTO
+        .getResponseMessage()
+        .contains("Source Channel does not exist for Offset Migration");
+  }
+
+  @Test(expected = JsonProcessingException.class)
+  public void testChannelMigrationResponse_InvalidResponse() throws Exception {
+    SnowflakeConnectionServiceV1 v1MockConnectionService = mock(SnowflakeConnectionServiceV1.class);
+    final String validMigrationResponse =
+        "{\"responseCode\": 51, \"responseMessage\": \"Source Channel does not exist for Offset"
+            + " Migration\", \"unknown\":62}";
+    when(v1MockConnectionService.getChannelMigrateOffsetTokenResponseDTO(anyString()))
+        .thenCallRealMethod();
+    v1MockConnectionService.getChannelMigrateOffsetTokenResponseDTO(validMigrationResponse);
+  }
+}

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2IT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2IT.java
@@ -1,6 +1,5 @@
 package com.snowflake.kafka.connector.internal.streaming;
 
-import static com.snowflake.kafka.connector.internal.TestUtils.TEST_CONNECTOR_NAME;
 import static com.snowflake.kafka.connector.internal.streaming.SnowflakeSinkServiceV2.partitionChannelKey;
 import static com.snowflake.kafka.connector.internal.streaming.TopicPartitionChannel.NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE;
 
@@ -221,8 +220,7 @@ public class SnowflakeSinkServiceV2IT {
 
     Assert.assertTrue(
         snowflakeSinkServiceV2
-            .getTopicPartitionChannelFromCacheKey(
-                partitionChannelKey(TEST_CONNECTOR_NAME, tp2.topic(), tp2.partition()))
+            .getTopicPartitionChannelFromCacheKey(partitionChannelKey(tp2.topic(), tp2.partition()))
             .isPresent());
 
     List<SinkRecord> newRecordsPartition1 =
@@ -412,8 +410,7 @@ public class SnowflakeSinkServiceV2IT {
     // verify all metrics
     Map<String, Gauge> metricRegistry =
         service
-            .getMetricRegistry(
-                SnowflakeSinkServiceV2.partitionChannelKey(TEST_CONNECTOR_NAME, topic, partition))
+            .getMetricRegistry(SnowflakeSinkServiceV2.partitionChannelKey(topic, partition))
             .get()
             .getGauges();
     assert metricRegistry.size()
@@ -422,7 +419,7 @@ public class SnowflakeSinkServiceV2IT {
     // partition 1
     this.verifyPartitionMetrics(
         metricRegistry,
-        partitionChannelKey(TEST_CONNECTOR_NAME, topic, partition),
+        partitionChannelKey(topic, partition),
         NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE,
         recordsInPartition1 - 1,
         recordsInPartition1,
@@ -430,7 +427,7 @@ public class SnowflakeSinkServiceV2IT {
         this.conn.getConnectorName());
     this.verifyPartitionMetrics(
         metricRegistry,
-        partitionChannelKey(TEST_CONNECTOR_NAME, topic, partition2),
+        partitionChannelKey(topic, partition2),
         NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE,
         recordsInPartition2 - 1,
         recordsInPartition2,
@@ -445,8 +442,7 @@ public class SnowflakeSinkServiceV2IT {
 
     // verify metrics closed
     assert !service
-        .getMetricRegistry(
-            SnowflakeSinkServiceV2.partitionChannelKey(TEST_CONNECTOR_NAME, topic, partition))
+        .getMetricRegistry(SnowflakeSinkServiceV2.partitionChannelKey(topic, partition))
         .isPresent();
 
     Mockito.verify(telemetryService, Mockito.times(2))

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelIT.java
@@ -1,7 +1,5 @@
 package com.snowflake.kafka.connector.internal.streaming;
 
-import static com.snowflake.kafka.connector.internal.TestUtils.TEST_CONNECTOR_NAME;
-import static com.snowflake.kafka.connector.internal.streaming.TopicPartitionChannel.NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE;
 import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
 import com.snowflake.kafka.connector.Utils;
 import com.snowflake.kafka.connector.dlq.InMemoryKafkaRecordErrorReporter;
@@ -96,6 +94,7 @@ public class TopicPartitionChannelIT {
             config,
             new InMemoryKafkaRecordErrorReporter(),
             new InMemorySinkTaskContext(Collections.singleton(topicPartition)),
+            conn,
             conn.getTelemetryClient());
 
     // since channel is updated, try to insert data again or may be call getOffsetToken

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelIT.java
@@ -1,7 +1,7 @@
 package com.snowflake.kafka.connector.internal.streaming;
 
 import static com.snowflake.kafka.connector.internal.TestUtils.TEST_CONNECTOR_NAME;
-
+import static com.snowflake.kafka.connector.internal.streaming.TopicPartitionChannel.NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE;
 import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
 import com.snowflake.kafka.connector.Utils;
 import com.snowflake.kafka.connector.dlq.InMemoryKafkaRecordErrorReporter;
@@ -45,11 +45,9 @@ public class TopicPartitionChannelIT {
 
     topicPartition2 = new TopicPartition(topic, PARTITION_2);
 
-    testChannelName =
-        SnowflakeSinkServiceV2.partitionChannelKey(TEST_CONNECTOR_NAME, topic, PARTITION);
+    testChannelName = SnowflakeSinkServiceV2.partitionChannelKey(topic, PARTITION);
 
-    testChannelName2 =
-        SnowflakeSinkServiceV2.partitionChannelKey(TEST_CONNECTOR_NAME, topic, PARTITION_2);
+    testChannelName2 = SnowflakeSinkServiceV2.partitionChannelKey(topic, PARTITION_2);
   }
 
   @After

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelIT.java
@@ -1,5 +1,9 @@
 package com.snowflake.kafka.connector.internal.streaming;
 
+import static com.snowflake.kafka.connector.internal.streaming.ChannelMigrationResponseCode.SUCCESS;
+import static com.snowflake.kafka.connector.internal.streaming.ChannelMigrationResponseCode.isChannelMigrationResponseSuccessful;
+import static com.snowflake.kafka.connector.internal.streaming.TopicPartitionChannel.NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE;
+
 import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
 import com.snowflake.kafka.connector.Utils;
 import com.snowflake.kafka.connector.dlq.InMemoryKafkaRecordErrorReporter;
@@ -556,6 +560,170 @@ public class TopicPartitionChannelIT {
             + secondBatchCount
             + " actual: "
             + TestUtils.tableSize(testTableName);
+
+    service.closeAll();
+  }
+
+  @Test
+  public void testChannelMigrateOffsetTokenSystemFunction_NonNullOffsetTokenForSourceChannel()
+      throws Exception {
+    Map<String, String> config = TestUtils.getConfForStreaming();
+    SnowflakeSinkConnectorConfig.setDefaultValues(config);
+
+    InMemorySinkTaskContext inMemorySinkTaskContext =
+        new InMemorySinkTaskContext(Collections.singleton(topicPartition));
+
+    // This will automatically create a channel for topicPartition.
+    SnowflakeSinkService service =
+        SnowflakeSinkServiceFactory.builder(conn, IngestionMethodConfig.SNOWPIPE_STREAMING, config)
+            .setRecordNumber(1)
+            .setErrorReporter(new InMemoryKafkaRecordErrorReporter())
+            .setSinkTaskContext(inMemorySinkTaskContext)
+            .addTask(testTableName, topicPartition)
+            .build();
+
+    TopicPartitionChannel topicPartitionChannel =
+        ((SnowflakeSinkServiceV2) service)
+            .getTopicPartitionChannelFromCacheKey(testChannelName)
+            .get();
+    // Channel does exist
+    Assert.assertNotNull(topicPartitionChannel);
+
+    // get the corresponding V2 format for above topic partition channel
+    final String channelNameFormatV2 =
+        topicPartitionChannel.generateChannelNameFormatV2(testChannelName, conn.getConnectorName());
+
+    // create a channel with new format and ingest few rows
+    // Ctor of TopicPartitionChannel tries to open the channel (new format) for same partition
+    TopicPartitionChannel topicPartitionChannelForFormatV2 =
+        new TopicPartitionChannel(
+            ((SnowflakeSinkServiceV2) service).getStreamingIngestClient(),
+            topicPartition,
+            channelNameFormatV2,
+            testTableName,
+            new StreamingBufferThreshold(10, 10_000, 1),
+            config,
+            new InMemoryKafkaRecordErrorReporter(),
+            new InMemorySinkTaskContext(Collections.singleton(topicPartition)),
+            conn,
+            conn.getTelemetryClient());
+
+    // insert few records via new channel
+    final int noOfRecords = 5;
+    // Since record 0 was not able to ingest, all records in this batch will not be added into the
+    // buffer.
+    List<SinkRecord> records =
+        TestUtils.createJsonStringSinkRecords(0, noOfRecords, testTableName, PARTITION);
+
+    records.forEach(topicPartitionChannelForFormatV2::insertRecordToBuffer);
+    TestUtils.assertWithRetry(
+        () -> topicPartitionChannelForFormatV2.getOffsetSafeToCommitToKafka() == noOfRecords, 5, 5);
+
+    // we migrate the offset from new channel format to old channel format
+    ChannelMigrateOffsetTokenResponseDTO channelMigrateOffsetTokenResponseDTO =
+        conn.migrateStreamingChannelOffsetToken(
+            testTableName, channelNameFormatV2, testChannelName);
+    Assert.assertTrue(isChannelMigrationResponseSuccessful(channelMigrateOffsetTokenResponseDTO));
+    Assert.assertEquals(
+        SUCCESS.getStatusCode(), channelMigrateOffsetTokenResponseDTO.getResponseCode());
+
+    // Fetch offsetToken from API should now give you same as other channel
+    TestUtils.assertWithRetry(
+        () -> service.getOffset(new TopicPartition(topic, PARTITION)) == noOfRecords, 5, 5);
+
+    service.closeAll();
+  }
+
+  @Test
+  public void testChannelMigrateOffsetTokenSystemFunction_NullOffsetTokenInFormatV2()
+      throws Exception {
+    Map<String, String> config = TestUtils.getConfForStreaming();
+    SnowflakeSinkConnectorConfig.setDefaultValues(config);
+
+    InMemorySinkTaskContext inMemorySinkTaskContext =
+        new InMemorySinkTaskContext(Collections.singleton(topicPartition));
+
+    // This will automatically create a channel for topicPartition.
+    SnowflakeSinkService service =
+        SnowflakeSinkServiceFactory.builder(conn, IngestionMethodConfig.SNOWPIPE_STREAMING, config)
+            .setRecordNumber(1)
+            .setErrorReporter(new InMemoryKafkaRecordErrorReporter())
+            .setSinkTaskContext(inMemorySinkTaskContext)
+            .addTask(testTableName, topicPartition)
+            .build();
+
+    TopicPartitionChannel topicPartitionChannel =
+        ((SnowflakeSinkServiceV2) service)
+            .getTopicPartitionChannelFromCacheKey(testChannelName)
+            .get();
+    // Channel does exist
+    Assert.assertNotNull(topicPartitionChannel);
+
+    final int recordsInPartition1 = 10;
+    List<SinkRecord> recordsPartition1 =
+        TestUtils.createJsonStringSinkRecords(0, recordsInPartition1, topic, PARTITION);
+
+    List<SinkRecord> records = new ArrayList<>(recordsPartition1);
+
+    service.insert(records);
+
+    TestUtils.assertWithRetry(
+        () -> service.getOffset(new TopicPartition(topic, PARTITION)) == recordsInPartition1, 5, 5);
+
+    // get the corresponding V2 format for above topic partition channel
+    final String channelNameFormatV2 =
+        topicPartitionChannel.generateChannelNameFormatV2(testChannelName, conn.getConnectorName());
+
+    // create a channel with new format and dont ingest anything
+    // Ctor of TopicPartitionChannel tries to open the channel (new format) for same partition
+    TopicPartitionChannel topicPartitionChannelForFormatV2 =
+        new TopicPartitionChannel(
+            ((SnowflakeSinkServiceV2) service).getStreamingIngestClient(),
+            topicPartition,
+            channelNameFormatV2,
+            testTableName,
+            new StreamingBufferThreshold(10, 10_000, 1),
+            config,
+            new InMemoryKafkaRecordErrorReporter(),
+            new InMemorySinkTaskContext(Collections.singleton(topicPartition)),
+            conn,
+            conn.getTelemetryClient());
+
+    // close the partition and open the partition to mimic migration
+    service.close(Collections.singletonList(topicPartition));
+
+    Map<String, String> topic2Table = new HashMap<>();
+    topic2Table.put(topic, testTableName);
+    service.startPartitions(Collections.singletonList(topicPartition), topic2Table);
+
+    // this instance has changed since we removed it from cache and loaded it again.
+    TopicPartitionChannel topicPartitionChannelAfterCloseAndStartPartition =
+        ((SnowflakeSinkServiceV2) service)
+            .getTopicPartitionChannelFromCacheKey(testChannelName)
+            .get();
+
+    // Fetch offsetToken from API should now give you same as other channel
+    TestUtils.assertWithRetry(
+        () ->
+            topicPartitionChannelAfterCloseAndStartPartition.fetchOffsetTokenWithRetry()
+                == NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE,
+        5,
+        5);
+
+    recordsPartition1 =
+        TestUtils.createJsonStringSinkRecords(
+            recordsInPartition1, recordsInPartition1, topic, PARTITION);
+
+    records = new ArrayList<>(recordsPartition1);
+
+    service.insert(records);
+
+    TestUtils.assertWithRetry(
+        () ->
+            service.getOffset(new TopicPartition(topic, PARTITION))
+                == recordsInPartition1 + recordsInPartition1,
+        5,
+        5);
 
     service.closeAll();
   }

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelIT.java
@@ -631,6 +631,15 @@ public class TopicPartitionChannelIT {
     TestUtils.assertWithRetry(
         () -> service.getOffset(new TopicPartition(topic, PARTITION)) == noOfRecords, 5, 5);
 
+    // add few more records
+    records =
+        TestUtils.createJsonStringSinkRecords(noOfRecords, noOfRecords, testTableName, PARTITION);
+    records.forEach(service::insert);
+    TestUtils.assertWithRetry(
+        () -> service.getOffset(new TopicPartition(topic, PARTITION)) == noOfRecords + noOfRecords,
+        5,
+        5);
+
     service.closeAll();
   }
 

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelTest.java
@@ -1,6 +1,9 @@
 package com.snowflake.kafka.connector.internal.streaming;
 
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.*;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_CHANNEL_OFFSET_TOKEN_MIGRATION_CONFIG;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_LOG_ENABLE_CONFIG;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_TOLERANCE_CONFIG;
 import static com.snowflake.kafka.connector.internal.TestUtils.TEST_CONNECTOR_NAME;
 import static com.snowflake.kafka.connector.internal.TestUtils.createBigAvroRecords;
 import static com.snowflake.kafka.connector.internal.TestUtils.createNativeJsonSinkRecords;
@@ -251,29 +254,29 @@ public class TopicPartitionChannelTest {
 
     Mockito.when(mockStreamingChannel.getFullyQualifiedName()).thenReturn(TEST_CHANNEL_NAME);
     Mockito.when(
-                    mockSnowflakeConnectionService.migrateStreamingChannelOffsetToken(
-                            anyString(), anyString(), Mockito.anyString()))
-            .thenReturn(true);
+            mockSnowflakeConnectionService.migrateStreamingChannelOffsetToken(
+                anyString(), anyString(), Mockito.anyString()))
+        .thenReturn(true);
 
     // checking default
     TopicPartitionChannel topicPartitionChannel =
-            new TopicPartitionChannel(
-                    mockStreamingClient,
-                    topicPartition,
-                    TEST_CHANNEL_NAME,
-                    TEST_TABLE_NAME,
-                    true,
-                    streamingBufferThreshold,
-                    sfConnectorConfig,
-                    mockKafkaRecordErrorReporter,
-                    mockSinkTaskContext,
-                    mockSnowflakeConnectionService,
-                    new RecordService(mockTelemetryService),
-                    mockTelemetryService,
-                    false,
-                    null);
+        new TopicPartitionChannel(
+            mockStreamingClient,
+            topicPartition,
+            TEST_CHANNEL_NAME,
+            TEST_TABLE_NAME,
+            true,
+            streamingBufferThreshold,
+            sfConnectorConfig,
+            mockKafkaRecordErrorReporter,
+            mockSinkTaskContext,
+            mockSnowflakeConnectionService,
+            new RecordService(mockTelemetryService),
+            mockTelemetryService,
+            false,
+            null);
     Mockito.verify(mockSnowflakeConnectionService, Mockito.times(1))
-            .migrateStreamingChannelOffsetToken(anyString(), anyString(), anyString());
+        .migrateStreamingChannelOffsetToken(anyString(), anyString(), anyString());
 
     Map<String, String> customSfConfig = new HashMap<>(sfConnectorConfig);
     customSfConfig.put(ENABLE_CHANNEL_OFFSET_TOKEN_MIGRATION_CONFIG, "true");
@@ -297,28 +300,28 @@ public class TopicPartitionChannelTest {
     Mockito.verify(mockSnowflakeConnectionService, Mockito.times(2))
         .migrateStreamingChannelOffsetToken(anyString(), anyString(), anyString());
 
-
     customSfConfig.put(ENABLE_CHANNEL_OFFSET_TOKEN_MIGRATION_CONFIG, "false");
-    SnowflakeConnectionService anotherMockForParamDisabled = Mockito.mock(SnowflakeConnectionService.class);
+    SnowflakeConnectionService anotherMockForParamDisabled =
+        Mockito.mock(SnowflakeConnectionService.class);
 
     topicPartitionChannel =
-            new TopicPartitionChannel(
-                    mockStreamingClient,
-                    topicPartition,
-                    TEST_CHANNEL_NAME,
-                    TEST_TABLE_NAME,
-                    true,
-                    streamingBufferThreshold,
-                    customSfConfig,
-                    mockKafkaRecordErrorReporter,
-                    mockSinkTaskContext,
-                    anotherMockForParamDisabled,
-                    new RecordService(mockTelemetryService),
-                    mockTelemetryService,
-                    false,
-                    null);
+        new TopicPartitionChannel(
+            mockStreamingClient,
+            topicPartition,
+            TEST_CHANNEL_NAME,
+            TEST_TABLE_NAME,
+            true,
+            streamingBufferThreshold,
+            customSfConfig,
+            mockKafkaRecordErrorReporter,
+            mockSinkTaskContext,
+            anotherMockForParamDisabled,
+            new RecordService(mockTelemetryService),
+            mockTelemetryService,
+            false,
+            null);
     Mockito.verify(anotherMockForParamDisabled, Mockito.times(0))
-            .migrateStreamingChannelOffsetToken(anyString(), anyString(), anyString());
+        .migrateStreamingChannelOffsetToken(anyString(), anyString(), anyString());
   }
 
   /* Only SFExceptions are retried and goes into fallback. */

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelTest.java
@@ -72,7 +72,7 @@ public class TopicPartitionChannelTest {
   private static final int PARTITION = 0;
 
   private static final String TEST_CHANNEL_NAME =
-      SnowflakeSinkServiceV2.partitionChannelKey(TEST_CONNECTOR_NAME, TOPIC, PARTITION);
+      SnowflakeSinkServiceV2.partitionChannelKey(TOPIC, PARTITION);
   private static final String TEST_TABLE_NAME = "TEST_TABLE";
 
   private TopicPartition topicPartition;
@@ -126,6 +126,7 @@ public class TopicPartitionChannelTest {
         sfConnectorConfig,
         mockKafkaRecordErrorReporter,
         mockSinkTaskContext,
+        mockSnowflakeConnectionService,
         mockTelemetryService);
   }
 
@@ -143,6 +144,7 @@ public class TopicPartitionChannelTest {
             sfConnectorConfig,
             mockKafkaRecordErrorReporter,
             mockSinkTaskContext,
+            mockSnowflakeConnectionService,
             mockTelemetryService);
 
     Assert.assertEquals(-1L, topicPartitionChannel.fetchOffsetTokenWithRetry());
@@ -163,6 +165,7 @@ public class TopicPartitionChannelTest {
             sfConnectorConfig,
             mockKafkaRecordErrorReporter,
             mockSinkTaskContext,
+            mockSnowflakeConnectionService,
             mockTelemetryService);
 
     Assert.assertEquals(100L, topicPartitionChannel.fetchOffsetTokenWithRetry());
@@ -188,6 +191,7 @@ public class TopicPartitionChannelTest {
             sfConnectorConfig,
             mockKafkaRecordErrorReporter,
             mockSinkTaskContext,
+            mockSnowflakeConnectionService,
             mockTelemetryService);
 
     JsonConverter converter = new JsonConverter();
@@ -258,6 +262,7 @@ public class TopicPartitionChannelTest {
             sfConnectorConfig,
             mockKafkaRecordErrorReporter,
             mockSinkTaskContext,
+            mockSnowflakeConnectionService,
             mockTelemetryService);
 
     try {
@@ -292,6 +297,7 @@ public class TopicPartitionChannelTest {
             sfConnectorConfig,
             mockKafkaRecordErrorReporter,
             mockSinkTaskContext,
+            mockSnowflakeConnectionService,
             mockTelemetryService);
 
     int expectedRetries = MAX_GET_OFFSET_TOKEN_RETRIES;
@@ -322,6 +328,7 @@ public class TopicPartitionChannelTest {
             sfConnectorConfig,
             mockKafkaRecordErrorReporter,
             mockSinkTaskContext,
+            mockSnowflakeConnectionService,
             mockTelemetryService);
 
     try {
@@ -354,6 +361,7 @@ public class TopicPartitionChannelTest {
             sfConnectorConfig,
             mockKafkaRecordErrorReporter,
             mockSinkTaskContext,
+            mockSnowflakeConnectionService,
             mockTelemetryService);
 
     try {
@@ -382,6 +390,7 @@ public class TopicPartitionChannelTest {
             sfConnectorConfig,
             mockKafkaRecordErrorReporter,
             mockSinkTaskContext,
+            mockSnowflakeConnectionService,
             mockTelemetryService);
 
     try {
@@ -425,6 +434,7 @@ public class TopicPartitionChannelTest {
             sfConnectorConfig,
             mockKafkaRecordErrorReporter,
             mockSinkTaskContext,
+            mockSnowflakeConnectionService,
             mockTelemetryService);
     expectedOpenChannelCount++;
     expectedGetOffsetCount++;
@@ -573,6 +583,7 @@ public class TopicPartitionChannelTest {
             sfConnectorConfig,
             mockKafkaRecordErrorReporter,
             mockSinkTaskContext,
+            mockSnowflakeConnectionService,
             mockTelemetryService);
 
     List<SinkRecord> records = TestUtils.createJsonStringSinkRecords(0, 1, TOPIC, PARTITION);
@@ -612,6 +623,7 @@ public class TopicPartitionChannelTest {
             sfConnectorConfig,
             mockKafkaRecordErrorReporter,
             mockSinkTaskContext,
+            mockSnowflakeConnectionService,
             mockTelemetryService);
 
     List<SinkRecord> records = TestUtils.createJsonStringSinkRecords(0, 1, TOPIC, PARTITION);
@@ -701,6 +713,7 @@ public class TopicPartitionChannelTest {
             sfConnectorConfigWithErrors,
             kafkaRecordErrorReporter,
             mockSinkTaskContext,
+            mockSnowflakeConnectionService,
             mockTelemetryService);
 
     List<SinkRecord> records = TestUtils.createJsonStringSinkRecords(0, 1, TOPIC, PARTITION);
@@ -746,6 +759,7 @@ public class TopicPartitionChannelTest {
             sfConnectorConfigWithErrors,
             kafkaRecordErrorReporter,
             mockSinkTaskContext,
+            mockSnowflakeConnectionService,
             mockTelemetryService);
 
     List<SinkRecord> records = TestUtils.createJsonStringSinkRecords(0, 1, TOPIC, PARTITION);
@@ -786,6 +800,7 @@ public class TopicPartitionChannelTest {
             sfConnectorConfig,
             mockKafkaRecordErrorReporter,
             mockSinkTaskContext,
+            mockSnowflakeConnectionService,
             mockTelemetryService);
 
     // Sending 5 records will trigger a buffer bytes based threshold after 4 records have been
@@ -835,6 +850,7 @@ public class TopicPartitionChannelTest {
             sfConnectorConfig,
             mockKafkaRecordErrorReporter,
             mockSinkTaskContext,
+            mockSnowflakeConnectionService,
             mockTelemetryService);
 
     // Sending 3 records will trigger a buffer bytes based threshold after 2 records have been

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelTest.java
@@ -256,7 +256,7 @@ public class TopicPartitionChannelTest {
     Mockito.when(
             mockSnowflakeConnectionService.migrateStreamingChannelOffsetToken(
                 anyString(), anyString(), Mockito.anyString()))
-        .thenReturn(true);
+        .thenReturn(new ChannelMigrateOffsetTokenResponseDTO(50, "SUCCESS"));
 
     // checking default
     TopicPartitionChannel topicPartitionChannel =

--- a/test/rest_request_template/test_snowpipe_streaming_channel_migration_disabled.json
+++ b/test/rest_request_template/test_snowpipe_streaming_channel_migration_disabled.json
@@ -1,0 +1,28 @@
+{
+  "name": "SNOWFLAKE_CONNECTOR_NAME",
+  "config": {
+    "connector.class": "com.snowflake.kafka.connector.SnowflakeSinkConnector",
+    "topics": "SNOWFLAKE_TEST_TOPIC",
+    "tasks.max": "1",
+    "buffer.flush.time": "60",
+    "buffer.count.records": "300",
+    "buffer.size.bytes": "5000000",
+    "snowflake.url.name": "SNOWFLAKE_HOST",
+    "snowflake.user.name": "SNOWFLAKE_USER",
+    "snowflake.private.key": "SNOWFLAKE_PRIVATE_KEY",
+    "snowflake.database.name": "SNOWFLAKE_DATABASE",
+    "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
+    "snowflake.role.name": "SNOWFLAKE_ROLE",
+    "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
+    "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+    "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+    "value.converter.schemas.enable": "false",
+    "enable.streaming.channel.offset.migration": "false",
+    "jmx": "true",
+    "errors.tolerance": "all",
+    "errors.log.enable": true,
+    "errors.deadletterqueue.topic.name": "DLQ_TOPIC",
+    "errors.deadletterqueue.topic.replication.factor": 1,
+    "snowflake.enable.schematization": true
+  }
+}

--- a/test/test_suit/test_snowpipe_streaming_channel_migration_disabled.py
+++ b/test/test_suit/test_snowpipe_streaming_channel_migration_disabled.py
@@ -1,0 +1,95 @@
+import datetime
+
+from test_suit.test_utils import RetryableError, NonRetryableError
+import json
+from time import sleep
+
+"""
+Only config added here is about migrating channel offsets from channel created in version 2.1.0 to any future versions.
+This test verifies if the functionality can be disabled
+"""
+class TestSnowpipeStreamingStringJsonChannelMigrationDisabled:
+    def __init__(self, driver, nameSalt):
+        self.driver = driver
+        self.fileName = "test_snowpipe_streaming_channel_migration_disabled"
+        self.topic = self.fileName + nameSalt
+
+        self.topicNum = 1
+        self.partitionNum = 3
+        self.recordNum = 1000
+
+        # create topic and partitions in constructor since the post REST api will automatically create topic with only one partition
+        self.driver.createTopics(self.topic, partitionNum=self.partitionNum, replicationNum=1)
+
+    def getConfigFileName(self):
+        return self.fileName + ".json"
+
+    def send(self):
+        # create topic with n partitions and only one replication factor
+        print("Partition count:" + str(self.partitionNum))
+        print("Topic:", self.topic)
+
+        self.driver.describeTopic(self.topic)
+
+        for p in range(self.partitionNum):
+            print("Sending in Partition:" + str(p))
+            key = []
+            value = []
+
+            # send two less record because we are sending tombstone records. tombstone ingestion is enabled by default
+            for e in range(self.recordNum - 2):
+                value.append(json.dumps(
+                    {'numbernumbernumbernumbernumbernumbernumbernumbernumbernumbernumbernumber': str(e)}
+                ).encode('utf-8'))
+
+            # append tombstone except for 2.5.1 due to this bug: https://issues.apache.org/jira/browse/KAFKA-10477
+            if self.driver.testVersion == '2.5.1':
+                value.append(json.dumps(
+                    {'numbernumbernumbernumbernumbernumbernumbernumbernumbernumbernumbernumber': str(self.recordNum - 1)}
+                ).encode('utf-8'))
+                value.append(json.dumps(
+                    {'numbernumbernumbernumbernumbernumbernumbernumbernumbernumbernumbernumber': str(self.recordNum)}
+                ).encode('utf-8'))
+            else:
+                value.append(None)
+                value.append("") # community converters treat this as a tombstone
+
+            self.driver.sendBytesData(self.topic, value, key, partition=p)
+            sleep(2)
+
+    def verify(self, round):
+        res = self.driver.snowflake_conn.cursor().execute(
+            "SELECT count(*) FROM {}".format(self.topic)).fetchone()[0]
+        print("Count records in table {}={}".format(self.topic, str(res)))
+        if res < (self.recordNum * self.partitionNum):
+            print("Topic:" + self.topic + " count is less, will retry")
+            raise RetryableError()
+        elif res > (self.recordNum * self.partitionNum):
+            print("Topic:" + self.topic + " count is more, duplicates detected")
+            raise NonRetryableError("Duplication occurred, number of record in table is larger than number of record sent")
+        else:
+            print("Table:" + self.topic + " count is exactly " + str(self.recordNum * self.partitionNum))
+
+        # for duplicates
+        res = self.driver.snowflake_conn.cursor().execute("Select record_metadata:\"offset\"::string as OFFSET_NO,record_metadata:\"partition\"::string as PARTITION_NO from {} group by OFFSET_NO, PARTITION_NO having count(*)>1".format(self.topic)).fetchone()
+        print("Duplicates:{}".format(res))
+        if res is not None:
+            raise NonRetryableError("Duplication detected")
+
+        # for uniqueness in offset numbers
+        rows = self.driver.snowflake_conn.cursor().execute("Select count(distinct record_metadata:\"offset\"::number) as UNIQUE_OFFSETS,record_metadata:\"partition\"::number as PARTITION_NO from {} group by PARTITION_NO order by PARTITION_NO".format(self.topic)).fetchall()
+
+        if rows is None:
+            raise NonRetryableError("Unique offsets for partitions not found")
+        else:
+            assert len(rows) == 3
+
+            for p in range(self.partitionNum):
+                # unique offset count and partition no are two columns (returns tuple)
+                if rows[p][0] != self.recordNum or rows[p][1] != p:
+                    raise NonRetryableError("Unique offsets for partitions count doesnt match")
+
+    def clean(self):
+        # dropping of stage and pipe doesnt apply for snowpipe streaming. (It executes drop if exists)
+        self.driver.cleanTableStagePipe(self.topic)
+        return

--- a/test/test_suites.py
+++ b/test/test_suites.py
@@ -47,6 +47,7 @@ from test_suit.test_string_avro import TestStringAvro
 from test_suit.test_string_avrosr import TestStringAvrosr
 from test_suit.test_string_json import TestStringJson
 from test_suit.test_string_json_ignore_tombstone import TestStringJsonIgnoreTombstone
+from test_suit.test_snowpipe_streaming_channel_migration_disabled import TestSnowpipeStreamingStringJsonChannelMigrationDisabled
 
 
 class EndToEndTestSuite:
@@ -133,6 +134,9 @@ def create_end_to_end_test_suites(driver, nameSalt, schemaRegistryAddress, testS
         ("TestSnowpipeStreamingStringJson", EndToEndTestSuite(
             test_instance=TestSnowpipeStreamingStringJson(driver, nameSalt), clean=True, run_in_confluent=True,
             run_in_apache=True
+        )),
+        ("TestSnowpipeStreamingStringJsonChannelMigrationDisabled", EndToEndTestSuite(
+            test_instance=TestSnowpipeStreamingStringJsonChannelMigrationDisabled(driver, nameSalt), clean=True, run_in_confluent=True, run_in_apache=True
         )),
         ("TestSnowpipeStreamingStringJsonIgnoreTombstone", EndToEndTestSuite(
             test_instance=TestSnowpipeStreamingStringJsonIgnoreTombstone(driver, nameSalt), clean=True,


### PR DESCRIPTION
PR https://github.com/snowflakedb/snowflake-kafka-connector/pull/750 but pushed in main. 

Copying it as is. 

This is a long term implementation for potential data duplication introduced because of a new channel name format. 
- It is about moving away for customers who might have onboarded to new channel format which was introduced in version 2.1.0 (Now de-listed)
- We will stick to old format for new customers running this for the first time. 
- Renamed channelName to channelNameFormatV1 and introduced `channelNameFormatV2`

Added tests in `TopicPartitionChannel` and `TopicPartitionChannel`

Notes:
- This PR is opened against [japatel-SNOW-971412-release-2-1-1-ready](https://github.com/snowflakedb/snowflake-kafka-connector/tree/japatel-SNOW-971412-release-2-1-1-ready) which is going to be the release branch for v2.1.1
- A similar PR will also be opened against master. 


End to End tests:
1. Use 2.1.0
2. Use two connectors:
3. Uses channel Name v2
![Screenshot 2023-11-20 at 4 54 59 PM](https://github.com/snowflakedb/snowflake-kafka-connector/assets/57274584/b9870a49-a28d-4332-b634-67b20f0f7783)
4. Stop 
5. Replace jar (2.1.1) and restart. 
6. Does the migration and you can only see old channel format
![Screenshot 2023-11-20 at 5 17 59 PM](https://github.com/snowflakedb/snowflake-kafka-connector/assets/57274584/c7618df2-846b-46f5-817d-5d9935ee3a5b)

7.  Stop again and restart in 2.1.1
Nothing happens and we do get a valid response saying newchannelFormatV2 doesnt exist
![Screenshot 2023-11-20 at 5 18 11 PM](https://github.com/snowflakedb/snowflake-kafka-connector/assets/57274584/c587b374-ee79-4a24-b2d1-a13df67d578e)
