### PR TITLE
[external contributor] Support config providers in validation by @swehner

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnector.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnector.java
@@ -194,6 +194,7 @@ public class SnowflakeSinkConnector extends SinkConnector {
 
   @Override
   public Config validate(Map<String, String> connectorConfigs) {
+    LOGGER.debug("Validating connector Config: Start");
     Pattern configProviderPrefix = Pattern.compile("[$][{][a-zA-Z]+:");
     // cross-fields validation here
     Config result = super.validate(connectorConfigs);

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorIT.java
@@ -251,9 +251,25 @@ public class ConnectorIT {
   }
 
   @Test
+  public void testValidateConfigProviderPasswordConfig() {
+    Map<String, String> config = getCorrectConfig();
+    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_PRIVATE_KEY, " ${configProvider:/");
+    Map<String, ConfigValue> validateMap = toValidateMap(config);
+    assertPropHasError(validateMap, new String[] {});
+  }
+
+  @Test
   public void testValidateFilePassphraseConfig() {
     Map<String, String> config = getCorrectConfig();
     config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_PRIVATE_KEY_PASSPHRASE, " ${file:/");
+    Map<String, ConfigValue> validateMap = toValidateMap(config);
+    assertPropHasError(validateMap, new String[] {});
+  }
+
+  @Test
+  public void testValidateConfigProviderPassphraseConfig() {
+    Map<String, String> config = getCorrectConfig();
+    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_PRIVATE_KEY_PASSPHRASE, " ${configProvider:/");
     Map<String, ConfigValue> validateMap = toValidateMap(config);
     assertPropHasError(validateMap, new String[] {});
   }

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorIT.java
@@ -269,7 +269,8 @@ public class ConnectorIT {
   @Test
   public void testValidateConfigProviderPassphraseConfig() {
     Map<String, String> config = getCorrectConfig();
-    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_PRIVATE_KEY_PASSPHRASE, " ${configProvider:/");
+    config.put(
+        SnowflakeSinkConnectorConfig.SNOWFLAKE_PRIVATE_KEY_PASSPHRASE, " ${configProvider:/");
     Map<String, ConfigValue> validateMap = toValidateMap(config);
     assertPropHasError(validateMap, new String[] {});
   }


### PR DESCRIPTION
Copy @swehner 's [PR](https://github.com/snowflakedb/snowflake-kafka-connector/pull/747) for github actions runs. 
@sfc-gh-xhuang please confirm that CLA was signed

### Original PR description:
I'm trying to use different config providers in my snowflake connector, but get an error during validation because the snowflake private key is not valid.
This is because validation seems to receive the raw config values (not running through configProviders which seems iffy).

In any case there was already a workaround to support ${file: as a config provider value and to skip validation. I've extended it to include any configProvider with a different name.

Fixes issue https://github.com/snowflakedb/snowflake-kafka-connector/issues/748