### PR TITLE
Add authentication for max lag parameter and fix IT

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
@@ -227,7 +227,12 @@ public class StreamingUtils {
             try {
               Long.parseLong(inputConfig.get(SNOWPIPE_STREAMING_MAX_CLIENT_LAG));
             } catch (NumberFormatException exception) {
-              invalidParams.put(SNOWPIPE_STREAMING_MAX_CLIENT_LAG, Utils.formatString("Max client lag configuration must be a parsable long. Given configuration was: {}", inputConfig.get(SNOWPIPE_STREAMING_MAX_CLIENT_LAG)));
+              invalidParams.put(
+                  SNOWPIPE_STREAMING_MAX_CLIENT_LAG,
+                  Utils.formatString(
+                      "Max client lag configuration must be a parsable long. Given configuration"
+                          + " was: {}",
+                      inputConfig.get(SNOWPIPE_STREAMING_MAX_CLIENT_LAG)));
             }
           }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
@@ -8,6 +8,7 @@ import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ErrorTolerance;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.KEY_CONVERTER_CONFIG_FIELD;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_MAX_CLIENT_LAG;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.VALUE_CONVERTER_CONFIG_FIELD;
 
 import com.google.common.base.Strings;
@@ -220,6 +221,14 @@ public class StreamingUtils {
           if (inputConfig.containsKey(ERRORS_LOG_ENABLE_CONFIG)) {
             BOOLEAN_VALIDATOR.ensureValid(
                 ERRORS_LOG_ENABLE_CONFIG, inputConfig.get(ERRORS_LOG_ENABLE_CONFIG));
+          }
+
+          if (inputConfig.containsKey(SNOWPIPE_STREAMING_MAX_CLIENT_LAG)) {
+            try {
+              Long.parseLong(inputConfig.get(SNOWPIPE_STREAMING_MAX_CLIENT_LAG));
+            } catch (NumberFormatException exception) {
+              invalidParams.put(SNOWPIPE_STREAMING_MAX_CLIENT_LAG, Utils.formatString("Max client lag configuration must be a parsable long. Given configuration was: {}", inputConfig.get(SNOWPIPE_STREAMING_MAX_CLIENT_LAG)));
+            }
           }
 
           // Valid schematization for Snowpipe Streaming

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
@@ -742,8 +742,8 @@ public class ConnectorConfigTest {
         });
   }
 
-  @Test
-  public void testInValidConfigFileTypeForSnowpipe() {
+  @Test (expected = SnowflakeKafkaConnectorException.class)
+  public void testInalidMaxClientLagForSnowpipe() {
     try {
       Map<String, String> config = getConfig();
       config.put(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_MAX_CLIENT_LAG, "3");
@@ -752,11 +752,12 @@ public class ConnectorConfigTest {
       assert exception
           .getMessage()
           .contains(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_MAX_CLIENT_LAG);
+      throw exception;
     }
   }
 
-  @Test
-  public void testValidFileTypesForSnowpipeStreaming() {
+  @Test (expected = SnowflakeKafkaConnectorException.class)
+  public void testMaxClientLagForSnowpipeStreaming() {
     Map<String, String> config = getConfig();
     config.put(
         SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
@@ -769,9 +770,16 @@ public class ConnectorConfigTest {
     config.put(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_MAX_CLIENT_LAG, "1");
     Utils.validateConfig(config);
 
-    // lower case
-    config.put(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_MAX_CLIENT_LAG, "abcd");
-    Utils.validateConfig(config);
+    // pass in string
+    try {
+      config.put(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_MAX_CLIENT_LAG, "abcd");
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception
+          .getMessage()
+          .contains(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_MAX_CLIENT_LAG);
+      throw exception;
+    }
   }
 
   @Test

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
@@ -742,7 +742,7 @@ public class ConnectorConfigTest {
         });
   }
 
-  @Test (expected = SnowflakeKafkaConnectorException.class)
+  @Test(expected = SnowflakeKafkaConnectorException.class)
   public void testInalidMaxClientLagForSnowpipe() {
     try {
       Map<String, String> config = getConfig();
@@ -756,7 +756,7 @@ public class ConnectorConfigTest {
     }
   }
 
-  @Test (expected = SnowflakeKafkaConnectorException.class)
+  @Test(expected = SnowflakeKafkaConnectorException.class)
   public void testMaxClientLagForSnowpipeStreaming() {
     Map<String, String> config = getConfig();
     config.put(

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2IT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2IT.java
@@ -1463,7 +1463,6 @@ public class SnowflakeSinkServiceV2IT {
   }
 
   @Test
-  @Ignore // SNOW-986359: disable for now due to failure in merge gate
   public void testStreamingIngestionValidClientLag() throws Exception {
     Map<String, String> config = getConfig();
     config.put(SNOWPIPE_STREAMING_MAX_CLIENT_LAG, "30");
@@ -1484,7 +1483,9 @@ public class SnowflakeSinkServiceV2IT {
     List<SinkRecord> sinkRecords =
         TestUtils.createJsonStringSinkRecords(0, noOfRecords, topic, partition);
 
+    Thread.sleep(1000); // to ensure we flush buffer on time threshold
     service.insert(sinkRecords);
+
     try {
       // Wait 20 seconds here and no flush should happen since the max client lag is 30 seconds
       TestUtils.assertWithRetry(

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2IT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2IT.java
@@ -44,7 +44,6 @@ import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.After;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;


### PR DESCRIPTION
- Validates that the given parameter for SNOWPIPE_STREAMING_MAX_CLIENT_LAG is a long
- Fixes a max lag IT