### PR TITLE
Create private jar for SNOW-954150

### DIFF
--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -28,9 +28,9 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-maven-
     - name: Install Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
-        python-version: '3.6'
+        python-version: '3.9'
         architecture: 'x64'
     - name: Decrypt profile.json in Snowflake Cloud ${{ matrix.snowflake_cloud }}
       run: ./.github/scripts/decrypt_secret.sh ${{ matrix.snowflake_cloud }}

--- a/.github/workflows/PerfTest.yml
+++ b/.github/workflows/PerfTest.yml
@@ -22,9 +22,9 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-maven-
     - name: Install Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
-        python-version: '3.6'
+        python-version: '3.9'
         architecture: 'x64'
     - name: Decrypt snowflake.json
       run: ./.github/scripts/perf_test_decrypt_secret.sh

--- a/pom.xml
+++ b/pom.xml
@@ -334,7 +334,7 @@
         <dependency>
             <groupId>net.snowflake</groupId>
             <artifactId>snowflake-ingest-sdk</artifactId>
-            <version>2.0.2</version>
+            <version>2.0.4</version>
             <exclusions>
                 <exclusion>
                     <groupId>net.snowflake</groupId>
@@ -346,7 +346,7 @@
         <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
-            <version>1.11.1</version>
+            <version>1.11.3</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -386,7 +386,7 @@
         <dependency>
             <groupId>net.snowflake</groupId>
             <artifactId>snowflake-ingest-sdk</artifactId>
-            <version>2.0.2</version>
+            <version>2.0.4</version>
             <exclusions>
                 <exclusion>
                     <groupId>net.snowflake</groupId>
@@ -420,7 +420,7 @@
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>            
+            <artifactId>jackson-core</artifactId>
             <version>2.15.2</version>
         </dependency>
         <dependency>

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -113,9 +113,9 @@ public class SnowflakeSinkConnectorConfig {
   public static final String INGESTION_METHOD_DEFAULT_SNOWPIPE =
       IngestionMethodConfig.SNOWPIPE.toString();
 
-  // This is the streaming bdec file version which can be defined in config
-  // NOTE: Please do not override this value unless recommended from snowflake
-  public static final String SNOWPIPE_STREAMING_FILE_VERSION = "snowflake.streaming.file.version";
+  // This is the streaming max client lag which can be defined in config
+  public static final String SNOWPIPE_STREAMING_MAX_CLIENT_LAG =
+      "snowflake.streaming.max.client.lag";
 
   // TESTING
   public static final String REBALANCING = "snowflake.test.rebalancing";
@@ -486,17 +486,16 @@ public class SnowflakeSinkConnectorConfig {
             ConfigDef.Width.NONE,
             INGESTION_METHOD_OPT)
         .define(
-            SNOWPIPE_STREAMING_FILE_VERSION,
-            Type.STRING,
-            "", // default is handled in Ingest SDK
-            null, // no validator
+            SNOWPIPE_STREAMING_MAX_CLIENT_LAG,
+            Type.LONG,
+            StreamingUtils.STREAMING_BUFFER_FLUSH_TIME_MINIMUM_SEC,
+            ConfigDef.Range.atLeast(StreamingUtils.STREAMING_BUFFER_FLUSH_TIME_MINIMUM_SEC),
             Importance.LOW,
-            "Acceptable values for Snowpipe Streaming BDEC Versions: 1 and 3. Check Ingest"
-                + " SDK for default behavior. Please do not set this unless Absolutely needed. ",
+            "Decide how often the buffer in the Ingest SDK will be flushed",
             CONNECTOR_CONFIG,
             6,
             ConfigDef.Width.NONE,
-            SNOWPIPE_STREAMING_FILE_VERSION)
+            SNOWPIPE_STREAMING_MAX_CLIENT_LAG)
         .define(
             ERRORS_TOLERANCE_CONFIG,
             Type.STRING,

--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -393,12 +393,12 @@ public class Utils {
                 "Schematization is only available with {}.",
                 IngestionMethodConfig.SNOWPIPE_STREAMING.toString()));
       }
-      if (config.containsKey(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_FILE_VERSION)) {
+      if (config.containsKey(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_MAX_CLIENT_LAG)) {
         invalidConfigParams.put(
-            SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_FILE_VERSION,
+            SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_MAX_CLIENT_LAG,
             Utils.formatString(
                 "{} is only available with ingestion type: {}.",
-                SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_FILE_VERSION,
+                SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_MAX_CLIENT_LAG,
                 IngestionMethodConfig.SNOWPIPE_STREAMING.toString()));
       }
       if (config.containsKey(

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -298,7 +298,7 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
     partitionsToChannel.clear();
 
     StreamingClientProvider.getStreamingClientProviderInstance()
-        .closeClient(this.streamingIngestClient);
+        .closeClient(this.connectorConfig, this.streamingIngestClient);
   }
 
   /**

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProperties.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProperties.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2023 Snowflake Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.snowflake.kafka.connector.internal.streaming;
+
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_FILE_VERSION;
+import static net.snowflake.ingest.utils.ParameterProvider.BLOB_FORMAT_VERSION;
+
+import com.snowflake.kafka.connector.Utils;
+import com.snowflake.kafka.connector.internal.KCLogger;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import net.snowflake.ingest.utils.Constants;
+
+/**
+ * Object to convert and store properties for {@link
+ * net.snowflake.ingest.streaming.SnowflakeStreamingIngestClient}. This object is used to compare
+ * equality between clients in {@link StreamingClientProvider}.
+ */
+public class StreamingClientProperties {
+  public static final String STREAMING_CLIENT_PREFIX_NAME = "KC_CLIENT_";
+  public static final String DEFAULT_CLIENT_NAME = "DEFAULT_CLIENT";
+
+  private static final KCLogger LOGGER = new KCLogger(StreamingClientProperties.class.getName());
+
+  // contains converted config properties that are loggable (not PII data)
+  public static final List<String> LOGGABLE_STREAMING_CONFIG_PROPERTIES =
+      Stream.of(
+              Constants.ACCOUNT_URL,
+              Constants.ROLE,
+              Constants.USER,
+              StreamingUtils.STREAMING_CONSTANT_AUTHORIZATION_TYPE)
+          .collect(Collectors.toList());
+
+  public final Properties clientProperties;
+  public final String clientName;
+  public final Map<String, Object> parameterOverrides;
+
+  /**
+   * Creates non-null properties, client name and parameter overrides for the {@link
+   * net.snowflake.ingest.streaming.SnowflakeStreamingIngestClient} from the given connectorConfig
+   * Properties are created by {@link StreamingUtils#convertConfigForStreamingClient(Map)} and are a
+   * subset of the given connector configuration
+   *
+   * @param connectorConfig Given connector configuration. Null configs are treated as an empty map
+   */
+  public StreamingClientProperties(Map<String, String> connectorConfig) {
+    // treat null config as empty config
+    if (connectorConfig == null) {
+      LOGGER.warn(
+          "Creating empty streaming client properties because given connector config was empty");
+      connectorConfig = new HashMap<>();
+    }
+
+    this.clientProperties = StreamingUtils.convertConfigForStreamingClient(connectorConfig);
+
+    this.clientName =
+        STREAMING_CLIENT_PREFIX_NAME
+            + connectorConfig.getOrDefault(Utils.NAME, DEFAULT_CLIENT_NAME);
+
+    // Override only if bdec version is explicitly set in config, default to the version set
+    // inside Ingest SDK
+    this.parameterOverrides = new HashMap<>();
+    Optional<String> snowpipeStreamingBdecVersion =
+        Optional.ofNullable(connectorConfig.get(SNOWPIPE_STREAMING_FILE_VERSION));
+    snowpipeStreamingBdecVersion.ifPresent(
+        overriddenValue -> {
+          LOGGER.info("Config is overridden for {} ", SNOWPIPE_STREAMING_FILE_VERSION);
+          parameterOverrides.put(BLOB_FORMAT_VERSION, overriddenValue);
+        });
+  }
+
+  /**
+   * Gets the loggable properties, see {@link
+   * StreamingClientProperties#LOGGABLE_STREAMING_CONFIG_PROPERTIES}
+   *
+   * @return A formatted string with the loggable properties
+   */
+  public String getLoggableClientProperties() {
+    return this.clientProperties == null | this.clientProperties.isEmpty()
+        ? ""
+        : this.clientProperties.entrySet().stream()
+            .filter(
+                propKvp ->
+                    LOGGABLE_STREAMING_CONFIG_PROPERTIES.stream()
+                        .anyMatch(propKvp.getKey().toString()::equalsIgnoreCase))
+            .collect(Collectors.toList())
+            .toString();
+  }
+
+  /**
+   * Determines equality between StreamingClientProperties by only looking at the parsed
+   * clientProperties. This is used in {@link StreamingClientProvider} to determine equality in
+   * registered clients
+   *
+   * @param other other object to determine equality
+   * @return if the given object's clientProperties exists and is equal
+   */
+  @Override
+  public boolean equals(Object other) {
+    return other.getClass().equals(StreamingClientProperties.class)
+        & ((StreamingClientProperties) other).clientProperties.equals(this.clientProperties);
+  }
+
+  /**
+   * Creates the hashcode for this object from the clientProperties. This is used in {@link
+   * StreamingClientProvider} to determine equality in registered clients
+   *
+   * @return the clientProperties' hashcode
+   */
+  @Override
+  public int hashCode() {
+    return this.clientProperties.hashCode();
+  }
+}

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProperties.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProperties.java
@@ -48,8 +48,7 @@ public class StreamingClientProperties {
       Stream.of(
               Constants.ACCOUNT_URL,
               Constants.ROLE,
-              Constants.USER,
-              StreamingUtils.STREAMING_CONSTANT_AUTHORIZATION_TYPE)
+              Constants.USER)
           .collect(Collectors.toList());
 
   public final Properties clientProperties;

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProperties.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProperties.java
@@ -45,11 +45,7 @@ public class StreamingClientProperties {
 
   // contains converted config properties that are loggable (not PII data)
   public static final List<String> LOGGABLE_STREAMING_CONFIG_PROPERTIES =
-      Stream.of(
-              Constants.ACCOUNT_URL,
-              Constants.ROLE,
-              Constants.USER)
-          .collect(Collectors.toList());
+      Stream.of(Constants.ACCOUNT_URL, Constants.ROLE, Constants.USER).collect(Collectors.toList());
 
   public final Properties clientProperties;
   public final String clientName;

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProvider.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProvider.java
@@ -17,6 +17,8 @@
 
 package com.snowflake.kafka.connector.internal.streaming;
 
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_STREAMING_CLIENT_OPTIMIZATION_DEFAULT;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
 import com.snowflake.kafka.connector.internal.KCLogger;
@@ -84,8 +86,9 @@ public class StreamingClientProvider {
   public SnowflakeStreamingIngestClient getClient(Map<String, String> connectorConfig) {
     if (Boolean.parseBoolean(
         connectorConfig.getOrDefault(
-            SnowflakeSinkConnectorConfig.ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG, "false"))) {
-      LOGGER.debug(
+            SnowflakeSinkConnectorConfig.ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG,
+            Boolean.toString(ENABLE_STREAMING_CLIENT_OPTIMIZATION_DEFAULT)))) {
+      LOGGER.info(
           "Streaming client optimization is enabled, returning the existing streaming client if"
               + " valid");
       this.providerLock.lock();
@@ -97,7 +100,7 @@ public class StreamingClientProvider {
       this.providerLock.unlock();
       return this.parameterEnabledClient;
     } else {
-      LOGGER.debug("Streaming client optimization is disabled, creating a new streaming client");
+      LOGGER.info("Streaming client optimization is disabled, creating a new streaming client");
       return this.streamingClientHandler.createClient(connectorConfig);
     }
   }

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
@@ -8,6 +8,7 @@ import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ErrorTolerance;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.KEY_CONVERTER_CONFIG_FIELD;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_MAX_CLIENT_LAG;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.VALUE_CONVERTER_CONFIG_FIELD;
 
 import com.google.common.base.Strings;
@@ -178,6 +179,19 @@ public class StreamingUtils {
           if (inputConfig.containsKey(ERRORS_LOG_ENABLE_CONFIG)) {
             BOOLEAN_VALIDATOR.ensureValid(
                 ERRORS_LOG_ENABLE_CONFIG, inputConfig.get(ERRORS_LOG_ENABLE_CONFIG));
+          }
+
+          if (inputConfig.containsKey(SNOWPIPE_STREAMING_MAX_CLIENT_LAG)) {
+            try {
+              Long.parseLong(inputConfig.get(SNOWPIPE_STREAMING_MAX_CLIENT_LAG));
+            } catch (NumberFormatException exception) {
+              invalidParams.put(
+                  SNOWPIPE_STREAMING_MAX_CLIENT_LAG,
+                  Utils.formatString(
+                      "Max client lag configuration must be a parsable long. Given configuration"
+                          + " was: {}",
+                      inputConfig.get(SNOWPIPE_STREAMING_MAX_CLIENT_LAG)));
+            }
           }
 
           // Valid schematization for Snowpipe Streaming

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
@@ -19,6 +19,7 @@ import com.snowflake.kafka.connector.internal.BufferThreshold;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import net.snowflake.ingest.utils.Constants;
 import org.apache.kafka.common.config.ConfigException;
@@ -66,34 +67,34 @@ public class StreamingUtils {
   public static final int MAX_RECORD_OVERHEAD_BYTES = DefaultRecord.MAX_RECORD_OVERHEAD;
 
   /* Maps streaming client's property keys to what we got from snowflake KC config file. */
-  public static Map<String, String> convertConfigForStreamingClient(
-      Map<String, String> connectorConfig) {
-    Map<String, String> streamingPropertiesMap = new HashMap<>();
+  public static Properties convertConfigForStreamingClient(Map<String, String> connectorConfig) {
+    Properties streamingProperties = new Properties();
+
     connectorConfig.computeIfPresent(
         Utils.SF_URL,
         (key, value) -> {
-          streamingPropertiesMap.put(Constants.ACCOUNT_URL, value);
+          streamingProperties.put(Constants.ACCOUNT_URL, value);
           return value;
         });
 
     connectorConfig.computeIfPresent(
         Utils.SF_ROLE,
         (key, value) -> {
-          streamingPropertiesMap.put(Constants.ROLE, value);
+          streamingProperties.put(Constants.ROLE, value);
           return value;
         });
 
     connectorConfig.computeIfPresent(
         Utils.SF_USER,
         (key, value) -> {
-          streamingPropertiesMap.put(Constants.USER, value);
+          streamingProperties.put(Constants.USER, value);
           return value;
         });
 
     connectorConfig.computeIfPresent(
         Utils.SF_PRIVATE_KEY,
         (key, value) -> {
-          streamingPropertiesMap.put(Constants.PRIVATE_KEY, value);
+          streamingProperties.put(Constants.PRIVATE_KEY, value);
           return value;
         });
 
@@ -101,11 +102,12 @@ public class StreamingUtils {
         Utils.PRIVATE_KEY_PASSPHRASE,
         (key, value) -> {
           if (!value.isEmpty()) {
-            streamingPropertiesMap.put(Constants.PRIVATE_KEY_PASSPHRASE, value);
+            streamingProperties.put(Constants.PRIVATE_KEY_PASSPHRASE, value);
           }
           return value;
         });
-    return streamingPropertiesMap;
+
+    return streamingProperties;
   }
 
   /* Returns true if sf connector config has error.tolerance = ALL */

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
@@ -733,8 +733,8 @@ public class ConnectorConfigTest {
     }
   }
 
-  @Test
-  public void testInValidConfigFileTypeForSnowpipe() {
+  @Test(expected = SnowflakeKafkaConnectorException.class)
+  public void testInalidMaxClientLagForSnowpipe() {
     try {
       Map<String, String> config = getConfig();
       config.put(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_MAX_CLIENT_LAG, "3");
@@ -743,11 +743,12 @@ public class ConnectorConfigTest {
       assert exception
           .getMessage()
           .contains(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_MAX_CLIENT_LAG);
+      throw exception;
     }
   }
 
-  @Test
-  public void testValidFileTypesForSnowpipeStreaming() {
+  @Test(expected = SnowflakeKafkaConnectorException.class)
+  public void testMaxClientLagForSnowpipeStreaming() {
     Map<String, String> config = getConfig();
     config.put(
         SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
@@ -760,9 +761,16 @@ public class ConnectorConfigTest {
     config.put(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_MAX_CLIENT_LAG, "1");
     Utils.validateConfig(config);
 
-    // lower case
-    config.put(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_MAX_CLIENT_LAG, "abcd");
-    Utils.validateConfig(config);
+    // pass in string
+    try {
+      config.put(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_MAX_CLIENT_LAG, "abcd");
+      Utils.validateConfig(config);
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception
+          .getMessage()
+          .contains(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_MAX_CLIENT_LAG);
+      throw exception;
+    }
   }
 
   @Test

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
@@ -737,12 +737,12 @@ public class ConnectorConfigTest {
   public void testInValidConfigFileTypeForSnowpipe() {
     try {
       Map<String, String> config = getConfig();
-      config.put(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_FILE_VERSION, "3");
+      config.put(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_MAX_CLIENT_LAG, "3");
       Utils.validateConfig(config);
     } catch (SnowflakeKafkaConnectorException exception) {
       assert exception
           .getMessage()
-          .contains(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_FILE_VERSION);
+          .contains(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_MAX_CLIENT_LAG);
     }
   }
 
@@ -754,14 +754,14 @@ public class ConnectorConfigTest {
         IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
     config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
 
-    config.put(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_FILE_VERSION, "3");
+    config.put(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_MAX_CLIENT_LAG, "3");
     Utils.validateConfig(config);
 
-    config.put(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_FILE_VERSION, "1");
+    config.put(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_MAX_CLIENT_LAG, "1");
     Utils.validateConfig(config);
 
     // lower case
-    config.put(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_FILE_VERSION, "abcd");
+    config.put(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_MAX_CLIENT_LAG, "abcd");
     Utils.validateConfig(config);
   }
 

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2IT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2IT.java
@@ -37,7 +37,6 @@ import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.After;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class SnowflakeSinkServiceV2IT {
@@ -1133,7 +1132,6 @@ public class SnowflakeSinkServiceV2IT {
   }
 
   @Test
-  @Ignore // SNOW-986359: disable for now due to failure in merge gate
   public void testStreamingIngestionValidClientLag() throws Exception {
     Map<String, String> config = getConfig();
     config.put(SNOWPIPE_STREAMING_MAX_CLIENT_LAG, "30");
@@ -1154,7 +1152,9 @@ public class SnowflakeSinkServiceV2IT {
     List<SinkRecord> sinkRecords =
         TestUtils.createJsonStringSinkRecords(0, noOfRecords, topic, partition);
 
+    Thread.sleep(1000); // to ensure we flush buffer on time threshold
     service.insert(sinkRecords);
+
     try {
       // Wait 20 seconds here and no flush should happen since the max client lag is 30 seconds
       TestUtils.assertWithRetry(

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2IT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2IT.java
@@ -1,5 +1,6 @@
 package com.snowflake.kafka.connector.internal.streaming;
 
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_MAX_CLIENT_LAG;
 import static com.snowflake.kafka.connector.internal.streaming.TopicPartitionChannel.NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE;
 
 import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
@@ -1133,7 +1134,7 @@ public class SnowflakeSinkServiceV2IT {
 
   @Test
   public void testStreamingIngestionValidClientLag() throws Exception {
-    Map<String, String> config = getConfig();
+    Map<String, String> config = TestUtils.getConfForStreaming();
     config.put(SNOWPIPE_STREAMING_MAX_CLIENT_LAG, "30");
     SnowflakeSinkConnectorConfig.setDefaultValues(config);
     conn.createTable(table);
@@ -1177,7 +1178,7 @@ public class SnowflakeSinkServiceV2IT {
     SnowflakeSinkConnectorConfig.setDefaultValues(config);
     Map<String, String> overriddenConfig = new HashMap<>(config);
     overriddenConfig.put(
-        SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_MAX_CLIENT_LAG, "TWOO_HUNDRED");
+        SNOWPIPE_STREAMING_MAX_CLIENT_LAG, "TWOO_HUNDRED");
 
     conn.createTable(table);
 
@@ -1219,24 +1220,23 @@ public class SnowflakeSinkServiceV2IT {
     Map<String, String> catConfig = TestUtils.getConfForStreaming();
     SnowflakeSinkConnectorConfig.setDefaultValues(catConfig);
     catConfig.put(SnowflakeSinkConnectorConfig.ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG, "true");
-    catConfig.put(Utils.SF_OAUTH_CLIENT_ID, "1");
+    catConfig.put(SNOWPIPE_STREAMING_MAX_CLIENT_LAG, "1");
     catConfig.put(Utils.NAME, catTopic);
 
     String dogTopic = "dogTopic_" + TestUtils.randomTableName();
     Map<String, String> dogConfig = TestUtils.getConfForStreaming();
     SnowflakeSinkConnectorConfig.setDefaultValues(dogConfig);
     dogConfig.put(SnowflakeSinkConnectorConfig.ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG, "true");
-    dogConfig.put(Utils.SF_OAUTH_CLIENT_ID, "2");
+    dogConfig.put(SNOWPIPE_STREAMING_MAX_CLIENT_LAG, "2");
     dogConfig.put(Utils.NAME, dogTopic);
 
     String fishTopic = "fishTopic_" + TestUtils.randomTableName();
-    Map<String, String> fishConfig = getConfig();
+    Map<String, String> fishConfig = TestUtils.getConfForStreaming();
     SnowflakeSinkConnectorConfig.setDefaultValues(fishConfig);
     fishConfig.put(
         SnowflakeSinkConnectorConfig.ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG, "true");
-    fishConfig.put(Utils.SF_OAUTH_CLIENT_ID, "2");
+    fishConfig.put(SNOWPIPE_STREAMING_MAX_CLIENT_LAG, "3");
     fishConfig.put(Utils.NAME, fishTopic);
-    fishConfig.put(SNOWPIPE_STREAMING_MAX_CLIENT_LAG, "1");
 
     // setup connection and create tables
     TopicPartition catTp = new TopicPartition(catTopic, 0);

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2IT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2IT.java
@@ -3,9 +3,11 @@ package com.snowflake.kafka.connector.internal.streaming;
 import static com.snowflake.kafka.connector.internal.streaming.TopicPartitionChannel.NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE;
 
 import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
+import com.snowflake.kafka.connector.Utils;
 import com.snowflake.kafka.connector.dlq.InMemoryKafkaRecordErrorReporter;
 import com.snowflake.kafka.connector.internal.SchematizationTestUtils;
 import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
+import com.snowflake.kafka.connector.internal.SnowflakeConnectionServiceFactory;
 import com.snowflake.kafka.connector.internal.SnowflakeErrors;
 import com.snowflake.kafka.connector.internal.SnowflakeSinkService;
 import com.snowflake.kafka.connector.internal.SnowflakeSinkServiceFactory;
@@ -1165,5 +1167,93 @@ public class SnowflakeSinkServiceV2IT {
     } catch (SQLException e) {
       throw SnowflakeErrors.ERROR_2007.getException(e);
     }
+  }
+
+  // note this test relies on testrole_kafka and testrole_kafka_1 roles being granted to test_kafka
+  // user
+  @Test
+  public void testStreamingIngest_multipleChannel_distinctClients() throws Exception {
+    // create cat and dog configs and partitions
+    // one client is enabled but two clients should be created because different roles in config
+    String catTopic = "catTopic_" + TestUtils.randomTableName();
+    Map<String, String> catConfig = TestUtils.getConfForStreaming();
+    SnowflakeSinkConnectorConfig.setDefaultValues(catConfig);
+    catConfig.put(SnowflakeSinkConnectorConfig.ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG, "true");
+    catConfig.put(Utils.SF_OAUTH_CLIENT_ID, "1");
+    catConfig.put(Utils.NAME, catTopic);
+
+    String dogTopic = "dogTopic_" + TestUtils.randomTableName();
+    Map<String, String> dogConfig = TestUtils.getConfForStreaming();
+    SnowflakeSinkConnectorConfig.setDefaultValues(dogConfig);
+    dogConfig.put(SnowflakeSinkConnectorConfig.ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG, "true");
+    dogConfig.put(Utils.SF_OAUTH_CLIENT_ID, "2");
+    dogConfig.put(Utils.NAME, dogTopic);
+
+    // setup connection and create tables
+    TopicPartition catTp = new TopicPartition(catTopic, 0);
+    SnowflakeConnectionService catConn =
+        SnowflakeConnectionServiceFactory.builder().setProperties(catConfig).build();
+    catConn.createTable(catTopic);
+
+    TopicPartition dogTp = new TopicPartition(dogTopic, 1);
+    SnowflakeConnectionService dogconn =
+        SnowflakeConnectionServiceFactory.builder().setProperties(dogConfig).build();
+    dogconn.createTable(dogTopic);
+
+    // create the sink services
+    SnowflakeSinkService catService =
+        SnowflakeSinkServiceFactory.builder(
+                catConn, IngestionMethodConfig.SNOWPIPE_STREAMING, catConfig)
+            .setRecordNumber(1)
+            .setErrorReporter(new InMemoryKafkaRecordErrorReporter())
+            .setSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(catTp)))
+            .addTask(catTopic, catTp) // Internally calls startTask
+            .build();
+
+    SnowflakeSinkService dogService =
+        SnowflakeSinkServiceFactory.builder(
+                dogconn, IngestionMethodConfig.SNOWPIPE_STREAMING, dogConfig)
+            .setRecordNumber(1)
+            .setErrorReporter(new InMemoryKafkaRecordErrorReporter())
+            .setSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(dogTp)))
+            .addTask(dogTopic, dogTp) // Internally calls startTask
+            .build();
+
+    // create records
+    final int catRecordCount = 9;
+    final int dogRecordCount = 3;
+
+    List<SinkRecord> catRecords =
+        TestUtils.createJsonStringSinkRecords(0, catRecordCount, catTp.topic(), catTp.partition());
+    List<SinkRecord> dogRecords =
+        TestUtils.createJsonStringSinkRecords(0, dogRecordCount, dogTp.topic(), dogTp.partition());
+
+    // insert records
+    catService.insert(catRecords);
+    dogService.insert(dogRecords);
+
+    // check data was ingested
+    TestUtils.assertWithRetry(() -> catService.getOffset(catTp) == catRecordCount, 20, 20);
+    TestUtils.assertWithRetry(() -> dogService.getOffset(dogTp) == dogRecordCount, 20, 20);
+
+    // verify two clients were created
+    assert StreamingClientProvider.getStreamingClientProviderInstance()
+        .getRegisteredClients()
+        .containsKey(new StreamingClientProperties(catConfig));
+    assert StreamingClientProvider.getStreamingClientProviderInstance()
+        .getRegisteredClients()
+        .containsKey(new StreamingClientProperties(dogConfig));
+
+    // close services
+    catService.closeAll();
+    dogService.closeAll();
+
+    // verify both clients were closed
+    assert !StreamingClientProvider.getStreamingClientProviderInstance()
+        .getRegisteredClients()
+        .containsKey(new StreamingClientProperties(catConfig));
+    assert !StreamingClientProvider.getStreamingClientProviderInstance()
+        .getRegisteredClients()
+        .containsKey(new StreamingClientProperties(dogConfig));
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2IT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2IT.java
@@ -1177,8 +1177,7 @@ public class SnowflakeSinkServiceV2IT {
     Map<String, String> config = TestUtils.getConfForStreaming();
     SnowflakeSinkConnectorConfig.setDefaultValues(config);
     Map<String, String> overriddenConfig = new HashMap<>(config);
-    overriddenConfig.put(
-        SNOWPIPE_STREAMING_MAX_CLIENT_LAG, "TWOO_HUNDRED");
+    overriddenConfig.put(SNOWPIPE_STREAMING_MAX_CLIENT_LAG, "TWOO_HUNDRED");
 
     conn.createTable(table);
 

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2IT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2IT.java
@@ -37,6 +37,7 @@ import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.After;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class SnowflakeSinkServiceV2IT {
@@ -1132,12 +1133,51 @@ public class SnowflakeSinkServiceV2IT {
   }
 
   @Test
-  public void testStreamingIngestion_invalid_file_version() throws Exception {
+  @Ignore // SNOW-986359: disable for now due to failure in merge gate
+  public void testStreamingIngestionValidClientLag() throws Exception {
+    Map<String, String> config = getConfig();
+    config.put(SNOWPIPE_STREAMING_MAX_CLIENT_LAG, "30");
+    SnowflakeSinkConnectorConfig.setDefaultValues(config);
+    conn.createTable(table);
+
+    // opens a channel for partition 0, table and topic
+    SnowflakeSinkService service =
+        SnowflakeSinkServiceFactory.builder(conn, IngestionMethodConfig.SNOWPIPE_STREAMING, config)
+            .setRecordNumber(100)
+            .setFlushTime(1)
+            .setErrorReporter(new InMemoryKafkaRecordErrorReporter())
+            .setSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(topicPartition)))
+            .addTask(table, new TopicPartition(topic, partition)) // Internally calls startTask
+            .build();
+
+    final long noOfRecords = 50;
+    List<SinkRecord> sinkRecords =
+        TestUtils.createJsonStringSinkRecords(0, noOfRecords, topic, partition);
+
+    service.insert(sinkRecords);
+    try {
+      // Wait 20 seconds here and no flush should happen since the max client lag is 30 seconds
+      TestUtils.assertWithRetry(
+          () -> service.getOffset(new TopicPartition(topic, partition)) == noOfRecords, 5, 4);
+      Assert.fail("The rows should not be flushed");
+    } catch (Exception e) {
+      // do nothing
+    }
+
+    // Wait for enough time, the rows should be flushed
+    TestUtils.assertWithRetry(
+        () -> service.getOffset(new TopicPartition(topic, partition)) == noOfRecords, 30, 30);
+
+    service.closeAll();
+  }
+
+  @Test
+  public void testStreamingIngestionInvalidClientLag() {
     Map<String, String> config = TestUtils.getConfForStreaming();
     SnowflakeSinkConnectorConfig.setDefaultValues(config);
     Map<String, String> overriddenConfig = new HashMap<>(config);
     overriddenConfig.put(
-        SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_FILE_VERSION, "TWOO_HUNDRED");
+        SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_MAX_CLIENT_LAG, "TWOO_HUNDRED");
 
     conn.createTable(table);
 
@@ -1189,6 +1229,15 @@ public class SnowflakeSinkServiceV2IT {
     dogConfig.put(Utils.SF_OAUTH_CLIENT_ID, "2");
     dogConfig.put(Utils.NAME, dogTopic);
 
+    String fishTopic = "fishTopic_" + TestUtils.randomTableName();
+    Map<String, String> fishConfig = getConfig();
+    SnowflakeSinkConnectorConfig.setDefaultValues(fishConfig);
+    fishConfig.put(
+        SnowflakeSinkConnectorConfig.ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG, "true");
+    fishConfig.put(Utils.SF_OAUTH_CLIENT_ID, "2");
+    fishConfig.put(Utils.NAME, fishTopic);
+    fishConfig.put(SNOWPIPE_STREAMING_MAX_CLIENT_LAG, "1");
+
     // setup connection and create tables
     TopicPartition catTp = new TopicPartition(catTopic, 0);
     SnowflakeConnectionService catConn =
@@ -1196,9 +1245,14 @@ public class SnowflakeSinkServiceV2IT {
     catConn.createTable(catTopic);
 
     TopicPartition dogTp = new TopicPartition(dogTopic, 1);
-    SnowflakeConnectionService dogconn =
+    SnowflakeConnectionService dogConn =
         SnowflakeConnectionServiceFactory.builder().setProperties(dogConfig).build();
-    dogconn.createTable(dogTopic);
+    dogConn.createTable(dogTopic);
+
+    TopicPartition fishTp = new TopicPartition(fishTopic, 1);
+    SnowflakeConnectionService fishConn =
+        SnowflakeConnectionServiceFactory.builder().setProperties(fishConfig).build();
+    fishConn.createTable(fishTopic);
 
     // create the sink services
     SnowflakeSinkService catService =
@@ -1212,48 +1266,70 @@ public class SnowflakeSinkServiceV2IT {
 
     SnowflakeSinkService dogService =
         SnowflakeSinkServiceFactory.builder(
-                dogconn, IngestionMethodConfig.SNOWPIPE_STREAMING, dogConfig)
+                dogConn, IngestionMethodConfig.SNOWPIPE_STREAMING, dogConfig)
             .setRecordNumber(1)
             .setErrorReporter(new InMemoryKafkaRecordErrorReporter())
             .setSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(dogTp)))
             .addTask(dogTopic, dogTp) // Internally calls startTask
             .build();
 
+    SnowflakeSinkService fishService =
+        SnowflakeSinkServiceFactory.builder(
+                dogConn, IngestionMethodConfig.SNOWPIPE_STREAMING, fishConfig)
+            .setRecordNumber(1)
+            .setErrorReporter(new InMemoryKafkaRecordErrorReporter())
+            .setSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(fishTp)))
+            .addTask(fishTopic, fishTp) // Internally calls startTask
+            .build();
+
     // create records
     final int catRecordCount = 9;
     final int dogRecordCount = 3;
+    final int fishRecordCount = 1;
 
     List<SinkRecord> catRecords =
         TestUtils.createJsonStringSinkRecords(0, catRecordCount, catTp.topic(), catTp.partition());
     List<SinkRecord> dogRecords =
         TestUtils.createJsonStringSinkRecords(0, dogRecordCount, dogTp.topic(), dogTp.partition());
+    List<SinkRecord> fishRecords =
+        TestUtils.createJsonStringSinkRecords(
+            0, fishRecordCount, fishTp.topic(), fishTp.partition());
 
     // insert records
     catService.insert(catRecords);
     dogService.insert(dogRecords);
+    fishService.insert(fishRecords);
 
     // check data was ingested
     TestUtils.assertWithRetry(() -> catService.getOffset(catTp) == catRecordCount, 20, 20);
     TestUtils.assertWithRetry(() -> dogService.getOffset(dogTp) == dogRecordCount, 20, 20);
+    TestUtils.assertWithRetry(() -> fishService.getOffset(fishTp) == fishRecordCount, 20, 20);
 
-    // verify two clients were created
+    // verify three clients were created
     assert StreamingClientProvider.getStreamingClientProviderInstance()
         .getRegisteredClients()
         .containsKey(new StreamingClientProperties(catConfig));
     assert StreamingClientProvider.getStreamingClientProviderInstance()
         .getRegisteredClients()
         .containsKey(new StreamingClientProperties(dogConfig));
+    assert StreamingClientProvider.getStreamingClientProviderInstance()
+        .getRegisteredClients()
+        .containsKey(new StreamingClientProperties(fishConfig));
 
     // close services
     catService.closeAll();
     dogService.closeAll();
+    fishService.closeAll();
 
-    // verify both clients were closed
+    // verify three clients were closed
     assert !StreamingClientProvider.getStreamingClientProviderInstance()
         .getRegisteredClients()
         .containsKey(new StreamingClientProperties(catConfig));
     assert !StreamingClientProvider.getStreamingClientProviderInstance()
         .getRegisteredClients()
         .containsKey(new StreamingClientProperties(dogConfig));
+    assert !StreamingClientProvider.getStreamingClientProviderInstance()
+        .getRegisteredClients()
+        .containsKey(new StreamingClientProperties(fishConfig));
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientHandlerTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientHandlerTest.java
@@ -61,7 +61,7 @@ public class StreamingClientHandlerTest {
     client2.close();
   }
 
-  @Test
+  @Test (expected = ConnectException.class)
   public void testCreateClientException() {
     // invalidate the config
     this.connectorConfig.remove(Utils.SF_PRIVATE_KEY); // private key is required

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientHandlerTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientHandlerTest.java
@@ -61,7 +61,7 @@ public class StreamingClientHandlerTest {
     client2.close();
   }
 
-  @Test (expected = ConnectException.class)
+  @Test(expected = ConnectException.class)
   public void testCreateClientException() {
     // invalidate the config
     this.connectorConfig.remove(Utils.SF_PRIVATE_KEY); // private key is required

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientHandlerTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientHandlerTest.java
@@ -17,7 +17,6 @@
 
 package com.snowflake.kafka.connector.internal.streaming;
 
-import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
 import com.snowflake.kafka.connector.Utils;
 import com.snowflake.kafka.connector.internal.TestUtils;
 import java.util.Map;
@@ -73,15 +72,6 @@ public class StreamingClientHandlerTest {
       assert ex.getCause().getClass().equals(SFException.class);
       throw ex;
     }
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testCreateClientInvalidBdecVersion() {
-    // add invalid bdec version
-    this.connectorConfig.put(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_FILE_VERSION, "1");
-
-    // test create
-    this.streamingClientHandler.createClient(new StreamingClientProperties(this.connectorConfig));
   }
 
   @Test

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientHandlerTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientHandlerTest.java
@@ -39,24 +39,39 @@ public class StreamingClientHandlerTest {
   }
 
   @Test
-  public void testCreateClient() {
-    SnowflakeStreamingIngestClient client =
-        this.streamingClientHandler.createClient(this.connectorConfig);
+  public void testCreateClient() throws Exception {
+    SnowflakeStreamingIngestClient client1 =
+        this.streamingClientHandler.createClient(
+            new StreamingClientProperties(this.connectorConfig));
 
     // verify valid client against config
-    assert !client.isClosed();
-    assert client.getName().contains(this.connectorConfig.get(Utils.NAME));
+    assert !client1.isClosed();
+    assert client1.getName().contains(this.connectorConfig.get(Utils.NAME) + "_0");
+
+    // create another client, confirm that the name was incremented
+    SnowflakeStreamingIngestClient client2 =
+        this.streamingClientHandler.createClient(
+            new StreamingClientProperties(this.connectorConfig));
+
+    // verify valid client against config
+    assert !client2.isClosed();
+    assert client2.getName().contains(this.connectorConfig.get(Utils.NAME) + "_1");
+
+    // cleanup
+    client1.close();
+    client2.close();
   }
 
   @Test
   public void testCreateClientException() {
     // invalidate the config
-    this.connectorConfig.remove(Utils.SF_ROLE);
+    this.connectorConfig.remove(Utils.SF_PRIVATE_KEY); // private key is required
 
     try {
-      this.streamingClientHandler.createClient(this.connectorConfig);
+      this.streamingClientHandler.createClient(new StreamingClientProperties(this.connectorConfig));
     } catch (ConnectException ex) {
       assert ex.getCause().getClass().equals(SFException.class);
+      throw ex;
     }
   }
 
@@ -66,7 +81,7 @@ public class StreamingClientHandlerTest {
     this.connectorConfig.put(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_FILE_VERSION, "1");
 
     // test create
-    this.streamingClientHandler.createClient(this.connectorConfig);
+    this.streamingClientHandler.createClient(new StreamingClientProperties(this.connectorConfig));
   }
 
   @Test

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientPropertiesTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientPropertiesTest.java
@@ -17,11 +17,11 @@
 
 package com.snowflake.kafka.connector.internal.streaming;
 
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_FILE_VERSION;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_MAX_CLIENT_LAG;
 import static com.snowflake.kafka.connector.internal.streaming.StreamingClientProperties.DEFAULT_CLIENT_NAME;
 import static com.snowflake.kafka.connector.internal.streaming.StreamingClientProperties.LOGGABLE_STREAMING_CONFIG_PROPERTIES;
 import static com.snowflake.kafka.connector.internal.streaming.StreamingClientProperties.STREAMING_CLIENT_PREFIX_NAME;
-import static net.snowflake.ingest.utils.ParameterProvider.BLOB_FORMAT_VERSION;
+import static net.snowflake.ingest.utils.ParameterProvider.MAX_CLIENT_LAG;
 
 import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
 import com.snowflake.kafka.connector.Utils;
@@ -35,7 +35,7 @@ public class StreamingClientPropertiesTest {
 
   @Test
   public void testGetValidProperties() {
-    String overrideValue = "overrideValue";
+    String overrideValue = "10";
 
     // setup config with all loggable properties and parameter override
     Map<String, String> connectorConfig = TestUtils.getConfForStreaming();
@@ -44,12 +44,12 @@ public class StreamingClientPropertiesTest {
     connectorConfig.put(Utils.SF_ROLE, "testRole");
     connectorConfig.put(Utils.SF_USER, "testUser");
     connectorConfig.put(Utils.SF_AUTHENTICATOR, Utils.SNOWFLAKE_JWT);
-    connectorConfig.put(SNOWPIPE_STREAMING_FILE_VERSION, overrideValue);
+    connectorConfig.put(SNOWPIPE_STREAMING_MAX_CLIENT_LAG, overrideValue);
 
     Properties expectedProps = StreamingUtils.convertConfigForStreamingClient(connectorConfig);
     String expectedClientName = STREAMING_CLIENT_PREFIX_NAME + connectorConfig.get(Utils.NAME);
     Map<String, String> expectedParameterOverrides = new HashMap<>();
-    expectedParameterOverrides.put(BLOB_FORMAT_VERSION, overrideValue);
+    expectedParameterOverrides.put(MAX_CLIENT_LAG, String.format("%s second", overrideValue));
 
     // test get properties
     StreamingClientProperties resultProperties = new StreamingClientProperties(connectorConfig);
@@ -99,5 +99,14 @@ public class StreamingClientPropertiesTest {
 
     assert prop1.equals(prop2);
     assert prop1.hashCode() == prop2.hashCode();
+
+    config1.put(SNOWPIPE_STREAMING_MAX_CLIENT_LAG, "1");
+    config2.put(SNOWPIPE_STREAMING_MAX_CLIENT_LAG, "10");
+
+    prop1 = new StreamingClientProperties(config1);
+    prop2 = new StreamingClientProperties(config2);
+
+    assert !prop1.equals(prop2);
+    assert prop1.hashCode() != prop2.hashCode();
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientPropertiesTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientPropertiesTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2023 Snowflake Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.snowflake.kafka.connector.internal.streaming;
+
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_FILE_VERSION;
+import static com.snowflake.kafka.connector.internal.streaming.StreamingClientProperties.DEFAULT_CLIENT_NAME;
+import static com.snowflake.kafka.connector.internal.streaming.StreamingClientProperties.LOGGABLE_STREAMING_CONFIG_PROPERTIES;
+import static com.snowflake.kafka.connector.internal.streaming.StreamingClientProperties.STREAMING_CLIENT_PREFIX_NAME;
+import static net.snowflake.ingest.utils.ParameterProvider.BLOB_FORMAT_VERSION;
+
+import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
+import com.snowflake.kafka.connector.Utils;
+import com.snowflake.kafka.connector.internal.TestUtils;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import org.junit.Test;
+
+public class StreamingClientPropertiesTest {
+
+  @Test
+  public void testGetValidProperties() {
+    String overrideValue = "overrideValue";
+
+    // setup config with all loggable properties and parameter override
+    Map<String, String> connectorConfig = TestUtils.getConfForStreaming();
+    connectorConfig.put(Utils.NAME, "testName");
+    connectorConfig.put(Utils.SF_URL, "testUrl");
+    connectorConfig.put(Utils.SF_ROLE, "testRole");
+    connectorConfig.put(Utils.SF_USER, "testUser");
+    connectorConfig.put(Utils.SF_AUTHENTICATOR, Utils.SNOWFLAKE_JWT);
+    connectorConfig.put(SNOWPIPE_STREAMING_FILE_VERSION, overrideValue);
+
+    Properties expectedProps = StreamingUtils.convertConfigForStreamingClient(connectorConfig);
+    String expectedClientName = STREAMING_CLIENT_PREFIX_NAME + connectorConfig.get(Utils.NAME);
+    Map<String, String> expectedParameterOverrides = new HashMap<>();
+    expectedParameterOverrides.put(BLOB_FORMAT_VERSION, overrideValue);
+
+    // test get properties
+    StreamingClientProperties resultProperties = new StreamingClientProperties(connectorConfig);
+
+    // verify
+    assert resultProperties.clientProperties.equals(expectedProps);
+    assert resultProperties.clientName.equals(expectedClientName);
+    assert resultProperties.parameterOverrides.equals(expectedParameterOverrides);
+
+    // verify only loggable props are returned
+    String loggableProps = resultProperties.getLoggableClientProperties();
+    for (Object key : expectedProps.keySet()) {
+      Object value = expectedProps.get(key);
+      if (LOGGABLE_STREAMING_CONFIG_PROPERTIES.stream()
+          .anyMatch(key.toString()::equalsIgnoreCase)) {
+        assert loggableProps.contains(
+            Utils.formatString("{}={}", key.toString(), value.toString()));
+      } else {
+        assert !loggableProps.contains(key.toString()) && !loggableProps.contains(value.toString());
+      }
+    }
+  }
+
+  @Test
+  public void testGetInvalidProperties() {
+    StreamingClientProperties nullProperties = new StreamingClientProperties(null);
+    StreamingClientProperties emptyProperties = new StreamingClientProperties(new HashMap<>());
+
+    assert nullProperties.equals(emptyProperties);
+    assert nullProperties.clientName.equals(STREAMING_CLIENT_PREFIX_NAME + DEFAULT_CLIENT_NAME);
+    assert nullProperties.getLoggableClientProperties().equals("");
+  }
+
+  @Test
+  public void testStreamingClientPropertiesEquality() {
+    Map<String, String> config1 = TestUtils.getConfForStreaming();
+    config1.put(Utils.NAME, "catConnector");
+    config1.put(SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS, "100");
+
+    Map<String, String> config2 = TestUtils.getConfForStreaming();
+    config1.put(Utils.NAME, "dogConnector");
+    config1.put(SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS, "1000000");
+
+    // get properties
+    StreamingClientProperties prop1 = new StreamingClientProperties(config1);
+    StreamingClientProperties prop2 = new StreamingClientProperties(config2);
+
+    assert prop1.equals(prop2);
+    assert prop1.hashCode() == prop2.hashCode();
+  }
+}

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientPropertiesTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientPropertiesTest.java
@@ -43,7 +43,6 @@ public class StreamingClientPropertiesTest {
     connectorConfig.put(Utils.SF_URL, "testUrl");
     connectorConfig.put(Utils.SF_ROLE, "testRole");
     connectorConfig.put(Utils.SF_USER, "testUser");
-    connectorConfig.put(Utils.SF_AUTHENTICATOR, Utils.SNOWFLAKE_JWT);
     connectorConfig.put(SNOWPIPE_STREAMING_MAX_CLIENT_LAG, overrideValue);
 
     Properties expectedProps = StreamingUtils.convertConfigForStreamingClient(connectorConfig);

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProviderIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProviderIT.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2023 Snowflake Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.snowflake.kafka.connector.internal.streaming;
+
+import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
+import com.snowflake.kafka.connector.Utils;
+import com.snowflake.kafka.connector.internal.TestUtils;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import net.snowflake.ingest.internal.com.github.benmanes.caffeine.cache.LoadingCache;
+import net.snowflake.ingest.streaming.SnowflakeStreamingIngestClient;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mockito.Mockito;
+
+@RunWith(Parameterized.class)
+public class StreamingClientProviderIT {
+  private final boolean enableClientOptimization;
+  private final Map<String, String> clientConfig = TestUtils.getConfForStreaming();
+
+  @Parameterized.Parameters(name = "enableClientOptimization: {0}")
+  public static Collection<Object[]> input() {
+    return Arrays.asList(new Object[][] {{true}, {false}});
+  }
+
+  public StreamingClientProviderIT(boolean enableClientOptimization) {
+    this.enableClientOptimization = enableClientOptimization;
+    this.clientConfig.put(
+        SnowflakeSinkConnectorConfig.ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG,
+        String.valueOf(this.enableClientOptimization));
+  }
+
+  @Test
+  public void testGetMultipleClients() throws Exception {
+    String validRegisteredClientName = "openRegisteredClient";
+    String invalidRegisteredClientName = "closedRegisteredClient";
+    String validUnregisteredClientName = "openUnregisteredClient";
+    StreamingClientHandler clientCreator = new StreamingClientHandler();
+
+    // setup registered valid client
+    Map<String, String> validRegisteredClientConfig = new HashMap<>(this.clientConfig);
+    validRegisteredClientConfig.put(Utils.NAME, validRegisteredClientName);
+    validRegisteredClientConfig.put(Utils.SF_OAUTH_CLIENT_ID, "0");
+    StreamingClientProperties validRegisteredClientProps =
+        new StreamingClientProperties(validRegisteredClientConfig);
+    SnowflakeStreamingIngestClient validRegisteredClient =
+        clientCreator.createClient(validRegisteredClientProps);
+
+    // setup registered invalid client
+    Map<String, String> invalidRegisteredClientConfig = new HashMap<>(this.clientConfig);
+    invalidRegisteredClientConfig.put(Utils.NAME, invalidRegisteredClientName);
+    invalidRegisteredClientConfig.put(Utils.SF_OAUTH_CLIENT_ID, "1");
+    StreamingClientProperties invalidRegisteredClientProps =
+        new StreamingClientProperties(invalidRegisteredClientConfig);
+    SnowflakeStreamingIngestClient invalidRegisteredClient =
+        clientCreator.createClient(invalidRegisteredClientProps);
+    invalidRegisteredClient.close();
+
+    // setup unregistered valid client
+    Map<String, String> validUnregisteredClientConfig = new HashMap<>(this.clientConfig);
+    validUnregisteredClientConfig.put(Utils.NAME, validUnregisteredClientName);
+    validUnregisteredClientConfig.put(Utils.SF_OAUTH_CLIENT_ID, "2");
+    StreamingClientProperties validUnregisteredClientProps =
+        new StreamingClientProperties(validUnregisteredClientConfig);
+    SnowflakeStreamingIngestClient validUnregisteredClient =
+        clientCreator.createClient(validUnregisteredClientProps);
+
+    // inject registered clients
+    StreamingClientHandler streamingClientHandlerSpy =
+        Mockito.spy(StreamingClientHandler.class); // use this to verify behavior
+    LoadingCache<StreamingClientProperties, SnowflakeStreamingIngestClient> registeredClients =
+        StreamingClientProvider.buildLoadingCache(streamingClientHandlerSpy);
+
+    registeredClients.put(validRegisteredClientProps, validRegisteredClient);
+    registeredClients.put(invalidRegisteredClientProps, invalidRegisteredClient);
+
+    StreamingClientProvider streamingClientProvider =
+        StreamingClientProvider.getStreamingClientProviderForTests(
+            streamingClientHandlerSpy, registeredClients);
+
+    assert streamingClientProvider.getRegisteredClients().size() == 2;
+
+    // test 1: get registered valid client optimization returns existing client
+    SnowflakeStreamingIngestClient resultValidRegisteredClient =
+        streamingClientProvider.getClient(validRegisteredClientConfig);
+
+    assert StreamingClientHandler.isClientValid(resultValidRegisteredClient);
+    assert resultValidRegisteredClient.getName().contains("_0");
+    assert this.enableClientOptimization
+        == resultValidRegisteredClient.equals(validRegisteredClient);
+    Mockito.verify(streamingClientHandlerSpy, Mockito.times(this.enableClientOptimization ? 0 : 1))
+        .createClient(validRegisteredClientProps);
+    assert streamingClientProvider.getRegisteredClients().size() == 2;
+
+    // test 2: get registered invalid client creates new client regardless of optimization
+    SnowflakeStreamingIngestClient resultInvalidRegisteredClient =
+        streamingClientProvider.getClient(invalidRegisteredClientConfig);
+
+    assert StreamingClientHandler.isClientValid(resultInvalidRegisteredClient);
+    assert resultInvalidRegisteredClient
+        .getName()
+        .contains("_" + (this.enableClientOptimization ? 0 : 1));
+    assert !resultInvalidRegisteredClient.equals(invalidRegisteredClient);
+    Mockito.verify(streamingClientHandlerSpy, Mockito.times(1))
+        .createClient(invalidRegisteredClientProps);
+    assert streamingClientProvider.getRegisteredClients().size() == 2;
+
+    // test 3: get unregistered valid client creates and registers new client with optimization
+    SnowflakeStreamingIngestClient resultValidUnregisteredClient =
+        streamingClientProvider.getClient(validUnregisteredClientConfig);
+
+    assert StreamingClientHandler.isClientValid(resultValidUnregisteredClient);
+    assert resultValidUnregisteredClient
+        .getName()
+        .contains("_" + (this.enableClientOptimization ? 1 : 2));
+    assert !resultValidUnregisteredClient.equals(validUnregisteredClient);
+    Mockito.verify(streamingClientHandlerSpy, Mockito.times(1))
+        .createClient(validUnregisteredClientProps);
+    assert streamingClientProvider.getRegisteredClients().size()
+        == (this.enableClientOptimization ? 3 : 2);
+
+    // verify streamingClientHandler behavior
+    Mockito.verify(streamingClientHandlerSpy, Mockito.times(this.enableClientOptimization ? 2 : 3))
+        .createClient(Mockito.any());
+
+    // test 4: get all clients multiple times and verify optimization doesn't create new clients
+    List<SnowflakeStreamingIngestClient> gotClientList = new ArrayList<>();
+
+    for (int i = 0; i < 5; i++) {
+      gotClientList.add(streamingClientProvider.getClient(validRegisteredClientConfig));
+      gotClientList.add(streamingClientProvider.getClient(invalidRegisteredClientConfig));
+      gotClientList.add(streamingClientProvider.getClient(validUnregisteredClientConfig));
+    }
+
+    List<SnowflakeStreamingIngestClient> distinctClients =
+        gotClientList.stream().distinct().collect(Collectors.toList());
+    assert distinctClients.size() == (this.enableClientOptimization ? 3 : gotClientList.size());
+    Mockito.verify(
+            streamingClientHandlerSpy,
+            Mockito.times(this.enableClientOptimization ? 2 : 3 + gotClientList.size()))
+        .createClient(Mockito.any());
+    assert streamingClientProvider.getRegisteredClients().size()
+        == (this.enableClientOptimization ? 3 : 2);
+
+    // close all clients
+    validRegisteredClient.close();
+    invalidRegisteredClient.close();
+    validUnregisteredClient.close();
+
+    resultValidRegisteredClient.close();
+    resultInvalidRegisteredClient.close();
+    resultValidUnregisteredClient.close();
+
+    distinctClients.stream()
+        .forEach(
+            client -> {
+              try {
+                client.close();
+              } catch (Exception e) {
+                // do nothing
+              }
+            });
+  }
+}

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProviderIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProviderIT.java
@@ -61,7 +61,7 @@ public class StreamingClientProviderIT {
     // setup registered valid client
     Map<String, String> validRegisteredClientConfig = new HashMap<>(this.clientConfig);
     validRegisteredClientConfig.put(Utils.NAME, validRegisteredClientName);
-    validRegisteredClientConfig.put(Utils.SF_OAUTH_CLIENT_ID, "0");
+    validRegisteredClientConfig.put(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_MAX_CLIENT_LAG, "1");
     StreamingClientProperties validRegisteredClientProps =
         new StreamingClientProperties(validRegisteredClientConfig);
     SnowflakeStreamingIngestClient validRegisteredClient =
@@ -70,7 +70,7 @@ public class StreamingClientProviderIT {
     // setup registered invalid client
     Map<String, String> invalidRegisteredClientConfig = new HashMap<>(this.clientConfig);
     invalidRegisteredClientConfig.put(Utils.NAME, invalidRegisteredClientName);
-    invalidRegisteredClientConfig.put(Utils.SF_OAUTH_CLIENT_ID, "1");
+    invalidRegisteredClientConfig.put(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_MAX_CLIENT_LAG, "2");
     StreamingClientProperties invalidRegisteredClientProps =
         new StreamingClientProperties(invalidRegisteredClientConfig);
     SnowflakeStreamingIngestClient invalidRegisteredClient =
@@ -80,7 +80,7 @@ public class StreamingClientProviderIT {
     // setup unregistered valid client
     Map<String, String> validUnregisteredClientConfig = new HashMap<>(this.clientConfig);
     validUnregisteredClientConfig.put(Utils.NAME, validUnregisteredClientName);
-    validUnregisteredClientConfig.put(Utils.SF_OAUTH_CLIENT_ID, "2");
+    validUnregisteredClientConfig.put(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_MAX_CLIENT_LAG, "3");
     StreamingClientProperties validUnregisteredClientProps =
         new StreamingClientProperties(validUnregisteredClientConfig);
     SnowflakeStreamingIngestClient validUnregisteredClient =

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProviderIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProviderIT.java
@@ -61,7 +61,8 @@ public class StreamingClientProviderIT {
     // setup registered valid client
     Map<String, String> validRegisteredClientConfig = new HashMap<>(this.clientConfig);
     validRegisteredClientConfig.put(Utils.NAME, validRegisteredClientName);
-    validRegisteredClientConfig.put(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_MAX_CLIENT_LAG, "1");
+    validRegisteredClientConfig.put(
+        SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_MAX_CLIENT_LAG, "1");
     StreamingClientProperties validRegisteredClientProps =
         new StreamingClientProperties(validRegisteredClientConfig);
     SnowflakeStreamingIngestClient validRegisteredClient =
@@ -70,7 +71,8 @@ public class StreamingClientProviderIT {
     // setup registered invalid client
     Map<String, String> invalidRegisteredClientConfig = new HashMap<>(this.clientConfig);
     invalidRegisteredClientConfig.put(Utils.NAME, invalidRegisteredClientName);
-    invalidRegisteredClientConfig.put(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_MAX_CLIENT_LAG, "2");
+    invalidRegisteredClientConfig.put(
+        SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_MAX_CLIENT_LAG, "2");
     StreamingClientProperties invalidRegisteredClientProps =
         new StreamingClientProperties(invalidRegisteredClientConfig);
     SnowflakeStreamingIngestClient invalidRegisteredClient =
@@ -80,7 +82,8 @@ public class StreamingClientProviderIT {
     // setup unregistered valid client
     Map<String, String> validUnregisteredClientConfig = new HashMap<>(this.clientConfig);
     validUnregisteredClientConfig.put(Utils.NAME, validUnregisteredClientName);
-    validUnregisteredClientConfig.put(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_MAX_CLIENT_LAG, "3");
+    validUnregisteredClientConfig.put(
+        SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_MAX_CLIENT_LAG, "3");
     StreamingClientProperties validUnregisteredClientProps =
         new StreamingClientProperties(validUnregisteredClientConfig);
     SnowflakeStreamingIngestClient validUnregisteredClient =

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProviderTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProviderTest.java
@@ -186,14 +186,11 @@ public class StreamingClientProviderTest {
     this.client1 = this.streamingClientProvider.getClient(this.clientConfig1);
     this.client2 = this.streamingClientProvider.getClient(this.clientConfig1);
 
-    // verify - should be two different clients, since missing config defaults to disable
-    // optimization
-    assert !this.client1.getName().equals(this.client2.getName());
+    // Since it is enabled by default, we should only create one client.
+    assert this.client1.getName().equals(this.client2.getName());
 
     assert StreamingClientHandler.isClientValid(this.client1);
-    assert StreamingClientHandler.isClientValid(this.client2);
     assert this.client1.getName().contains(this.clientConfig1.get(Utils.NAME));
-    assert this.client2.getName().contains(this.clientConfig1.get(Utils.NAME));
-    Mockito.verify(this.streamingClientHandler, Mockito.times(2)).createClient(this.clientConfig1);
+    Mockito.verify(this.streamingClientHandler, Mockito.times(1)).createClient(this.clientConfig1);
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelIT.java
@@ -101,6 +101,7 @@ public class TopicPartitionChannelIT {
     assert inMemorySinkTaskContext.offsets().get(topicPartition) == 1;
     assert TestUtils.tableSize(testTableName) == noOfRecords
         : "expected: " + noOfRecords + " actual: " + TestUtils.tableSize(testTableName);
+    service.closeAll();
   }
 
   /* This will automatically open the channel. */
@@ -157,6 +158,7 @@ public class TopicPartitionChannelIT {
             + (noOfRecords + noOfRecords)
             + " actual: "
             + TestUtils.tableSize(testTableName);
+    service.closeAll();
   }
 
   /**
@@ -370,6 +372,7 @@ public class TopicPartitionChannelIT {
                 + anotherSetOfRecords)
             + " actual: "
             + TestUtils.tableSize(testTableName);
+    service.closeAll();
   }
 
   @Test
@@ -444,6 +447,7 @@ public class TopicPartitionChannelIT {
             + (recordsInPartition1 + anotherSetOfRecords)
             + " actual: "
             + TestUtils.tableSize(testTableName);
+    service.closeAll();
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -473,5 +477,6 @@ public class TopicPartitionChannelIT {
 
     // should throw because we don't take arrow version 1 anymore
     service.insert(records);
+    service.closeAll();
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelIT.java
@@ -449,34 +449,4 @@ public class TopicPartitionChannelIT {
             + TestUtils.tableSize(testTableName);
     service.closeAll();
   }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testSimpleInsertRowsFailureWithArrowBDECFormat() throws Exception {
-    // add config which overrides the bdec file format
-    Map<String, String> overriddenConfig = new HashMap<>(TestUtils.getConfForStreaming());
-    overriddenConfig.put(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_FILE_VERSION, "1");
-
-    InMemorySinkTaskContext inMemorySinkTaskContext =
-        new InMemorySinkTaskContext(Collections.singleton(topicPartition));
-
-    // This will automatically create a channel for topicPartition.
-    SnowflakeSinkService service =
-        SnowflakeSinkServiceFactory.builder(
-                conn, IngestionMethodConfig.SNOWPIPE_STREAMING, overriddenConfig)
-            .setRecordNumber(1)
-            .setErrorReporter(new InMemoryKafkaRecordErrorReporter())
-            .setSinkTaskContext(inMemorySinkTaskContext)
-            .addTask(testTableName, topicPartition)
-            .build();
-
-    final long noOfRecords = 1;
-
-    // send regular data
-    List<SinkRecord> records =
-        TestUtils.createJsonStringSinkRecords(0, noOfRecords, topic, PARTITION);
-
-    // should throw because we don't take arrow version 1 anymore
-    service.insert(records);
-    service.closeAll();
-  }
 }

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelIT.java
@@ -9,7 +9,6 @@ import com.snowflake.kafka.connector.internal.SnowflakeSinkServiceFactory;
 import com.snowflake.kafka.connector.internal.TestUtils;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import net.snowflake.ingest.streaming.OpenChannelRequest;


### PR DESCRIPTION
Cherrypicks commits on top of 2.0.0

Main commits
- Registers multiple clients depending on required configurations: https://github.com/snowflakedb/snowflake-kafka-connector/pull/744
  - For https://snowflakecomputing.atlassian.net/browse/SNOW-954150
- Exposes ingest sdk MAX_CLIENT_LAG configuration: https://github.com/snowflakedb/snowflake-kafka-connector/pull/695

Smaller required commits
- One client optimization defaults to true: https://github.com/snowflakedb/snowflake-kafka-connector/pull/695
- Upgrade github actions test python version: https://github.com/snowflakedb/snowflake-kafka-connector/pull/708

