### PR TITLE
Add connector version in RECORD_METADATA

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -100,6 +100,7 @@ public class SnowflakeSinkConnectorConfig {
   public static final String SNOWFLAKE_METADATA_CREATETIME = "snowflake.metadata.createtime";
   public static final String SNOWFLAKE_METADATA_TOPIC = "snowflake.metadata.topic";
   public static final String SNOWFLAKE_METADATA_SF_CONNECTOR_VERSION = "snowflake.metadata.sf.connector.version";
+  public static final String SNOWFLAKE_METADATA_SF_CONNECTOR_VERSION_DEFAULT = "false";
   public static final String SNOWFLAKE_METADATA_OFFSET_AND_PARTITION =
       "snowflake.metadata.offset.and.partition";
   public static final String SNOWFLAKE_METADATA_ALL = "snowflake.metadata.all";
@@ -490,7 +491,7 @@ public class SnowflakeSinkConnectorConfig {
         .define(
                 SNOWFLAKE_METADATA_SF_CONNECTOR_VERSION,
             Type.BOOLEAN,
-            SNOWFLAKE_METADATA_DEFAULT,
+            SNOWFLAKE_METADATA_SF_CONNECTOR_VERSION_DEFAULT,
             Importance.LOW,
             "Flag to control whether Snowflake Connector version is collected in snowflake metadata",
             SNOWFLAKE_METADATA_FLAGS,

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -99,7 +99,7 @@ public class SnowflakeSinkConnectorConfig {
   private static final String SNOWFLAKE_METADATA_FLAGS = "Snowflake Metadata Flags";
   public static final String SNOWFLAKE_METADATA_CREATETIME = "snowflake.metadata.createtime";
   public static final String SNOWFLAKE_METADATA_TOPIC = "snowflake.metadata.topic";
-  public static final String SNOWFLAKE_METADATA_VERSION = "snowflake.metadata.version";
+  public static final String SNOWFLAKE_METADATA_SF_CONNECTOR_VERSION = "snowflake.metadata.sf.connector.version";
   public static final String SNOWFLAKE_METADATA_OFFSET_AND_PARTITION =
       "snowflake.metadata.offset.and.partition";
   public static final String SNOWFLAKE_METADATA_ALL = "snowflake.metadata.all";
@@ -488,15 +488,15 @@ public class SnowflakeSinkConnectorConfig {
             ConfigDef.Width.NONE,
             SNOWFLAKE_METADATA_TOPIC)
         .define(
-            SNOWFLAKE_METADATA_VERSION,
+                SNOWFLAKE_METADATA_SF_CONNECTOR_VERSION,
             Type.BOOLEAN,
             SNOWFLAKE_METADATA_DEFAULT,
             Importance.LOW,
-            "Flag to control whether connector version is collected in snowflake metadata",
+            "Flag to control whether Snowflake Connector version is collected in snowflake metadata",
             SNOWFLAKE_METADATA_FLAGS,
             3,
             ConfigDef.Width.NONE,
-            SNOWFLAKE_METADATA_VERSION)
+                SNOWFLAKE_METADATA_SF_CONNECTOR_VERSION)
         .define(
             SNOWFLAKE_METADATA_OFFSET_AND_PARTITION,
             Type.BOOLEAN,

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -99,7 +99,8 @@ public class SnowflakeSinkConnectorConfig {
   private static final String SNOWFLAKE_METADATA_FLAGS = "Snowflake Metadata Flags";
   public static final String SNOWFLAKE_METADATA_CREATETIME = "snowflake.metadata.createtime";
   public static final String SNOWFLAKE_METADATA_TOPIC = "snowflake.metadata.topic";
-  public static final String SNOWFLAKE_METADATA_SF_CONNECTOR_VERSION = "snowflake.metadata.sf.connector.version";
+  public static final String SNOWFLAKE_METADATA_SF_CONNECTOR_VERSION =
+      "snowflake.metadata.sf.connector.version";
   public static final String SNOWFLAKE_METADATA_SF_CONNECTOR_VERSION_DEFAULT = "false";
   public static final String SNOWFLAKE_METADATA_OFFSET_AND_PARTITION =
       "snowflake.metadata.offset.and.partition";
@@ -489,15 +490,16 @@ public class SnowflakeSinkConnectorConfig {
             ConfigDef.Width.NONE,
             SNOWFLAKE_METADATA_TOPIC)
         .define(
-                SNOWFLAKE_METADATA_SF_CONNECTOR_VERSION,
+            SNOWFLAKE_METADATA_SF_CONNECTOR_VERSION,
             Type.BOOLEAN,
             SNOWFLAKE_METADATA_SF_CONNECTOR_VERSION_DEFAULT,
             Importance.LOW,
-            "Flag to control whether Snowflake Connector version is collected in snowflake metadata",
+            "Flag to control whether Snowflake Connector version is collected in snowflake"
+                + " metadata",
             SNOWFLAKE_METADATA_FLAGS,
             3,
             ConfigDef.Width.NONE,
-                SNOWFLAKE_METADATA_SF_CONNECTOR_VERSION)
+            SNOWFLAKE_METADATA_SF_CONNECTOR_VERSION)
         .define(
             SNOWFLAKE_METADATA_OFFSET_AND_PARTITION,
             Type.BOOLEAN,

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -99,6 +99,7 @@ public class SnowflakeSinkConnectorConfig {
   private static final String SNOWFLAKE_METADATA_FLAGS = "Snowflake Metadata Flags";
   public static final String SNOWFLAKE_METADATA_CREATETIME = "snowflake.metadata.createtime";
   public static final String SNOWFLAKE_METADATA_TOPIC = "snowflake.metadata.topic";
+  public static final String SNOWFLAKE_METADATA_VERSION = "snowflake.metadata.version";
   public static final String SNOWFLAKE_METADATA_OFFSET_AND_PARTITION =
       "snowflake.metadata.offset.and.partition";
   public static final String SNOWFLAKE_METADATA_ALL = "snowflake.metadata.all";
@@ -487,6 +488,16 @@ public class SnowflakeSinkConnectorConfig {
             ConfigDef.Width.NONE,
             SNOWFLAKE_METADATA_TOPIC)
         .define(
+            SNOWFLAKE_METADATA_VERSION,
+            Type.BOOLEAN,
+            SNOWFLAKE_METADATA_DEFAULT,
+            Importance.LOW,
+            "Flag to control whether connector version is collected in snowflake metadata",
+            SNOWFLAKE_METADATA_FLAGS,
+            3,
+            ConfigDef.Width.NONE,
+            SNOWFLAKE_METADATA_VERSION)
+        .define(
             SNOWFLAKE_METADATA_OFFSET_AND_PARTITION,
             Type.BOOLEAN,
             SNOWFLAKE_METADATA_DEFAULT,
@@ -494,7 +505,7 @@ public class SnowflakeSinkConnectorConfig {
             "Flag to control whether kafka partition and offset are collected in snowflake"
                 + " metadata",
             SNOWFLAKE_METADATA_FLAGS,
-            3,
+            4,
             ConfigDef.Width.NONE,
             SNOWFLAKE_METADATA_OFFSET_AND_PARTITION)
         .define(

--- a/src/main/java/com/snowflake/kafka/connector/records/RecordService.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/RecordService.java
@@ -66,7 +66,7 @@ public class RecordService {
   static final String CONTENT = "content";
   static final String META = "meta";
   static final String SCHEMA_ID = "schema_id";
-  static final String VERSION = "version";
+  static final String SF_CONNECTOR_VERSION = "sf_connector_version";
   private static final String KEY_SCHEMA_ID = "key_schema_id";
   static final String HEADERS = "headers";
 
@@ -192,8 +192,8 @@ public class RecordService {
     if (metadataConfig.topicFlag) {
       meta.put(TOPIC, record.topic());
     }
-    if (metadataConfig.versionFlag) {
-      meta.put(VERSION, Utils.VERSION);
+    if (metadataConfig.sfConnectorVersionFlag) {
+      meta.put(SF_CONNECTOR_VERSION, Utils.VERSION);
     }
     if (metadataConfig.offsetAndPartitionFlag) {
       meta.put(OFFSET, record.kafkaOffset());

--- a/src/main/java/com/snowflake/kafka/connector/records/RecordService.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/RecordService.java
@@ -66,6 +66,7 @@ public class RecordService {
   static final String CONTENT = "content";
   static final String META = "meta";
   static final String SCHEMA_ID = "schema_id";
+  static final String VERSION = "version";
   private static final String KEY_SCHEMA_ID = "key_schema_id";
   static final String HEADERS = "headers";
 
@@ -190,6 +191,9 @@ public class RecordService {
     ObjectNode meta = MAPPER.createObjectNode();
     if (metadataConfig.topicFlag) {
       meta.put(TOPIC, record.topic());
+    }
+    if (metadataConfig.versionFlag) {
+      meta.put(VERSION, Utils.VERSION);
     }
     if (metadataConfig.offsetAndPartitionFlag) {
       meta.put(OFFSET, record.kafkaOffset());

--- a/src/main/java/com/snowflake/kafka/connector/records/SnowflakeMetadataConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/SnowflakeMetadataConfig.java
@@ -8,6 +8,7 @@ public class SnowflakeMetadataConfig {
   final boolean createtimeFlag;
   final boolean topicFlag;
   final boolean offsetAndPartitionFlag;
+  final boolean versionFlag;
   final boolean allFlag;
 
   /** initialize with default config */
@@ -25,6 +26,7 @@ public class SnowflakeMetadataConfig {
     // these values are the default values of the configuration
     boolean createtime = true;
     boolean topic = true;
+    boolean version = true;
     boolean offsetAndPartition = true;
     boolean all = true;
     if (config.containsKey(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_CREATETIME)
@@ -38,6 +40,12 @@ public class SnowflakeMetadataConfig {
             .get(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_TOPIC)
             .equals(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_DEFAULT)) {
       topic = false;
+    }
+    if (config.containsKey(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_VERSION)
+            && !config
+            .get(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_ALL)
+            .equals(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_DEFAULT)) {
+      version = false;
     }
     if (config.containsKey(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_OFFSET_AND_PARTITION)
         && !config
@@ -54,6 +62,7 @@ public class SnowflakeMetadataConfig {
 
     createtimeFlag = createtime;
     topicFlag = topic;
+    versionFlag = version;
     offsetAndPartitionFlag = offsetAndPartition;
     allFlag = all;
   }
@@ -64,6 +73,8 @@ public class SnowflakeMetadataConfig {
         + ", "
         + "topicFlag: "
         + topicFlag
+        + "versionFlag: "
+        + versionFlag
         + ", "
         + "offsetAndPartitionFlag: "
         + offsetAndPartitionFlag

--- a/src/main/java/com/snowflake/kafka/connector/records/SnowflakeMetadataConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/SnowflakeMetadataConfig.java
@@ -42,9 +42,9 @@ public class SnowflakeMetadataConfig {
       topic = false;
     }
     if (config.containsKey(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_SF_CONNECTOR_VERSION)
-        && !config
+        && config
             .get(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_SF_CONNECTOR_VERSION)
-            .equals(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_SF_CONNECTOR_VERSION_DEFAULT)) {
+            .equals(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_DEFAULT)) {
       version = true;
     }
     if (config.containsKey(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_OFFSET_AND_PARTITION)

--- a/src/main/java/com/snowflake/kafka/connector/records/SnowflakeMetadataConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/SnowflakeMetadataConfig.java
@@ -8,7 +8,7 @@ public class SnowflakeMetadataConfig {
   final boolean createtimeFlag;
   final boolean topicFlag;
   final boolean offsetAndPartitionFlag;
-  final boolean versionFlag;
+  final boolean sfConnectorVersionFlag;
   final boolean allFlag;
 
   /** initialize with default config */
@@ -26,7 +26,7 @@ public class SnowflakeMetadataConfig {
     // these values are the default values of the configuration
     boolean createtime = true;
     boolean topic = true;
-    boolean version = true;
+    boolean version = false;
     boolean offsetAndPartition = true;
     boolean all = true;
     if (config.containsKey(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_CREATETIME)
@@ -41,7 +41,7 @@ public class SnowflakeMetadataConfig {
             .equals(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_DEFAULT)) {
       topic = false;
     }
-    if (config.containsKey(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_VERSION)
+    if (config.containsKey(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_SF_CONNECTOR_VERSION)
             && !config
             .get(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_ALL)
             .equals(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_DEFAULT)) {
@@ -62,7 +62,7 @@ public class SnowflakeMetadataConfig {
 
     createtimeFlag = createtime;
     topicFlag = topic;
-    versionFlag = version;
+    sfConnectorVersionFlag = version;
     offsetAndPartitionFlag = offsetAndPartition;
     allFlag = all;
   }
@@ -74,7 +74,7 @@ public class SnowflakeMetadataConfig {
         + "topicFlag: "
         + topicFlag
         + "versionFlag: "
-        + versionFlag
+        + sfConnectorVersionFlag
         + ", "
         + "offsetAndPartitionFlag: "
         + offsetAndPartitionFlag

--- a/src/main/java/com/snowflake/kafka/connector/records/SnowflakeMetadataConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/SnowflakeMetadataConfig.java
@@ -42,7 +42,7 @@ public class SnowflakeMetadataConfig {
       topic = false;
     }
     if (config.containsKey(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_SF_CONNECTOR_VERSION)
-            && !config
+        && !config
             .get(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_ALL)
             .equals(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_DEFAULT)) {
       version = false;

--- a/src/main/java/com/snowflake/kafka/connector/records/SnowflakeMetadataConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/SnowflakeMetadataConfig.java
@@ -43,7 +43,7 @@ public class SnowflakeMetadataConfig {
     }
     if (config.containsKey(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_SF_CONNECTOR_VERSION)
         && !config
-            .get(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_ALL)
+            .get(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_SF_CONNECTOR_VERSION)
             .equals(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_DEFAULT)) {
       version = false;
     }

--- a/src/main/java/com/snowflake/kafka/connector/records/SnowflakeMetadataConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/SnowflakeMetadataConfig.java
@@ -44,8 +44,8 @@ public class SnowflakeMetadataConfig {
     if (config.containsKey(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_SF_CONNECTOR_VERSION)
         && !config
             .get(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_SF_CONNECTOR_VERSION)
-            .equals(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_DEFAULT)) {
-      version = false;
+            .equals(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_SF_CONNECTOR_VERSION_DEFAULT)) {
+      version = true;
     }
     if (config.containsKey(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_OFFSET_AND_PARTITION)
         && !config

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorIT.java
@@ -24,7 +24,7 @@ public class ConnectorIT {
     SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC,
     SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_ALL,
     SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_TOPIC,
-    SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_VERSION,
+    SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_SF_CONNECTOR_VERSION,
     SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_OFFSET_AND_PARTITION,
     SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_CREATETIME,
     SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP,
@@ -79,7 +79,7 @@ public class ConnectorIT {
     config.put(SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC, "-1");
     config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_ALL, "falseee");
     config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_TOPIC, "falseee");
-    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_VERSION, "falseee");
+    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_SF_CONNECTOR_VERSION, "falseee");
     config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_OFFSET_AND_PARTITION, "falseee");
     config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_CREATETIME, "falseee");
     config.put(SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP, "jfsja,,");

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorIT.java
@@ -24,6 +24,7 @@ public class ConnectorIT {
     SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC,
     SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_ALL,
     SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_TOPIC,
+    SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_VERSION,
     SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_OFFSET_AND_PARTITION,
     SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_CREATETIME,
     SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP,
@@ -78,6 +79,7 @@ public class ConnectorIT {
     config.put(SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC, "-1");
     config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_ALL, "falseee");
     config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_TOPIC, "falseee");
+    config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_VERSION, "falseee");
     config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_OFFSET_AND_PARTITION, "falseee");
     config.put(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_CREATETIME, "falseee");
     config.put(SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP, "jfsja,,");

--- a/src/test/java/com/snowflake/kafka/connector/records/MetaColumnTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/records/MetaColumnTest.java
@@ -38,6 +38,12 @@ public class MetaColumnTest {
           put(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_TOPIC, "false");
         }
       };
+  private HashMap<String, String> versionConfig =
+      new HashMap<String, String>() {
+        {
+          put(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_VERSION, "false");
+        }
+      };
   private HashMap<String, String> offsetAndPartitionConfig =
       new HashMap<String, String>() {
         {
@@ -113,6 +119,18 @@ public class MetaColumnTest {
     assert result.get(META).has(RecordService.OFFSET);
     assert result.get(META).has(RecordService.PARTITION);
     assert result.get(META).has(record.timestampType().name);
+    assert result.get(META).has(RecordService.VERSION);
+
+    // test metadata configuration -- remove version
+    metadataConfig = new SnowflakeMetadataConfig(versionConfig);
+    service.setMetadataConfig(metadataConfig);
+    result = mapper.readTree(service.getProcessedRecordForSnowpipe(record));
+    assert result.has(META);
+    assert !result.get(META).has(RecordService.VERSION);
+    assert result.get(META).has(RecordService.OFFSET);
+    assert result.get(META).has(RecordService.PARTITION);
+    assert result.get(META).has(record.timestampType().name);
+    assert result.get(META).has(RecordService.TOPIC);
 
     // test metadata configuration -- remove offset and partition
     metadataConfig = new SnowflakeMetadataConfig(offsetAndPartitionConfig);
@@ -123,6 +141,7 @@ public class MetaColumnTest {
     assert !result.get(META).has(RecordService.PARTITION);
     assert result.get(META).has(record.timestampType().name);
     assert result.get(META).has(RecordService.TOPIC);
+    assert result.get(META).has(RecordService.VERSION);
 
     // test metadata configuration -- remove time stamp
     metadataConfig = new SnowflakeMetadataConfig(createTimeConfig);
@@ -131,6 +150,7 @@ public class MetaColumnTest {
     assert result.has(META);
     assert !result.get(META).has(record.timestampType().name);
     assert result.get(META).has(RecordService.TOPIC);
+    assert result.get(META).has(RecordService.VERSION);
     assert result.get(META).has(RecordService.OFFSET);
     assert result.get(META).has(RecordService.PARTITION);
 

--- a/src/test/java/com/snowflake/kafka/connector/records/MetaColumnTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/records/MetaColumnTest.java
@@ -41,7 +41,7 @@ public class MetaColumnTest {
   private HashMap<String, String> versionConfig =
       new HashMap<String, String>() {
         {
-          put(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_VERSION, "false");
+          put(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_SF_CONNECTOR_VERSION, "false");
         }
       };
   private HashMap<String, String> offsetAndPartitionConfig =
@@ -119,14 +119,14 @@ public class MetaColumnTest {
     assert result.get(META).has(RecordService.OFFSET);
     assert result.get(META).has(RecordService.PARTITION);
     assert result.get(META).has(record.timestampType().name);
-    assert result.get(META).has(RecordService.VERSION);
+    assert result.get(META).has(RecordService.SF_CONNECTOR_VERSION);
 
     // test metadata configuration -- remove version
     metadataConfig = new SnowflakeMetadataConfig(versionConfig);
     service.setMetadataConfig(metadataConfig);
     result = mapper.readTree(service.getProcessedRecordForSnowpipe(record));
     assert result.has(META);
-    assert !result.get(META).has(RecordService.VERSION);
+    assert !result.get(META).has(RecordService.SF_CONNECTOR_VERSION);
     assert result.get(META).has(RecordService.OFFSET);
     assert result.get(META).has(RecordService.PARTITION);
     assert result.get(META).has(record.timestampType().name);
@@ -141,7 +141,7 @@ public class MetaColumnTest {
     assert !result.get(META).has(RecordService.PARTITION);
     assert result.get(META).has(record.timestampType().name);
     assert result.get(META).has(RecordService.TOPIC);
-    assert result.get(META).has(RecordService.VERSION);
+    assert result.get(META).has(RecordService.SF_CONNECTOR_VERSION);
 
     // test metadata configuration -- remove time stamp
     metadataConfig = new SnowflakeMetadataConfig(createTimeConfig);
@@ -150,7 +150,7 @@ public class MetaColumnTest {
     assert result.has(META);
     assert !result.get(META).has(record.timestampType().name);
     assert result.get(META).has(RecordService.TOPIC);
-    assert result.get(META).has(RecordService.VERSION);
+    assert result.get(META).has(RecordService.SF_CONNECTOR_VERSION);
     assert result.get(META).has(RecordService.OFFSET);
     assert result.get(META).has(RecordService.PARTITION);
 

--- a/src/test/java/com/snowflake/kafka/connector/records/MetaColumnTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/records/MetaColumnTest.java
@@ -41,7 +41,7 @@ public class MetaColumnTest {
   private HashMap<String, String> versionConfig =
       new HashMap<String, String>() {
         {
-          put(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_SF_CONNECTOR_VERSION, "false");
+          put(SnowflakeSinkConnectorConfig.SNOWFLAKE_METADATA_SF_CONNECTOR_VERSION, "true");
         }
       };
   private HashMap<String, String> offsetAndPartitionConfig =
@@ -119,7 +119,6 @@ public class MetaColumnTest {
     assert result.get(META).has(RecordService.OFFSET);
     assert result.get(META).has(RecordService.PARTITION);
     assert result.get(META).has(record.timestampType().name);
-    assert result.get(META).has(RecordService.SF_CONNECTOR_VERSION);
 
     // test metadata configuration -- remove version
     metadataConfig = new SnowflakeMetadataConfig(versionConfig);
@@ -141,7 +140,6 @@ public class MetaColumnTest {
     assert !result.get(META).has(RecordService.PARTITION);
     assert result.get(META).has(record.timestampType().name);
     assert result.get(META).has(RecordService.TOPIC);
-    assert result.get(META).has(RecordService.SF_CONNECTOR_VERSION);
 
     // test metadata configuration -- remove time stamp
     metadataConfig = new SnowflakeMetadataConfig(createTimeConfig);
@@ -150,7 +148,6 @@ public class MetaColumnTest {
     assert result.has(META);
     assert !result.get(META).has(record.timestampType().name);
     assert result.get(META).has(RecordService.TOPIC);
-    assert result.get(META).has(RecordService.SF_CONNECTOR_VERSION);
     assert result.get(META).has(RecordService.OFFSET);
     assert result.get(META).has(RecordService.PARTITION);
 

--- a/src/test/java/com/snowflake/kafka/connector/records/MetaColumnTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/records/MetaColumnTest.java
@@ -119,13 +119,14 @@ public class MetaColumnTest {
     assert result.get(META).has(RecordService.OFFSET);
     assert result.get(META).has(RecordService.PARTITION);
     assert result.get(META).has(record.timestampType().name);
+    assert !result.get(META).has(RecordService.SF_CONNECTOR_VERSION);
 
     // test metadata configuration -- remove version
     metadataConfig = new SnowflakeMetadataConfig(versionConfig);
     service.setMetadataConfig(metadataConfig);
     result = mapper.readTree(service.getProcessedRecordForSnowpipe(record));
     assert result.has(META);
-    assert !result.get(META).has(RecordService.SF_CONNECTOR_VERSION);
+    assert result.get(META).has(RecordService.SF_CONNECTOR_VERSION);
     assert result.get(META).has(RecordService.OFFSET);
     assert result.get(META).has(RecordService.PARTITION);
     assert result.get(META).has(record.timestampType().name);
@@ -138,6 +139,7 @@ public class MetaColumnTest {
     assert result.has(META);
     assert !result.get(META).has(RecordService.OFFSET);
     assert !result.get(META).has(RecordService.PARTITION);
+    assert !result.get(META).has(RecordService.SF_CONNECTOR_VERSION);
     assert result.get(META).has(record.timestampType().name);
     assert result.get(META).has(RecordService.TOPIC);
 
@@ -147,6 +149,7 @@ public class MetaColumnTest {
     result = mapper.readTree(service.getProcessedRecordForSnowpipe(record));
     assert result.has(META);
     assert !result.get(META).has(record.timestampType().name);
+    assert !result.get(META).has(RecordService.SF_CONNECTOR_VERSION);
     assert result.get(META).has(RecordService.TOPIC);
     assert result.get(META).has(RecordService.OFFSET);
     assert result.get(META).has(RecordService.PARTITION);

--- a/src/test/java/com/snowflake/kafka/connector/records/RecordContentTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/records/RecordContentTest.java
@@ -264,7 +264,8 @@ public class RecordContentTest {
     service.setEnableSchematization(true);
     String value =
         "{\"players\":[{\"name\":\"John Doe\",\"age\":30},{\"name\":\"Jane Doe\",\"age\":30}]}";
-    byte[] valueContents = (value).getBytes(StandardCharsets.UTF_8);
+    String value2 = "{\"cricket\":{\"team\":{\"MI\":{\"players\":[{\"name\":\"John Doe\",\"age\":30},{\"name\":\"Jane Doe\",\"age\":30}]}}}}";
+    byte[] valueContents = (value2).getBytes(StandardCharsets.UTF_8);
     SchemaAndValue sv = jsonConverter.toConnectData(topic, valueContents);
 
     SinkRecord record =

--- a/src/test/java/com/snowflake/kafka/connector/records/RecordContentTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/records/RecordContentTest.java
@@ -264,7 +264,9 @@ public class RecordContentTest {
     service.setEnableSchematization(true);
     String value =
         "{\"players\":[{\"name\":\"John Doe\",\"age\":30},{\"name\":\"Jane Doe\",\"age\":30}]}";
-    String value2 = "{\"cricket\":{\"team\":{\"MI\":{\"players\":[{\"name\":\"John Doe\",\"age\":30},{\"name\":\"Jane Doe\",\"age\":30}]}}}}";
+    String value2 =
+        "{\"cricket\":{\"team\":{\"MI\":{\"players\":[{\"name\":\"John"
+            + " Doe\",\"age\":30},{\"name\":\"Jane Doe\",\"age\":30}]}}}}";
     byte[] valueContents = (value2).getBytes(StandardCharsets.UTF_8);
     SchemaAndValue sv = jsonConverter.toConnectData(topic, valueContents);
 


### PR DESCRIPTION
This comes handy while comparing data after connector version upgrade. Especially useful if you want to identify rows impacted by a certain version of the connector that had a bug. 