### PR TITLE
resolves issue with generating and building java libary

### DIFF
--- a/test/test_data/protobuf/pom.xml
+++ b/test/test_data/protobuf/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>3.19.6</version>
+            <version>3.25.2</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
it seems the version of `protoc` tool was out of sync with the jar used to compile the generated code .
upgrading jar to latest version solved the issue of missing method. 