### PR TITLE
Run subset of e2e tests

### DIFF
--- a/README-TEST.md
+++ b/README-TEST.md
@@ -58,9 +58,9 @@ Run end to end test on Apache 2.2.0 without stress test, with ssl
 	./run_test_apache.sh 2.2.0 ./apache_properties_ssl false true
 ```
 
-There is also option to run selected tests locally for Apache using additional named parameters:
+There is also option to run selected tests locally using additional named parameters:
 ```
-./run_test_apache.sh <version> <path to apache config folder> <stress> <ssl> --local=true --tests=TestStringJson,TestAvroAvro
+./run_test_<confluent/apache>.sh <version> <path to apache config folder> <stress> <ssl> --local=true --tests=TestStringJson,TestAvroAvro
 ```
 
 Note: if ssl is set to true, path to apache config folder must be `apache_properties_ssl` instead of `apache_properties`

--- a/README-TEST.md
+++ b/README-TEST.md
@@ -51,16 +51,15 @@ Checkout from GitHub master and run integration test:
 The above command build a jar file and put it at `/usr/local/share/kafka/plugins`. Then the following command will spin up Kafka and Kafka Connect cluster and execute the test suits. 
 
 ```
-./run_test_<confluent/apache>.sh <version> <path to apache config folder> <stress> <ssl>
+./run_test_<confluent/apache>.sh <version> <path to apache config folder> <stress> <ssl> [--skipProxy] [--tests=TestStringJson,TestAvroAvro,...]
 Run end to end test on Confluent 5.5.0 with stress test, without ssl
 	./run_test_confluent.sh 5.5.0 ./apache_properties true
 Run end to end test on Apache 2.2.0 without stress test, with ssl
 	./run_test_apache.sh 2.2.0 ./apache_properties_ssl false true
-```
-
-There is also option to run selected tests locally using additional named parameters:
-```
-./run_test_<confluent/apache>.sh <version> <path to apache config folder> <stress> <ssl> --local=true --tests=TestStringJson,TestAvroAvro
+	
+Optional arguments (useful for local development):
+    --skipProxy - skip running proxy tests
+    --tests - comma separated list of test suites to run
 ```
 
 Note: if ssl is set to true, path to apache config folder must be `apache_properties_ssl` instead of `apache_properties`

--- a/README-TEST.md
+++ b/README-TEST.md
@@ -58,6 +58,11 @@ Run end to end test on Apache 2.2.0 without stress test, with ssl
 	./run_test_apache.sh 2.2.0 ./apache_properties_ssl false true
 ```
 
+There is also option to run selected tests locally for Apache using additional named parameters:
+```
+./run_test_apache.sh <version> <path to apache config folder> <stress> <ssl> --local=true --tests=TestStringJson,TestAvroAvro
+```
+
 Note: if ssl is set to true, path to apache config folder must be `apache_properties_ssl` instead of `apache_properties`
 
 Inside the run test script there are five steps: starting cluster, generating connector configuration, sending records, verifying result, and cleaning up test.

--- a/test/run_test_apache.sh
+++ b/test/run_test_apache.sh
@@ -17,7 +17,7 @@ source ./utils.sh
 
 # check argument number
 if [ "$#" -lt 2 ] || [ "$#" -gt 6 ] ; then
-    error_exit "Usage: ./run_test.sh <version> <path to apache config folder> <pressure> <ssl> [--local=true] [--tests=TestStringJson,TestStringAvro,...].  Aborting."
+    error_exit "Usage: ./run_test.sh <version> <path to apache config folder> <pressure> <ssl> [--skipProxy] [--tests=TestStringJson,TestStringAvro,...].  Aborting."
 fi
 
 APACHE_VERSION=$1
@@ -33,10 +33,10 @@ else
   SSL="false"
 fi
 
-if [ "$#" -gt 4 ] && [[ $5 == "--local=true" ]] ; then
-  LOCAL=true
+if [ "$#" -gt 4 ] && [[ $5 == "--skipProxy" ]] ; then
+  SKIP_PROXY=true
 else
-  LOCAL=false
+  SKIP_PROXY=false
 fi
 
 tests_pattern="[^(--tests=).*]"
@@ -159,15 +159,15 @@ KC_PORT=8083
 
 set +e -x
 echo -e "\n=== Clean table stage and pipe ==="
-python3 test_verify.py $LOCAL_IP:$SNOWFLAKE_KAFKA_PORT http://$LOCAL_IP:$SC_PORT $LOCAL_IP:$KC_PORT clean $APACHE_VERSION $NAME_SALT $PRESSURE $SSL $LOCAL $TESTS
+python3 test_verify.py $LOCAL_IP:$SNOWFLAKE_KAFKA_PORT http://$LOCAL_IP:$SC_PORT $LOCAL_IP:$KC_PORT clean $APACHE_VERSION $NAME_SALT $PRESSURE $SSL $SKIP_PROXY $TESTS
 
 #create_connectors_with_salt $SNOWFLAKE_CREDENTIAL_FILE $NAME_SALT $LOCAL_IP $KC_PORT
 
 # Send test data and verify DB result from Python
-python3 test_verify.py $LOCAL_IP:$SNOWFLAKE_KAFKA_PORT http://$LOCAL_IP:$SC_PORT $LOCAL_IP:$KC_PORT $TEST_SET $APACHE_VERSION $NAME_SALT $PRESSURE $SSL $LOCAL $TESTS
+python3 test_verify.py $LOCAL_IP:$SNOWFLAKE_KAFKA_PORT http://$LOCAL_IP:$SC_PORT $LOCAL_IP:$KC_PORT $TEST_SET $APACHE_VERSION $NAME_SALT $PRESSURE $SSL $SKIP_PROXY $TESTS
 testError=$?
 # delete_connectors_with_salt $NAME_SALT $LOCAL_IP $KC_PORT
-python3 test_verify.py $LOCAL_IP:$SNOWFLAKE_KAFKA_PORT http://$LOCAL_IP:$SC_PORT $LOCAL_IP:$KC_PORT clean $APACHE_VERSION $NAME_SALT $PRESSURE $SSL $LOCAL $TESTS
+python3 test_verify.py $LOCAL_IP:$SNOWFLAKE_KAFKA_PORT http://$LOCAL_IP:$SC_PORT $LOCAL_IP:$KC_PORT clean $APACHE_VERSION $NAME_SALT $PRESSURE $SSL $SKIP_PROXY $TESTS
 
 if [ $testError -ne 0 ]; then
     RED='\033[0;31m'

--- a/test/run_test_apache.sh
+++ b/test/run_test_apache.sh
@@ -16,8 +16,8 @@ function random-string() {
 source ./utils.sh
 
 # check argument number
-if [ "$#" -lt 2 ] || [ "$#" -gt 4 ] ; then
-    error_exit "Usage: ./run_test.sh <version> <path to apache config folder> <pressure> <ssl>.  Aborting."
+if [ "$#" -lt 2 ] || [ "$#" -gt 6 ] ; then
+    error_exit "Usage: ./run_test.sh <version> <path to apache config folder> <pressure> <ssl> [--local=true] [--tests=TestStringJson,TestStringAvro,...].  Aborting."
 fi
 
 APACHE_VERSION=$1
@@ -32,6 +32,21 @@ if [ "$#" -gt 3 ] ; then
 else
   SSL="false"
 fi
+
+if [ "$#" -gt 4 ] && [[ $5 == "--local=true" ]] ; then
+  LOCAL=true
+else
+  LOCAL=false
+fi
+
+tests_pattern="[^(--tests=).*]"
+if [ "$#" -gt 5 ] && [[ $6 =~ $tests_pattern ]] ; then
+  # skip initial '--tests='
+  TESTS=`echo $6 | cut -c9-`
+else
+  TESTS=""
+fi
+
 SNOWFLAKE_ZOOKEEPER_CONFIG="zookeeper.properties"
 SNOWFLAKE_KAFKA_CONFIG="server.properties"
 SNOWFLAKE_KAFKA_CONNECT_CONFIG="connect-distributed.properties"
@@ -142,20 +157,17 @@ LOCAL_IP="localhost"
 SC_PORT=8081
 KC_PORT=8083
 
-# Add list of test names for local development
-ALLOWED_TESTS={}
-
 set +e -x
 echo -e "\n=== Clean table stage and pipe ==="
-python3 test_verify.py $LOCAL_IP:$SNOWFLAKE_KAFKA_PORT http://$LOCAL_IP:$SC_PORT $LOCAL_IP:$KC_PORT clean $APACHE_VERSION $NAME_SALT $PRESSURE $SSL $ALLOWED_TESTS
+python3 test_verify.py $LOCAL_IP:$SNOWFLAKE_KAFKA_PORT http://$LOCAL_IP:$SC_PORT $LOCAL_IP:$KC_PORT clean $APACHE_VERSION $NAME_SALT $PRESSURE $SSL $LOCAL $TESTS
 
 #create_connectors_with_salt $SNOWFLAKE_CREDENTIAL_FILE $NAME_SALT $LOCAL_IP $KC_PORT
 
 # Send test data and verify DB result from Python
-python3 test_verify.py $LOCAL_IP:$SNOWFLAKE_KAFKA_PORT http://$LOCAL_IP:$SC_PORT $LOCAL_IP:$KC_PORT $TEST_SET $APACHE_VERSION $NAME_SALT $PRESSURE $SSL $ALLOWED_TESTS
+python3 test_verify.py $LOCAL_IP:$SNOWFLAKE_KAFKA_PORT http://$LOCAL_IP:$SC_PORT $LOCAL_IP:$KC_PORT $TEST_SET $APACHE_VERSION $NAME_SALT $PRESSURE $SSL $LOCAL $TESTS
 testError=$?
 # delete_connectors_with_salt $NAME_SALT $LOCAL_IP $KC_PORT
-python3 test_verify.py $LOCAL_IP:$SNOWFLAKE_KAFKA_PORT http://$LOCAL_IP:$SC_PORT $LOCAL_IP:$KC_PORT clean $APACHE_VERSION $NAME_SALT $PRESSURE $SSL $ALLOWED_TESTS
+python3 test_verify.py $LOCAL_IP:$SNOWFLAKE_KAFKA_PORT http://$LOCAL_IP:$SC_PORT $LOCAL_IP:$KC_PORT clean $APACHE_VERSION $NAME_SALT $PRESSURE $SSL $LOCAL $TESTS
 
 if [ $testError -ne 0 ]; then
     RED='\033[0;31m'

--- a/test/run_test_apache.sh
+++ b/test/run_test_apache.sh
@@ -142,17 +142,20 @@ LOCAL_IP="localhost"
 SC_PORT=8081
 KC_PORT=8083
 
+# Add list of test names for local development
+ALLOWED_TESTS={}
+
 set +e -x
 echo -e "\n=== Clean table stage and pipe ==="
-python3 test_verify.py $LOCAL_IP:$SNOWFLAKE_KAFKA_PORT http://$LOCAL_IP:$SC_PORT $LOCAL_IP:$KC_PORT clean $APACHE_VERSION $NAME_SALT $PRESSURE $SSL
+python3 test_verify.py $LOCAL_IP:$SNOWFLAKE_KAFKA_PORT http://$LOCAL_IP:$SC_PORT $LOCAL_IP:$KC_PORT clean $APACHE_VERSION $NAME_SALT $PRESSURE $SSL $ALLOWED_TESTS
 
 #create_connectors_with_salt $SNOWFLAKE_CREDENTIAL_FILE $NAME_SALT $LOCAL_IP $KC_PORT
 
 # Send test data and verify DB result from Python
-python3 test_verify.py $LOCAL_IP:$SNOWFLAKE_KAFKA_PORT http://$LOCAL_IP:$SC_PORT $LOCAL_IP:$KC_PORT $TEST_SET $APACHE_VERSION $NAME_SALT $PRESSURE $SSL
+python3 test_verify.py $LOCAL_IP:$SNOWFLAKE_KAFKA_PORT http://$LOCAL_IP:$SC_PORT $LOCAL_IP:$KC_PORT $TEST_SET $APACHE_VERSION $NAME_SALT $PRESSURE $SSL $ALLOWED_TESTS
 testError=$?
 # delete_connectors_with_salt $NAME_SALT $LOCAL_IP $KC_PORT
-python3 test_verify.py $LOCAL_IP:$SNOWFLAKE_KAFKA_PORT http://$LOCAL_IP:$SC_PORT $LOCAL_IP:$KC_PORT clean $APACHE_VERSION $NAME_SALT $PRESSURE $SSL
+python3 test_verify.py $LOCAL_IP:$SNOWFLAKE_KAFKA_PORT http://$LOCAL_IP:$SC_PORT $LOCAL_IP:$KC_PORT clean $APACHE_VERSION $NAME_SALT $PRESSURE $SSL $ALLOWED_TESTS
 
 if [ $testError -ne 0 ]; then
     RED='\033[0;31m'

--- a/test/run_test_confluent.sh
+++ b/test/run_test_confluent.sh
@@ -16,8 +16,8 @@ function random-string() {
 source ./utils.sh
 
 # check argument number
-if [ "$#" -lt 2 ] || [ "$#" -gt 4 ] ; then
-    error_exit "Usage: ./run_test.sh <version> <path to apache config folder> <pressure> <ssl>.  Aborting."
+if [ "$#" -lt 2 ] || [ "$#" -gt 6 ] ; then
+    error_exit "Usage: ./run_test.sh <version> <path to apache config folder> <pressure> <ssl> [--local=true] [--tests=TestStringJson,TestStringAvro,...].  Aborting."
 fi
 
 CONFLUENT_VERSION=$1
@@ -31,7 +31,22 @@ if [ "$#" -gt 3 ] ; then
   SSL=$4
 else
   SSL="false"
-fi 
+fi
+
+if [ "$#" -gt 4 ] && [[ $5 == "--local=true" ]] ; then
+  LOCAL=true
+else
+  LOCAL=false
+fi
+
+tests_pattern="[^(--tests=).*]"
+if [ "$#" -gt 5 ] && [[ $6 =~ $tests_pattern ]] ; then
+  # skip initial '--tests='
+  TESTS=`echo $6 | cut -c9-`
+else
+  TESTS=""
+fi
+
 SNOWFLAKE_ZOOKEEPER_CONFIG="zookeeper.properties"
 SNOWFLAKE_KAFKA_CONFIG="server.properties"
 SNOWFLAKE_KAFKA_CONNECT_CONFIG="connect-distributed.properties"
@@ -153,15 +168,15 @@ KC_PORT=8083
 
 set +e -x
 echo -e "\n=== Clean table stage and pipe ==="
-python3 test_verify.py $SNOWFLAKE_KAFKA_ADDRESS http://$LOCAL_IP:$SC_PORT $LOCAL_IP:$KC_PORT clean $CONFLUENT_VERSION $NAME_SALT $PRESSURE $SSL
+python3 test_verify.py $SNOWFLAKE_KAFKA_ADDRESS http://$LOCAL_IP:$SC_PORT $LOCAL_IP:$KC_PORT clean $CONFLUENT_VERSION $NAME_SALT $PRESSURE $SSL $LOCAL $TESTS
 
 # record_thread_count 2>&1 &
 # Send test data and verify DB result from Python
-python3 test_verify.py $SNOWFLAKE_KAFKA_ADDRESS http://$LOCAL_IP:$SC_PORT $LOCAL_IP:$KC_PORT $TEST_SET $CONFLUENT_VERSION $NAME_SALT $PRESSURE $SSL
+python3 test_verify.py $SNOWFLAKE_KAFKA_ADDRESS http://$LOCAL_IP:$SC_PORT $LOCAL_IP:$KC_PORT $TEST_SET $CONFLUENT_VERSION $NAME_SALT $PRESSURE $SSL $LOCAL $TESTS
 testError=$?
 
 # delete_connectors_with_salt $NAME_SALT $LOCAL_IP $KC_PORT
-python3 test_verify.py $SNOWFLAKE_KAFKA_ADDRESS http://$LOCAL_IP:$SC_PORT $LOCAL_IP:$KC_PORT clean $CONFLUENT_VERSION $NAME_SALT $PRESSURE $SSL
+python3 test_verify.py $SNOWFLAKE_KAFKA_ADDRESS http://$LOCAL_IP:$SC_PORT $LOCAL_IP:$KC_PORT clean $CONFLUENT_VERSION $NAME_SALT $PRESSURE $SSL $LOCAL $TESTS
 
 
 ##### Following commented code is used to track thread leak

--- a/test/run_test_confluent.sh
+++ b/test/run_test_confluent.sh
@@ -17,7 +17,7 @@ source ./utils.sh
 
 # check argument number
 if [ "$#" -lt 2 ] || [ "$#" -gt 6 ] ; then
-    error_exit "Usage: ./run_test.sh <version> <path to apache config folder> <pressure> <ssl> [--local=true] [--tests=TestStringJson,TestStringAvro,...].  Aborting."
+    error_exit "Usage: ./run_test.sh <version> <path to apache config folder> <pressure> <ssl> [--skipProxy] [--tests=TestStringJson,TestStringAvro,...].  Aborting."
 fi
 
 CONFLUENT_VERSION=$1
@@ -33,10 +33,10 @@ else
   SSL="false"
 fi
 
-if [ "$#" -gt 4 ] && [[ $5 == "--local=true" ]] ; then
-  LOCAL=true
+if [ "$#" -gt 4 ] && [[ $5 == "--skipProxy" ]] ; then
+  SKIP_PROXY=true
 else
-  LOCAL=false
+  SKIP_PROXY=false
 fi
 
 tests_pattern="[^(--tests=).*]"
@@ -168,15 +168,15 @@ KC_PORT=8083
 
 set +e -x
 echo -e "\n=== Clean table stage and pipe ==="
-python3 test_verify.py $SNOWFLAKE_KAFKA_ADDRESS http://$LOCAL_IP:$SC_PORT $LOCAL_IP:$KC_PORT clean $CONFLUENT_VERSION $NAME_SALT $PRESSURE $SSL $LOCAL $TESTS
+python3 test_verify.py $SNOWFLAKE_KAFKA_ADDRESS http://$LOCAL_IP:$SC_PORT $LOCAL_IP:$KC_PORT clean $CONFLUENT_VERSION $NAME_SALT $PRESSURE $SSL $SKIP_PROXY $TESTS
 
 # record_thread_count 2>&1 &
 # Send test data and verify DB result from Python
-python3 test_verify.py $SNOWFLAKE_KAFKA_ADDRESS http://$LOCAL_IP:$SC_PORT $LOCAL_IP:$KC_PORT $TEST_SET $CONFLUENT_VERSION $NAME_SALT $PRESSURE $SSL $LOCAL $TESTS
+python3 test_verify.py $SNOWFLAKE_KAFKA_ADDRESS http://$LOCAL_IP:$SC_PORT $LOCAL_IP:$KC_PORT $TEST_SET $CONFLUENT_VERSION $NAME_SALT $PRESSURE $SSL $SKIP_PROXY $TESTS
 testError=$?
 
 # delete_connectors_with_salt $NAME_SALT $LOCAL_IP $KC_PORT
-python3 test_verify.py $SNOWFLAKE_KAFKA_ADDRESS http://$LOCAL_IP:$SC_PORT $LOCAL_IP:$KC_PORT clean $CONFLUENT_VERSION $NAME_SALT $PRESSURE $SSL $LOCAL $TESTS
+python3 test_verify.py $SNOWFLAKE_KAFKA_ADDRESS http://$LOCAL_IP:$SC_PORT $LOCAL_IP:$KC_PORT clean $CONFLUENT_VERSION $NAME_SALT $PRESSURE $SSL $SKIP_PROXY $TESTS
 
 
 ##### Following commented code is used to track thread leak

--- a/test/test_suites.py
+++ b/test/test_suites.py
@@ -83,14 +83,14 @@ class EndToEndTestSuite:
         return self._run_in_apache
 
 
-def create_end_to_end_test_suites(driver, nameSalt, schemaRegistryAddress, testSet, allowedTests):
+def create_end_to_end_test_suites(driver, nameSalt, schemaRegistryAddress, testSet, allowedTestsCsv):
     '''
     Creates all End to End tests which needs to run against Confluent Kafka or Apache Kafka.
     :param driver: Driver holds all helper function for tests - Create topic, create connector, send data are few functions amongst many present in Class KafkaTest.
     :param nameSalt: random string appended for uniqueness of Connector Name
     :param schemaRegistryAddress: Schema registry For confluent runs
     :param testSet: confluent Kafka or apache Kafka (OSS)
-    :param allowedTests: set of tests to run. If empty run all tests.
+    :param allowedTestsCsv: comma separated list of tests to be run. Run all tests when no value given.
     :return:
     '''
     test_suites = OrderedDict([
@@ -264,7 +264,9 @@ def create_end_to_end_test_suites(driver, nameSalt, schemaRegistryAddress, testS
     ])
 
     # Return all suites or only selected subset
-    if allowedTests is None:
+    if allowedTestsCsv is None or allowedTestsCsv == "":
         return test_suites
     else:
-        return dict((k, v) for k, v in test_suites.items() if k in allowedTests)
+        testsToRun = dict((k, v) for k, v in test_suites.items() if k in allowedTestsCsv.split(','))
+        print("Running", len(testsToRun), "tests")
+        return testsToRun

--- a/test/test_suites.py
+++ b/test/test_suites.py
@@ -83,13 +83,14 @@ class EndToEndTestSuite:
         return self._run_in_apache
 
 
-def create_end_to_end_test_suites(driver, nameSalt, schemaRegistryAddress, testSet):
+def create_end_to_end_test_suites(driver, nameSalt, schemaRegistryAddress, testSet, allowedTests):
     '''
     Creates all End to End tests which needs to run against Confluent Kafka or Apache Kafka.
     :param driver: Driver holds all helper function for tests - Create topic, create connector, send data are few functions amongst many present in Class KafkaTest.
     :param nameSalt: random string appended for uniqueness of Connector Name
     :param schemaRegistryAddress: Schema registry For confluent runs
     :param testSet: confluent Kafka or apache Kafka (OSS)
+    :param allowedTests: set of tests to run. If empty run all tests.
     :return:
     '''
     test_suites = OrderedDict([
@@ -261,4 +262,9 @@ def create_end_to_end_test_suites(driver, nameSalt, schemaRegistryAddress, testS
             run_in_apache=True
         )),
     ])
-    return test_suites
+
+    # Return all suites or only selected subset
+    if allowedTests is None:
+        return test_suites
+    else:
+        return dict((k, v) for k, v in test_suites.items() if k in allowedTests)

--- a/test/test_verify.py
+++ b/test/test_verify.py
@@ -467,7 +467,7 @@ def runStressTests(driver, testSet, nameSalt):
     ############################ Stress Tests Round 2 ############################
 
 
-def runTestSet(driver, testSet, nameSalt, enable_stress_test, localDev, allowedTestsCsv):
+def runTestSet(driver, testSet, nameSalt, enable_stress_test, skipProxy, allowedTestsCsv):
     if enable_stress_test:
         runStressTests(driver, testSet, nameSalt)
     else:
@@ -495,7 +495,7 @@ def runTestSet(driver, testSet, nameSalt, enable_stress_test, localDev, allowedT
 
         ############################ Proxy End To End Test ############################
         # Don't run proxy tests locally
-        if localDev:
+        if skipProxy:
             return
 
         print("Running Proxy tests")
@@ -572,7 +572,7 @@ if __name__ == "__main__":
     if len(sys.argv) < 10:
         errorExit(
             """\n=== Usage: ./ingest.py <kafka address> <schema registry address> <kafka connect address>
-             <test set> <test version> <name salt> <pressure> <enableSSL> [localDev] [allowedTestsCsv]===""")
+             <test set> <test version> <name salt> <pressure> <enableSSL> [skipProxy] [allowedTestsCsv]===""")
 
     kafkaAddress = sys.argv[1]
     global schemaRegistryAddress
@@ -583,7 +583,7 @@ if __name__ == "__main__":
     nameSalt = sys.argv[6]
     pressure = (sys.argv[7] == 'true')
     enableSSL = (sys.argv[8] == 'true')
-    localDev = (sys.argv[9] == 'true')
+    skipProxy = (sys.argv[9] == 'true')
     allowedTestsCsv = sys.argv[10] if len(sys.argv) == 11 else None
 
     if "SNOWFLAKE_CREDENTIAL_FILE" not in os.environ:
@@ -616,4 +616,4 @@ if __name__ == "__main__":
                           snowflakeCloudPlatform,
                           False)
 
-    runTestSet(kafkaTest, testSet, nameSalt, pressure, localDev, allowedTestsCsv)
+    runTestSet(kafkaTest, testSet, nameSalt, pressure, skipProxy, allowedTestsCsv)

--- a/test/test_verify.py
+++ b/test/test_verify.py
@@ -467,11 +467,12 @@ def runStressTests(driver, testSet, nameSalt):
     ############################ Stress Tests Round 2 ############################
 
 
-def runTestSet(driver, testSet, nameSalt, enable_stress_test):
+def runTestSet(driver, testSet, nameSalt, enable_stress_test, allowedTests):
     if enable_stress_test:
         runStressTests(driver, testSet, nameSalt)
     else:
-        test_suites = create_end_to_end_test_suites(driver, nameSalt, schemaRegistryAddress, testSet)
+        localDev = allowedTests is not None and len(allowedTests) > 0
+        test_suites = create_end_to_end_test_suites(driver, nameSalt, schemaRegistryAddress, testSet, allowedTests)
 
         ############################ round 1 ############################
         print(datetime.now().strftime("\n%H:%M:%S "), "=== Round 1 ===")
@@ -494,6 +495,9 @@ def runTestSet(driver, testSet, nameSalt, enable_stress_test):
         ############################ Always run Proxy tests in the end ############################
 
         ############################ Proxy End To End Test ############################
+        # Don't run proxy tests locally
+        if (localDev):
+            return
 
         from test_suit.test_string_json_proxy import TestStringJsonProxy
         from test_suites import EndToEndTestSuite
@@ -564,10 +568,10 @@ def execution(testSet, testSuitList, testCleanEnableList, testSuitEnableList, dr
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 9:
+    if len(sys.argv) != 10:
         errorExit(
             """\n=== Usage: ./ingest.py <kafka address> <schema registry address> <kafka connect address>
-             <test set> <test version> <name salt> <pressure> <enableSSL>===""")
+             <test set> <test version> <name salt> <pressure> <enableSSL> <allowedTests>===""")
 
     kafkaAddress = sys.argv[1]
     global schemaRegistryAddress
@@ -578,6 +582,7 @@ if __name__ == "__main__":
     nameSalt = sys.argv[6]
     pressure = (sys.argv[7] == 'true')
     enableSSL = (sys.argv[8] == 'true')
+    allowedTests = sys.argv[9]
 
     if "SNOWFLAKE_CREDENTIAL_FILE" not in os.environ:
         errorExit(
@@ -609,4 +614,4 @@ if __name__ == "__main__":
                           snowflakeCloudPlatform,
                           False)
 
-    runTestSet(kafkaTest, testSet, nameSalt, pressure)
+    runTestSet(kafkaTest, testSet, nameSalt, pressure, allowedTests)

--- a/test/test_verify.py
+++ b/test/test_verify.py
@@ -572,7 +572,7 @@ if __name__ == "__main__":
     if len(sys.argv) < 10:
         errorExit(
             """\n=== Usage: ./ingest.py <kafka address> <schema registry address> <kafka connect address>
-             <test set> <test version> <name salt> <pressure> <enableSSL> [skipProxy] [allowedTestsCsv]===""")
+             <test set> <test version> <name salt> <pressure> <enableSSL> <skipProxy> [allowedTestsCsv]===""")
 
     kafkaAddress = sys.argv[1]
     global schemaRegistryAddress

--- a/test/test_verify.py
+++ b/test/test_verify.py
@@ -467,12 +467,11 @@ def runStressTests(driver, testSet, nameSalt):
     ############################ Stress Tests Round 2 ############################
 
 
-def runTestSet(driver, testSet, nameSalt, enable_stress_test, allowedTests):
+def runTestSet(driver, testSet, nameSalt, enable_stress_test, localDev, allowedTestsCsv):
     if enable_stress_test:
         runStressTests(driver, testSet, nameSalt)
     else:
-        localDev = allowedTests is not None and len(allowedTests) > 0
-        test_suites = create_end_to_end_test_suites(driver, nameSalt, schemaRegistryAddress, testSet, allowedTests)
+        test_suites = create_end_to_end_test_suites(driver, nameSalt, schemaRegistryAddress, testSet, allowedTestsCsv)
 
         ############################ round 1 ############################
         print(datetime.now().strftime("\n%H:%M:%S "), "=== Round 1 ===")
@@ -496,8 +495,10 @@ def runTestSet(driver, testSet, nameSalt, enable_stress_test, allowedTests):
 
         ############################ Proxy End To End Test ############################
         # Don't run proxy tests locally
-        if (localDev):
+        if localDev:
             return
+
+        print("Running Proxy tests")
 
         from test_suit.test_string_json_proxy import TestStringJsonProxy
         from test_suites import EndToEndTestSuite
@@ -568,10 +569,10 @@ def execution(testSet, testSuitList, testCleanEnableList, testSuitEnableList, dr
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 10:
+    if len(sys.argv) < 10:
         errorExit(
             """\n=== Usage: ./ingest.py <kafka address> <schema registry address> <kafka connect address>
-             <test set> <test version> <name salt> <pressure> <enableSSL> <allowedTests>===""")
+             <test set> <test version> <name salt> <pressure> <enableSSL> [localDev] [allowedTestsCsv]===""")
 
     kafkaAddress = sys.argv[1]
     global schemaRegistryAddress
@@ -582,7 +583,8 @@ if __name__ == "__main__":
     nameSalt = sys.argv[6]
     pressure = (sys.argv[7] == 'true')
     enableSSL = (sys.argv[8] == 'true')
-    allowedTests = sys.argv[9]
+    localDev = (sys.argv[9] == 'true')
+    allowedTestsCsv = sys.argv[10] if len(sys.argv) == 11 else None
 
     if "SNOWFLAKE_CREDENTIAL_FILE" not in os.environ:
         errorExit(
@@ -614,4 +616,4 @@ if __name__ == "__main__":
                           snowflakeCloudPlatform,
                           False)
 
-    runTestSet(kafkaTest, testSet, nameSalt, pressure, allowedTests)
+    runTestSet(kafkaTest, testSet, nameSalt, pressure, localDev, allowedTestsCsv)


### PR DESCRIPTION
This PR enables running subset of e2e tests `./run_test_apache.sh 2.5.1 apache_properties false false --skipTests --tests=TestStringJson,TestAvroAvro` 

There is still huge space for improvement here:
- turn all parameters from non-named into named for both Shell and Python
- add decent named parameters parsing for Shell (like https://unix.stackexchange.com/questions/331522/how-do-i-parse-optional-arguments-in-a-bash-script-if-no-order-is-given)
- handle default arguments values
- skip unnecessary downloading for local development

Anyway let's do it step-by-step. This PR alone will save us hours in long term.