### PR TITLE
SNOW-1117446 Snowpipe Streaming client provider map

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -18,7 +18,6 @@ package com.snowflake.kafka.connector;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
-import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.CommaSeparatedKeyValueValidator;
 import com.snowflake.kafka.connector.internal.KCLogger;
 import com.snowflake.kafka.connector.internal.streaming.IngestionMethodConfig;
 import com.snowflake.kafka.connector.internal.streaming.StreamingUtils;
@@ -122,7 +121,7 @@ public class SnowflakeSinkConnectorConfig {
   public static final String SNOWPIPE_STREAMING_MAX_CLIENT_LAG =
       "snowflake.streaming.max.client.lag";
 
-  public static final String SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP =
+  public static final String SNOWPIPE_STREAMING_CLIENT_PROVIDER_OVERRIDE_MAP =
       "snowflake.streaming.client.provider.override.map";
 
   // TESTING
@@ -135,7 +134,7 @@ public class SnowflakeSinkConnectorConfig {
   private static final ConfigDef.Validator topicToTableValidator = new TopicToTableValidator();
   private static final ConfigDef.Validator KAFKA_PROVIDER_VALIDATOR = new KafkaProviderValidator();
 
-  private static final ConfigDef.Validator STREAMING_CLIENT_PROVIDER_PROPERTIES_VALIDATOR =
+  private static final ConfigDef.Validator STREAMING_CLIENT_PROVIDER_OVERRIDE_MAP_VALIDATOR =
       new CommaSeparatedKeyValueValidator();
 
   // For error handling
@@ -559,19 +558,19 @@ public class SnowflakeSinkConnectorConfig {
             ConfigDef.Width.NONE,
             SNOWPIPE_STREAMING_MAX_CLIENT_LAG)
         .define(
-            SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP,
+            SNOWPIPE_STREAMING_CLIENT_PROVIDER_OVERRIDE_MAP,
             Type.STRING,
             "",
-            STREAMING_CLIENT_PROVIDER_PROPERTIES_VALIDATOR,
+            STREAMING_CLIENT_PROVIDER_OVERRIDE_MAP_VALIDATOR,
             Importance.LOW,
             "Map of Key value pairs representing Streaming Client Properties to Override. These are"
                 + " optional and recommended to use ONLY after consulting Snowflake Support. Format"
                 + " : comma-separated tuples, e.g.:"
-                + " MAX_CHANNEL_SIZE_IN_BYTES:10000000,MAX_CLIENT_LAG:5000,ENABLE_SNOWPIPE_STREAMING_JMX_METRICS:false...",
+                + " MAX_CLIENT_LAG:5000,other_key:value...",
             CONNECTOR_CONFIG,
             0,
             ConfigDef.Width.NONE,
-            SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP)
+            SNOWPIPE_STREAMING_CLIENT_PROVIDER_OVERRIDE_MAP)
         .define(
             ERRORS_TOLERANCE_CONFIG,
             Type.STRING,

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -564,9 +564,9 @@ public class SnowflakeSinkConnectorConfig {
             "",
             STREAMING_CLIENT_PROVIDER_PROPERTIES_VALIDATOR,
             Importance.LOW,
-            "Map of Key value pairs representing Streaming Client Properties to Override (optional"
-                + " and recommended to use only after consulting Snowflake Support). Format :"
-                + " comma-separated tuples, e.g.:"
+            "Map of Key value pairs representing Streaming Client Properties to Override. These are"
+                + " optional and recommended to use ONLY after consulting Snowflake Support. Format"
+                + " : comma-separated tuples, e.g.:"
                 + " MAX_CHANNEL_SIZE_IN_BYTES:10000000,MAX_CLIENT_LAG:5000,ENABLE_SNOWPIPE_STREAMING_JMX_METRICS:false...",
             CONNECTOR_CONFIG,
             0,
@@ -847,11 +847,9 @@ public class SnowflakeSinkConnectorConfig {
 
     public void ensureValid(String name, Object value) {
       String s = (String) value;
-      if (s != null && !s.isEmpty()) {
-        // Validate the comma-separated key-value pairs string
-        if (!isValidCommaSeparatedKeyValueString(s)) {
-          throw new ConfigException(name, value, "Format: <key-1>:<value-1>,<key-2>:<value-2>,...");
-        }
+      // Validate the comma-separated key-value pairs string
+      if (s != null && !s.isEmpty() && !isValidCommaSeparatedKeyValueString(s)) {
+        throw new ConfigException(name, value, "Format: <key-1>:<value-1>,<key-2>:<value-2>,...");
       }
     }
 

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -18,6 +18,7 @@ package com.snowflake.kafka.connector;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
+import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.CommaSeparatedKeyValueValidator;
 import com.snowflake.kafka.connector.internal.KCLogger;
 import com.snowflake.kafka.connector.internal.streaming.IngestionMethodConfig;
 import com.snowflake.kafka.connector.internal.streaming.StreamingUtils;
@@ -121,6 +122,9 @@ public class SnowflakeSinkConnectorConfig {
   public static final String SNOWPIPE_STREAMING_MAX_CLIENT_LAG =
       "snowflake.streaming.max.client.lag";
 
+  public static final String SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP =
+      "snowflake.streaming.client.provider.override.map";
+
   // TESTING
   public static final String REBALANCING = "snowflake.test.rebalancing";
   public static final boolean REBALANCING_DEFAULT = false;
@@ -130,6 +134,9 @@ public class SnowflakeSinkConnectorConfig {
   private static final ConfigDef.Validator nonEmptyStringValidator = new ConfigDef.NonEmptyString();
   private static final ConfigDef.Validator topicToTableValidator = new TopicToTableValidator();
   private static final ConfigDef.Validator KAFKA_PROVIDER_VALIDATOR = new KafkaProviderValidator();
+
+  private static final ConfigDef.Validator STREAMING_CLIENT_PROVIDER_PROPERTIES_VALIDATOR =
+      new CommaSeparatedKeyValueValidator();
 
   // For error handling
   public static final String ERROR_GROUP = "ERRORS";
@@ -552,6 +559,20 @@ public class SnowflakeSinkConnectorConfig {
             ConfigDef.Width.NONE,
             SNOWPIPE_STREAMING_MAX_CLIENT_LAG)
         .define(
+            SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP,
+            Type.STRING,
+            "",
+            STREAMING_CLIENT_PROVIDER_PROPERTIES_VALIDATOR,
+            Importance.LOW,
+            "Map of Key value pairs representing Streaming Client Properties to Override (optional"
+                + " and recommended to use only after consulting Snowflake Support). Format :"
+                + " comma-separated tuples, e.g.:"
+                + " MAX_CHANNEL_SIZE_IN_BYTES:10000000,MAX_CLIENT_LAG:5000,ENABLE_SNOWPIPE_STREAMING_JMX_METRICS:false...",
+            CONNECTOR_CONFIG,
+            0,
+            ConfigDef.Width.NONE,
+            SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP)
+        .define(
             ERRORS_TOLERANCE_CONFIG,
             Type.STRING,
             ERRORS_TOLERANCE_DEFAULT,
@@ -815,4 +836,47 @@ public class SnowflakeSinkConnectorConfig {
           this.validator.ensureValid(name, value);
         }
       };
+
+  /**
+   * Class which validates key value pairs in the format <key-1>:<value-1>,<key-2>:<value-2>
+   *
+   * <p>It doesn't validate the type of values, only making sure the format is correct.
+   */
+  public static class CommaSeparatedKeyValueValidator implements ConfigDef.Validator {
+    public CommaSeparatedKeyValueValidator() {}
+
+    public void ensureValid(String name, Object value) {
+      String s = (String) value;
+      if (s != null && !s.isEmpty()) {
+        // Validate the comma-separated key-value pairs string
+        if (!isValidCommaSeparatedKeyValueString(s)) {
+          throw new ConfigException(name, value, "Format: <key-1>:<value-1>,<key-2>:<value-2>,...");
+        }
+      }
+    }
+
+    private boolean isValidCommaSeparatedKeyValueString(String input) {
+      // Split the input string by commas
+      String[] pairs = input.split(",");
+      for (String pair : pairs) {
+        // Trim the pair to remove leading and trailing whitespaces
+        pair = pair.trim();
+        // Split each pair by colon
+        String[] keyValue = pair.split(":");
+        // Check if the pair has exactly two elements after trimming
+        if (keyValue.length != 2) {
+          return false;
+        }
+        // Check if the key or value is empty after trimming
+        if (keyValue[0].trim().isEmpty() || keyValue[1].trim().isEmpty()) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    public String toString() {
+      return "Comma-separated key-value pairs format: <key-1>:<value-1>,<key-2>:<value-2>,...";
+    }
+  }
 }

--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -444,6 +444,15 @@ public class Utils {
                 IngestionMethodConfig.SNOWPIPE_STREAMING.toString()));
       }
       if (config.containsKey(
+          SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP)) {
+        invalidConfigParams.put(
+            SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP,
+            Utils.formatString(
+                "{} is only available with ingestion type: {}.",
+                SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP,
+                IngestionMethodConfig.SNOWPIPE_STREAMING.toString()));
+      }
+      if (config.containsKey(
               SnowflakeSinkConnectorConfig.ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG)
           && Boolean.parseBoolean(
               config.get(
@@ -725,6 +734,33 @@ public class Utils {
       throw SnowflakeErrors.ERROR_0021.getException();
     }
     return topic2Table;
+  }
+
+  /**
+   * Convert a Comma separated key value pairs into a Map
+   *
+   * @param input Provided in KC config
+   * @return Map
+   */
+  public static Map<String, String> parseCommaSeparatedKeyValuePairs(String input) {
+    Map<String, String> pairs = new HashMap<>();
+    boolean isInvalid = false;
+    for (String str : input.split(",")) {
+      String[] tt = str.split(":");
+
+      if (tt.length != 2 || tt[0].trim().isEmpty() || tt[1].trim().isEmpty()) {
+        LOGGER.error(
+            "Invalid {} config format: {}",
+            SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP,
+            input);
+        isInvalid = true;
+      }
+      pairs.put(tt[0].trim(), tt[1].trim());
+    }
+    if (isInvalid) {
+      throw SnowflakeErrors.ERROR_0030.getException();
+    }
+    return pairs;
   }
 
   static final String loginPropList[] = {SF_URL, SF_USER, SF_SCHEMA, SF_DATABASE};

--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -744,7 +744,6 @@ public class Utils {
    */
   public static Map<String, String> parseCommaSeparatedKeyValuePairs(String input) {
     Map<String, String> pairs = new HashMap<>();
-    boolean isInvalid = false;
     for (String str : input.split(",")) {
       String[] tt = str.split(":");
 
@@ -753,13 +752,9 @@ public class Utils {
             "Invalid {} config format: {}",
             SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP,
             input);
-        isInvalid = true;
-        break;
+        throw SnowflakeErrors.ERROR_0030.getException();
       }
       pairs.put(tt[0].trim(), tt[1].trim());
-    }
-    if (isInvalid) {
-      throw SnowflakeErrors.ERROR_0030.getException();
     }
     return pairs;
   }

--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -444,12 +444,12 @@ public class Utils {
                 IngestionMethodConfig.SNOWPIPE_STREAMING.toString()));
       }
       if (config.containsKey(
-          SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP)) {
+          SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_CLIENT_PROVIDER_OVERRIDE_MAP)) {
         invalidConfigParams.put(
-            SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP,
+            SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_CLIENT_PROVIDER_OVERRIDE_MAP,
             Utils.formatString(
                 "{} is only available with ingestion type: {}.",
-                SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP,
+                SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_CLIENT_PROVIDER_OVERRIDE_MAP,
                 IngestionMethodConfig.SNOWPIPE_STREAMING.toString()));
       }
       if (config.containsKey(
@@ -750,7 +750,7 @@ public class Utils {
       if (tt.length != 2 || tt[0].trim().isEmpty() || tt[1].trim().isEmpty()) {
         LOGGER.error(
             "Invalid {} config format: {}",
-            SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP,
+            SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_CLIENT_PROVIDER_OVERRIDE_MAP,
             input);
         throw SnowflakeErrors.ERROR_0030.getException();
       }

--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -754,6 +754,7 @@ public class Utils {
             SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP,
             input);
         isInvalid = true;
+        break;
       }
       pairs.put(tt[0].trim(), tt[1].trim());
     }

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeErrors.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeErrors.java
@@ -132,10 +132,10 @@ public enum SnowflakeErrors {
       "0030",
       String.format(
           "Invalid %s map",
-          SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP),
+          SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_CLIENT_PROVIDER_OVERRIDE_MAP),
       String.format(
           "Failed to parse %s map",
-          SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP)),
+          SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_CLIENT_PROVIDER_OVERRIDE_MAP)),
 
   // Snowflake connection issues 1---
   ERROR_1001(

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeErrors.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeErrors.java
@@ -128,6 +128,15 @@ public enum SnowflakeErrors {
           + " parameter when using oauth as authenticator"),
   ERROR_0029(
       "0029", "Invalid authenticator", "Authenticator should be either oauth or snowflake_jwt"),
+  ERROR_0030(
+      "0030",
+      String.format(
+          "Invalid %s map",
+          SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP),
+      String.format(
+          "Failed to parse %s map",
+          SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP)),
+
   // Snowflake connection issues 1---
   ERROR_1001(
       "1001",

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProperties.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProperties.java
@@ -93,15 +93,30 @@ public class StreamingClientProperties {
   /**
    * Fetches the properties from {@link SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP} and
    * combines it with parameter provider. This parameter provider needs a lowercase String in its
-   * key since Ingest SDK fetches the key from
+   * key since Ingest SDK fetches the key from <a
+   * href="https://github.com/snowflakedb/snowflake-ingest-java/blob/master/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java">Ingest
+   * SDK</a>
    *
-   * @see <a
-   *     href="https://github.com/snowflakedb/snowflake-ingest-java/blob/master/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java">Ingest
-   *     SDK</a>
+   * <p>MAX_CLIENT_LAG can be provided in SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP or in
+   * SNOWPIPE_STREAMING_MAX_CLIENT_LAG.
    *
-   *     <p>MAX_CLIENT_LAG can be provided in SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP or in
-   *     SNOWPIPE_STREAMING_MAX_CLIENT_LAG.
-   *     <p>We will honor the value provided in SNOWPIPE_STREAMING_MAX_CLIENT_LAG
+   * <p>We will honor the value provided in SNOWPIPE_STREAMING_MAX_CLIENT_LAG
+   *
+   * <p>Example, if two configs are provided and map has MAX_CLIENT_LAG, Value from
+   * snowflake.streaming.max.client.lag will be honored.
+   *
+   * <ol>
+   *   <li>snowflake.streaming.client.provider.override.map =
+   *       MAX_CLIENT_LAG:30,MAX_CHANNEL_SIZE_IN_BYTES:10000000
+   *   <li>snowflake.streaming.max.client.lag = 60
+   *   <li>MAX_CLIENT_LAG will honor 60 seconds.
+   * </ol>
+   *
+   * If <b>snowflake.streaming.max.client.lag</b> is not provided, we pass in the map as is to
+   * Streaming Client (all lowercase keys).
+   *
+   * <p>Please note, Streaming Client
+   *
    * @param connectorConfig Input connector config
    */
   private void combineStreamingClientOverriddenProperties(Map<String, String> connectorConfig) {

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProperties.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProperties.java
@@ -17,6 +17,7 @@
 
 package com.snowflake.kafka.connector.internal.streaming;
 
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_MAX_CLIENT_LAG;
 import static net.snowflake.ingest.utils.ParameterProvider.MAX_CLIENT_LAG;
 
@@ -84,10 +85,48 @@ public class StreamingClientProperties {
         Optional.ofNullable(connectorConfig.get(SNOWPIPE_STREAMING_MAX_CLIENT_LAG));
     snowpipeStreamingMaxClientLag.ifPresent(
         overriddenValue -> {
-          LOGGER.info(
-              "Config is overridden for {}={}", SNOWPIPE_STREAMING_MAX_CLIENT_LAG, overriddenValue);
           parameterOverrides.put(MAX_CLIENT_LAG, String.format("%s second", overriddenValue));
         });
+    combineStreamingClientOverriddenProperties(connectorConfig);
+  }
+
+  private void combineStreamingClientOverriddenProperties(Map<String, String> connectorConfig) {
+    // MAX_CLIENT_LAG property can also be present in override map, in that case, we will honor the
+    // value
+    // provided in SNOWPIPE_STREAMING_MAX_CLIENT_LAG since it preceded and was released in earlier
+    // versions.
+    Optional<String> clientOverrideProperties =
+        Optional.ofNullable(connectorConfig.get(SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP));
+    Map<String, String> clientOverridePropertiesMap = new HashMap<>();
+    clientOverrideProperties.ifPresent(
+        overriddenKeyValuePairs -> {
+          LOGGER.info(
+              "Overridden map provided for streaming client Properties: {}",
+              overriddenKeyValuePairs);
+          Map<String, String> overriddenPairs =
+              Utils.parseCommaSeparatedKeyValuePairs(overriddenKeyValuePairs);
+          overriddenPairs.forEach(
+              (overriddenKey, overriddenValue) -> {
+                if (overriddenKey.equalsIgnoreCase(MAX_CLIENT_LAG)) {
+                  clientOverridePropertiesMap.put(
+                      MAX_CLIENT_LAG, String.format("%s second", overriddenValue));
+                } else {
+                  clientOverridePropertiesMap.put(overriddenKey.toLowerCase(), overriddenValue);
+                }
+              });
+          if (clientOverridePropertiesMap.containsKey(MAX_CLIENT_LAG)
+              && parameterOverrides.containsKey(MAX_CLIENT_LAG)) {
+            LOGGER.info(
+                "Honoring {} value in MAX_CLIENT_LAG for streaming client provider, since it is"
+                    + " explicitly provided. Using: {}",
+                SNOWPIPE_STREAMING_MAX_CLIENT_LAG,
+                parameterOverrides.get(MAX_CLIENT_LAG));
+            clientOverridePropertiesMap.remove(MAX_CLIENT_LAG);
+          }
+          parameterOverrides.putAll(clientOverridePropertiesMap);
+        });
+    parameterOverrides.forEach(
+        (key, value) -> LOGGER.info("Streaming Client Config is overridden for {}={}", key, value));
   }
 
   /**

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProperties.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProperties.java
@@ -17,7 +17,7 @@
 
 package com.snowflake.kafka.connector.internal.streaming;
 
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_CLIENT_PROVIDER_OVERRIDE_MAP;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_MAX_CLIENT_LAG;
 import static net.snowflake.ingest.utils.ParameterProvider.MAX_CLIENT_LAG;
 
@@ -124,7 +124,7 @@ public class StreamingClientProperties {
     // value provided in SNOWPIPE_STREAMING_MAX_CLIENT_LAG since it preceded and was released in
     // earlier versions.
     Optional<String> clientOverrideProperties =
-        Optional.ofNullable(connectorConfig.get(SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP));
+        Optional.ofNullable(connectorConfig.get(SNOWPIPE_STREAMING_CLIENT_PROVIDER_OVERRIDE_MAP));
     Map<String, String> clientOverridePropertiesMap = new HashMap<>();
     clientOverrideProperties.ifPresent(
         overriddenKeyValuePairs -> {

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProperties.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProperties.java
@@ -90,18 +90,31 @@ public class StreamingClientProperties {
     combineStreamingClientOverriddenProperties(connectorConfig);
   }
 
+  /**
+   * Fetches the properties from {@link SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP} and
+   * combines it with parameter provider. This parameter provider needs a lowercase String in its
+   * key since Ingest SDK fetches the key from
+   *
+   * @see <a
+   *     href="https://github.com/snowflakedb/snowflake-ingest-java/blob/master/src/main/java/net/snowflake/ingest/utils/ParameterProvider.java">Ingest
+   *     SDK</a>
+   *
+   *     <p>MAX_CLIENT_LAG can be provided in SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP or in
+   *     SNOWPIPE_STREAMING_MAX_CLIENT_LAG.
+   *     <p>We will honor the value provided in SNOWPIPE_STREAMING_MAX_CLIENT_LAG
+   * @param connectorConfig Input connector config
+   */
   private void combineStreamingClientOverriddenProperties(Map<String, String> connectorConfig) {
     // MAX_CLIENT_LAG property can also be present in override map, in that case, we will honor the
-    // value
-    // provided in SNOWPIPE_STREAMING_MAX_CLIENT_LAG since it preceded and was released in earlier
-    // versions.
+    // value provided in SNOWPIPE_STREAMING_MAX_CLIENT_LAG since it preceded and was released in
+    // earlier versions.
     Optional<String> clientOverrideProperties =
         Optional.ofNullable(connectorConfig.get(SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP));
     Map<String, String> clientOverridePropertiesMap = new HashMap<>();
     clientOverrideProperties.ifPresent(
         overriddenKeyValuePairs -> {
           LOGGER.info(
-              "Overridden map provided for streaming client Properties: {}",
+              "Overridden map provided for streaming client properties: {}",
               overriddenKeyValuePairs);
           Map<String, String> overriddenPairs =
               Utils.parseCommaSeparatedKeyValuePairs(overriddenKeyValuePairs);

--- a/src/main/java/com/snowflake/kafka/connector/internal/telemetry/SnowflakeTelemetryService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/telemetry/SnowflakeTelemetryService.java
@@ -3,6 +3,7 @@ package com.snowflake.kafka.connector.internal.telemetry;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BUFFER_COUNT_RECORDS;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_CHANNEL_OFFSET_TOKEN_MIGRATION_CONFIG;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_SCHEMATIZATION_CONFIG;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_SCHEMATIZATION_DEFAULT;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG;
@@ -10,6 +11,8 @@ import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.INGESTION_METHOD_DEFAULT_SNOWPIPE;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.KEY_CONVERTER_CONFIG_FIELD;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_CLIENT_PROVIDER_OVERRIDE_MAP;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_MAX_CLIENT_LAG;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.VALUE_CONVERTER_CONFIG_FIELD;
 
 import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
@@ -272,6 +275,22 @@ public abstract class SnowflakeTelemetryService {
         userProvidedConfig.getOrDefault(
             ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG,
             ENABLE_STREAMING_CLIENT_OPTIMIZATION_DEFAULT + ""));
+    if (userProvidedConfig.containsKey(ENABLE_CHANNEL_OFFSET_TOKEN_MIGRATION_CONFIG)) {
+      dataObjectNode.put(
+          ENABLE_CHANNEL_OFFSET_TOKEN_MIGRATION_CONFIG,
+          userProvidedConfig.get(ENABLE_CHANNEL_OFFSET_TOKEN_MIGRATION_CONFIG));
+    }
+    // These are Optional, so we add only if it's provided in user config
+    if (userProvidedConfig.containsKey(SNOWPIPE_STREAMING_MAX_CLIENT_LAG)) {
+      dataObjectNode.put(
+          SNOWPIPE_STREAMING_MAX_CLIENT_LAG,
+          userProvidedConfig.get(SNOWPIPE_STREAMING_MAX_CLIENT_LAG));
+    }
+    if (userProvidedConfig.containsKey(SNOWPIPE_STREAMING_CLIENT_PROVIDER_OVERRIDE_MAP)) {
+      dataObjectNode.put(
+          SNOWPIPE_STREAMING_CLIENT_PROVIDER_OVERRIDE_MAP,
+          userProvidedConfig.get(SNOWPIPE_STREAMING_CLIENT_PROVIDER_OVERRIDE_MAP));
+    }
   }
 
   public enum TelemetryType {

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
@@ -930,14 +930,14 @@ public class ConnectorConfigTest {
           SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
           IngestionMethodConfig.SNOWPIPE.toString());
       config.put(
-          SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP, "a:b,c:d");
+          SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_CLIENT_PROVIDER_OVERRIDE_MAP, "a:b,c:d");
 
       Utils.validateConfig(config);
       Assert.fail("exception expected");
     } catch (SnowflakeKafkaConnectorException exception) {
       assert exception
           .getMessage()
-          .contains(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP);
+          .contains(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_CLIENT_PROVIDER_OVERRIDE_MAP);
     }
   }
 
@@ -950,7 +950,7 @@ public class ConnectorConfigTest {
         IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
     config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
     config.put(
-        SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP,
+        SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_CLIENT_PROVIDER_OVERRIDE_MAP,
         "a:b,c:d,e:100,f:true");
     Utils.validateConfig(config);
   }

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
@@ -923,6 +923,39 @@ public class ConnectorConfigTest {
   }
 
   @Test
+  public void testStreamingProviderOverrideConfig_invalidWithSnowpipe() {
+    try {
+      Map<String, String> config = getConfig();
+      config.put(
+          SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
+          IngestionMethodConfig.SNOWPIPE.toString());
+      config.put(
+          SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP, "a:b,c:d");
+
+      Utils.validateConfig(config);
+      Assert.fail("exception expected");
+    } catch (SnowflakeKafkaConnectorException exception) {
+      assert exception
+          .getMessage()
+          .contains(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP);
+    }
+  }
+
+  @Test
+  public void testStreamingProviderOverrideConfig_validWithSnowpipeStreaming() {
+
+    Map<String, String> config = getConfig();
+    config.put(
+        SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT,
+        IngestionMethodConfig.SNOWPIPE_STREAMING.toString());
+    config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
+    config.put(
+        SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP,
+        "a:b,c:d,e:100,f:true");
+    Utils.validateConfig(config);
+  }
+
+  @Test
   public void testInvalidEmptyConfig() {
     try {
       Map<String, String> config = new HashMap<>();

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2IT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2IT.java
@@ -1529,23 +1529,25 @@ public class SnowflakeSinkServiceV2IT {
   @Test
   public void testStreamingIngestionValidClientPropertiesOverride() throws Exception {
     Map<String, String> config = new HashMap<>(getConfig());
-    config.put(SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP, "MAX_CHANNEL_SIZE_IN_BYTES:10000000,ENABLE_SNOWPIPE_STREAMING_JMX_METRICS:false");
+    config.put(
+        SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP,
+        "MAX_CHANNEL_SIZE_IN_BYTES:10000000,ENABLE_SNOWPIPE_STREAMING_JMX_METRICS:false");
     SnowflakeSinkConnectorConfig.setDefaultValues(config);
     conn.createTable(table);
 
     // opens a channel for partition 0, table and topic
     SnowflakeSinkService service =
-            SnowflakeSinkServiceFactory.builder(conn, IngestionMethodConfig.SNOWPIPE_STREAMING, config)
-                    .setRecordNumber(100)
-                    .setFlushTime(1)
-                    .setErrorReporter(new InMemoryKafkaRecordErrorReporter())
-                    .setSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(topicPartition)))
-                    .addTask(table, new TopicPartition(topic, partition)) // Internally calls startTask
-                    .build();
+        SnowflakeSinkServiceFactory.builder(conn, IngestionMethodConfig.SNOWPIPE_STREAMING, config)
+            .setRecordNumber(100)
+            .setFlushTime(1)
+            .setErrorReporter(new InMemoryKafkaRecordErrorReporter())
+            .setSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(topicPartition)))
+            .addTask(table, new TopicPartition(topic, partition)) // Internally calls startTask
+            .build();
 
     final long noOfRecords = 10;
     List<SinkRecord> sinkRecords =
-            TestUtils.createJsonStringSinkRecords(0, noOfRecords, topic, partition);
+        TestUtils.createJsonStringSinkRecords(0, noOfRecords, topic, partition);
 
     Thread.sleep(1000); // to ensure we flush buffer on time threshold
     service.insert(sinkRecords);
@@ -1553,7 +1555,7 @@ public class SnowflakeSinkServiceV2IT {
     try {
       // Wait 20 seconds here and no flush should happen since the max client lag is 30 seconds
       TestUtils.assertWithRetry(
-              () -> service.getOffset(new TopicPartition(topic, partition)) == noOfRecords, 5, 4);
+          () -> service.getOffset(new TopicPartition(topic, partition)) == noOfRecords, 5, 4);
     } catch (Exception e) {
       // do nothing
     }
@@ -1561,7 +1563,8 @@ public class SnowflakeSinkServiceV2IT {
   }
 
   /**
-   * Even if override key is invalid, we will still create a client since we dont verify key and values, only format.
+   * Even if override key is invalid, we will still create a client since we dont verify key and
+   * values, only format.
    */
   @Test
   public void testStreamingIngestion_invalidClientPropertiesOverride() throws Exception {
@@ -1572,17 +1575,17 @@ public class SnowflakeSinkServiceV2IT {
 
     // opens a channel for partition 0, table and topic
     SnowflakeSinkService service =
-            SnowflakeSinkServiceFactory.builder(conn, IngestionMethodConfig.SNOWPIPE_STREAMING, config)
-                    .setRecordNumber(100)
-                    .setFlushTime(1)
-                    .setErrorReporter(new InMemoryKafkaRecordErrorReporter())
-                    .setSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(topicPartition)))
-                    .addTask(table, new TopicPartition(topic, partition)) // Internally calls startTask
-                    .build();
+        SnowflakeSinkServiceFactory.builder(conn, IngestionMethodConfig.SNOWPIPE_STREAMING, config)
+            .setRecordNumber(100)
+            .setFlushTime(1)
+            .setErrorReporter(new InMemoryKafkaRecordErrorReporter())
+            .setSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(topicPartition)))
+            .addTask(table, new TopicPartition(topic, partition)) // Internally calls startTask
+            .build();
 
     final long noOfRecords = 10;
     List<SinkRecord> sinkRecords =
-            TestUtils.createJsonStringSinkRecords(0, noOfRecords, topic, partition);
+        TestUtils.createJsonStringSinkRecords(0, noOfRecords, topic, partition);
 
     Thread.sleep(1000); // to ensure we flush buffer on time threshold
     service.insert(sinkRecords);
@@ -1590,13 +1593,12 @@ public class SnowflakeSinkServiceV2IT {
     try {
       // Wait 20 seconds here and no flush should happen since the max client lag is 30 seconds
       TestUtils.assertWithRetry(
-              () -> service.getOffset(new TopicPartition(topic, partition)) == noOfRecords, 5, 4);
+          () -> service.getOffset(new TopicPartition(topic, partition)) == noOfRecords, 5, 4);
     } catch (Exception e) {
       // do nothing
     }
     service.closeAll();
   }
-
 
   private void createNonNullableColumn(String tableName, String colName) {
     String createTableQuery = "alter table identifier(?) add " + colName + " int not null";

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2IT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2IT.java
@@ -1,6 +1,6 @@
 package com.snowflake.kafka.connector.internal.streaming;
 
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_CLIENT_PROVIDER_OVERRIDE_MAP;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_MAX_CLIENT_LAG;
 import static com.snowflake.kafka.connector.internal.streaming.SnowflakeSinkServiceV2.partitionChannelKey;
 import static com.snowflake.kafka.connector.internal.streaming.TopicPartitionChannel.NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE;
@@ -1530,7 +1530,7 @@ public class SnowflakeSinkServiceV2IT {
   public void testStreamingIngestionValidClientPropertiesOverride() throws Exception {
     Map<String, String> config = new HashMap<>(getConfig());
     config.put(
-        SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP,
+        SNOWPIPE_STREAMING_CLIENT_PROVIDER_OVERRIDE_MAP,
         "MAX_CHANNEL_SIZE_IN_BYTES:10000000,ENABLE_SNOWPIPE_STREAMING_JMX_METRICS:false");
     SnowflakeSinkConnectorConfig.setDefaultValues(config);
     conn.createTable(table);
@@ -1569,7 +1569,7 @@ public class SnowflakeSinkServiceV2IT {
   @Test
   public void testStreamingIngestion_invalidClientPropertiesOverride() throws Exception {
     Map<String, String> config = new HashMap<>(getConfig());
-    config.put(SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP, "MAX_SOMETHING_SOMETHING:1");
+    config.put(SNOWPIPE_STREAMING_CLIENT_PROVIDER_OVERRIDE_MAP, "MAX_SOMETHING_SOMETHING:1");
     SnowflakeSinkConnectorConfig.setDefaultValues(config);
     conn.createTable(table);
 

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2IT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2IT.java
@@ -1,5 +1,6 @@
 package com.snowflake.kafka.connector.internal.streaming;
 
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_MAX_CLIENT_LAG;
 import static com.snowflake.kafka.connector.internal.streaming.SnowflakeSinkServiceV2.partitionChannelKey;
 import static com.snowflake.kafka.connector.internal.streaming.TopicPartitionChannel.NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE;
@@ -1524,6 +1525,78 @@ public class SnowflakeSinkServiceV2IT {
       Assert.assertEquals(NumberFormatException.class, ex.getCause().getClass());
     }
   }
+
+  @Test
+  public void testStreamingIngestionValidClientPropertiesOverride() throws Exception {
+    Map<String, String> config = new HashMap<>(getConfig());
+    config.put(SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP, "MAX_CHANNEL_SIZE_IN_BYTES:10000000,ENABLE_SNOWPIPE_STREAMING_JMX_METRICS:false");
+    SnowflakeSinkConnectorConfig.setDefaultValues(config);
+    conn.createTable(table);
+
+    // opens a channel for partition 0, table and topic
+    SnowflakeSinkService service =
+            SnowflakeSinkServiceFactory.builder(conn, IngestionMethodConfig.SNOWPIPE_STREAMING, config)
+                    .setRecordNumber(100)
+                    .setFlushTime(1)
+                    .setErrorReporter(new InMemoryKafkaRecordErrorReporter())
+                    .setSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(topicPartition)))
+                    .addTask(table, new TopicPartition(topic, partition)) // Internally calls startTask
+                    .build();
+
+    final long noOfRecords = 10;
+    List<SinkRecord> sinkRecords =
+            TestUtils.createJsonStringSinkRecords(0, noOfRecords, topic, partition);
+
+    Thread.sleep(1000); // to ensure we flush buffer on time threshold
+    service.insert(sinkRecords);
+
+    try {
+      // Wait 20 seconds here and no flush should happen since the max client lag is 30 seconds
+      TestUtils.assertWithRetry(
+              () -> service.getOffset(new TopicPartition(topic, partition)) == noOfRecords, 5, 4);
+    } catch (Exception e) {
+      // do nothing
+    }
+    service.closeAll();
+  }
+
+  /**
+   * Even if override key is invalid, we will still create a client since we dont verify key and values, only format.
+   */
+  @Test
+  public void testStreamingIngestion_invalidClientPropertiesOverride() throws Exception {
+    Map<String, String> config = new HashMap<>(getConfig());
+    config.put(SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP, "MAX_SOMETHING_SOMETHING:1");
+    SnowflakeSinkConnectorConfig.setDefaultValues(config);
+    conn.createTable(table);
+
+    // opens a channel for partition 0, table and topic
+    SnowflakeSinkService service =
+            SnowflakeSinkServiceFactory.builder(conn, IngestionMethodConfig.SNOWPIPE_STREAMING, config)
+                    .setRecordNumber(100)
+                    .setFlushTime(1)
+                    .setErrorReporter(new InMemoryKafkaRecordErrorReporter())
+                    .setSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(topicPartition)))
+                    .addTask(table, new TopicPartition(topic, partition)) // Internally calls startTask
+                    .build();
+
+    final long noOfRecords = 10;
+    List<SinkRecord> sinkRecords =
+            TestUtils.createJsonStringSinkRecords(0, noOfRecords, topic, partition);
+
+    Thread.sleep(1000); // to ensure we flush buffer on time threshold
+    service.insert(sinkRecords);
+
+    try {
+      // Wait 20 seconds here and no flush should happen since the max client lag is 30 seconds
+      TestUtils.assertWithRetry(
+              () -> service.getOffset(new TopicPartition(topic, partition)) == noOfRecords, 5, 4);
+    } catch (Exception e) {
+      // do nothing
+    }
+    service.closeAll();
+  }
+
 
   private void createNonNullableColumn(String tableName, String colName) {
     String createTableQuery = "alter table identifier(?) add " + colName + " int not null";

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientPropertiesTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientPropertiesTest.java
@@ -31,7 +31,6 @@ import com.snowflake.kafka.connector.internal.TestUtils;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
-
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -186,8 +185,8 @@ public class StreamingClientPropertiesTest {
     connectorConfig.put(Utils.SF_USER, "testUser");
     connectorConfig.put(Utils.SF_AUTHENTICATOR, Utils.SNOWFLAKE_JWT);
     connectorConfig.put(
-            SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP,
-            "MAX_CHANNEL_SIZE_IN_BYTES->10000000,MAX_CLIENT_LAG100");
+        SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP,
+        "MAX_CHANNEL_SIZE_IN_BYTES->10000000,MAX_CLIENT_LAG100");
 
     // test get properties
     try {
@@ -195,13 +194,12 @@ public class StreamingClientPropertiesTest {
       Assert.fail("Should throw an exception");
     } catch (SnowflakeKafkaConnectorException exception) {
       assert exception
-              .getMessage()
-              .contains(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP);
+          .getMessage()
+          .contains(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP);
     }
 
     connectorConfig.put(
-            SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP,
-            "MAX_CHANNEL_SIZE_IN_BYTES->10000000");
+        SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP, "MAX_CHANNEL_SIZE_IN_BYTES->10000000");
 
     // test get properties
     try {
@@ -209,8 +207,8 @@ public class StreamingClientPropertiesTest {
       Assert.fail("Should throw an exception");
     } catch (SnowflakeKafkaConnectorException exception) {
       assert exception
-              .getMessage()
-              .contains(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP);
+          .getMessage()
+          .contains(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP);
     }
   }
 

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientPropertiesTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientPropertiesTest.java
@@ -17,7 +17,7 @@
 
 package com.snowflake.kafka.connector.internal.streaming;
 
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_CLIENT_PROVIDER_OVERRIDE_MAP;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_MAX_CLIENT_LAG;
 import static com.snowflake.kafka.connector.internal.streaming.StreamingClientProperties.DEFAULT_CLIENT_NAME;
 import static com.snowflake.kafka.connector.internal.streaming.StreamingClientProperties.LOGGABLE_STREAMING_CONFIG_PROPERTIES;
@@ -88,7 +88,7 @@ public class StreamingClientPropertiesTest {
     connectorConfig.put(Utils.SF_AUTHENTICATOR, Utils.SNOWFLAKE_JWT);
     connectorConfig.put(SNOWPIPE_STREAMING_MAX_CLIENT_LAG, overrideValue);
     connectorConfig.put(
-        SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP,
+        SNOWPIPE_STREAMING_CLIENT_PROVIDER_OVERRIDE_MAP,
         "MAX_CHANNEL_SIZE_IN_BYTES:10000000,ENABLE_SNOWPIPE_STREAMING_JMX_METRICS:false");
 
     Properties expectedProps = StreamingUtils.convertConfigForStreamingClient(connectorConfig);
@@ -119,7 +119,7 @@ public class StreamingClientPropertiesTest {
     connectorConfig.put(Utils.SF_AUTHENTICATOR, Utils.SNOWFLAKE_JWT);
     connectorConfig.put(SNOWPIPE_STREAMING_MAX_CLIENT_LAG, overrideValue);
     connectorConfig.put(
-        SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP,
+        SNOWPIPE_STREAMING_CLIENT_PROVIDER_OVERRIDE_MAP,
         "MAX_CHANNEL_SIZE_IN_BYTES:10000000,MAX_CLIENT_LAG:100");
 
     Properties expectedProps = StreamingUtils.convertConfigForStreamingClient(connectorConfig);
@@ -148,7 +148,7 @@ public class StreamingClientPropertiesTest {
     connectorConfig.put(Utils.SF_USER, "testUser");
     connectorConfig.put(Utils.SF_AUTHENTICATOR, Utils.SNOWFLAKE_JWT);
     connectorConfig.put(
-        SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP,
+        SNOWPIPE_STREAMING_CLIENT_PROVIDER_OVERRIDE_MAP,
         "MAX_CHANNEL_SIZE_IN_BYTES:10000000,MAX_CLIENT_LAG:100");
 
     Properties expectedProps = StreamingUtils.convertConfigForStreamingClient(connectorConfig);
@@ -185,7 +185,7 @@ public class StreamingClientPropertiesTest {
     connectorConfig.put(Utils.SF_USER, "testUser");
     connectorConfig.put(Utils.SF_AUTHENTICATOR, Utils.SNOWFLAKE_JWT);
     connectorConfig.put(
-        SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP,
+        SNOWPIPE_STREAMING_CLIENT_PROVIDER_OVERRIDE_MAP,
         "MAX_CHANNEL_SIZE_IN_BYTES->10000000,MAX_CLIENT_LAG100");
 
     // test get properties
@@ -195,11 +195,11 @@ public class StreamingClientPropertiesTest {
     } catch (SnowflakeKafkaConnectorException exception) {
       assert exception
           .getMessage()
-          .contains(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP);
+          .contains(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_CLIENT_PROVIDER_OVERRIDE_MAP);
     }
 
     connectorConfig.put(
-        SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP, "MAX_CHANNEL_SIZE_IN_BYTES->10000000");
+        SNOWPIPE_STREAMING_CLIENT_PROVIDER_OVERRIDE_MAP, "MAX_CHANNEL_SIZE_IN_BYTES->10000000");
 
     // test get properties
     try {
@@ -208,7 +208,7 @@ public class StreamingClientPropertiesTest {
     } catch (SnowflakeKafkaConnectorException exception) {
       assert exception
           .getMessage()
-          .contains(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_CLIENT_PARAMETER_OVERRIDE_MAP);
+          .contains(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_CLIENT_PROVIDER_OVERRIDE_MAP);
     }
   }
 

--- a/test/rest_request_template/test_streaming_client_parameter_override.json
+++ b/test/rest_request_template/test_streaming_client_parameter_override.json
@@ -4,8 +4,8 @@
     "connector.class": "com.snowflake.kafka.connector.SnowflakeSinkConnector",
     "topics": "SNOWFLAKE_TEST_TOPIC",
     "tasks.max": "1",
-    "buffer.flush.time": "60",
-    "buffer.count.records": "300",
+    "buffer.flush.time": "10",
+    "buffer.count.records": "100",
     "buffer.size.bytes": "5000000",
     "snowflake.url.name": "SNOWFLAKE_HOST",
     "snowflake.user.name": "SNOWFLAKE_USER",
@@ -22,7 +22,6 @@
     "errors.log.enable": true,
     "errors.deadletterqueue.topic.name": "DLQ_TOPIC",
     "errors.deadletterqueue.topic.replication.factor": 1,
-    "snowflake.enable.schematization": true,
     "snowflake.streaming.client.provider.override.map": "MAX_CLIENT_LAG:30,MAX_CHANNEL_SIZE_IN_BYTES:10000000,enable_snowpipe_streaming_jmx_metrics:false"
   }
 }

--- a/test/rest_request_template/test_streaming_client_parameter_override.json
+++ b/test/rest_request_template/test_streaming_client_parameter_override.json
@@ -1,0 +1,28 @@
+{
+  "name": "SNOWFLAKE_CONNECTOR_NAME",
+  "config": {
+    "connector.class": "com.snowflake.kafka.connector.SnowflakeSinkConnector",
+    "topics": "SNOWFLAKE_TEST_TOPIC",
+    "tasks.max": "1",
+    "buffer.flush.time": "60",
+    "buffer.count.records": "300",
+    "buffer.size.bytes": "5000000",
+    "snowflake.url.name": "SNOWFLAKE_HOST",
+    "snowflake.user.name": "SNOWFLAKE_USER",
+    "snowflake.private.key": "SNOWFLAKE_PRIVATE_KEY",
+    "snowflake.database.name": "SNOWFLAKE_DATABASE",
+    "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
+    "snowflake.role.name": "SNOWFLAKE_ROLE",
+    "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
+    "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+    "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+    "value.converter.schemas.enable": "false",
+    "jmx": "true",
+    "errors.tolerance": "all",
+    "errors.log.enable": true,
+    "errors.deadletterqueue.topic.name": "DLQ_TOPIC",
+    "errors.deadletterqueue.topic.replication.factor": 1,
+    "snowflake.enable.schematization": true,
+    "snowflake.streaming.client.provider.override.map": "MAX_CLIENT_LAG:30,MAX_CHANNEL_SIZE_IN_BYTES:10000000,enable_snowpipe_streaming_jmx_metrics:false"
+  }
+}

--- a/test/test_suit/test_streaming_client_parameter_override.py
+++ b/test/test_suit/test_streaming_client_parameter_override.py
@@ -1,0 +1,89 @@
+from test_suit.test_utils import RetryableError, NonRetryableError
+import json
+from time import sleep
+
+class TestStreamingClientParameterOverride:
+    def __init__(self, driver, nameSalt):
+        self.driver = driver
+        self.fileName = "test_streaming_client_parameter_override.json"
+        self.topic = self.fileName + nameSalt
+
+        self.topicNum = 1
+        self.partitionNum = 3
+        self.recordNum = 1000
+
+        # create topic and partitions in constructor since the post REST api will automatically create topic with only one partition
+        self.driver.createTopics(self.topic, partitionNum=self.partitionNum, replicationNum=1)
+
+    def getConfigFileName(self):
+        return self.fileName + ".json"
+
+    def send(self):
+        # create topic with n partitions and only one replication factor
+        print("Partition count:" + str(self.partitionNum))
+        print("Topic:", self.topic)
+
+        self.driver.describeTopic(self.topic)
+
+        for p in range(self.partitionNum):
+            print("Sending in Partition:" + str(p))
+            key = []
+            value = []
+
+            # send two less record because we are sending tombstone records. tombstone ingestion is enabled by default
+            for e in range(self.recordNum - 2):
+                value.append(json.dumps(
+                    {'numbernumbernumbernumbernumbernumbernumbernumbernumbernumbernumbernumber': str(e)}
+                ).encode('utf-8'))
+
+            # append tombstone except for 2.5.1 due to this bug: https://issues.apache.org/jira/browse/KAFKA-10477
+            if self.driver.testVersion == '2.5.1':
+                value.append(json.dumps(
+                    {'numbernumbernumbernumbernumbernumbernumbernumbernumbernumbernumbernumber': str(self.recordNum - 1)}
+                ).encode('utf-8'))
+                value.append(json.dumps(
+                    {'numbernumbernumbernumbernumbernumbernumbernumbernumbernumbernumbernumber': str(self.recordNum)}
+                ).encode('utf-8'))
+            else:
+                value.append(None)
+                value.append("") # community converters treat this as a tombstone
+
+            self.driver.sendBytesData(self.topic, value, key, partition=p)
+            sleep(2)
+
+    def verify(self, round):
+        res = self.driver.snowflake_conn.cursor().execute(
+            "SELECT count(*) FROM {}".format(self.topic)).fetchone()[0]
+        print("Count records in table {}={}".format(self.topic, str(res)))
+        if res < (self.recordNum * self.partitionNum):
+            print("Topic:" + self.topic + " count is less, will retry")
+            raise RetryableError()
+        elif res > (self.recordNum * self.partitionNum):
+            print("Topic:" + self.topic + " count is more, duplicates detected")
+            raise NonRetryableError("Duplication occurred, number of record in table is larger than number of record sent")
+        else:
+            print("Table:" + self.topic + " count is exactly " + str(self.recordNum * self.partitionNum))
+
+        # for duplicates
+        res = self.driver.snowflake_conn.cursor().execute("Select record_metadata:\"offset\"::string as OFFSET_NO,record_metadata:\"partition\"::string as PARTITION_NO from {} group by OFFSET_NO, PARTITION_NO having count(*)>1".format(self.topic)).fetchone()
+        print("Duplicates:{}".format(res))
+        if res is not None:
+            raise NonRetryableError("Duplication detected")
+
+        # for uniqueness in offset numbers
+        rows = self.driver.snowflake_conn.cursor().execute("Select count(distinct record_metadata:\"offset\"::number) as UNIQUE_OFFSETS,record_metadata:\"partition\"::number as PARTITION_NO from {} group by PARTITION_NO order by PARTITION_NO".format(self.topic)).fetchall()
+
+        if rows is None:
+            raise NonRetryableError("Unique offsets for partitions not found")
+        else:
+            assert len(rows) == 3
+
+            for p in range(self.partitionNum):
+                # unique offset count and partition no are two columns (returns tuple)
+                if rows[p][0] != self.recordNum or rows[p][1] != p:
+                    raise NonRetryableError("Unique offsets for partitions count doesnt match")
+
+    def clean(self):
+        # dropping of stage and pipe doesnt apply for snowpipe streaming. (It executes drop if exists)
+        self.driver.cleanTableStagePipe(self.topic)
+        return

--- a/test/test_suit/test_streaming_client_parameter_override.py
+++ b/test/test_suit/test_streaming_client_parameter_override.py
@@ -5,7 +5,7 @@ from time import sleep
 class TestStreamingClientParameterOverride:
     def __init__(self, driver, nameSalt):
         self.driver = driver
-        self.fileName = "test_streaming_client_parameter_override.json"
+        self.fileName = "test_streaming_client_parameter_override"
         self.topic = self.fileName + nameSalt
 
         self.topicNum = 1

--- a/test/test_suites.py
+++ b/test/test_suites.py
@@ -51,6 +51,7 @@ from test_suit.test_string_avro import TestStringAvro
 from test_suit.test_string_avrosr import TestStringAvrosr
 from test_suit.test_string_json import TestStringJson
 from test_suit.test_string_json_ignore_tombstone import TestStringJsonIgnoreTombstone
+from test_suit.test_streaming_client_parameter_override import TestStreamingClientParameterOverride
 
 
 class EndToEndTestSuite:
@@ -259,6 +260,10 @@ def create_end_to_end_test_suites(driver, nameSalt, schemaRegistryAddress, testS
         )),
         ("TestSchemaEvolutionMultiTopicDropTable", EndToEndTestSuite(
             test_instance=TestSchemaEvolutionMultiTopicDropTable(driver, nameSalt), clean=True, run_in_confluent=True,
+            run_in_apache=True
+        )),
+        ("TestStreamingClientParameterOverride", EndToEndTestSuite(
+            test_instance=TestStreamingClientParameterOverride(driver, nameSalt), clean=True, run_in_confluent=True,
             run_in_apache=True
         )),
     ])


### PR DESCRIPTION
SNOW-1117446

Instead of having a new property in KC config for every overridden key value pair, we input a comma separated KV pair. 

## Pre-review checklist
- [ ] This change should be part of a Behavior Change Release. See [go/behavior-change](http://go/behavior-change).
- [ ] This change has passed Merge gate tests
- [ ] Snowpipe Changes
- [X] Snowpipe Streaming Changes
- [ ] This change is TEST-ONLY
- [ ] This change is README/Javadocs only
- [ ] This change is protected by a config parameter <PARAMETER_NAME> eg `snowflake.ingestion.method`.
    - [X] `Yes` - Added end to end and Unit Tests. `snowflake.streaming.client.provider.override.map`
    - [ ] `No` - Suggest why it is not param protected
- [ ] Is his change protected by parameter <PARAMETER_NAME> on the server side?
    - [ ] The parameter/feature is not yet active in production (partial rollout or PrPr, see [Changes for Unreleased Features and Fixes](http://go/ppp-prpr)).
    - [ ] If there is an issue, it can be safely mitigated by turning the parameter off. This is also verified by a test (See [go/ppp](http://go/ppp)).


## Urgency
This review is ***URGENT*** priority


## Backward and forward Compatible
Imagine customer upgrading to new version and rolling back to older version. Will there be any concerns?
[X] Backward compatible - They will have to remove the new config since we dont validate this new config in older versions. 
[ ] Forward compatible
-->



Reviewers:  Every review must have at least two reviewers for bug fixes, GA'ed component. One reviewer is enough for test only, doc changes.
- Minimum # of Required Reviewers - **Two** for Improvements and Bugfixes - Toby, Tyler, Revi
- Educational purposes - @ Warsaw Team


