### PR TITLE
SNOW-1049869 Cleanup streaming ingest threads when SinkTask stop() is called

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -463,6 +463,7 @@
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
             <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
         </dependency>
         <!-- Optional : override the JUnit 4 API version provided by junit-vintage-engine -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
         <skipTests>false</skipTests>
         <skipUnitTests>${skipTests}</skipUnitTests>
         <skipIntegrationTests>${skipTests}</skipIntegrationTests>
+        <junit-jupiter.version>5.10.2</junit-jupiter.version>
     </properties>
 
 
@@ -445,6 +446,25 @@
         </dependency>
 
         <!--junit for unit test-->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!--JUnit Jupiter Engine to depend on the JUnit4 engine and JUnit 4 API  -->
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>${junit-jupiter.version}</version>
+        </dependency>
+        <!-- Optional : override the JUnit 4 API version provided by junit-vintage-engine -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,6 @@
         <skipTests>false</skipTests>
         <skipUnitTests>${skipTests}</skipUnitTests>
         <skipIntegrationTests>${skipTests}</skipIntegrationTests>
-        <junit-jupiter.version>5.10.2</junit-jupiter.version>
     </properties>
 
 
@@ -449,20 +448,17 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit-jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>${junit-jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <!--JUnit Jupiter Engine to depend on the JUnit4 engine and JUnit 4 API  -->
         <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
-            <version>${junit-jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <!-- Optional : override the JUnit 4 API version provided by junit-vintage-engine -->
@@ -512,4 +508,16 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.10.2</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -49,7 +49,6 @@
         <skipTests>false</skipTests>
         <skipUnitTests>${skipTests}</skipUnitTests>
         <skipIntegrationTests>${skipTests}</skipIntegrationTests>
-        <junit-jupiter.version>5.10.2</junit-jupiter.version>
         <license.processing.dependencyJarsDir>${project.build.directory}/dependency-jars
         </license.processing.dependencyJarsDir>
         <license.processing.dependencyListFile>${project.build.directory}/dependency-list.txt
@@ -660,4 +659,16 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.10.2</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -596,20 +596,17 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>${junit-jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
-            <version>${junit-jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <!--JUnit Jupiter Engine to depend on the JUnit4 engine and JUnit 4 API  -->
         <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
-            <version>${junit-jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <!-- Optional : override the JUnit 4 API version provided by junit-vintage-engine -->

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -611,6 +611,7 @@
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
             <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
         </dependency>
         <!-- Optional : override the JUnit 4 API version provided by junit-vintage-engine -->
         <dependency>

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -49,6 +49,7 @@
         <skipTests>false</skipTests>
         <skipUnitTests>${skipTests}</skipUnitTests>
         <skipIntegrationTests>${skipTests}</skipIntegrationTests>
+        <junit-jupiter.version>5.10.2</junit-jupiter.version>
         <license.processing.dependencyJarsDir>${project.build.directory}/dependency-jars
         </license.processing.dependencyJarsDir>
         <license.processing.dependencyListFile>${project.build.directory}/dependency-list.txt
@@ -593,6 +594,25 @@
         </dependency>
 
         <!--junit for unit test-->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!--JUnit Jupiter Engine to depend on the JUnit4 engine and JUnit 4 API  -->
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <version>${junit-jupiter.version}</version>
+        </dependency>
+        <!-- Optional : override the JUnit 4 API version provided by junit-vintage-engine -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
@@ -236,11 +236,14 @@ public class SnowflakeSinkTask extends SinkTask {
   /**
    * stop method is invoked only once outstanding calls to other methods have completed. e.g. after
    * current put, and a final preCommit has completed.
+   *
+   * <p>Note that calling this method does not perform synchronous cleanup in Snowpipe based
+   * implementation
    */
   @Override
   public void stop() {
     if (this.sink != null) {
-      this.sink.setIsStoppedToTrue(); // close cleaner thread
+      this.sink.stop();
     }
 
     this.DYNAMIC_LOGGER.info(

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkService.java
@@ -73,8 +73,13 @@ public interface SnowflakeSinkService {
    */
   void close(Collection<TopicPartition> partitions);
 
-  /** close all cleaner thread but have no effect on sink service context */
-  void setIsStoppedToTrue();
+  /**
+   * close all cleaner thread but have no effect on sink service context
+   *
+   * <p>Note that calling this method does not perform synchronous cleanup in Snowpipe based
+   * implementation
+   */
+  void stop();
 
   /**
    * retrieve sink service status

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
@@ -230,7 +230,7 @@ class SnowflakeSinkServiceV1 implements SnowflakeSinkService {
   }
 
   @Override
-  public void setIsStoppedToTrue() {
+  public void stop() {
     this.isStopped = true; // release all cleaner and flusher threads
   }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -406,6 +406,8 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
             connectorConfig.getOrDefault(
                 SnowflakeSinkConnectorConfig.ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG,
                 Boolean.toString(ENABLE_STREAMING_CLIENT_OPTIMIZATION_DEFAULT)));
+    // when optimization is enabled single streamingIngestClient instance may be used by many SinkService instances
+    // stopping the client may cause unexpected behaviour
     if (!isOptimizationEnabled) {
       try {
         StreamingClientProvider.getStreamingClientProviderInstance()

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -1,6 +1,8 @@
 package com.snowflake.kafka.connector.internal.streaming;
 
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.*;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES_DEFAULT;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_STREAMING_CLIENT_OPTIMIZATION_DEFAULT;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWFLAKE_ROLE;
 import static com.snowflake.kafka.connector.internal.streaming.StreamingUtils.STREAMING_BUFFER_COUNT_RECORDS_DEFAULT;
 import static com.snowflake.kafka.connector.internal.streaming.StreamingUtils.STREAMING_BUFFER_FLUSH_TIME_DEFAULT_SEC;
 import static com.snowflake.kafka.connector.internal.streaming.TopicPartitionChannel.NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE;
@@ -406,9 +408,13 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
                 Boolean.toString(ENABLE_STREAMING_CLIENT_OPTIMIZATION_DEFAULT)));
     if (!isOptimizationEnabled) {
       try {
-        this.streamingIngestClient.close();
+        StreamingClientProvider.getStreamingClientProviderInstance()
+            .closeClient(connectorConfig, this.streamingIngestClient);
       } catch (Exception e) {
-        LOGGER.warn("Could not close streaming ingest client. {}", e.getMessage());
+        LOGGER.warn(
+            "Could not close streaming ingest client {}. Reason: {}",
+            streamingIngestClient.getName(),
+            e.getMessage());
       }
     }
   }

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -406,7 +406,8 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
             connectorConfig.getOrDefault(
                 SnowflakeSinkConnectorConfig.ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG,
                 Boolean.toString(ENABLE_STREAMING_CLIENT_OPTIMIZATION_DEFAULT)));
-    // when optimization is enabled single streamingIngestClient instance may be used by many SinkService instances
+    // when optimization is enabled single streamingIngestClient instance may be used by many
+    // SinkService instances
     // stopping the client may cause unexpected behaviour
     if (!isOptimizationEnabled) {
       try {

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProvider.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProvider.java
@@ -79,7 +79,7 @@ public class StreamingClientProvider {
   /***************************** BEGIN SINGLETON CODE *****************************/
   private static final KCLogger LOGGER = new KCLogger(StreamingClientProvider.class.getName());
 
-  private StreamingClientHandler streamingClientHandler;
+  private final StreamingClientHandler streamingClientHandler;
   private LoadingCache<StreamingClientProperties, SnowflakeStreamingIngestClient> registeredClients;
 
   /**
@@ -179,7 +179,6 @@ public class StreamingClientProvider {
   private StreamingClientProvider(
       StreamingClientHandler streamingClientHandler,
       LoadingCache<StreamingClientProperties, SnowflakeStreamingIngestClient> registeredClients) {
-    this();
     this.streamingClientHandler = streamingClientHandler;
     this.registeredClients = registeredClients;
   }

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2StopIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2StopIT.java
@@ -1,0 +1,72 @@
+package com.snowflake.kafka.connector.internal.streaming;
+
+import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
+import com.snowflake.kafka.connector.dlq.InMemoryKafkaRecordErrorReporter;
+import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
+import com.snowflake.kafka.connector.internal.SnowflakeSinkServiceFactory;
+import com.snowflake.kafka.connector.internal.TestUtils;
+import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Stream;
+import net.snowflake.ingest.streaming.SnowflakeStreamingIngestClient;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class SnowflakeSinkServiceV2StopIT {
+
+  private String topicAndTableName;
+
+  @BeforeEach
+  public void beforeEach() {
+    topicAndTableName = TestUtils.randomTableName();
+  }
+
+  @AfterEach
+  public void afterEach() {
+    TestUtils.dropTable(topicAndTableName);
+  }
+
+  @ParameterizedTest
+  @MethodSource("singleServiceTestCases")
+  public void stop_forSingleService_closesClientDependingOnOptimization(
+      boolean optimizationEnabled, boolean clientClosed) {
+    // given
+    SnowflakeConnectionService conn = TestUtils.getConnectionServiceForStreaming();
+    Map<String, String> config = TestUtils.getConfForStreaming();
+    SnowflakeSinkConnectorConfig.setDefaultValues(config);
+    config.put(
+        SnowflakeSinkConnectorConfig.ENABLE_STREAMING_CLIENT_OPTIMIZATION_CONFIG,
+        String.valueOf(optimizationEnabled));
+    conn.createTable(topicAndTableName);
+    int partition = 0;
+    TopicPartition topicPartition = new TopicPartition(topicAndTableName, partition);
+
+    // opens a channel for partition 0, table and topic
+    SnowflakeSinkServiceV2 service =
+        (SnowflakeSinkServiceV2)
+            SnowflakeSinkServiceFactory.builder(
+                    conn, IngestionMethodConfig.SNOWPIPE_STREAMING, config)
+                .setRecordNumber(1)
+                .setErrorReporter(new InMemoryKafkaRecordErrorReporter())
+                .setSinkTaskContext(
+                    new InMemorySinkTaskContext(Collections.singleton(topicPartition)))
+                .addTask(topicAndTableName, topicPartition)
+                .build();
+    SnowflakeStreamingIngestClient client = service.getStreamingIngestClient();
+
+    // when
+    service.stop();
+
+    // then
+    Assertions.assertEquals(clientClosed, client.isClosed());
+  }
+
+  public static Stream<Arguments> singleServiceTestCases() {
+    return Stream.of(Arguments.of(true, false), Arguments.of(false, true));
+  }
+}

--- a/test/perf_test/pom.xml
+++ b/test/perf_test/pom.xml
@@ -46,6 +46,26 @@
     </dependency>
     <!--junit for unit test-->
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${junit-jupiter.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>${junit-jupiter.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <!--JUnit Jupiter Engine to depend on the JUnit4 engine and JUnit 4 API  -->
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <version>${junit-jupiter.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- Optional : override the JUnit 4 API version provided by junit-vintage-engine -->
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13.1</version>

--- a/test/perf_test/pom.xml
+++ b/test/perf_test/pom.xml
@@ -48,20 +48,17 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
-      <version>${junit-jupiter.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
-      <version>${junit-jupiter.version}</version>
       <scope>test</scope>
     </dependency>
     <!--JUnit Jupiter Engine to depend on the JUnit4 engine and JUnit 4 API  -->
     <dependency>
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
-      <version>${junit-jupiter.version}</version>
       <scope>test</scope>
     </dependency>
     <!-- Optional : override the JUnit 4 API version provided by junit-vintage-engine -->
@@ -77,6 +74,18 @@
       <version>1.11.3</version>
     </dependency>
   </dependencies>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>5.10.2</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <build>
     <plugins>


### PR DESCRIPTION
https://snowflakecomputing.atlassian.net/browse/SNOW-1049869

KC does not call `close()` method on streaming ingest client instance when `stop()` is called on task restart or termination. It results in some internal threads not being closed and probably a memory leak as well. 

If one client optimization is enabled it is not a big deal. Client will be reused on task restart and will leak only on task termination which is rare.  Max 10000 clients are cached so no more threads will leak.

When client optimization is disabled then we will experience a massive thread leak as new streaming ingest client is created on every task restart.