### PR TITLE
SNOW-1055524 E2E test with nullable SMT

### DIFF
--- a/test/rest_request_template/nullable_values_after_smt.json
+++ b/test/rest_request_template/nullable_values_after_smt.json
@@ -2,8 +2,8 @@
   "name": "SNOWFLAKE_CONNECTOR_NAME",
   "config": {
     "connector.class": "com.snowflake.kafka.connector.SnowflakeSinkConnector",
-    "topics": "SNOWFLAKE_TEST_TOPIC0",
-    "snowflake.topic2table.map": "SNOWFLAKE_TEST_TOPIC0:SNOWFLAKE_CONNECTOR_NAME",
+    "topics": "SNOWFLAKE_TEST_TOPIC",
+    "snowflake.topic2table.map": "SNOWFLAKE_TEST_TOPIC:SNOWFLAKE_CONNECTOR_NAME",
     "tasks.max": "1",
     "buffer.flush.time": "10",
     "buffer.count.records": "100",

--- a/test/rest_request_template/travis_correct_nullable_values_after_smt.json
+++ b/test/rest_request_template/travis_correct_nullable_values_after_smt.json
@@ -1,0 +1,32 @@
+{
+  "name": "SNOWFLAKE_CONNECTOR_NAME",
+  "config": {
+    "connector.class": "com.snowflake.kafka.connector.SnowflakeSinkConnector",
+    "topics": "SNOWFLAKE_TEST_TOPIC0",
+    "snowflake.topic2table.map": "SNOWFLAKE_TEST_TOPIC0:SNOWFLAKE_CONNECTOR_NAME",
+    "tasks.max": "1",
+    "buffer.flush.time": "10",
+    "buffer.count.records": "100",
+    "buffer.size.bytes": "5000000",
+    "snowflake.url.name": "SNOWFLAKE_HOST",
+    "snowflake.user.name": "SNOWFLAKE_USER",
+    "snowflake.private.key": "SNOWFLAKE_PRIVATE_KEY",
+    "snowflake.database.name": "SNOWFLAKE_DATABASE",
+    "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
+    "snowflake.role.name": "SNOWFLAKE_ROLE",
+    "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
+    "snowflake.enable.schematization": true,
+    "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+    "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+    "value.converter.schemas.enable": "false",
+    "jmx": "true",
+    "errors.tolerance": "all",
+    "errors.log.enable": true,
+    "errors.deadletterqueue.topic.name": "DLQ_TOPIC",
+    "errors.deadletterqueue.topic.replication.factor": 1,
+    "behavior.on.null.values": "IGNORE",
+    "transforms": "extractField",
+    "transforms.extractField.type": "org.apache.kafka.connect.transforms.ExtractField$Value",
+    "transforms.extractField.field": "optionalField"
+  }
+}

--- a/test/test_suit/test_nullable_values_after_smt.py
+++ b/test/test_suit/test_nullable_values_after_smt.py
@@ -1,0 +1,59 @@
+import json
+from snowflake.connector import DictCursor
+from test_suit.test_utils import NonRetryableError, RetryableError
+
+
+class TestNullableValuesAfterSmt:
+
+    def __init__(self, driver, nameSalt):
+        self.driver = driver
+        self.fileName = 'travis_correct_nullable_values_after_smt'
+        self.table = self.fileName + nameSalt
+        self.topic = self.table + '0'
+
+        self.driver.snowflake_conn.cursor().execute(
+            f'create or replace table {self.table} (index number not null)')
+
+        self.driver.snowflake_conn.cursor().execute(
+            f'alter table {self.table} set enable_schema_evolution = true')
+
+    def getConfigFileName(self):
+        return self.fileName + '.json'
+
+    def send(self):
+        value = []
+        for idx in range(200):
+            event = { 'index': idx, 'someKey': 'someValue' }
+
+            if idx % 2 == 0: # Only every other event contains optionalField.
+                optional_value = { 'index': idx, 'from_optional_field': True }
+                event.update({ 'optionalField': optional_value })
+
+            value.append(json.dumps(event).encode('utf-8'))
+
+        self.driver.sendBytesData(self.topic, value)
+
+    def verify(self, round):
+        cur = self.driver.snowflake_conn.cursor(DictCursor)
+        res = cur.execute(f'select index, from_optional_field, record_metadata:offset::number as offset from {self.table}').fetchall()
+
+        if len(res) == 0:
+            raise RetryableError()
+        elif len(res) != 100:
+            raise NonRetryableError('Number of record in table is different from number of expected records')
+
+        idx = 0
+        for rec in res:
+            if rec['INDEX'] != idx:
+                raise NonRetryableError(f"Invalid index value. Expected: {idx}, got: {rec['INDEX']}")
+
+            if not rec['FROM_OPTIONAL_FIELD']:
+                raise NonRetryableError('Invalid from_optional_field value. Expected to be true')
+
+            if rec['OFFSET'] != idx:
+                raise NonRetryableError(f"Invalid offset value. Expected: {idx}, got: {rec['OFFSET']}")
+
+            idx += 2  # Only every other event is going to be ingested.
+
+    def clean(self):
+        self.driver.cleanTableStagePipe(self.topic, self.table)

--- a/test/test_suit/test_nullable_values_after_smt.py
+++ b/test/test_suit/test_nullable_values_after_smt.py
@@ -3,13 +3,14 @@ from snowflake.connector import DictCursor
 from test_suit.test_utils import NonRetryableError, RetryableError
 
 
+# Testing behavior for behavior.on.null.values = IGNORE and SMTs that can return null values.
 class TestNullableValuesAfterSmt:
 
     def __init__(self, driver, nameSalt):
         self.driver = driver
-        self.fileName = 'travis_correct_nullable_values_after_smt'
+        self.fileName = 'nullable_values_after_smt'
         self.table = self.fileName + nameSalt
-        self.topic = self.table + '0'
+        self.topic = self.table
 
         self.driver.snowflake_conn.cursor().execute(
             f'create or replace table {self.table} (index number not null)')

--- a/test/test_suites.py
+++ b/test/test_suites.py
@@ -24,6 +24,7 @@ from test_suit.test_native_complex_smt import TestNativeComplexSmt
 from test_suit.test_native_string_avrosr import TestNativeStringAvrosr
 from test_suit.test_native_string_json_without_schema import TestNativeStringJsonWithoutSchema
 from test_suit.test_native_string_protobuf import TestNativeStringProtobuf
+from test_suit.test_nullable_values_after_smt import TestNullableValuesAfterSmt
 from test_suit.test_schema_evolution_avro_sr import TestSchemaEvolutionAvroSR
 from test_suit.test_schema_evolution_avro_sr_logical_types import TestSchemaEvolutionAvroSRLogicalTypes
 from test_suit.test_schema_evolution_drop_table import TestSchemaEvolutionDropTable
@@ -130,6 +131,10 @@ def create_end_to_end_test_suites(driver, nameSalt, schemaRegistryAddress, testS
         )),
         ("TestNativeStringProtobuf", EndToEndTestSuite(
             test_instance=TestNativeStringProtobuf(driver, nameSalt), clean=True, run_in_confluent=True,
+            run_in_apache=True
+        )),
+        ("TestNullableValuesAfterSmt", EndToEndTestSuite(
+            test_instance=TestNullableValuesAfterSmt(driver, nameSalt), clean=True, run_in_confluent=True,
             run_in_apache=True
         )),
         ("TestConfluentProtobufProtobuf", EndToEndTestSuite(


### PR DESCRIPTION
<!-- Text inside of HTML comment blocks will NOT appear in your pull request description -->
<!-- Formatting information can be found at https://www.markdownguide.org/basic-syntax/ -->
# Overview

SNOW-1055524
Implementing an e2e test with an SMT that can return a nullable value.
To keep things simple, `org.apache.kafka.connect.transforms.ExtractField` has been used. By filling in an optional value for half of the events only we achieve alteration between non-nullable and nullable values.

<!--
Why is this review being requested?  The full details should be in the JIRA, but the review should focus on the fix/change being implemented.
If there are multiple steps in the Jira, which step is this?
-->

## Pre-review checklist
- [ ] This change should be part of a Behavior Change Release. See [go/behavior-change](http://go/behavior-change).
- [x] This change has passed Merge gate tests
- [ ] Snowpipe Changes
- [ ] Snowpipe Streaming Changes
- [x] This change is TEST-ONLY
- [ ] This change is README/Javadocs only
- [ ] This change is protected by a config parameter <PARAMETER_NAME> eg `snowflake.ingestion.method`.
    - [ ] `Yes` - Added end to end and Unit Tests. 
    - [ ] `No` - Suggest why it is not param protected
- [ ] Is his change protected by parameter <PARAMETER_NAME> on the server side?
    - [ ] The parameter/feature is not yet active in production (partial rollout or PrPr, see [Changes for Unreleased Features and Fixes](http://go/ppp-prpr)).
    - [ ] If there is an issue, it can be safely mitigated by turning the parameter off. This is also verified by a test (See [go/ppp](http://go/ppp)).


<!--
## Urgency
This review is *normal* priority
This review is **high** priority
This review is ***URGENT*** priority
-->

<!--
Indicate any urgency for performing the review.  Perhaps it is a fix for a prod issue or is blocking a customer.
-->

<!--
## Risks
What are the risks associated to your change?
-->

<!--
## Backward and forward Compatible
Imagine customer upgrading to new version and rolling back to older version. Will there be any concerns?
[ ] Backward compatible
[ ] Forward compatible
-->

<!--
Suggested reading order:   Provide an order in which to read files, classes, and methods.  Without this your reader will spend lots of time reading code without understanding the context (imagine the top file references a new class in methods of a file below it).  You need to tell your reviewers how to learn your code.
-->

<!--
## Reviewer roles
Every reviewer must be told their role and what actions are expected of them.  Tell every reviewer what will happen if they don't complete the review.  If you aren't sure who the secondary owner is then work with a manager and/or tech lead to figure this out.
If there are specific items or subsets of the change that you want a particular reviewer to focus on, mention it here.  You can @-mention people using their github username
-->

<!--
Reviewers:  Every review must have at least two reviewers for bug fixes, GA'ed component. One reviewer is enough for test only, doc changes.
Example:
- Minimum # of Required Reviewers - **Two** for Improvements and Bugfixes - <@github alias> 
- Educational purposes - <@github alias>
- Manager/TL approval (If patch critical and requires a release) - <@github alias>
-->

