### PR TITLE
Adds "if not exists" to non-first columns when altering tables.

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
@@ -503,7 +503,7 @@ public class SnowflakeConnectionServiceV1 implements SnowflakeConnectionService 
       if (first) {
         first = false;
       } else {
-        appendColumnQuery.append(", ");
+        appendColumnQuery.append(", if not exists ");
         logColumn.append(",");
       }
       appendColumnQuery


### PR DESCRIPTION
<!-- Text inside of HTML comment blocks will NOT appear in your pull request description -->
<!-- Formatting information can be found at https://www.markdownguide.org/basic-syntax/ -->
# Overview

When schema evolution detects multiple columns changing the DDL generated only has one column with `if not exists`. If you run multiple instances of the connector subsequent queries will fail with "column $NAME already exists" errors.

```sql
alter table identifier('EXISTING_TABLE') add column if not exists "STRING_COLUMN" VARCHAR comment 'column created by schema evolution from Snowflake Kafka Connector', "STRING_COLUMN2" VARCHAR comment 'column created by schema evolution from Snowflake Kafka Connector';
```

expected:

```sql
alter table identifier('EXISTING_TABLE') add column if not exists "STRING_COLUMN" VARCHAR comment 'column created by schema evolution from Snowflake Kafka Connector', if not exists "STRING_COLUMN2" VARCHAR comment 'column created by schema evolution from Snowflake Kafka Connector';
```

I'm not sure the best way to add tests for this change in the E2E test cases.

## Pre-review checklist
- [ ] This change should be part of a Behavior Change Release. See [go/behavior-change](http://go/behavior-change).
- [ ] This change has passed Merge gate tests
- [ ] Snowpipe Changes
- [x] Snowpipe Streaming Changes
- [ ] This change is TEST-ONLY
- [ ] This change is README/Javadocs only
- [ ] This change is protected by a config parameter <PARAMETER_NAME> eg `snowflake.ingestion.method`.
    - [ ] `Yes` - Added end to end and Unit Tests. 
    - [ ] `No` - Suggest why it is not param protected
- [ ] Is his change protected by parameter <PARAMETER_NAME> on the server side?
    - [ ] The parameter/feature is not yet active in production (partial rollout or PrPr, see [Changes for Unreleased Features and Fixes](http://go/ppp-prpr)).
    - [ ] If there is an issue, it can be safely mitigated by turning the parameter off. This is also verified by a test (See [go/ppp](http://go/ppp)).


<!--
## Urgency
This review is *normal* priority
This review is **high** priority
This review is ***URGENT*** priority
-->

<!--
Indicate any urgency for performing the review.  Perhaps it is a fix for a prod issue or is blocking a customer.
-->


## Risks
What are the risks associated to your change?

Failed DDL queries.

<!--
## Backward and forward Compatible
Imagine customer upgrading to new version and rolling back to older version. Will there be any concerns?
[ ] Backward compatible
[ ] Forward compatible
-->

<!--
Suggested reading order:   Provide an order in which to read files, classes, and methods.  Without this your reader will spend lots of time reading code without understanding the context (imagine the top file references a new class in methods of a file below it).  You need to tell your reviewers how to learn your code.
-->

<!--
## Reviewer roles
Every reviewer must be told their role and what actions are expected of them.  Tell every reviewer what will happen if they don't complete the review.  If you aren't sure who the secondary owner is then work with a manager and/or tech lead to figure this out.
If there are specific items or subsets of the change that you want a particular reviewer to focus on, mention it here.  You can @-mention people using their github username
-->

<!--
Reviewers:  Every review must have at least two reviewers for bug fixes, GA'ed component. One reviewer is enough for test only, doc changes.
Example:
- Minimum # of Required Reviewers - **Two** for Improvements and Bugfixes - <@github alias> 
- Educational purposes - <@github alias>
- Manager/TL approval (If patch critical and requires a release) - <@github alias>
-->

