### PR TITLE
SNOW-1151484 Use insertRows for schema evolution

### DIFF
--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelTest.java
@@ -806,10 +806,11 @@ public class TopicPartitionChannelTest {
   }
 
   @Test
-  public void testInsertRowsWithSchemaEvolution() throws Exception {
+  public void testInsertRowsWithSchemaEvolution_onlySingleBuffer() throws Exception {
     if (this.sfConnectorConfig
-        .get(SnowflakeSinkConnectorConfig.ENABLE_SCHEMATIZATION_CONFIG)
-        .equals("true")) {
+            .get(SnowflakeSinkConnectorConfig.ENABLE_SCHEMATIZATION_CONFIG)
+            .equals("true")
+        && !useDoubleBuffer) {
       InsertValidationResponse validationResponse1 = new InsertValidationResponse();
       InsertValidationResponse.InsertError insertError1 =
           new InsertValidationResponse.InsertError("CONTENT", 0);


### PR DESCRIPTION
<!-- Text inside of HTML comment blocks will NOT appear in your pull request description -->
<!-- Formatting information can be found at https://www.markdownguide.org/basic-syntax/ -->
# Overview

SNOW-1161484 

Mostly copy of old PR https://github.com/snowflakedb/snowflake-kafka-connector/pull/796

Create channel with SKIP_BATCH instead of CONTINUE, to avoid the case that KC can crash right after adding the good rows to table, and the bad rows will be missing in the DLQ
Update the schematization code to use insertRows instead of insertRow
- Better performance
- If KC is configured with a longer buffer flush time, everything will be ingested as one batch so that the 1 second flush or 32MB channel size won't apply

<!--
Why is this review being requested?  The full details should be in the JIRA, but the review should focus on the fix/change being implemented.
If there are multiple steps in the Jira, which step is this?
-->

## Pre-review checklist
- [ ] This change should be part of a Behavior Change Release. See [go/behavior-change](http://go/behavior-change).
- [ ] This change has passed Merge gate tests
- [ ] Snowpipe Changes
- [ ] Snowpipe Streaming Changes
- [ ] This change is TEST-ONLY
- [ ] This change is README/Javadocs only
- [ ] This change is protected by a config parameter <PARAMETER_NAME> eg `snowflake.ingestion.method`.
    - [ ] `Yes` - Added end to end and Unit Tests. 
    - [ ] `No` - Suggest why it is not param protected
- [ ] Is his change protected by parameter <PARAMETER_NAME> on the server side?
    - [ ] The parameter/feature is not yet active in production (partial rollout or PrPr, see [Changes for Unreleased Features and Fixes](http://go/ppp-prpr)).
    - [ ] If there is an issue, it can be safely mitigated by turning the parameter off. This is also verified by a test (See [go/ppp](http://go/ppp)).


<!--
## Urgency
This review is *normal* priority
This review is **high** priority
This review is ***URGENT*** priority
-->

<!--
Indicate any urgency for performing the review.  Perhaps it is a fix for a prod issue or is blocking a customer.
-->

<!--
## Risks
What are the risks associated to your change?
-->

<!--
## Backward and forward Compatible
Imagine customer upgrading to new version and rolling back to older version. Will there be any concerns?
[ ] Backward compatible
[ ] Forward compatible
-->

<!--
Suggested reading order:   Provide an order in which to read files, classes, and methods.  Without this your reader will spend lots of time reading code without understanding the context (imagine the top file references a new class in methods of a file below it).  You need to tell your reviewers how to learn your code.
-->

<!--
## Reviewer roles
Every reviewer must be told their role and what actions are expected of them.  Tell every reviewer what will happen if they don't complete the review.  If you aren't sure who the secondary owner is then work with a manager and/or tech lead to figure this out.
If there are specific items or subsets of the change that you want a particular reviewer to focus on, mention it here.  You can @-mention people using their github username
-->

<!--
Reviewers:  Every review must have at least two reviewers for bug fixes, GA'ed component. One reviewer is enough for test only, doc changes.
Example:
- Minimum # of Required Reviewers - **Two** for Improvements and Bugfixes - <@github alias> 
- Educational purposes - <@github alias>
- Manager/TL approval (If patch critical and requires a release) - <@github alias>
-->

