### PR TITLE
SNOW-1061854 Run e2e tests with single buffer

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -416,14 +416,6 @@ public class Utils {
               SnowflakeSinkConnectorConfig.NAME));
     }
 
-    if (config.containsKey(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_ENABLE_SINGLE_BUFFER)
-        && Boolean.parseBoolean(
-            config.get(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_ENABLE_SINGLE_BUFFER))) {
-      invalidConfigParams.put(
-          SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_ENABLE_SINGLE_BUFFER,
-          "Currently not supported.");
-    }
-
     // If config doesnt have ingestion method defined, default is snowpipe or if snowpipe is
     // explicitly passed in as ingestion method
     // Below checks are just for snowpipe.

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
@@ -12,7 +12,6 @@ import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWFLA
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWFLAKE_SCHEMA;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWFLAKE_URL;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWFLAKE_USER;
-import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_ENABLE_SINGLE_BUFFER;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_MAX_CLIENT_LAG;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_MAX_MEMORY_LIMIT_IN_BYTES;
 import static com.snowflake.kafka.connector.Utils.HTTP_NON_PROXY_HOSTS;
@@ -36,7 +35,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
 public class ConnectorConfigTest {

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigTest.java
@@ -699,22 +699,6 @@ public class ConnectorConfigTest {
         .hasMessageContaining(prop);
   }
 
-  @ParameterizedTest
-  @EnumSource(IngestionMethodConfig.class)
-  public void shouldThrowExceptionWHenStreamingSingleBufferEnabled(
-      IngestionMethodConfig ingestionMethod) {
-    // GIVEN
-    Map<String, String> config = getConfig();
-    config.put(SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT, ingestionMethod.toString());
-    config.put(Utils.SF_ROLE, "ACCOUNTADMIN");
-    config.put(SNOWPIPE_STREAMING_ENABLE_SINGLE_BUFFER, "true");
-
-    // WHEN/THEN
-    assertThatThrownBy(() -> Utils.validateConfig(config))
-        .isInstanceOf(SnowflakeKafkaConnectorException.class)
-        .hasMessageContaining(SNOWPIPE_STREAMING_ENABLE_SINGLE_BUFFER);
-  }
-
   @Test
   public void testInvalidSchematizationForSnowpipe() {
     Map<String, String> config = getConfig();

--- a/test/rest_request_template/schema_evolution_nullable_values_after_smt.json
+++ b/test/rest_request_template/schema_evolution_nullable_values_after_smt.json
@@ -15,6 +15,7 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
+    "snowflake.streaming.max.client.lag": 10,
     "snowflake.streaming.enable.single.buffer": "$SNOWFLAKE_STREAMING_ENABLE_SINGLE_BUFFER",
     "snowflake.streaming.closeChannelsInParallel.enabled": true,
     "snowflake.enable.schematization": true,

--- a/test/rest_request_template/schema_evolution_nullable_values_after_smt.json
+++ b/test/rest_request_template/schema_evolution_nullable_values_after_smt.json
@@ -15,6 +15,7 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
+    "snowflake.streaming.enable.single.buffer": "$SNOWFLAKE_STREAMING_ENABLE_SINGLE_BUFFER",
     "snowflake.streaming.closeChannelsInParallel.enabled": true,
     "snowflake.enable.schematization": true,
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",

--- a/test/rest_request_template/snowpipe_streaming_nullable_values_after_smt.json
+++ b/test/rest_request_template/snowpipe_streaming_nullable_values_after_smt.json
@@ -14,6 +14,7 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
+    "snowflake.streaming.enable.single.buffer": "$SNOWFLAKE_STREAMING_ENABLE_SINGLE_BUFFER",
     "snowflake.streaming.closeChannelsInParallel.enabled": true,
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",
     "value.converter": "org.apache.kafka.connect.json.JsonConverter",

--- a/test/rest_request_template/snowpipe_streaming_nullable_values_after_smt.json
+++ b/test/rest_request_template/snowpipe_streaming_nullable_values_after_smt.json
@@ -14,6 +14,7 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
+    "snowflake.streaming.max.client.lag": 10,
     "snowflake.streaming.enable.single.buffer": "$SNOWFLAKE_STREAMING_ENABLE_SINGLE_BUFFER",
     "snowflake.streaming.closeChannelsInParallel.enabled": true,
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",

--- a/test/rest_request_template/snowpipe_streaming_schema_mapping_dlq.json
+++ b/test/rest_request_template/snowpipe_streaming_schema_mapping_dlq.json
@@ -14,6 +14,7 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
+    "snowflake.streaming.enable.single.buffer": "$SNOWFLAKE_STREAMING_ENABLE_SINGLE_BUFFER",
     "snowflake.streaming.closeChannelsInParallel.enabled": true,
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",
     "value.converter": "org.apache.kafka.connect.json.JsonConverter",

--- a/test/rest_request_template/snowpipe_streaming_string_json_dlq.json
+++ b/test/rest_request_template/snowpipe_streaming_string_json_dlq.json
@@ -14,6 +14,7 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
+    "snowflake.streaming.enable.single.buffer": "$SNOWFLAKE_STREAMING_ENABLE_SINGLE_BUFFER",
     "snowflake.streaming.closeChannelsInParallel.enabled": true,
     "snowflake.enable.schematization": "false",
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",

--- a/test/rest_request_template/test_kc_delete_create.json
+++ b/test/rest_request_template/test_kc_delete_create.json
@@ -14,6 +14,7 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
+    "snowflake.streaming.enable.single.buffer": "$SNOWFLAKE_STREAMING_ENABLE_SINGLE_BUFFER",
     "snowflake.streaming.closeChannelsInParallel.enabled": true,
     "enable.streaming.client.optimization": "true",
     "snowflake.enable.schematization": "false",

--- a/test/rest_request_template/test_kc_delete_create_chaos.json
+++ b/test/rest_request_template/test_kc_delete_create_chaos.json
@@ -14,6 +14,7 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
+    "snowflake.streaming.enable.single.buffer": "$SNOWFLAKE_STREAMING_ENABLE_SINGLE_BUFFER",
     "snowflake.streaming.closeChannelsInParallel.enabled": true,
     "enable.streaming.client.optimization": "true",
     "snowflake.enable.schematization": "false",

--- a/test/rest_request_template/test_kc_delete_resume.json
+++ b/test/rest_request_template/test_kc_delete_resume.json
@@ -14,6 +14,7 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
+    "snowflake.streaming.enable.single.buffer": "$SNOWFLAKE_STREAMING_ENABLE_SINGLE_BUFFER",
     "snowflake.streaming.closeChannelsInParallel.enabled": true,
     "enable.streaming.client.optimization": "true",
     "snowflake.enable.schematization": "false",

--- a/test/rest_request_template/test_kc_delete_resume_chaos.json
+++ b/test/rest_request_template/test_kc_delete_resume_chaos.json
@@ -14,6 +14,7 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
+    "snowflake.streaming.enable.single.buffer": "$SNOWFLAKE_STREAMING_ENABLE_SINGLE_BUFFER",
     "snowflake.streaming.closeChannelsInParallel.enabled": true,
     "enable.streaming.client.optimization": "true",
     "snowflake.enable.schematization": "false",

--- a/test/rest_request_template/test_kc_pause_create.json
+++ b/test/rest_request_template/test_kc_pause_create.json
@@ -14,6 +14,7 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
+    "snowflake.streaming.enable.single.buffer": "$SNOWFLAKE_STREAMING_ENABLE_SINGLE_BUFFER",
     "snowflake.streaming.closeChannelsInParallel.enabled": true,
     "enable.streaming.client.optimization": "true",
     "snowflake.enable.schematization": "false",

--- a/test/rest_request_template/test_kc_pause_create_chaos.json
+++ b/test/rest_request_template/test_kc_pause_create_chaos.json
@@ -13,7 +13,7 @@
     "snowflake.database.name": "SNOWFLAKE_DATABASE",
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
-    "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
+    "snowflake.streaming.enable.single.buffer": "$SNOWFLAKE_STREAMING_ENABLE_SINGLE_BUFFER",
     "snowflake.streaming.closeChannelsInParallel.enabled": true,
     "enable.streaming.client.optimization": "true",
     "snowflake.enable.schematization": "false",

--- a/test/rest_request_template/test_kc_pause_create_chaos.json
+++ b/test/rest_request_template/test_kc_pause_create_chaos.json
@@ -13,6 +13,7 @@
     "snowflake.database.name": "SNOWFLAKE_DATABASE",
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
+    "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
     "snowflake.streaming.enable.single.buffer": "$SNOWFLAKE_STREAMING_ENABLE_SINGLE_BUFFER",
     "snowflake.streaming.closeChannelsInParallel.enabled": true,
     "enable.streaming.client.optimization": "true",

--- a/test/rest_request_template/test_kc_pause_resume.json
+++ b/test/rest_request_template/test_kc_pause_resume.json
@@ -14,6 +14,7 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
+    "snowflake.streaming.enable.single.buffer": "$SNOWFLAKE_STREAMING_ENABLE_SINGLE_BUFFER",
     "snowflake.streaming.closeChannelsInParallel.enabled": true,
     "enable.streaming.client.optimization": "true",
     "snowflake.enable.schematization": "false",

--- a/test/rest_request_template/test_kc_pause_resume_chaos.json
+++ b/test/rest_request_template/test_kc_pause_resume_chaos.json
@@ -14,6 +14,7 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
+    "snowflake.streaming.enable.single.buffer": "$SNOWFLAKE_STREAMING_ENABLE_SINGLE_BUFFER",
     "snowflake.streaming.closeChannelsInParallel.enabled": true,
     "enable.streaming.client.optimization": "true",
     "snowflake.enable.schematization": "false",

--- a/test/rest_request_template/test_kc_recreate.json
+++ b/test/rest_request_template/test_kc_recreate.json
@@ -14,6 +14,7 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
+    "snowflake.streaming.enable.single.buffer": "$SNOWFLAKE_STREAMING_ENABLE_SINGLE_BUFFER",
     "snowflake.streaming.closeChannelsInParallel.enabled": true,
     "enable.streaming.client.optimization": "true",
     "snowflake.enable.schematization": "false",

--- a/test/rest_request_template/test_kc_recreate_chaos.json
+++ b/test/rest_request_template/test_kc_recreate_chaos.json
@@ -14,6 +14,7 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
+    "snowflake.streaming.enable.single.buffer": "$SNOWFLAKE_STREAMING_ENABLE_SINGLE_BUFFER",
     "snowflake.streaming.closeChannelsInParallel.enabled": true,
     "enable.streaming.client.optimization": "true",
     "snowflake.enable.schematization": "false",

--- a/test/rest_request_template/test_kc_resilience.json
+++ b/test/rest_request_template/test_kc_resilience.json
@@ -14,6 +14,7 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
+    "snowflake.streaming.enable.single.buffer": "$SNOWFLAKE_STREAMING_ENABLE_SINGLE_BUFFER",
     "snowflake.streaming.closeChannelsInParallel.enabled": true,
     "enable.streaming.client.optimization": "true",
     "snowflake.enable.schematization": "false",

--- a/test/rest_request_template/test_kc_restart.json
+++ b/test/rest_request_template/test_kc_restart.json
@@ -14,6 +14,7 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
+    "snowflake.streaming.enable.single.buffer": "$SNOWFLAKE_STREAMING_ENABLE_SINGLE_BUFFER",
     "snowflake.streaming.closeChannelsInParallel.enabled": true,
     "enable.streaming.client.optimization": "true",
     "snowflake.enable.schematization": "false",

--- a/test/rest_request_template/test_schema_evolution_json_ignore_tombstone.json
+++ b/test/rest_request_template/test_schema_evolution_json_ignore_tombstone.json
@@ -15,6 +15,7 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
+    "snowflake.streaming.enable.single.buffer": "$SNOWFLAKE_STREAMING_ENABLE_SINGLE_BUFFER",
     "snowflake.streaming.closeChannelsInParallel.enabled": true,
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",
     "value.converter": "org.apache.kafka.connect.json.JsonConverter",

--- a/test/rest_request_template/test_schema_evolution_w_random_row_count.json
+++ b/test/rest_request_template/test_schema_evolution_w_random_row_count.json
@@ -15,6 +15,7 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
+    "snowflake.streaming.enable.single.buffer": "$SNOWFLAKE_STREAMING_ENABLE_SINGLE_BUFFER",
     "snowflake.streaming.closeChannelsInParallel.enabled": true,
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",
     "value.converter": "org.apache.kafka.connect.json.JsonConverter",

--- a/test/rest_request_template/test_snowpipe_streaming_channel_migration_disabled.json
+++ b/test/rest_request_template/test_snowpipe_streaming_channel_migration_disabled.json
@@ -14,6 +14,7 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
+    "snowflake.streaming.enable.single.buffer": "$SNOWFLAKE_STREAMING_ENABLE_SINGLE_BUFFER",
     "snowflake.streaming.closeChannelsInParallel.enabled": true,
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",
     "value.converter": "org.apache.kafka.connect.json.JsonConverter",

--- a/test/rest_request_template/test_snowpipe_streaming_string_json_ignore_tombstone.json
+++ b/test/rest_request_template/test_snowpipe_streaming_string_json_ignore_tombstone.json
@@ -14,6 +14,7 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
+    "snowflake.streaming.enable.single.buffer": "$SNOWFLAKE_STREAMING_ENABLE_SINGLE_BUFFER",
     "snowflake.streaming.closeChannelsInParallel.enabled": true,
     "snowflake.enable.schematization": "false",
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",

--- a/test/rest_request_template/test_streaming_client_parameter_override.json
+++ b/test/rest_request_template/test_streaming_client_parameter_override.json
@@ -14,6 +14,7 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
+    "snowflake.streaming.enable.single.buffer": "$SNOWFLAKE_STREAMING_ENABLE_SINGLE_BUFFER",
     "snowflake.streaming.closeChannelsInParallel.enabled": true,
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",
     "value.converter": "org.apache.kafka.connect.json.JsonConverter",

--- a/test/rest_request_template/travis_correct_auto_table_creation.json
+++ b/test/rest_request_template/travis_correct_auto_table_creation.json
@@ -14,6 +14,7 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
+    "snowflake.streaming.enable.single.buffer": "$SNOWFLAKE_STREAMING_ENABLE_SINGLE_BUFFER",
     "snowflake.streaming.closeChannelsInParallel.enabled": true,
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",
     "value.converter": "io.confluent.connect.avro.AvroConverter",

--- a/test/rest_request_template/travis_correct_auto_table_creation_topic2table.json
+++ b/test/rest_request_template/travis_correct_auto_table_creation_topic2table.json
@@ -15,6 +15,7 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
+    "snowflake.streaming.enable.single.buffer": "$SNOWFLAKE_STREAMING_ENABLE_SINGLE_BUFFER",
     "snowflake.streaming.closeChannelsInParallel.enabled": true,
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",
     "value.converter": "io.confluent.connect.avro.AvroConverter",

--- a/test/rest_request_template/travis_correct_multiple_topic_to_one_table_snowpipe_streaming.json
+++ b/test/rest_request_template/travis_correct_multiple_topic_to_one_table_snowpipe_streaming.json
@@ -15,6 +15,7 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
+    "snowflake.streaming.enable.single.buffer": "$SNOWFLAKE_STREAMING_ENABLE_SINGLE_BUFFER",
     "snowflake.streaming.closeChannelsInParallel.enabled": true,
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",
     "value.converter": "org.apache.kafka.connect.json.JsonConverter",

--- a/test/rest_request_template/travis_correct_schema_evolution_avro_sr.json
+++ b/test/rest_request_template/travis_correct_schema_evolution_avro_sr.json
@@ -15,6 +15,7 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
+    "snowflake.streaming.enable.single.buffer": "$SNOWFLAKE_STREAMING_ENABLE_SINGLE_BUFFER",
     "snowflake.streaming.closeChannelsInParallel.enabled": true,
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",
     "value.converter":"io.confluent.connect.avro.AvroConverter",

--- a/test/rest_request_template/travis_correct_schema_evolution_avro_sr_logical_types.json
+++ b/test/rest_request_template/travis_correct_schema_evolution_avro_sr_logical_types.json
@@ -15,6 +15,7 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
+    "snowflake.streaming.enable.single.buffer": "$SNOWFLAKE_STREAMING_ENABLE_SINGLE_BUFFER",
     "snowflake.streaming.closeChannelsInParallel.enabled": true,
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",
     "value.converter":"io.confluent.connect.avro.AvroConverter",

--- a/test/rest_request_template/travis_correct_schema_evolution_drop_table.json
+++ b/test/rest_request_template/travis_correct_schema_evolution_drop_table.json
@@ -15,6 +15,7 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
+    "snowflake.streaming.enable.single.buffer": "$SNOWFLAKE_STREAMING_ENABLE_SINGLE_BUFFER",
     "snowflake.streaming.closeChannelsInParallel.enabled": true,
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",
     "value.converter": "org.apache.kafka.connect.json.JsonConverter",

--- a/test/rest_request_template/travis_correct_schema_evolution_drop_table.json
+++ b/test/rest_request_template/travis_correct_schema_evolution_drop_table.json
@@ -15,7 +15,7 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
-    "snowflake.streaming.enable.single.buffer": "$SNOWFLAKE_STREAMING_ENABLE_SINGLE_BUFFER",
+    "snowflake.streaming.enable.single.buffer": "false",
     "snowflake.streaming.closeChannelsInParallel.enabled": true,
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",
     "value.converter": "org.apache.kafka.connect.json.JsonConverter",

--- a/test/rest_request_template/travis_correct_schema_evolution_json.json
+++ b/test/rest_request_template/travis_correct_schema_evolution_json.json
@@ -15,6 +15,7 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
+    "snowflake.streaming.enable.single.buffer": "$SNOWFLAKE_STREAMING_ENABLE_SINGLE_BUFFER",
     "snowflake.streaming.closeChannelsInParallel.enabled": true,
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",
     "value.converter": "org.apache.kafka.connect.json.JsonConverter",

--- a/test/rest_request_template/travis_correct_schema_evolution_multi_topic_drop_table.json
+++ b/test/rest_request_template/travis_correct_schema_evolution_multi_topic_drop_table.json
@@ -15,6 +15,7 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
+    "snowflake.streaming.enable.single.buffer": "$SNOWFLAKE_STREAMING_ENABLE_SINGLE_BUFFER",
     "snowflake.streaming.closeChannelsInParallel.enabled": true,
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",
     "value.converter": "org.apache.kafka.connect.json.JsonConverter",

--- a/test/rest_request_template/travis_correct_schema_evolution_multi_topic_drop_table.json
+++ b/test/rest_request_template/travis_correct_schema_evolution_multi_topic_drop_table.json
@@ -15,7 +15,7 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
-    "snowflake.streaming.enable.single.buffer": "$SNOWFLAKE_STREAMING_ENABLE_SINGLE_BUFFER",
+    "snowflake.streaming.enable.single.buffer": "false",
     "snowflake.streaming.closeChannelsInParallel.enabled": true,
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",
     "value.converter": "org.apache.kafka.connect.json.JsonConverter",

--- a/test/rest_request_template/travis_correct_schema_evolution_nonnullable_json.json
+++ b/test/rest_request_template/travis_correct_schema_evolution_nonnullable_json.json
@@ -15,6 +15,7 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
+    "snowflake.streaming.enable.single.buffer": "$SNOWFLAKE_STREAMING_ENABLE_SINGLE_BUFFER",
     "snowflake.streaming.closeChannelsInParallel.enabled": true,
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",
     "value.converter": "org.apache.kafka.connect.json.JsonConverter",

--- a/test/rest_request_template/travis_correct_schema_evolution_w_auto_table_creation_avro_sr.json
+++ b/test/rest_request_template/travis_correct_schema_evolution_w_auto_table_creation_avro_sr.json
@@ -15,6 +15,7 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
+    "snowflake.streaming.enable.single.buffer": "$SNOWFLAKE_STREAMING_ENABLE_SINGLE_BUFFER",
     "snowflake.streaming.closeChannelsInParallel.enabled": true,
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",
     "value.converter":"io.confluent.connect.avro.AvroConverter",

--- a/test/rest_request_template/travis_correct_schema_evolution_w_auto_table_creation_json.json
+++ b/test/rest_request_template/travis_correct_schema_evolution_w_auto_table_creation_json.json
@@ -15,6 +15,7 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
+    "snowflake.streaming.enable.single.buffer": "$SNOWFLAKE_STREAMING_ENABLE_SINGLE_BUFFER",
     "snowflake.streaming.closeChannelsInParallel.enabled": true,
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",
     "value.converter": "org.apache.kafka.connect.json.JsonConverter",

--- a/test/rest_request_template/travis_correct_schema_mapping.json
+++ b/test/rest_request_template/travis_correct_schema_mapping.json
@@ -14,6 +14,7 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
+    "snowflake.streaming.enable.single.buffer": "$SNOWFLAKE_STREAMING_ENABLE_SINGLE_BUFFER",
     "snowflake.streaming.closeChannelsInParallel.enabled": true,
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",
     "value.converter": "org.apache.kafka.connect.json.JsonConverter",

--- a/test/rest_request_template/travis_correct_schema_not_supported_converter.json
+++ b/test/rest_request_template/travis_correct_schema_not_supported_converter.json
@@ -14,6 +14,7 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
+    "snowflake.streaming.enable.single.buffer": "$SNOWFLAKE_STREAMING_ENABLE_SINGLE_BUFFER",
     "snowflake.streaming.closeChannelsInParallel.enabled": true,
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",
     "value.converter": "org.apache.kafka.connect.storage.StringConverter",

--- a/test/rest_request_template/travis_correct_snowpipe_streaming_string_avro_sr.json
+++ b/test/rest_request_template/travis_correct_snowpipe_streaming_string_avro_sr.json
@@ -14,6 +14,7 @@
     "snowflake.schema.name":"SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
+    "snowflake.streaming.enable.single.buffer": "$SNOWFLAKE_STREAMING_ENABLE_SINGLE_BUFFER",
     "snowflake.streaming.closeChannelsInParallel.enabled": true,
     "key.converter":"org.apache.kafka.connect.storage.StringConverter",
     "value.converter":"io.confluent.connect.avro.AvroConverter",

--- a/test/rest_request_template/travis_correct_snowpipe_streaming_string_json.json
+++ b/test/rest_request_template/travis_correct_snowpipe_streaming_string_json.json
@@ -14,6 +14,7 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
+    "snowflake.streaming.enable.single.buffer": "$SNOWFLAKE_STREAMING_ENABLE_SINGLE_BUFFER",
     "snowflake.streaming.closeChannelsInParallel.enabled": true,
     "snowflake.enable.schematization": "false",
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",

--- a/test/run_test_apache.sh
+++ b/test/run_test_apache.sh
@@ -175,7 +175,6 @@ if [ $testError -ne 0 ]; then
     RED='\033[0;31m'
     NC='\033[0m' # No Color
     echo -e "${RED} There is error above this line ${NC}"
-    #    Ignore for e2e test draft. Todo: turn back again?
-    #    cat $APACHE_LOG_PATH/kc.log
+    cat $APACHE_LOG_PATH/kc.log
     error_exit "=== test_verify.py failed ==="
 fi

--- a/test/run_test_apache.sh
+++ b/test/run_test_apache.sh
@@ -175,6 +175,7 @@ if [ $testError -ne 0 ]; then
     RED='\033[0;31m'
     NC='\033[0m' # No Color
     echo -e "${RED} There is error above this line ${NC}"
-    cat $APACHE_LOG_PATH/kc.log
+    #    Ignore for e2e test draft. Todo: turn back again?
+    #    cat $APACHE_LOG_PATH/kc.log
     error_exit "=== test_verify.py failed ==="
 fi

--- a/test/test_suit/test_avro_avro.py
+++ b/test/test_suit/test_avro_avro.py
@@ -33,7 +33,7 @@ class TestAvroAvro:
             "Select * from {} limit 1".format(self.topic)).fetchone()
         goldMeta = r'{"CreateTime":\d*,"key":[{"timestamp":\d*,"tweet":"Rock:Nerfpaper,scissorsisfine.",' \
                    r'"username":"miguno"},{"timestamp":\d*,"tweet":"Worksasintended.TerranisIMBA.",' \
-                   r'"username":"BlizzardCS"}],"offset":0,"partition":0,"topic":"travis_correct_avro_avro....."}'
+                   r'"username":"BlizzardCS"}],"offset":0,"partition":0,"topic":"travis_correct_avro_avro_\w*"}'
         goldContent = r'{"timestamp":\d*,"tweet":"Rock:Nerfpaper,scissorsisfine.","username":"miguno"}'
         self.driver.regexMatchOneLine(res, goldMeta, goldContent)
 

--- a/test/test_suit/test_avrosr_avrosr.py
+++ b/test/test_suit/test_avrosr_avrosr.py
@@ -57,7 +57,7 @@ class TestAvrosrAvrosr:
         res = self.driver.snowflake_conn.cursor().execute(
             "Select * from {} limit 1".format(self.topic)).fetchone()
         goldMeta = r'{"CreateTime":\d*,"key":{"id":0},"key_schema_id":\d*,"offset":0,"partition":0,"schema_id":\d*,' \
-                   r'"topic":"travis_correct_avrosr_avrosr....."}'
+                   r'"topic":"travis_correct_avrosr_avrosr_\w*"}'
         goldContent = r'{"firstName":"abc0","id":0,"time":1835}'
         self.driver.regexMatchOneLine(res, goldMeta, goldContent)
 

--- a/test/test_suit/test_confluent_protobuf_protobuf.py
+++ b/test/test_suit/test_confluent_protobuf_protobuf.py
@@ -65,7 +65,7 @@ class TestConfluentProtobufProtobuf:
                    r'{"deviceID":"555-4321","enabled":true},"double_array_val":' \
                    r'[0.3333333333333333,32.21,4.343243210000000e+08],"float_val":4321.432,' \
                    r'"int32_val":2147483647,"reading":321.321,"sint32_val":2147483647,"sint64_val":9223372036854775807,' \
-                   r'"uint32_val":4294967295,"uint64_val":-1},"offset":\d*,"partition":\d*,"topic":"travis_correct_confluent_protobuf_protobuf....."}'
+                   r'"uint32_val":4294967295,"uint64_val":-1},"offset":\d*,"partition":\d*,"topic":"travis_correct_confluent_protobuf_protobuf_\w*"}'
         goldContent = r'{"bytes_val":"3q0=","dateTime":1234,"device":{"deviceID":"555-4321","enabled":true},"double_array_val":' \
                       r'[0.3333333333333333,32.21,4.343243210000000e+08],"float_val":4321.432,"int32_val":2147483647,' \
                       r'"reading":321.321,"sint32_val":2147483647,"sint64_val":9223372036854775807,"uint32_val":4294967295,"uint64_val":-1}'

--- a/test/test_suit/test_native_complex_smt.py
+++ b/test/test_suit/test_native_complex_smt.py
@@ -30,7 +30,7 @@ class TestNativeComplexSmt:
         res = self.driver.snowflake_conn.cursor().execute(
             "Select * from {} limit 1".format(self.table)).fetchone()
         goldMeta = r'{"CreateTime":\d*,"key":{"int":"\d"},"offset":\d,"partition":\d,' \
-                   r'"topic":"travis_correct_native_complex_smt....."}'
+                   r'"topic":"travis_correct_native_complex_smt_\w*"}'
         goldContent = r'{"c1":{"int":"\d"}}'
         self.driver.regexMatchOneLine(res, goldMeta, goldContent)
 

--- a/test/test_suit/test_native_string_avrosr.py
+++ b/test/test_suit/test_native_string_avrosr.py
@@ -44,7 +44,7 @@ class TestNativeStringAvrosr:
 
         # "schema_id" is lost since they are using native avro converter
         goldMeta = r'{"CreateTime":\d*,"offset":0,"partition":0,' \
-                   r'"topic":"travis_correct_native_string_avrosr....."}'
+                   r'"topic":"travis_correct_native_string_avrosr_\w*"}'
         goldContent = r'{"firstName":"abc0","time":1835}'
         self.driver.regexMatchOneLine(res, goldMeta, goldContent)
 

--- a/test/test_suit/test_native_string_json_without_schema.py
+++ b/test/test_suit/test_native_string_json_without_schema.py
@@ -30,7 +30,7 @@ class TestNativeStringJsonWithoutSchema:
         res = self.driver.snowflake_conn.cursor().execute(
             "Select * from {} limit 1".format(self.topic)).fetchone()
         goldMeta = r'{"CreateTime":\d*,"offset":0,"partition":0,' \
-                   r'"topic":"travis_correct_native_string_json_without_schema....."}'
+                   r'"topic":"travis_correct_native_string_json_without_schema_\w*"}'
         goldContent = r'{"number":"0"}'
         self.driver.regexMatchOneLine(res, goldMeta, goldContent)
 

--- a/test/test_suit/test_native_string_protobuf.py
+++ b/test/test_suit/test_native_string_protobuf.py
@@ -46,7 +46,7 @@ class TestNativeStringProtobuf:
 
         # "schema_id" is lost since they are using native avro converter
         goldMeta = r'{"CreateTime":\d*,"offset":0,"partition":0,' \
-                   r'"topic":"travis_correct_native_string_protobuf....."}'
+                   r'"topic":"travis_correct_native_string_protobuf_\w*"}'
         goldContent = r'{"bytes_val":"3q0=","dateTime":1234,"device":{"deviceID":"555-4321","enabled":true},' \
                       r'"double_array_val":[0.3333333333333333,32.21,4.343243210000000e+08],' \
                       r'"float_val":4321.432,"int32_val":2147483647,"reading":321.321,"sint32_val":2147483647,' \

--- a/test/test_suit/test_string_avro.py
+++ b/test/test_suit/test_string_avro.py
@@ -30,7 +30,7 @@ class TestStringAvro:
         res = self.driver.snowflake_conn.cursor().execute(
             "Select * from {} limit 1".format(self.topic)).fetchone()
         goldMeta = r'{"CreateTime":\d*,"offset":0,"partition":0,' \
-                   r'"topic":"travis_correct_string_avro....."}'
+                   r'"topic":"travis_correct_string_avro_\w*"}'
         goldContent = r'{"timestamp":\d*,"tweet":"Rock:Nerfpaper,scissorsisfine.","username":"miguno"}'
         self.driver.regexMatchOneLine(res, goldMeta, goldContent)
 

--- a/test/test_suit/test_string_avrosr.py
+++ b/test/test_suit/test_string_avrosr.py
@@ -42,7 +42,7 @@ class TestStringAvrosr:
         res = self.driver.snowflake_conn.cursor().execute(
             "Select * from {} limit 1".format(self.topic)).fetchone()
         goldMeta = r'{"CreateTime":\d*,"offset":0,"partition":0,"schema_id":\d*,' \
-                   r'"topic":"travis_correct_string_avrosr....."}'
+                   r'"topic":"travis_correct_string_avrosr_\w*"}'
         goldContent = r'{"firstName":"abc0","id":0,"time":1835}'
         self.driver.regexMatchOneLine(res, goldMeta, goldContent)
 

--- a/test/test_suit/test_string_json.py
+++ b/test/test_suit/test_string_json.py
@@ -43,9 +43,9 @@ class TestStringJson:
         # validate content of line 1
         oldVersions = ["5.4.0", "5.3.0", "5.2.0", "2.4.0", "2.3.0", "2.2.0"]
         if self.driver.testVersion in oldVersions:
-            goldMeta = r'{"CreateTime":\d*,"headers":{"header1":"value1","header2":{}},"offset":0,"partition":0,"topic":"travis_correct_string_json....."}'
+            goldMeta = r'{"CreateTime":\d*,"headers":{"header1":"value1","header2":{}},"offset":0,"partition":0,"topic":"travis_correct_string_json_\w*"}'
         else:
-            goldMeta = r'{"CreateTime":\d*,"headers":{"header1":"value1","header2":[]},"offset":0,"partition":0,"topic":"travis_correct_string_json....."}'
+            goldMeta = r'{"CreateTime":\d*,"headers":{"header1":"value1","header2":[]},"offset":0,"partition":0,"topic":"travis_correct_string_json_\w*"}'
 
         res = self.driver.snowflake_conn.cursor().execute(
             "Select * from {} limit 1".format(self.topic)).fetchone()

--- a/test/test_suit/test_string_json_ignore_tombstone.py
+++ b/test/test_suit/test_string_json_ignore_tombstone.py
@@ -41,9 +41,9 @@ class TestStringJsonIgnoreTombstone:
         # validate content of line 1
         oldVersions = ["5.4.0", "5.3.0", "5.2.0", "2.4.0", "2.3.0", "2.2.0"]
         if self.driver.testVersion in oldVersions:
-            goldMeta = r'{"CreateTime":\d*,"headers":{"header1":"value1","header2":{}},"offset":0,"partition":0,"topic":"test_string_json_ignore_tombstone....."}'
+            goldMeta = r'{"CreateTime":\d*,"headers":{"header1":"value1","header2":{}},"offset":0,"partition":0,"topic":"test_string_json_ignore_tombstone_\w*"}'
         else:
-            goldMeta = r'{"CreateTime":\d*,"headers":{"header1":"value1","header2":[]},"offset":0,"partition":0,"topic":"test_string_json_ignore_tombstone....."}'
+            goldMeta = r'{"CreateTime":\d*,"headers":{"header1":"value1","header2":[]},"offset":0,"partition":0,"topic":"test_string_json_ignore_tombstone_\w*"}'
 
         res = self.driver.snowflake_conn.cursor().execute(
             "Select * from {} limit 1".format(self.topic)).fetchone()

--- a/test/test_suit/test_string_json_proxy.py
+++ b/test/test_suit/test_string_json_proxy.py
@@ -29,9 +29,9 @@ class TestStringJsonProxy:
         # validate content of line 1
         oldVersions = ["5.4.0", "5.3.0", "5.2.0", "2.4.0", "2.3.0", "2.2.0"]
         if self.driver.testVersion in oldVersions:
-            goldMeta = r'{"CreateTime":\d*,"headers":{"header1":"value1","header2":{}},"offset":0,"partition":0,"topic":"travis_correct_string_proxy....."}'
+            goldMeta = r'{"CreateTime":\d*,"headers":{"header1":"value1","header2":{}},"offset":0,"partition":0,"topic":"travis_correct_string_proxy_\w*"}'
         else:
-            goldMeta = r'{"CreateTime":\d*,"headers":{"header1":"value1","header2":[]},"offset":0,"partition":0,"topic":"travis_correct_string_proxy....."}'
+            goldMeta = r'{"CreateTime":\d*,"headers":{"header1":"value1","header2":[]},"offset":0,"partition":0,"topic":"travis_correct_string_proxy_\w*"}'
 
         res = self.driver.snowflake_conn.cursor().execute(
             "Select * from {} limit 1".format(self.topic)).fetchone()

--- a/test/test_suit/test_string_json_proxy.py
+++ b/test/test_suit/test_string_json_proxy.py
@@ -44,12 +44,20 @@ class TestStringJsonProxy:
         self.driver.cleanTableStagePipe(self.topic)
         # unset the JVM parameters
         print("Unset JVM Parameters in Clean phase of testing")
-        path_parent = os.path.dirname(os.getcwd())
-        print("Current Directory:{0}".format(path_parent))
+
+        current_dir = os.getcwd()
+        print(f"Current Directory:{current_dir}")
+
+        path_parent = os.path.dirname(current_dir)
+
+        print(f"Changing working directory to:{path_parent}")
         os.chdir(path_parent)
-        print("One directory Up:{0}".format(os.getcwd()))
+
         mvnExecMain = "mvn exec:java -Dexec.mainClass=\"com.snowflake.kafka.connector.internal.ResetProxyConfigExec\""
         print(self.run_cmd(mvnExecMain))
+
+        print(f"Changing working directory back to:{current_dir}")
+        os.chdir(current_dir)
 
     def run_cmd(self, command):
         import subprocess

--- a/test/test_verify.py
+++ b/test/test_verify.py
@@ -29,11 +29,11 @@ class ConnectorParametersList:
     def __init__(self, connectorParametersList: list[ConnectorParameters]):
         self.connectorParametersList = connectorParametersList
 
-    def for_each(self, function: Callable[[ConnectorParameters], None]) -> None:
-        for conenctor_parameters in self.connectorParametersList:
-            print(datetime.now().strftime("%H:%M:%S "), f'=== Using parameters: {conenctor_parameters} ===')
+    def for_each(self, function: Callable[[int, ConnectorParameters], None]) -> None:
+        for idx, conenctor_parameters in enumerate(self.connectorParametersList):
+            print(datetime.now().strftime("%H:%M:%S "), f'=== Using parameters. {idx}: {conenctor_parameters} ===')
 
-            function(conenctor_parameters)
+            function(idx, conenctor_parameters)
 
 
 def errorExit(message):
@@ -294,9 +294,6 @@ class KafkaTest:
             pipeName = "SNOWFLAKE_KAFKA_CONNECTOR_{}_PIPE_{}_{}".format(connectorName, topicName, p)
             print(datetime.now().strftime("%H:%M:%S "), "=== Drop pipe {} ===".format(pipeName))
             self.snowflake_conn.cursor().execute("DROP pipe IF EXISTS {}".format(pipeName))
-
-        print(datetime.now().strftime("%H:%M:%S "), f"=== Delete Kafka topic {topicName} ===")
-        self.deleteTopic(topicName)
 
         print(datetime.now().strftime("%H:%M:%S "), "=== Done ===", flush=True)
 
@@ -593,10 +590,6 @@ def execution(testSet, testSuitList, testCleanEnableList, testSuitEnableList, dr
 
 
 def run_test_set_with_parameters(kafka_test: KafkaTest, testSet, nameSalt, pressure, skipProxy, allowedTestsCsv):
-    if testSet != 'clean':
-        # Running clean before a test set.
-        runTestSet(kafka_test, 'clean', nameSalt, pressure, skipProxy, allowedTestsCsv)
-
     runTestSet(kafka_test, testSet, nameSalt, pressure, skipProxy, allowedTestsCsv)
 
 
@@ -645,7 +638,7 @@ if __name__ == "__main__":
     ])
 
     parametersList.for_each(
-        lambda parameters: run_test_set_with_parameters(
+        lambda idx, parameters: runTestSet(
             KafkaTest(kafkaAddress,
                       schemaRegistryAddress,
                       kafkaConnectAddress,
@@ -656,7 +649,7 @@ if __name__ == "__main__":
                       snowflakeCloudPlatform,
                       False),
             testSet,
-            nameSalt,
+            nameSalt + str(idx),
             pressure,
             skipProxy,
             allowedTestsCsv)

--- a/test/test_verify.py
+++ b/test/test_verify.py
@@ -31,7 +31,7 @@ class ConnectorParametersList:
 
     def for_each(self, function: Callable[[int, ConnectorParameters], None]) -> None:
         for idx, conenctor_parameters in enumerate(self.connectorParametersList):
-            print(datetime.now().strftime("%H:%M:%S "), f'=== Using parameters. {idx}: {conenctor_parameters} ===')
+            print(datetime.now().strftime("%H:%M:%S "), f'=== Using parameters {idx}: {conenctor_parameters} ===')
 
             function(idx, conenctor_parameters)
 

--- a/test/test_verify.py
+++ b/test/test_verify.py
@@ -29,11 +29,11 @@ class ConnectorParametersList:
     def __init__(self, connectorParametersList: list[ConnectorParameters]):
         self.connectorParametersList = connectorParametersList
 
-    def for_each(self, function: Callable[[int, ConnectorParameters], None]) -> None:
-        for idx, conenctor_parameters in enumerate(self.connectorParametersList):
-            print(datetime.now().strftime("%H:%M:%S "), f'=== Using parameters {idx}: {conenctor_parameters} ===')
+    def for_each(self, func: Callable[[int, ConnectorParameters], None]) -> None:
+        for idx, connector_parameters in enumerate(self.connectorParametersList):
+            print(datetime.now().strftime("%H:%M:%S "), f'=== Using parameters {idx}: {connector_parameters} ===')
 
-            function(idx, conenctor_parameters)
+            func(idx, connector_parameters)
 
 
 def errorExit(message):
@@ -380,7 +380,7 @@ class KafkaTest:
             pkEncrypted = credentialJson["encrypted_private_key"]
 
         print(datetime.now().strftime("\n%H:%M:%S "),
-              "=== generate sink connector rest reqeuest from {} ===".format(rest_template_path))
+              "=== generate sink connector rest request from {} ===".format(rest_template_path))
         if not os.path.exists(rest_generate_path):
             os.makedirs(rest_generate_path)
         snowflake_connector_name = fileName.split(".")[0] + nameSalt

--- a/test/test_verify.py
+++ b/test/test_verify.py
@@ -3,8 +3,10 @@ import os
 import re
 import sys
 import traceback
+from dataclasses import dataclass
 from datetime import datetime
 from time import sleep
+from typing import Callable
 
 import requests, uuid
 import snowflake.connector
@@ -18,14 +20,32 @@ import test_suit
 from test_suit.test_utils import parsePrivateKey, RetryableError
 
 
+@dataclass
+class ConnectorParameters:
+    snowflake_streaming_enable_single_buffer: str
+
+
+class ConnectorParametersList:
+    def __init__(self, connectorParametersList: list[ConnectorParameters]):
+        self.connectorParametersList = connectorParametersList
+
+    def for_each(self, function: Callable[[ConnectorParameters], None]) -> None:
+        # This should be improved when number of parameter grows.
+        for conenctor_parameters in self.connectorParametersList:
+            print(datetime.now().strftime("%H:%M:%S "), '=== Running tests with parameters ===')
+            print('===', conenctor_parameters, '===')
+
+            function(conenctor_parameters)
+
+
 def errorExit(message):
     print(datetime.now().strftime("%H:%M:%S "), message)
     exit(1)
 
 
 class KafkaTest:
-    def __init__(self, kafkaAddress, schemaRegistryAddress, kafkaConnectAddress, credentialPath, testVersion, enableSSL,
-                 snowflakeCloudPlatform, enableDeliveryGuaranteeTests=False):
+    def __init__(self, kafkaAddress, schemaRegistryAddress, kafkaConnectAddress, credentialPath, connectorParameters: ConnectorParameters,
+                 testVersion, enableSSL, snowflakeCloudPlatform, enableDeliveryGuaranteeTests=False):
         self.testVersion = testVersion
         self.credentialPath = credentialPath
         # can be None or one of AWS, AZURE, GCS
@@ -94,6 +114,8 @@ class KafkaTest:
             database=testDatabase,
             schema=testSchema
         )
+
+        self.connectorParameters = connectorParameters
 
     def msgSendInterval(self):
         # sleep self.SEND_INTERVAL before send the second message
@@ -383,7 +405,8 @@ class KafkaTest:
                 .replace("CONFLUENT_SCHEMA_REGISTRY", self.schemaRegistryAddress) \
                 .replace("SNOWFLAKE_TEST_TOPIC", snowflake_topic_name) \
                 .replace("SNOWFLAKE_CONNECTOR_NAME", snowflake_connector_name) \
-                .replace("SNOWFLAKE_ROLE", testRole)
+                .replace("SNOWFLAKE_ROLE", testRole) \
+                .replace("$SNOWFLAKE_STREAMING_ENABLE_SINGLE_BUFFER", self.connectorParameters.snowflake_streaming_enable_single_buffer)
             with open("{}/{}".format(rest_generate_path, fileName), 'w') as fw:
                 fw.write(fileContent)
 
@@ -561,11 +584,26 @@ def execution(testSet, testSuitList, testCleanEnableList, testSuitEnableList, dr
                               flush=True)
 
             print(datetime.now().strftime("\n%H:%M:%S "), "=== All test passed ===")
+            print(driver.connectorParameters)
         except Exception as e:
             print(datetime.now().strftime("%H:%M:%S "), e)
             traceback.print_tb(e.__traceback__)
-            print(datetime.now().strftime("%H:%M:%S "), "Error: ", sys.exc_info()[0])
+            print(datetime.now().strftime("%H:%M:%S "), "Error: ", sys.exc_info()[0], driver.connectorParameters)
             exit(1)
+
+
+def run_test_set_with_parameters(connectorParameters, testSet, nameSalt, pressure, skipProxy, allowedTestsCsv):
+    kafka_test = KafkaTest(kafkaAddress,
+                          schemaRegistryAddress,
+                          kafkaConnectAddress,
+                          credentialPath,
+                          connectorParameters,
+                          testVersion,
+                          enableSSL,
+                          snowflakeCloudPlatform,
+                          False)
+
+    runTestSet(kafka_test, testSet, nameSalt, pressure, skipProxy, allowedTestsCsv)
 
 
 if __name__ == "__main__":
@@ -607,13 +645,11 @@ if __name__ == "__main__":
     if "ENABLE_DELIVERY_GUARANTEE_TESTS" in os.environ:
         enableDeliveryGuaranteeTests = (os.environ['ENABLE_DELIVERY_GUARANTEE_TESTS'] == 'True')
 
-    kafkaTest = KafkaTest(kafkaAddress,
-                          schemaRegistryAddress,
-                          kafkaConnectAddress,
-                          credentialPath,
-                          testVersion,
-                          enableSSL,
-                          snowflakeCloudPlatform,
-                          False)
+    parametersList = ConnectorParametersList([
+        ConnectorParameters(snowflake_streaming_enable_single_buffer='false'),
+        ConnectorParameters(snowflake_streaming_enable_single_buffer='true'),
+    ])
 
-    runTestSet(kafkaTest, testSet, nameSalt, pressure, skipProxy, allowedTestsCsv)
+    parametersList.for_each(
+        lambda parameters: run_test_set_with_parameters(parameters, testSet, nameSalt, pressure, skipProxy, allowedTestsCsv)
+    )


### PR DESCRIPTION
<!-- Text inside of HTML comment blocks will NOT appear in your pull request description -->
<!-- Formatting information can be found at https://www.markdownguide.org/basic-syntax/ -->
# Overview

SNOW-1061854

Running e2e tests with single and double buffers. In every snowpipe_streaming test we'll need to specify `$SNOWFLAKE_STREAMING_ENABLE_SINGLE_BUFFER` property that's later substituted with `true` and `false` values. To achieve isolation between different parameter sets, a parameter set index is added to test salt.

I wouldn't use github test matrix, as this solution seems to be temporary and removed shortly.

**Note that currently the tests are run sequentially that will take about 2x time!** File generation logic needs to be rewritten to allow running a test suite with different parameters in parallel.

All related changes are in [test_verfiy.py](https://github.com/snowflakedb/snowflake-kafka-connector/pull/867/files#diff-0eb8c275e2e077d9fe6b7d9a9e45cd7887d93c752cb0013ccf646fb41e90de59). 
Also removed a check for enabled `SNOWPIPE_STREAMING_ENABLE_SINGLE_BUFFER` in [Utils.java](https://github.com/snowflakedb/snowflake-kafka-connector/pull/867/files#diff-371eabc61cd3788bddba04e3204eaa5ad54d315769e30def9b88095307e5a4b1).
The rest are json request and test verification adjustments.

A few e2e tests don't pass with a single buffer. See SNOW-1061855 and SNOW-1475664 for the details.

<!--
Why is this review being requested?  The full details should be in the JIRA, but the review should focus on the fix/change being implemented.
If there are multiple steps in the Jira, which step is this?
-->

## Pre-review checklist
- [ ] This change should be part of a Behavior Change Release. See [go/behavior-change](http://go/behavior-change).
- [ ] This change has passed Merge gate tests
- [ ] Snowpipe Changes
- [x] Snowpipe Streaming Changes
- [ ] This change is TEST-ONLY
- [ ] This change is README/Javadocs only
- [ ] This change is protected by a config parameter <PARAMETER_NAME> eg `snowflake.ingestion.method`.
    - [ ] `Yes` - Added end to end and Unit Tests. 
    - [ ] `No` - Suggest why it is not param protected
- [ ] Is his change protected by parameter <PARAMETER_NAME> on the server side?
    - [ ] The parameter/feature is not yet active in production (partial rollout or PrPr, see [Changes for Unreleased Features and Fixes](http://go/ppp-prpr)).
    - [ ] If there is an issue, it can be safely mitigated by turning the parameter off. This is also verified by a test (See [go/ppp](http://go/ppp)).


<!--
## Urgency
This review is *normal* priority
This review is **high** priority
This review is ***URGENT*** priority
-->

<!--
Indicate any urgency for performing the review.  Perhaps it is a fix for a prod issue or is blocking a customer.
-->

<!--
## Risks
What are the risks associated to your change?
-->

<!--
## Backward and forward Compatible
Imagine customer upgrading to new version and rolling back to older version. Will there be any concerns?
[ ] Backward compatible
[ ] Forward compatible
-->

<!--
Suggested reading order:   Provide an order in which to read files, classes, and methods.  Without this your reader will spend lots of time reading code without understanding the context (imagine the top file references a new class in methods of a file below it).  You need to tell your reviewers how to learn your code.
-->

<!--
## Reviewer roles
Every reviewer must be told their role and what actions are expected of them.  Tell every reviewer what will happen if they don't complete the review.  If you aren't sure who the secondary owner is then work with a manager and/or tech lead to figure this out.
If there are specific items or subsets of the change that you want a particular reviewer to focus on, mention it here.  You can @-mention people using their github username
-->

<!--
Reviewers:  Every review must have at least two reviewers for bug fixes, GA'ed component. One reviewer is enough for test only, doc changes.
Example:
- Minimum # of Required Reviewers - **Two** for Improvements and Bugfixes - <@github alias> 
- Educational purposes - <@github alias>
- Manager/TL approval (If patch critical and requires a release) - <@github alias>
-->

