### PR TITLE
SNOW-1514185: Do assign the reopened channel unless kafka offsets are fully reset

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/BufferedTopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/BufferedTopicPartitionChannel.java
@@ -861,7 +861,8 @@ public class BufferedTopicPartitionChannel implements TopicPartitionChannel {
         this.getChannelNameFormatV1());
     long offsetRecoveredFromSnowflake = fetchLatestOffsetFromChannel(newChannel);
 
-    resetChannelMetadataAfterRecovery(streamingApiFallbackInvoker, offsetRecoveredFromSnowflake, newChannel);
+    resetChannelMetadataAfterRecovery(
+        streamingApiFallbackInvoker, offsetRecoveredFromSnowflake, newChannel);
 
     return offsetRecoveredFromSnowflake;
   }
@@ -874,15 +875,16 @@ public class BufferedTopicPartitionChannel implements TopicPartitionChannel {
    * <p>Idea behind resetting offset (1 more than what we found in snowflake) is that Kafka should
    * send offsets from this offset number so as to not miss any data.
    *
-   * @param streamingApiFallbackInvoker  Streaming API which is using this fallback function. Used
-   *                                     for logging mainly.
+   * @param streamingApiFallbackInvoker Streaming API which is using this fallback function. Used
+   *     for logging mainly.
    * @param offsetRecoveredFromSnowflake offset number found in snowflake for this
-   *                                     channel(partition)
-   * @param newChannel                   a channel to assign to the current instance
+   *     channel(partition)
+   * @param newChannel a channel to assign to the current instance
    */
   private void resetChannelMetadataAfterRecovery(
-          final StreamingApiFallbackInvoker streamingApiFallbackInvoker,
-          final long offsetRecoveredFromSnowflake, SnowflakeStreamingIngestChannel newChannel) {
+      final StreamingApiFallbackInvoker streamingApiFallbackInvoker,
+      final long offsetRecoveredFromSnowflake,
+      SnowflakeStreamingIngestChannel newChannel) {
     if (offsetRecoveredFromSnowflake == NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE) {
       LOGGER.info(
           "{} Channel:{}, offset token is NULL, will use the consumer offset managed by the"

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/BufferedTopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/BufferedTopicPartitionChannel.java
@@ -54,7 +54,6 @@ import net.snowflake.ingest.streaming.InsertValidationResponse;
 import net.snowflake.ingest.streaming.OpenChannelRequest;
 import net.snowflake.ingest.streaming.SnowflakeStreamingIngestChannel;
 import net.snowflake.ingest.streaming.SnowflakeStreamingIngestClient;
-import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.Pair;
 import net.snowflake.ingest.utils.SFException;
 import org.apache.kafka.common.TopicPartition;
@@ -857,12 +856,13 @@ public class BufferedTopicPartitionChannel implements TopicPartitionChannel {
     SnowflakeStreamingIngestChannel newChannel = reopenChannel(streamingApiFallbackInvoker);
 
     LOGGER.warn(
-            "{} Fetching offsetToken after re-opening the channel:{}",
-            streamingApiFallbackInvoker,
-            this.getChannelNameFormatV1());
+        "{} Fetching offsetToken after re-opening the channel:{}",
+        streamingApiFallbackInvoker,
+        this.getChannelNameFormatV1());
     long offsetRecoveredFromSnowflake = fetchLatestOffsetFromChannel(newChannel);
 
-    resetChannelMetadataAfterRecovery(streamingApiFallbackInvoker, offsetRecoveredFromSnowflake);;
+    resetChannelMetadataAfterRecovery(streamingApiFallbackInvoker, offsetRecoveredFromSnowflake);
+    ;
 
     this.channel = newChannel;
     return offsetRecoveredFromSnowflake;
@@ -977,8 +977,8 @@ public class BufferedTopicPartitionChannel implements TopicPartitionChannel {
           this.getChannelNameFormatV1(),
           offsetToken);
       return offsetToken == null
-              ? NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE
-              : Long.parseLong(offsetToken);
+          ? NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE
+          : Long.parseLong(offsetToken);
     } catch (NumberFormatException ex) {
       LOGGER.error(
           "The offsetToken string does not contain a parsable long:{} for channel:{}",

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/BufferedTopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/BufferedTopicPartitionChannel.java
@@ -54,6 +54,7 @@ import net.snowflake.ingest.streaming.InsertValidationResponse;
 import net.snowflake.ingest.streaming.OpenChannelRequest;
 import net.snowflake.ingest.streaming.SnowflakeStreamingIngestChannel;
 import net.snowflake.ingest.streaming.SnowflakeStreamingIngestClient;
+import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.Pair;
 import net.snowflake.ingest.utils.SFException;
 import org.apache.kafka.common.TopicPartition;
@@ -853,9 +854,17 @@ public class BufferedTopicPartitionChannel implements TopicPartitionChannel {
    */
   private long streamingApiFallbackSupplier(
       final StreamingApiFallbackInvoker streamingApiFallbackInvoker) {
-    final long offsetRecoveredFromSnowflake =
-        getRecoveredOffsetFromSnowflake(streamingApiFallbackInvoker);
-    resetChannelMetadataAfterRecovery(streamingApiFallbackInvoker, offsetRecoveredFromSnowflake);
+    SnowflakeStreamingIngestChannel newChannel = reopenChannel(streamingApiFallbackInvoker);
+
+    LOGGER.warn(
+            "{} Fetching offsetToken after re-opening the channel:{}",
+            streamingApiFallbackInvoker,
+            this.getChannelNameFormatV1());
+    long offsetRecoveredFromSnowflake = fetchLatestOffsetFromChannel(newChannel);
+
+    resetChannelMetadataAfterRecovery(streamingApiFallbackInvoker, offsetRecoveredFromSnowflake);;
+
+    this.channel = newChannel;
     return offsetRecoveredFromSnowflake;
   }
 
@@ -935,16 +944,11 @@ public class BufferedTopicPartitionChannel implements TopicPartitionChannel {
    * @param streamingApiFallbackInvoker Streaming API which invoked this function.
    * @return offset which was last present in Snowflake
    */
-  private long getRecoveredOffsetFromSnowflake(
+  private SnowflakeStreamingIngestChannel reopenChannel(
       final StreamingApiFallbackInvoker streamingApiFallbackInvoker) {
     LOGGER.warn(
         "{} Re-opening channel:{}", streamingApiFallbackInvoker, this.getChannelNameFormatV1());
-    this.channel = Preconditions.checkNotNull(openChannelForTable());
-    LOGGER.warn(
-        "{} Fetching offsetToken after re-opening the channel:{}",
-        streamingApiFallbackInvoker,
-        this.getChannelNameFormatV1());
-    return fetchLatestCommittedOffsetFromSnowflake();
+    return Preconditions.checkNotNull(openChannelForTable());
   }
 
   /**
@@ -958,18 +962,23 @@ public class BufferedTopicPartitionChannel implements TopicPartitionChannel {
    *     snowflake.
    */
   private long fetchLatestCommittedOffsetFromSnowflake() {
+    SnowflakeStreamingIngestChannel channelToGetOffset = this.channel;
+    return fetchLatestOffsetFromChannel(channelToGetOffset);
+  }
+
+  private long fetchLatestOffsetFromChannel(SnowflakeStreamingIngestChannel channelToGetOffset) {
     LOGGER.debug(
         "Fetching last committed offset for partition channel:{}", this.getChannelNameFormatV1());
     String offsetToken = null;
     try {
-      offsetToken = this.channel.getLatestCommittedOffsetToken();
+      offsetToken = channelToGetOffset.getLatestCommittedOffsetToken();
       LOGGER.info(
           "Fetched offsetToken for channelName:{}, offset:{}",
           this.getChannelNameFormatV1(),
           offsetToken);
       return offsetToken == null
-          ? NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE
-          : Long.parseLong(offsetToken);
+              ? NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE
+              : Long.parseLong(offsetToken);
     } catch (NumberFormatException ex) {
       LOGGER.error(
           "The offsetToken string does not contain a parsable long:{} for channel:{}",

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/DirectTopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/DirectTopicPartitionChannel.java
@@ -648,7 +648,8 @@ public class DirectTopicPartitionChannel implements TopicPartitionChannel {
         this.getChannelNameFormatV1());
     long offsetRecoveredFromSnowflake = fetchLatestOffsetFromChannel(newChannel);
 
-    resetChannelMetadataAfterRecovery(streamingApiFallbackInvoker, offsetRecoveredFromSnowflake, newChannel);
+    resetChannelMetadataAfterRecovery(
+        streamingApiFallbackInvoker, offsetRecoveredFromSnowflake, newChannel);
 
     return offsetRecoveredFromSnowflake;
   }
@@ -661,15 +662,16 @@ public class DirectTopicPartitionChannel implements TopicPartitionChannel {
    * <p>Idea behind resetting offset (1 more than what we found in snowflake) is that Kafka should
    * send offsets from this offset number so as to not miss any data.
    *
-   * @param streamingApiFallbackInvoker  Streaming API which is using this fallback function. Used
-   *                                     for logging mainly.
+   * @param streamingApiFallbackInvoker Streaming API which is using this fallback function. Used
+   *     for logging mainly.
    * @param offsetRecoveredFromSnowflake offset number found in snowflake for this
-   *                                     channel(partition)
-   * @param newChannel                   a channel to assign to the current instance
+   *     channel(partition)
+   * @param newChannel a channel to assign to the current instance
    */
   private void resetChannelMetadataAfterRecovery(
-          final StreamingApiFallbackInvoker streamingApiFallbackInvoker,
-          final long offsetRecoveredFromSnowflake, SnowflakeStreamingIngestChannel newChannel) {
+      final StreamingApiFallbackInvoker streamingApiFallbackInvoker,
+      final long offsetRecoveredFromSnowflake,
+      SnowflakeStreamingIngestChannel newChannel) {
     if (offsetRecoveredFromSnowflake == NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE) {
       LOGGER.info(
           "{} Channel:{}, offset token is NULL",

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/DirectTopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/DirectTopicPartitionChannel.java
@@ -643,9 +643,9 @@ public class DirectTopicPartitionChannel implements TopicPartitionChannel {
     SnowflakeStreamingIngestChannel newChannel = reopenChannel(streamingApiFallbackInvoker);
 
     LOGGER.warn(
-            "{} Fetching offsetToken after re-opening the channel:{}",
-            streamingApiFallbackInvoker,
-            this.getChannelNameFormatV1());
+        "{} Fetching offsetToken after re-opening the channel:{}",
+        streamingApiFallbackInvoker,
+        this.getChannelNameFormatV1());
     long offsetRecoveredFromSnowflake = fetchLatestOffsetFromChannel(newChannel);
 
     resetChannelMetadataAfterRecovery(streamingApiFallbackInvoker, offsetRecoveredFromSnowflake);
@@ -737,7 +737,7 @@ public class DirectTopicPartitionChannel implements TopicPartitionChannel {
   private long fetchLatestCommittedOffsetFromSnowflake() {
     LOGGER.debug(
         "Fetching last committed offset for partition channel:{}", this.getChannelNameFormatV1());
-      SnowflakeStreamingIngestChannel channelToGetOffset = this.channel;
+    SnowflakeStreamingIngestChannel channelToGetOffset = this.channel;
     return fetchLatestOffsetFromChannel(channelToGetOffset);
   }
 
@@ -750,8 +750,8 @@ public class DirectTopicPartitionChannel implements TopicPartitionChannel {
           this.getChannelNameFormatV1(),
           offsetToken);
       return offsetToken == null
-              ? NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE
-              : Long.parseLong(offsetToken);
+          ? NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE
+          : Long.parseLong(offsetToken);
     } catch (NumberFormatException ex) {
       LOGGER.error(
           "The offsetToken string does not contain a parsable long:{} for channel:{}",

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelTest.java
@@ -11,6 +11,8 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyIterable;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 
@@ -1244,5 +1246,68 @@ public class TopicPartitionChannelTest {
     Assert.assertTrue(StreamingUtils.offsetTokenVerificationFunction.verify(null, null, null, 0));
     Assert.assertFalse(StreamingUtils.offsetTokenVerificationFunction.verify("1", "3", "4", 3));
     Assert.assertFalse(StreamingUtils.offsetTokenVerificationFunction.verify("2", "1", "4", 3));
+  }
+
+  @Test
+  public void assignANewChannelAfterTheSetupIsFullyDone() throws Exception {
+    // given
+
+    SnowflakeStreamingIngestChannel channel1 = Mockito.mock(SnowflakeStreamingIngestChannel.class);
+    Mockito.when(channel1.getLatestCommittedOffsetToken())
+            .thenReturn("0")
+            .thenThrow(new SFException(ErrorCode.CHANNEL_STATUS_INVALID));
+
+    Mockito.when(channel1.insertRow(anyMap(), anyString()))
+            .thenThrow(new SFException(ErrorCode.CHANNEL_STATUS_INVALID));
+    Mockito.when(channel1.insertRows(anyIterable(), anyString(), anyString()))
+            .thenThrow(new SFException(ErrorCode.CHANNEL_STATUS_INVALID));
+
+    SnowflakeStreamingIngestChannel channel2 = Mockito.mock(SnowflakeStreamingIngestChannel.class);
+    Mockito.when(channel2.getLatestCommittedOffsetToken())
+            .thenThrow(new SFException(ErrorCode.IO_ERROR));
+    Mockito.when(channel2.insertRow(anyMap(), anyString()))
+            .thenReturn(new InsertValidationResponse());
+    Mockito.when(channel2.insertRows(anyIterable(), anyString(), anyString()))
+            .thenReturn(new InsertValidationResponse());
+
+    Mockito.when(mockStreamingClient.openChannel(any(OpenChannelRequest.class)))
+            .thenReturn(channel1, channel2);
+
+    TopicPartitionChannel topicPartitionChannel =
+            createTopicPartitionChannel(
+                    this.mockStreamingClient,
+                    this.topicPartition,
+                    TEST_CHANNEL_NAME,
+                    TEST_TABLE_NAME,
+                    this.enableSchematization,
+                    this.streamingBufferThreshold,
+                    this.sfConnectorConfig,
+                    this.mockKafkaRecordErrorReporter,
+                    this.mockSinkTaskContext,
+                    this.mockSnowflakeConnectionService,
+                    new RecordService(),
+                    this.mockTelemetryService,
+                    true,
+                    null);
+
+    // expect
+    Assert.assertThrows(SFException.class, () -> topicPartitionChannel.getOffsetSafeToCommitToKafka());
+
+
+    // when
+    List<SinkRecord> records = TestUtils.createJsonStringSinkRecords(0, 2, TOPIC, PARTITION);
+
+    // expect
+    Assert.assertThrows(SFException.class, () -> insertAndFlush(topicPartitionChannel, records));
+  }
+
+  private void insertAndFlush(TopicPartitionChannel channel, List<SinkRecord> records) throws InterruptedException {
+    for (int idx = 0; idx < records.size(); idx++) {
+      channel.insertRecord(records.get(idx), idx == 0);
+    }
+
+    // expect
+    Thread.sleep(this.streamingBufferThreshold.getFlushTimeThresholdSeconds() + 1);
+    channel.insertBufferedRecordsIfFlushTimeThresholdReached();
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelTest.java
@@ -10,9 +10,9 @@ import static com.snowflake.kafka.connector.internal.streaming.StreamingUtils.MA
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyIterable;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 
@@ -1254,45 +1254,45 @@ public class TopicPartitionChannelTest {
 
     SnowflakeStreamingIngestChannel channel1 = Mockito.mock(SnowflakeStreamingIngestChannel.class);
     Mockito.when(channel1.getLatestCommittedOffsetToken())
-            .thenReturn("0")
-            .thenThrow(new SFException(ErrorCode.CHANNEL_STATUS_INVALID));
+        .thenReturn("0")
+        .thenThrow(new SFException(ErrorCode.CHANNEL_STATUS_INVALID));
 
     Mockito.when(channel1.insertRow(anyMap(), anyString()))
-            .thenThrow(new SFException(ErrorCode.CHANNEL_STATUS_INVALID));
+        .thenThrow(new SFException(ErrorCode.CHANNEL_STATUS_INVALID));
     Mockito.when(channel1.insertRows(anyIterable(), anyString(), anyString()))
-            .thenThrow(new SFException(ErrorCode.CHANNEL_STATUS_INVALID));
+        .thenThrow(new SFException(ErrorCode.CHANNEL_STATUS_INVALID));
 
     SnowflakeStreamingIngestChannel channel2 = Mockito.mock(SnowflakeStreamingIngestChannel.class);
     Mockito.when(channel2.getLatestCommittedOffsetToken())
-            .thenThrow(new SFException(ErrorCode.IO_ERROR));
+        .thenThrow(new SFException(ErrorCode.IO_ERROR));
     Mockito.when(channel2.insertRow(anyMap(), anyString()))
-            .thenReturn(new InsertValidationResponse());
+        .thenReturn(new InsertValidationResponse());
     Mockito.when(channel2.insertRows(anyIterable(), anyString(), anyString()))
-            .thenReturn(new InsertValidationResponse());
+        .thenReturn(new InsertValidationResponse());
 
     Mockito.when(mockStreamingClient.openChannel(any(OpenChannelRequest.class)))
-            .thenReturn(channel1, channel2);
+        .thenReturn(channel1, channel2);
 
     TopicPartitionChannel topicPartitionChannel =
-            createTopicPartitionChannel(
-                    this.mockStreamingClient,
-                    this.topicPartition,
-                    TEST_CHANNEL_NAME,
-                    TEST_TABLE_NAME,
-                    this.enableSchematization,
-                    this.streamingBufferThreshold,
-                    this.sfConnectorConfig,
-                    this.mockKafkaRecordErrorReporter,
-                    this.mockSinkTaskContext,
-                    this.mockSnowflakeConnectionService,
-                    new RecordService(),
-                    this.mockTelemetryService,
-                    true,
-                    null);
+        createTopicPartitionChannel(
+            this.mockStreamingClient,
+            this.topicPartition,
+            TEST_CHANNEL_NAME,
+            TEST_TABLE_NAME,
+            this.enableSchematization,
+            this.streamingBufferThreshold,
+            this.sfConnectorConfig,
+            this.mockKafkaRecordErrorReporter,
+            this.mockSinkTaskContext,
+            this.mockSnowflakeConnectionService,
+            new RecordService(),
+            this.mockTelemetryService,
+            true,
+            null);
 
     // expect
-    Assert.assertThrows(SFException.class, () -> topicPartitionChannel.getOffsetSafeToCommitToKafka());
-
+    Assert.assertThrows(
+        SFException.class, () -> topicPartitionChannel.getOffsetSafeToCommitToKafka());
 
     // when
     List<SinkRecord> records = TestUtils.createJsonStringSinkRecords(0, 2, TOPIC, PARTITION);
@@ -1301,7 +1301,8 @@ public class TopicPartitionChannelTest {
     Assert.assertThrows(SFException.class, () -> insertAndFlush(topicPartitionChannel, records));
   }
 
-  private void insertAndFlush(TopicPartitionChannel channel, List<SinkRecord> records) throws InterruptedException {
+  private void insertAndFlush(TopicPartitionChannel channel, List<SinkRecord> records)
+      throws InterruptedException {
     for (int idx = 0; idx < records.size(); idx++) {
       channel.insertRecord(records.get(idx), idx == 0);
     }


### PR DESCRIPTION
<!-- Text inside of HTML comment blocks will NOT appear in your pull request description -->
<!-- Formatting information can be found at https://www.markdownguide.org/basic-syntax/ -->
# Overview

SNOW-1514185

The change applies to channel reopen logic. The process used to consists of 3 steps:
 - reopen the channel
 - fetch the offset from the channel
 - reset internal buffer
 - rest offset in Kafka

If any of the steps 2-4 fails during `getOffsetSafeToCommitToKafka` the error will be ignored in [SnowflakeSinkTask::preCommit](https://github.com/snowflakedb/snowflake-kafka-connector/blob/15df7115dc26a2ad015f8486d6dd3f48a460e525/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java#L347-L349)

After the change the channel is assigned to the TopicPartitionChannel after all the steps are done.

<!--
Why is this review being requested?  The full details should be in the JIRA, but the review should focus on the fix/change being implemented.
If there are multiple steps in the Jira, which step is this?
-->

## Pre-review checklist
- [ ] This change should be part of a Behavior Change Release. See [go/behavior-change](http://go/behavior-change).
- [ ] This change has passed Merge gate tests
- [ ] Snowpipe Changes
- [ ] Snowpipe Streaming Changes
- [ ] This change is TEST-ONLY
- [ ] This change is README/Javadocs only
- [ ] This change is protected by a config parameter <PARAMETER_NAME> eg `snowflake.ingestion.method`.
    - [ ] `Yes` - Added end to end and Unit Tests. 
    - [ ] `No` - Suggest why it is not param protected
- [ ] Is his change protected by parameter <PARAMETER_NAME> on the server side?
    - [ ] The parameter/feature is not yet active in production (partial rollout or PrPr, see [Changes for Unreleased Features and Fixes](http://go/ppp-prpr)).
    - [ ] If there is an issue, it can be safely mitigated by turning the parameter off. This is also verified by a test (See [go/ppp](http://go/ppp)).


<!--
## Urgency
This review is *normal* priority
This review is **high** priority
This review is ***URGENT*** priority
-->

<!--
Indicate any urgency for performing the review.  Perhaps it is a fix for a prod issue or is blocking a customer.
-->

<!--
## Risks
What are the risks associated to your change?
-->

<!--
## Backward and forward Compatible
Imagine customer upgrading to new version and rolling back to older version. Will there be any concerns?
[ ] Backward compatible
[ ] Forward compatible
-->

<!--
Suggested reading order:   Provide an order in which to read files, classes, and methods.  Without this your reader will spend lots of time reading code without understanding the context (imagine the top file references a new class in methods of a file below it).  You need to tell your reviewers how to learn your code.
-->

<!--
## Reviewer roles
Every reviewer must be told their role and what actions are expected of them.  Tell every reviewer what will happen if they don't complete the review.  If you aren't sure who the secondary owner is then work with a manager and/or tech lead to figure this out.
If there are specific items or subsets of the change that you want a particular reviewer to focus on, mention it here.  You can @-mention people using their github username
-->

<!--
Reviewers:  Every review must have at least two reviewers for bug fixes, GA'ed component. One reviewer is enough for test only, doc changes.
Example:
- Minimum # of Required Reviewers - **Two** for Improvements and Bugfixes - <@github alias> 
- Educational purposes - <@github alias>
- Manager/TL approval (If patch critical and requires a release) - <@github alias>
-->

