### PR TITLE
Adding logs to track schematization

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionServiceV1.java
@@ -425,6 +425,7 @@ public class SnowflakeConnectionServiceV1 implements SnowflakeConnectionService 
    */
   @Override
   public boolean hasSchemaEvolutionPermission(String tableName, String role) {
+    LOGGER.info("Checking schema evolution permission for table {}", tableName);
     checkConnection();
     InternalUtils.assertNotEmpty("tableName", tableName);
     String query = "show grants on table identifier(?)";

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/BufferedTopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/BufferedTopicPartitionChannel.java
@@ -669,9 +669,10 @@ public class BufferedTopicPartitionChannel implements TopicPartitionChannel {
               // Simply added to the final response if it's not schema related errors
               finalResponse.addError(insertError);
             } else {
-              LOGGER.info("Triggering schema evolution. NonNullableColumns={}, extraColumns={}",
-                      String.join("", nonNullableColumns),
-                      extraColNames == null ? "null" : String.join(", ", extraColNames));
+              LOGGER.info(
+                  "Triggering schema evolution. NonNullableColumns={}, extraColumns={}",
+                  String.join("", nonNullableColumns),
+                  extraColNames == null ? "null" : String.join(", ", extraColNames));
               SchematizationUtils.evolveSchemaIfNeeded(
                   this.conn,
                   this.channel.getTableName(),

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/BufferedTopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/BufferedTopicPartitionChannel.java
@@ -669,6 +669,9 @@ public class BufferedTopicPartitionChannel implements TopicPartitionChannel {
               // Simply added to the final response if it's not schema related errors
               finalResponse.addError(insertError);
             } else {
+              LOGGER.info("Triggering schema evolution. NonNullableColumns={}, extraColumns={}",
+                      String.join("", nonNullableColumns),
+                      extraColNames == null ? "null" : String.join(", ", extraColNames));
               SchematizationUtils.evolveSchemaIfNeeded(
                   this.conn,
                   this.channel.getTableName(),

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/BufferedTopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/BufferedTopicPartitionChannel.java
@@ -671,8 +671,8 @@ public class BufferedTopicPartitionChannel implements TopicPartitionChannel {
             } else {
               LOGGER.info(
                   "Triggering schema evolution. NonNullableColumns={}, extraColumns={}",
-                  String.join("", nonNullableColumns),
-                  extraColNames == null ? "null" : String.join(", ", extraColNames));
+                  String.join(",", nonNullableColumns),
+                  extraColNames == null ? "null" : String.join(",", extraColNames));
               SchematizationUtils.evolveSchemaIfNeeded(
                   this.conn,
                   this.channel.getTableName(),

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -707,12 +707,13 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
   private void populateSchemaEvolutionPermissions(String tableName) {
     if (!tableName2SchemaEvolutionPermission.containsKey(tableName)) {
       if (enableSchematization) {
-        tableName2SchemaEvolutionPermission.put(
-            tableName,
-            conn != null
+        boolean hasSchemaEvolutionPermission = conn != null
                 && conn.hasSchemaEvolutionPermission(
-                    tableName, connectorConfig.get(SNOWFLAKE_ROLE)));
+                tableName, connectorConfig.get(SNOWFLAKE_ROLE));
+        LOGGER.info("[SCHEMA_EVOLUTION_CACHE] Setting {} for table {}", hasSchemaEvolutionPermission, tableName);
+        tableName2SchemaEvolutionPermission.put(tableName, hasSchemaEvolutionPermission);
       } else {
+        LOGGER.info("[SCHEMA_EVOLUTION_CACHE] Schematization disabled. Setting false for table {}", tableName);
         tableName2SchemaEvolutionPermission.put(tableName, false);
       }
     }

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -707,13 +707,19 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
   private void populateSchemaEvolutionPermissions(String tableName) {
     if (!tableName2SchemaEvolutionPermission.containsKey(tableName)) {
       if (enableSchematization) {
-        boolean hasSchemaEvolutionPermission = conn != null
+        boolean hasSchemaEvolutionPermission =
+            conn != null
                 && conn.hasSchemaEvolutionPermission(
-                tableName, connectorConfig.get(SNOWFLAKE_ROLE));
-        LOGGER.info("[SCHEMA_EVOLUTION_CACHE] Setting {} for table {}", hasSchemaEvolutionPermission, tableName);
+                    tableName, connectorConfig.get(SNOWFLAKE_ROLE));
+        LOGGER.info(
+            "[SCHEMA_EVOLUTION_CACHE] Setting {} for table {}",
+            hasSchemaEvolutionPermission,
+            tableName);
         tableName2SchemaEvolutionPermission.put(tableName, hasSchemaEvolutionPermission);
       } else {
-        LOGGER.info("[SCHEMA_EVOLUTION_CACHE] Schematization disabled. Setting false for table {}", tableName);
+        LOGGER.info(
+            "[SCHEMA_EVOLUTION_CACHE] Schematization disabled. Setting false for table {}",
+            tableName);
         tableName2SchemaEvolutionPermission.put(tableName, false);
       }
     }


### PR DESCRIPTION
In the recent issue (https://github.com/snowflakedb/snowflake-kafka-connector/issues/878) I discovered that sadly we do not have any logs that can be used to track schematization settings and code execution. The reason for this PR is to close this gap.

The logs can be added at INFO level because they appear only at connector startup and when schema change is detected.