### PR TITLE
Remove insertRows DEBUG log (called once per row)

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/DirectTopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/DirectTopicPartitionChannel.java
@@ -484,11 +484,7 @@ public class DirectTopicPartitionChannel implements TopicPartitionChannel {
 
     return Failsafe.with(reopenChannelFallbackExecutorForInsertRows)
         .get(
-            () -> {
-              LOGGER.debug(
-                  "Invoking insertRows API for channel:{}", this.channel.getFullyQualifiedName());
-              return this.channel.insertRow(transformedRecord, Long.toString(offset));
-            });
+            () -> this.channel.insertRow(transformedRecord, Long.toString(offset)));
   }
 
   /**

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/DirectTopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/DirectTopicPartitionChannel.java
@@ -483,8 +483,7 @@ public class DirectTopicPartitionChannel implements TopicPartitionChannel {
             .build();
 
     return Failsafe.with(reopenChannelFallbackExecutorForInsertRows)
-        .get(
-            () -> this.channel.insertRow(transformedRecord, Long.toString(offset)));
+        .get(() -> this.channel.insertRow(transformedRecord, Long.toString(offset)));
   }
 
   /**


### PR DESCRIPTION
During performance tests I noticed huge amount of logs (15 times bigger than double buffer) being generated by this DEBUG level statement. We cannot afford it.