### PR TITLE
SNOW-1642799: added exception handler when moving invalid file to table stage; file cleaner will preserve 'dirty' files a bit longer

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -120,6 +120,10 @@ public class SnowflakeSinkConnectorConfig {
   public static final boolean SNOWPIPE_FILE_CLEANER_FIX_ENABLED_DEFAULT = true;
   public static final int SNOWPIPE_FILE_CLEANER_THREADS_DEFAULT = 1;
 
+  public static final String SNOWPIPE_SINGLE_TABLE_MULTIPLE_TOPICS_FIX_ENABLED =
+      "snowflake.snowpipe.stageFileNameExtensionEnabled";
+  public static final boolean SNOWPIPE_SINGLE_TABLE_MULTIPLE_TOPICS_FIX_ENABLED_DEFAULT = true;
+
   // Whether to close streaming channels in parallel.
   public static final String SNOWPIPE_STREAMING_CLOSE_CHANNELS_IN_PARALLEL =
       "snowflake.streaming.closeChannelsInParallel.enabled";

--- a/src/main/java/com/snowflake/kafka/connector/config/ConnectorConfigDefinition.java
+++ b/src/main/java/com/snowflake/kafka/connector/config/ConnectorConfigDefinition.java
@@ -350,6 +350,16 @@ public class ConnectorConfigDefinition {
             "Defines number of worker threads to associate with the cleaner task. By default there"
                 + " is one cleaner per topic's partition and they all share one worker thread")
         .define(
+            SNOWPIPE_SINGLE_TABLE_MULTIPLE_TOPICS_FIX_ENABLED,
+            ConfigDef.Type.BOOLEAN,
+            SNOWPIPE_SINGLE_TABLE_MULTIPLE_TOPICS_FIX_ENABLED_DEFAULT,
+            ConfigDef.Importance.LOW,
+            "Defines whether stage file names should be prefixed with source topic's name hash."
+                + " This is required in scenarios, when there are multiple topics configured to"
+                + " ingest data into a single table via topic2table map. If disabled, there is a"
+                + " risk that files from various topics may collide with each other and be deleted"
+                + " before ingestion.")
+        .define(
             SNOWPIPE_STREAMING_CLOSE_CHANNELS_IN_PARALLEL,
             ConfigDef.Type.BOOLEAN,
             SNOWPIPE_STREAMING_CLOSE_CHANNELS_IN_PARALLEL_DEFAULT,

--- a/src/main/java/com/snowflake/kafka/connector/config/TopicToTableModeExtractor.java
+++ b/src/main/java/com/snowflake/kafka/connector/config/TopicToTableModeExtractor.java
@@ -1,38 +1,37 @@
 package com.snowflake.kafka.connector.config;
 
 import com.snowflake.kafka.connector.Utils;
-
 import java.util.Map;
 
 public class TopicToTableModeExtractor {
 
-    /**
-     * Defines whether single target table is fed by one or many source topics.
-     */
-    public enum Topic2TableMode {
-        // Single topic = single table
-        SINGLE_TOPIC_SINGLE_TABLE,
-        // Multiple topics = single table
-        MANY_TOPICS_SINGLE_TABLE,
+  /** Defines whether single target table is fed by one or many source topics. */
+  public enum Topic2TableMode {
+    // Single topic = single table
+    SINGLE_TOPIC_SINGLE_TABLE,
+    // Multiple topics = single table
+    MANY_TOPICS_SINGLE_TABLE,
+  }
 
-    }
-    private TopicToTableModeExtractor(){}
+  private TopicToTableModeExtractor() {}
 
-    /**
-     * Util method - checks if given topic is defined in topic2Table map - if it is more than once, it means
-     * multiple topics will store data in single table - in such case, for SNOWPIPE ingestion we need to
-     * uniquely identify stage files so different instances of file cleaner won't handle other's channel files.
-     * @param topic
-     * @return
-     */
-    public static Topic2TableMode determineTopic2TableMode(Map<String, String> topic2TableMap, String topic) {
-        String tableName = Utils.tableName(topic, topic2TableMap);
-        return topic2TableMap
-                .values()
-                .stream()
+  /**
+   * Util method - checks if given topic is defined in topic2Table map - if it is more than once, it
+   * means multiple topics will store data in single table - in such case, for SNOWPIPE ingestion we
+   * need to uniquely identify stage files so different instances of file cleaner won't handle
+   * other's channel files.
+   *
+   * @param topic
+   * @return
+   */
+  public static Topic2TableMode determineTopic2TableMode(
+      Map<String, String> topic2TableMap, String topic) {
+    String tableName = Utils.tableName(topic, topic2TableMap);
+    return topic2TableMap.values().stream()
                 .filter(table -> table.equalsIgnoreCase(tableName))
-                .count() > 1
-                ? Topic2TableMode.MANY_TOPICS_SINGLE_TABLE
-                : Topic2TableMode.SINGLE_TOPIC_SINGLE_TABLE;
-    }
+                .count()
+            > 1
+        ? Topic2TableMode.MANY_TOPICS_SINGLE_TABLE
+        : Topic2TableMode.SINGLE_TOPIC_SINGLE_TABLE;
+  }
 }

--- a/src/main/java/com/snowflake/kafka/connector/config/TopicToTableModeExtractor.java
+++ b/src/main/java/com/snowflake/kafka/connector/config/TopicToTableModeExtractor.java
@@ -1,0 +1,38 @@
+package com.snowflake.kafka.connector.config;
+
+import com.snowflake.kafka.connector.Utils;
+
+import java.util.Map;
+
+public class TopicToTableModeExtractor {
+
+    /**
+     * Defines whether single target table is fed by one or many source topics.
+     */
+    public enum Topic2TableMode {
+        // Single topic = single table
+        SINGLE_TOPIC_SINGLE_TABLE,
+        // Multiple topics = single table
+        MANY_TOPICS_SINGLE_TABLE,
+
+    }
+    private TopicToTableModeExtractor(){}
+
+    /**
+     * Util method - checks if given topic is defined in topic2Table map - if it is more than once, it means
+     * multiple topics will store data in single table - in such case, for SNOWPIPE ingestion we need to
+     * uniquely identify stage files so different instances of file cleaner won't handle other's channel files.
+     * @param topic
+     * @return
+     */
+    public static Topic2TableMode determineTopic2TableMode(Map<String, String> topic2TableMap, String topic) {
+        String tableName = Utils.tableName(topic, topic2TableMap);
+        return topic2TableMap
+                .values()
+                .stream()
+                .filter(table -> table.equalsIgnoreCase(tableName))
+                .count() > 1
+                ? Topic2TableMode.MANY_TOPICS_SINGLE_TABLE
+                : Topic2TableMode.SINGLE_TOPIC_SINGLE_TABLE;
+    }
+}

--- a/src/main/java/com/snowflake/kafka/connector/internal/FileNameUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/FileNameUtils.java
@@ -1,12 +1,11 @@
 package com.snowflake.kafka.connector.internal;
 
 import com.google.common.base.Strings;
-import org.apache.kafka.common.utils.Crc32C;
-
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.apache.kafka.common.utils.Crc32C;
 
 public class FileNameUtils {
   private static final KCLogger LOGGER = new KCLogger(FileNameUtils.class.getName());
@@ -16,21 +15,27 @@ public class FileNameUtils {
    * Note: all file names should using the this format
    *
    * @param appName connector name
-   * @param table table name
-   * @Param topic name
+   * @param table table name @Param topic name
    * @param partition partition number
    * @param start start offset
    * @param end end offset
    * @return file name
    */
-  public static String fileName(String appName, String table, String topic, int partition, long start, long end) {
+  public static String fileName(
+      String appName, String table, String topic, int partition, long start, long end) {
     return fileName(filePrefix(appName, table, topic, partition), start, end);
   }
 
   // Used for testing only
   static String fileName(
       String appName, String table, String topic, int partition, long start, long end, long time) {
-    return filePrefix(appName, table, topic, partition) + start + "_" + end + "_" + time + ".json.gz";
+    return filePrefix(appName, table, topic, partition)
+        + start
+        + "_"
+        + end
+        + "_"
+        + time
+        + ".json.gz";
   }
 
   /**
@@ -90,7 +95,8 @@ public class FileNameUtils {
    */
   static String filePrefix(String appName, String table, String topic, int partition) {
     if (partition >= 0x8000) {
-      throw new IllegalArgumentException(String.format("partition id=%d is too large (max=%d)", partition, 0x8000));
+      throw new IllegalArgumentException(
+          String.format("partition id=%d is too large (max=%d)", partition, 0x8000));
     }
     BigInteger partitionPart = BigInteger.valueOf(partition);
     if (!Strings.isNullOrEmpty(topic)) {
@@ -98,11 +104,16 @@ public class FileNameUtils {
       // 1. lets calculate stable hash code out of it,
       // 2. bit shift it by 16 bits left,
       // 3. add 0x8000 (light up 15th bit as a marker)
-      // 4. add partition id (which should in production use cases never reach a value above 5.000 partitions pers topic).
+      // 4. add partition id (which should in production use cases never reach a value above 5.000
+      // partitions pers topic).
       // In theory - we would support 32767 partitions, which is more than
       byte[] bytes = topic.toUpperCase().getBytes(StandardCharsets.UTF_8);
       BigInteger hash = BigInteger.valueOf(Crc32C.compute(bytes, 0, bytes.length));
-      partitionPart = hash.abs().multiply(BigInteger.valueOf(0x10000)).add(BigInteger.valueOf(0x8000)).add(partitionPart);
+      partitionPart =
+          hash.abs()
+              .multiply(BigInteger.valueOf(0x10000))
+              .add(BigInteger.valueOf(0x8000))
+              .add(partitionPart);
     }
     return appName + "/" + table + "/" + partitionPart + "/";
   }

--- a/src/main/java/com/snowflake/kafka/connector/internal/FileNameUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/FileNameUtils.java
@@ -106,7 +106,8 @@ public class FileNameUtils {
       // 3. add 0x8000 (light up 15th bit as a marker)
       // 4. add partition id (which should in production use cases never reach a value above 5.000
       // partitions pers topic).
-      // In theory - we would support 32767 partitions, which is more than
+      // In theory - we would support 32767 partitions, which is more than any reasonable value for
+      // a single topic
       byte[] bytes = topic.toUpperCase().getBytes(StandardCharsets.UTF_8);
       BigInteger hash = BigInteger.valueOf(Crc32C.compute(bytes, 0, bytes.length));
       partitionPart =

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceFactory.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceFactory.java
@@ -84,7 +84,7 @@ public class SnowflakeSinkServiceFactory {
                       SnowflakeSinkConnectorConfig
                           .SNOWPIPE_SINGLE_TABLE_MULTIPLE_TOPICS_FIX_ENABLED));
         }
-        svc.configureSingleTableLoadFromMultipleTopcis(extendedStageFileNameFix);
+        svc.configureSingleTableLoadFromMultipleTopics(extendedStageFileNameFix);
       } else {
         this.service = new SnowflakeSinkServiceV2(conn, connectorConfig);
       }

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceFactory.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceFactory.java
@@ -72,6 +72,19 @@ public class SnowflakeSinkServiceFactory {
         if (useStageFilesProcessor) {
           svc.enableStageFilesProcessor(threadCount);
         }
+
+        boolean extendedStageFileNameFix =
+            SnowflakeSinkConnectorConfig.SNOWPIPE_SINGLE_TABLE_MULTIPLE_TOPICS_FIX_ENABLED_DEFAULT;
+        if (connectorConfig != null
+            && connectorConfig.containsKey(
+                SnowflakeSinkConnectorConfig.SNOWPIPE_SINGLE_TABLE_MULTIPLE_TOPICS_FIX_ENABLED)) {
+          extendedStageFileNameFix =
+              Boolean.parseBoolean(
+                  connectorConfig.get(
+                      SnowflakeSinkConnectorConfig
+                          .SNOWPIPE_SINGLE_TABLE_MULTIPLE_TOPICS_FIX_ENABLED));
+        }
+        svc.configureSingleTableLoadFromMultipleTopcis(extendedStageFileNameFix);
       } else {
         this.service = new SnowflakeSinkServiceV2(conn, connectorConfig);
       }

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
@@ -9,7 +9,6 @@ import static org.apache.kafka.common.record.TimestampType.NO_TIMESTAMP_TYPE;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Strings;
 import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
 import com.snowflake.kafka.connector.Utils;
 import com.snowflake.kafka.connector.config.TopicToTableModeExtractor;
@@ -435,9 +434,13 @@ class SnowflakeSinkServiceV1 implements SnowflakeSinkService {
       this.cleanerFileNames = new LinkedList<>();
       this.buffer = new SnowpipeBuffer();
       this.ingestionService = conn.buildIngestService(stageName, pipeName);
-      // SNOW-1642799 = if multiple topics load data into single table, we need to ensure prefix is unique per table - otherwise, file cleaners for different channels may run into race condition
-      if (determineTopic2TableMode(topic2TableMap, topicName) == TopicToTableModeExtractor.Topic2TableMode.MANY_TOPICS_SINGLE_TABLE) {
-        this.prefix = FileNameUtils.filePrefix(conn.getConnectorName(), tableName, topicName, partition);
+      // SNOW-1642799 = if multiple topics load data into single table, we need to ensure prefix is
+      // unique per table - otherwise, file cleaners for different channels may run into race
+      // condition
+      if (determineTopic2TableMode(topic2TableMap, topicName)
+          == TopicToTableModeExtractor.Topic2TableMode.MANY_TOPICS_SINGLE_TABLE) {
+        this.prefix =
+            FileNameUtils.filePrefix(conn.getConnectorName(), tableName, topicName, partition);
       } else {
         this.prefix = FileNameUtils.filePrefix(conn.getConnectorName(), tableName, "", partition);
       }

--- a/src/main/java/com/snowflake/kafka/connector/internal/StageFilesProcessor.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/StageFilesProcessor.java
@@ -183,7 +183,10 @@ class StageFilesProcessor {
    */
   @VisibleForTesting
   void trackFiles(ProgressRegisterImpl register, PipeProgressRegistryTelemetry progressTelemetry) {
-    LOGGER.info("Starting file cleaner for pipe {} ... [matching stage files with prefix: {}]", pipeName, prefix);
+    LOGGER.info(
+        "Starting file cleaner for pipe {} ... [matching stage files with prefix: {}]",
+        pipeName,
+        prefix);
 
     AtomicBoolean shouldFetchInitialStageFiles = new AtomicBoolean(true);
     AtomicBoolean isFirstRun = new AtomicBoolean(true);
@@ -194,7 +197,8 @@ class StageFilesProcessor {
     // required for testing purposes
     register.currentProcessorContext = ctx;
 
-    final String threadName = String.format("file-processor-[%s/%d:%s]", topic, partition, tableName);
+    final String threadName =
+        String.format("file-processor-[%s/%d:%s]", topic, partition, tableName);
 
     cleanerTaskHolder.set(
         schedulingExecutor.scheduleWithFixedDelay(

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigValidatorTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigValidatorTest.java
@@ -2,7 +2,6 @@ package com.snowflake.kafka.connector;
 
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.*;
 import static com.snowflake.kafka.connector.Utils.HTTP_NON_PROXY_HOSTS;
-import static com.snowflake.kafka.connector.internal.TestUtils.getConf;
 import static com.snowflake.kafka.connector.internal.TestUtils.getConfig;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.assertEquals;
@@ -228,9 +227,12 @@ public class ConnectorConfigValidatorTest {
     config.put(TOPICS_TABLES_MAP, "src1:target1,src2:target2,src3:target1");
     connectorConfigValidator.validateConfig(config);
     Map<String, String> topic2Table = Utils.parseTopicToTableMap(config.get(TOPICS_TABLES_MAP));
-    assertThat(TopicToTableModeExtractor.determineTopic2TableMode(topic2Table, "src1")).isEqualTo(TopicToTableModeExtractor.Topic2TableMode.MANY_TOPICS_SINGLE_TABLE);
-    assertThat(TopicToTableModeExtractor.determineTopic2TableMode(topic2Table, "src2")).isEqualTo(TopicToTableModeExtractor.Topic2TableMode.SINGLE_TOPIC_SINGLE_TABLE);
-    assertThat(TopicToTableModeExtractor.determineTopic2TableMode(topic2Table, "src3")).isEqualTo(TopicToTableModeExtractor.Topic2TableMode.MANY_TOPICS_SINGLE_TABLE);
+    assertThat(TopicToTableModeExtractor.determineTopic2TableMode(topic2Table, "src1"))
+        .isEqualTo(TopicToTableModeExtractor.Topic2TableMode.MANY_TOPICS_SINGLE_TABLE);
+    assertThat(TopicToTableModeExtractor.determineTopic2TableMode(topic2Table, "src2"))
+        .isEqualTo(TopicToTableModeExtractor.Topic2TableMode.SINGLE_TOPIC_SINGLE_TABLE);
+    assertThat(TopicToTableModeExtractor.determineTopic2TableMode(topic2Table, "src3"))
+        .isEqualTo(TopicToTableModeExtractor.Topic2TableMode.MANY_TOPICS_SINGLE_TABLE);
   }
 
   @Test

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigValidatorTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigValidatorTest.java
@@ -2,12 +2,14 @@ package com.snowflake.kafka.connector;
 
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.*;
 import static com.snowflake.kafka.connector.Utils.HTTP_NON_PROXY_HOSTS;
+import static com.snowflake.kafka.connector.internal.TestUtils.getConf;
 import static com.snowflake.kafka.connector.internal.TestUtils.getConfig;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.assertEquals;
 
 import com.snowflake.kafka.connector.config.IcebergConfigValidator;
 import com.snowflake.kafka.connector.config.SnowflakeSinkConnectorConfigBuilder;
+import com.snowflake.kafka.connector.config.TopicToTableModeExtractor;
 import com.snowflake.kafka.connector.internal.SnowflakeErrors;
 import com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException;
 import com.snowflake.kafka.connector.internal.streaming.DefaultStreamingConfigValidator;
@@ -218,6 +220,17 @@ public class ConnectorConfigValidatorTest {
     config.put(SnowflakeSinkConnectorConfig.TOPICS, "!@#,$%^,test");
     config.put(SnowflakeSinkConnectorConfig.TOPICS_TABLES_MAP, "!@#:table1,$%^:table2");
     connectorConfigValidator.validateConfig(config);
+  }
+
+  @Test
+  public void testTopic2TableCorrectlyDeterminesMode() {
+    Map<String, String> config = getConfig();
+    config.put(TOPICS_TABLES_MAP, "src1:target1,src2:target2,src3:target1");
+    connectorConfigValidator.validateConfig(config);
+    Map<String, String> topic2Table = Utils.parseTopicToTableMap(config.get(TOPICS_TABLES_MAP));
+    assertThat(TopicToTableModeExtractor.determineTopic2TableMode(topic2Table, "src1")).isEqualTo(TopicToTableModeExtractor.Topic2TableMode.MANY_TOPICS_SINGLE_TABLE);
+    assertThat(TopicToTableModeExtractor.determineTopic2TableMode(topic2Table, "src2")).isEqualTo(TopicToTableModeExtractor.Topic2TableMode.SINGLE_TOPIC_SINGLE_TABLE);
+    assertThat(TopicToTableModeExtractor.determineTopic2TableMode(topic2Table, "src3")).isEqualTo(TopicToTableModeExtractor.Topic2TableMode.MANY_TOPICS_SINGLE_TABLE);
   }
 
   @Test

--- a/src/test/java/com/snowflake/kafka/connector/SinkTaskProxyIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/SinkTaskProxyIT.java
@@ -98,7 +98,8 @@ public class SinkTaskProxyIT {
     SnowflakeIngestionService ingestionService = connectionService.buildIngestService(stage, pipe);
 
     String file = "{\"aa\":123}";
-    String fileName = FileNameUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, null, 0, 0, 1);
+    String fileName =
+        FileNameTestUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, null, 0, 0, 1);
 
     connectionService.putWithCache(stage, fileName, file);
     ingestionService.ingestFile(fileName);

--- a/src/test/java/com/snowflake/kafka/connector/SinkTaskProxyIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/SinkTaskProxyIT.java
@@ -98,7 +98,7 @@ public class SinkTaskProxyIT {
     SnowflakeIngestionService ingestionService = connectionService.buildIngestService(stage, pipe);
 
     String file = "{\"aa\":123}";
-    String fileName = FileNameUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, 0, 0, 1);
+    String fileName = FileNameUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, null, 0, 0, 1);
 
     connectionService.putWithCache(stage, fileName, file);
     ingestionService.ingestFile(fileName);

--- a/src/test/java/com/snowflake/kafka/connector/internal/ConnectionServiceIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/ConnectionServiceIT.java
@@ -47,6 +47,7 @@ public class ConnectionServiceIT {
   private final String pipeName = TestUtils.randomPipeName();
   private final String tableName1 = TestUtils.randomTableName();
   private final String stageName1 = TestUtils.randomStageName();
+  private final String topicName = TestUtils.randomTopicName();
 
   @Test
   public void testEncryptedKey() {
@@ -247,7 +248,7 @@ public class ConnectionServiceIT {
     // stage exists
     assert conn.stageExist(stageName);
     // put a file to stage
-    String fileName = FileNameUtils.fileName(TEST_CONNECTOR_NAME, tableName, 1, 123, 456);
+    String fileName = FileNameUtils.fileName(TEST_CONNECTOR_NAME, tableName, "topic", 1, 123, 456);
     conn.put(stageName, fileName, "test");
     // list stage with prefix
     List<String> files = conn.listStage(stageName, TEST_CONNECTOR_NAME);
@@ -336,17 +337,17 @@ public class ConnectionServiceIT {
     // stage exists
     assert conn.stageExist(stageName);
     // put two files to stage
-    String fileName1 = FileNameUtils.fileName(TEST_CONNECTOR_NAME, tableName, 1, 1, 3);
+    String fileName1 = FileNameUtils.fileName(TEST_CONNECTOR_NAME, tableName, topicName, 1, 1, 3);
     conn.put(stageName, fileName1, "test");
-    String fileName2 = FileNameUtils.fileName(TEST_CONNECTOR_NAME, tableName, 1, 4, 6);
+    String fileName2 = FileNameUtils.fileName(TEST_CONNECTOR_NAME, tableName, topicName, 1, 4, 6);
     conn.put(stageName, fileName2, "test");
-    String fileName3 = FileNameUtils.fileName(TEST_CONNECTOR_NAME, tableName, 1, 14, 16);
+    String fileName3 = FileNameUtils.fileName(TEST_CONNECTOR_NAME, tableName, topicName, 1, 14, 16);
     conn.put(stageName, fileName3, "test");
-    String fileName4 = FileNameUtils.fileName(TEST_CONNECTOR_NAME, tableName, 1, 24, 26);
+    String fileName4 = FileNameUtils.fileName(TEST_CONNECTOR_NAME, tableName, topicName, 1, 24, 26);
     conn.put(stageName, fileName4, "test");
-    String fileName5 = FileNameUtils.fileName(TEST_CONNECTOR_NAME, tableName, 1, 34, 36);
+    String fileName5 = FileNameUtils.fileName(TEST_CONNECTOR_NAME, tableName, topicName, 1, 34, 36);
     conn.put(stageName, fileName5, "test");
-    String fileName6 = FileNameUtils.fileName(TEST_CONNECTOR_NAME, tableName, 1, 44, 46);
+    String fileName6 = FileNameUtils.fileName(TEST_CONNECTOR_NAME, tableName, topicName, 1, 44, 46);
     conn.put(stageName, fileName6, "test");
     // list stage with prefix
     List<String> files = conn.listStage(stageName, TEST_CONNECTOR_NAME);

--- a/src/test/java/com/snowflake/kafka/connector/internal/ConnectionServiceIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/ConnectionServiceIT.java
@@ -248,7 +248,8 @@ public class ConnectionServiceIT {
     // stage exists
     assert conn.stageExist(stageName);
     // put a file to stage
-    String fileName = FileNameUtils.fileName(TEST_CONNECTOR_NAME, tableName, "topic", 1, 123, 456);
+    String fileName =
+        FileNameTestUtils.fileName(TEST_CONNECTOR_NAME, tableName, "topic", 1, 123, 456);
     conn.put(stageName, fileName, "test");
     // list stage with prefix
     List<String> files = conn.listStage(stageName, TEST_CONNECTOR_NAME);
@@ -337,17 +338,23 @@ public class ConnectionServiceIT {
     // stage exists
     assert conn.stageExist(stageName);
     // put two files to stage
-    String fileName1 = FileNameUtils.fileName(TEST_CONNECTOR_NAME, tableName, topicName, 1, 1, 3);
+    String fileName1 =
+        FileNameTestUtils.fileName(TEST_CONNECTOR_NAME, tableName, topicName, 1, 1, 3);
     conn.put(stageName, fileName1, "test");
-    String fileName2 = FileNameUtils.fileName(TEST_CONNECTOR_NAME, tableName, topicName, 1, 4, 6);
+    String fileName2 =
+        FileNameTestUtils.fileName(TEST_CONNECTOR_NAME, tableName, topicName, 1, 4, 6);
     conn.put(stageName, fileName2, "test");
-    String fileName3 = FileNameUtils.fileName(TEST_CONNECTOR_NAME, tableName, topicName, 1, 14, 16);
+    String fileName3 =
+        FileNameTestUtils.fileName(TEST_CONNECTOR_NAME, tableName, topicName, 1, 14, 16);
     conn.put(stageName, fileName3, "test");
-    String fileName4 = FileNameUtils.fileName(TEST_CONNECTOR_NAME, tableName, topicName, 1, 24, 26);
+    String fileName4 =
+        FileNameTestUtils.fileName(TEST_CONNECTOR_NAME, tableName, topicName, 1, 24, 26);
     conn.put(stageName, fileName4, "test");
-    String fileName5 = FileNameUtils.fileName(TEST_CONNECTOR_NAME, tableName, topicName, 1, 34, 36);
+    String fileName5 =
+        FileNameTestUtils.fileName(TEST_CONNECTOR_NAME, tableName, topicName, 1, 34, 36);
     conn.put(stageName, fileName5, "test");
-    String fileName6 = FileNameUtils.fileName(TEST_CONNECTOR_NAME, tableName, topicName, 1, 44, 46);
+    String fileName6 =
+        FileNameTestUtils.fileName(TEST_CONNECTOR_NAME, tableName, topicName, 1, 44, 46);
     conn.put(stageName, fileName6, "test");
     // list stage with prefix
     List<String> files = conn.listStage(stageName, TEST_CONNECTOR_NAME);

--- a/src/test/java/com/snowflake/kafka/connector/internal/FileNameTestUtils.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/FileNameTestUtils.java
@@ -1,0 +1,64 @@
+package com.snowflake.kafka.connector.internal;
+
+import static com.snowflake.kafka.connector.internal.FileNameUtils.filePrefix;
+
+public class FileNameTestUtils {
+  private FileNameTestUtils() {}
+
+  // Used for testing only
+  static String fileName(
+      String appName, String table, String topic, int partition, long start, long end, long time) {
+    return filePrefix(appName, table, topic, partition)
+        + start
+        + "_"
+        + end
+        + "_"
+        + time
+        + ".json.gz";
+  }
+
+  /**
+   * generate file name File Name Format: app/table/partition/start_end_timeStamp.fileFormat.gz
+   * Note: all file names should using the this format
+   *
+   * @param appName connector name
+   * @param table table name
+   * @param topic name
+   * @param partition partition number
+   * @param start start offset
+   * @param end end offset
+   * @return file name
+   */
+  public static String fileName(
+      String appName, String table, String topic, int partition, long start, long end) {
+    String prefix = filePrefix(appName, table, topic, partition);
+    return FileNameUtils.fileName(prefix, start, end);
+  }
+
+  /**
+   * generate file name for broken data
+   *
+   * @param appName app name
+   * @param table table name
+   * @param partition partition id
+   * @param offset record offset
+   * @param isKey is the broken record a key or a value
+   * @return file name
+   */
+  static String brokenRecordFileName(
+      String appName, String table, String topic, int partition, long offset, boolean isKey) {
+    return FileNameUtils.brokenRecordFileName(
+        filePrefix(appName, table, topic, partition), offset, isKey);
+  }
+
+  /**
+   * check whether the given file is expired
+   *
+   * @param fileName file name
+   * @return true if expired, otherwise false
+   */
+  static boolean isFileExpired(String fileName) {
+    return System.currentTimeMillis() - FileNameUtils.fileNameToTimeIngested(fileName)
+        > InternalUtils.MAX_RECOVERY_TIME;
+  }
+}

--- a/src/test/java/com/snowflake/kafka/connector/internal/FileNameUtilsTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/FileNameUtilsTest.java
@@ -1,9 +1,9 @@
 package com.snowflake.kafka.connector.internal;
 
-import org.junit.Test;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.Test;
 
 public class FileNameUtilsTest {
   @Test
@@ -27,9 +27,10 @@ public class FileNameUtilsTest {
     assertThat(FileNameUtils.fileNameToPartition(fileName)).isEqualTo(partition);
 
     long createTime = FileNameUtils.fileNameToTimeIngested(fileName);
-    assertThat( (createTime > time1) && (createTime < time2)).isTrue();
+    assertThat((createTime > time1) && (createTime < time2)).isTrue();
 
-    assertThat(FileNameUtils.removePrefixAndGZFromFileName("A/B/C/abc.tar.gz")).isEqualTo("abc.tar");
+    assertThat(FileNameUtils.removePrefixAndGZFromFileName("A/B/C/abc.tar.gz"))
+        .isEqualTo("abc.tar");
     assertThat(FileNameUtils.removePrefixAndGZFromFileName("A/B/C/abc.json")).isEqualTo("abc.json");
     assertThat(FileNameUtils.getPrefixFromFileName("A/B/C/abc.tar.gz")).isEqualTo("A/B/C");
     assertThat(FileNameUtils.getPrefixFromFileName("A/B/C/abc.json")).isEqualTo("A/B/C");
@@ -75,18 +76,21 @@ public class FileNameUtilsTest {
     String topicName = "test_topic";
     long now = System.currentTimeMillis();
     String fileName =
-            FileNameUtils.fileName(
-                    TestUtils.TEST_CONNECTOR_NAME, tableName, topicName, partition, startOffset, endOffset);
+        FileNameUtils.fileName(
+            TestUtils.TEST_CONNECTOR_NAME, tableName, topicName, partition, startOffset, endOffset);
 
     assertThat(fileName).isNotNull();
     assertThat(FileNameUtils.verifyFileName(fileName)).isTrue();
     assertThat(FileNameUtils.fileNameToPartition(fileName)).isEqualTo(partition);
     assertThat(FileNameUtils.fileNameToStartOffset(fileName)).isEqualTo(startOffset);
     assertThat(FileNameUtils.fileNameToEndOffset(fileName)).isEqualTo(endOffset);
-    assertThat(FileNameUtils.fileNameToTimeIngested(fileName)).isGreaterThanOrEqualTo(now - 5000L).isLessThanOrEqualTo(now + 5000L);
+    assertThat(FileNameUtils.fileNameToTimeIngested(fileName))
+        .isGreaterThanOrEqualTo(now - 5000L)
+        .isLessThanOrEqualTo(now + 5000L);
 
     String prefix = FileNameUtils.getPrefixFromFileName(fileName);
-    // without bit shifting - the expression would match \d\d\d expression, but since we are left shifting by 16 bits left, it is going to be a larger number
+    // without bit shifting - the expression would match \d\d\d expression, but since we are left
+    // shifting by 16 bits left, it is going to be a larger number
     assertThat(prefix).matches("^TEST_CONNECTOR/test_table/\\d\\d\\d\\d\\d\\d\\d\\d\\d.*");
   }
 
@@ -99,18 +103,27 @@ public class FileNameUtilsTest {
     String topicName1 = "test_topic1";
     String topicName2 = "test_topic2";
     String fileName1 =
-            FileNameUtils.fileName(
-                    TestUtils.TEST_CONNECTOR_NAME, tableName, topicName1, partition, startOffset, endOffset);
+        FileNameUtils.fileName(
+            TestUtils.TEST_CONNECTOR_NAME,
+            tableName,
+            topicName1,
+            partition,
+            startOffset,
+            endOffset);
     String fileName2 =
-            FileNameUtils.fileName(
-                    TestUtils.TEST_CONNECTOR_NAME, tableName, topicName2, partition, startOffset, endOffset);
+        FileNameUtils.fileName(
+            TestUtils.TEST_CONNECTOR_NAME,
+            tableName,
+            topicName2,
+            partition,
+            startOffset,
+            endOffset);
     String fileName3 =
-            FileNameUtils.fileName(
-                    TestUtils.TEST_CONNECTOR_NAME, tableName, "", partition, startOffset, endOffset);
+        FileNameUtils.fileName(
+            TestUtils.TEST_CONNECTOR_NAME, tableName, "", partition, startOffset, endOffset);
     String fileName4 =
-            FileNameUtils.fileName(
-                    TestUtils.TEST_CONNECTOR_NAME, tableName, "", partition, startOffset, endOffset);
-
+        FileNameUtils.fileName(
+            TestUtils.TEST_CONNECTOR_NAME, tableName, "", partition, startOffset, endOffset);
 
     String prefix1 = FileNameUtils.getPrefixFromFileName(fileName1);
     String prefix2 = FileNameUtils.getPrefixFromFileName(fileName2);
@@ -130,10 +143,15 @@ public class FileNameUtilsTest {
     long endOffset = 789L;
     String tableName = "test_table";
     String topicName = "test_topic";
-    assertThatThrownBy(() -> FileNameUtils.fileName(
-                    TestUtils.TEST_CONNECTOR_NAME, tableName, topicName, partition, startOffset, endOffset))
-            .isInstanceOf(IllegalArgumentException.class);
-
+    assertThatThrownBy(
+            () ->
+                FileNameUtils.fileName(
+                    TestUtils.TEST_CONNECTOR_NAME,
+                    tableName,
+                    topicName,
+                    partition,
+                    startOffset,
+                    endOffset))
+        .isInstanceOf(IllegalArgumentException.class);
   }
-
 }

--- a/src/test/java/com/snowflake/kafka/connector/internal/FileNameUtilsTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/FileNameUtilsTest.java
@@ -15,7 +15,7 @@ public class FileNameUtilsTest {
     long time1 = System.currentTimeMillis();
     Thread.sleep(5); // error in maven without sleep
     String fileName =
-        FileNameUtils.fileName(
+        FileNameTestUtils.fileName(
             TestUtils.TEST_CONNECTOR_NAME, tableName, "", partition, startOffset, endOffset);
     Thread.sleep(5);
     long time2 = System.currentTimeMillis();
@@ -40,12 +40,12 @@ public class FileNameUtilsTest {
     assertThatThrownBy(() -> FileNameUtils.getPrefixFromFileName(""));
 
     String brokenFileName =
-        FileNameUtils.brokenRecordFileName(
+        FileNameTestUtils.brokenRecordFileName(
             TestUtils.TEST_CONNECTOR_NAME, tableName, "", partition, startOffset, true);
     assertThat(TestUtils.verifyBrokenRecordName(brokenFileName)).isTrue();
 
     brokenFileName =
-        FileNameUtils.brokenRecordFileName(
+        FileNameTestUtils.brokenRecordFileName(
             TestUtils.TEST_CONNECTOR_NAME, tableName, "", partition, startOffset, false);
     assertThat(TestUtils.verifyBrokenRecordName(brokenFileName)).isTrue();
   }
@@ -63,8 +63,8 @@ public class FileNameUtilsTest {
             + (time - InternalUtils.MAX_RECOVERY_TIME + 3600 * 1000)
             + ".json.gz";
 
-    assertThat(FileNameUtils.isFileExpired(expiredFile)).isTrue();
-    assertThat(FileNameUtils.isFileExpired(unexpiredFile)).isFalse();
+    assertThat(FileNameTestUtils.isFileExpired(expiredFile)).isTrue();
+    assertThat(FileNameTestUtils.isFileExpired(unexpiredFile)).isFalse();
   }
 
   @Test
@@ -76,7 +76,7 @@ public class FileNameUtilsTest {
     String topicName = "test_topic";
     long now = System.currentTimeMillis();
     String fileName =
-        FileNameUtils.fileName(
+        FileNameTestUtils.fileName(
             TestUtils.TEST_CONNECTOR_NAME, tableName, topicName, partition, startOffset, endOffset);
 
     assertThat(fileName).isNotNull();
@@ -103,7 +103,7 @@ public class FileNameUtilsTest {
     String topicName1 = "test_topic1";
     String topicName2 = "test_topic2";
     String fileName1 =
-        FileNameUtils.fileName(
+        FileNameTestUtils.fileName(
             TestUtils.TEST_CONNECTOR_NAME,
             tableName,
             topicName1,
@@ -111,7 +111,7 @@ public class FileNameUtilsTest {
             startOffset,
             endOffset);
     String fileName2 =
-        FileNameUtils.fileName(
+        FileNameTestUtils.fileName(
             TestUtils.TEST_CONNECTOR_NAME,
             tableName,
             topicName2,
@@ -119,10 +119,10 @@ public class FileNameUtilsTest {
             startOffset,
             endOffset);
     String fileName3 =
-        FileNameUtils.fileName(
+        FileNameTestUtils.fileName(
             TestUtils.TEST_CONNECTOR_NAME, tableName, "", partition, startOffset, endOffset);
     String fileName4 =
-        FileNameUtils.fileName(
+        FileNameTestUtils.fileName(
             TestUtils.TEST_CONNECTOR_NAME, tableName, "", partition, startOffset, endOffset);
 
     String prefix1 = FileNameUtils.getPrefixFromFileName(fileName1);
@@ -145,7 +145,7 @@ public class FileNameUtilsTest {
     String topicName = "test_topic";
     assertThatThrownBy(
             () ->
-                FileNameUtils.fileName(
+                FileNameTestUtils.fileName(
                     TestUtils.TEST_CONNECTOR_NAME,
                     tableName,
                     topicName,

--- a/src/test/java/com/snowflake/kafka/connector/internal/FileNameUtilsTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/FileNameUtilsTest.java
@@ -2,56 +2,51 @@ package com.snowflake.kafka.connector.internal;
 
 import org.junit.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 public class FileNameUtilsTest {
   @Test
   public void testFileNameFunctions() throws InterruptedException {
     int partition = 123;
     long startOffset = 456L;
     long endOffset = 789L;
-    String topic = "test_topic";
+    String tableName = "test_table";
     long time1 = System.currentTimeMillis();
     Thread.sleep(5); // error in maven without sleep
     String fileName =
         FileNameUtils.fileName(
-            TestUtils.TEST_CONNECTOR_NAME, topic, partition, startOffset, endOffset);
+            TestUtils.TEST_CONNECTOR_NAME, tableName, "", partition, startOffset, endOffset);
     Thread.sleep(5);
     long time2 = System.currentTimeMillis();
 
-    assert !FileNameUtils.verifyFileName("asdasdasdasdsa.json.gz");
-    assert FileNameUtils.verifyFileName(fileName);
-    assert FileNameUtils.fileNameToStartOffset(fileName) == startOffset;
-    assert FileNameUtils.fileNameToEndOffset(fileName) == endOffset;
-    assert FileNameUtils.fileNameToPartition(fileName) == partition;
+    assertThat(FileNameUtils.verifyFileName("asdasdasdasdsa.json.gz")).isFalse();
+    assertThat(FileNameUtils.verifyFileName(fileName)).isTrue();
+    assertThat(FileNameUtils.fileNameToStartOffset(fileName)).isEqualTo(startOffset);
+    assertThat(FileNameUtils.fileNameToEndOffset(fileName)).isEqualTo(endOffset);
+    assertThat(FileNameUtils.fileNameToPartition(fileName)).isEqualTo(partition);
 
     long createTime = FileNameUtils.fileNameToTimeIngested(fileName);
-    assert (createTime > time1) && (createTime < time2);
+    assertThat( (createTime > time1) && (createTime < time2)).isTrue();
 
-    assert FileNameUtils.removePrefixAndGZFromFileName("A/B/C/abc.tar.gz").equals("abc.tar");
-    assert FileNameUtils.removePrefixAndGZFromFileName("A/B/C/abc.json").equals("abc.json");
-    assert FileNameUtils.getPrefixFromFileName("A/B/C/abc.tar.gz").equals("A/B/C");
-    assert FileNameUtils.getPrefixFromFileName("A/B/C/abc.json").equals("A/B/C");
-    assert FileNameUtils.getPrefixFromFileName("abc.json") == null;
-    assert FileNameUtils.getPrefixFromFileName("abc.json.gz") == null;
-    try {
-      FileNameUtils.getPrefixFromFileName("A/B/C/");
-      assert false;
-    } catch (Exception e) {
-    }
-    try {
-      FileNameUtils.getPrefixFromFileName("");
-      assert false;
-    } catch (Exception e) {
-    }
+    assertThat(FileNameUtils.removePrefixAndGZFromFileName("A/B/C/abc.tar.gz")).isEqualTo("abc.tar");
+    assertThat(FileNameUtils.removePrefixAndGZFromFileName("A/B/C/abc.json")).isEqualTo("abc.json");
+    assertThat(FileNameUtils.getPrefixFromFileName("A/B/C/abc.tar.gz")).isEqualTo("A/B/C");
+    assertThat(FileNameUtils.getPrefixFromFileName("A/B/C/abc.json")).isEqualTo("A/B/C");
+    assertThat(FileNameUtils.getPrefixFromFileName("abc.json")).isNull();
+    assertThat(FileNameUtils.getPrefixFromFileName("abc.json.gz")).isNull();
+    assertThatThrownBy(() -> FileNameUtils.getPrefixFromFileName("A/B/C/"));
+    assertThatThrownBy(() -> FileNameUtils.getPrefixFromFileName(""));
 
     String brokenFileName =
         FileNameUtils.brokenRecordFileName(
-            TestUtils.TEST_CONNECTOR_NAME, topic, partition, startOffset, true);
-    assert TestUtils.verifyBrokenRecordName(brokenFileName);
+            TestUtils.TEST_CONNECTOR_NAME, tableName, "", partition, startOffset, true);
+    assertThat(TestUtils.verifyBrokenRecordName(brokenFileName)).isTrue();
 
     brokenFileName =
         FileNameUtils.brokenRecordFileName(
-            TestUtils.TEST_CONNECTOR_NAME, topic, partition, startOffset, false);
-    assert TestUtils.verifyBrokenRecordName(brokenFileName);
+            TestUtils.TEST_CONNECTOR_NAME, tableName, "", partition, startOffset, false);
+    assertThat(TestUtils.verifyBrokenRecordName(brokenFileName)).isTrue();
   }
 
   @Test
@@ -67,8 +62,78 @@ public class FileNameUtilsTest {
             + (time - InternalUtils.MAX_RECOVERY_TIME + 3600 * 1000)
             + ".json.gz";
 
-    assert FileNameUtils.isFileExpired(expiredFile);
-
-    assert !FileNameUtils.isFileExpired(unexpiredFile);
+    assertThat(FileNameUtils.isFileExpired(expiredFile)).isTrue();
+    assertThat(FileNameUtils.isFileExpired(unexpiredFile)).isFalse();
   }
+
+  @Test
+  public void testFileNameWillEncodeTopicNameToCreateUniquePrefix() {
+    int partition = 123;
+    long startOffset = 456L;
+    long endOffset = 789L;
+    String tableName = "test_table";
+    String topicName = "test_topic";
+    long now = System.currentTimeMillis();
+    String fileName =
+            FileNameUtils.fileName(
+                    TestUtils.TEST_CONNECTOR_NAME, tableName, topicName, partition, startOffset, endOffset);
+
+    assertThat(fileName).isNotNull();
+    assertThat(FileNameUtils.verifyFileName(fileName)).isTrue();
+    assertThat(FileNameUtils.fileNameToPartition(fileName)).isEqualTo(partition);
+    assertThat(FileNameUtils.fileNameToStartOffset(fileName)).isEqualTo(startOffset);
+    assertThat(FileNameUtils.fileNameToEndOffset(fileName)).isEqualTo(endOffset);
+    assertThat(FileNameUtils.fileNameToTimeIngested(fileName)).isGreaterThanOrEqualTo(now - 5000L).isLessThanOrEqualTo(now + 5000L);
+
+    String prefix = FileNameUtils.getPrefixFromFileName(fileName);
+    // without bit shifting - the expression would match \d\d\d expression, but since we are left shifting by 16 bits left, it is going to be a larger number
+    assertThat(prefix).matches("^TEST_CONNECTOR/test_table/\\d\\d\\d\\d\\d\\d\\d\\d\\d.*");
+  }
+
+  @Test
+  public void testFileNameWillEncodeTopicNameToCreateUniquePrefixesAndNamesWontCollide() {
+    int partition = 123;
+    long startOffset = 456L;
+    long endOffset = 789L;
+    String tableName = "test_table";
+    String topicName1 = "test_topic1";
+    String topicName2 = "test_topic2";
+    String fileName1 =
+            FileNameUtils.fileName(
+                    TestUtils.TEST_CONNECTOR_NAME, tableName, topicName1, partition, startOffset, endOffset);
+    String fileName2 =
+            FileNameUtils.fileName(
+                    TestUtils.TEST_CONNECTOR_NAME, tableName, topicName2, partition, startOffset, endOffset);
+    String fileName3 =
+            FileNameUtils.fileName(
+                    TestUtils.TEST_CONNECTOR_NAME, tableName, "", partition, startOffset, endOffset);
+    String fileName4 =
+            FileNameUtils.fileName(
+                    TestUtils.TEST_CONNECTOR_NAME, tableName, "", partition, startOffset, endOffset);
+
+
+    String prefix1 = FileNameUtils.getPrefixFromFileName(fileName1);
+    String prefix2 = FileNameUtils.getPrefixFromFileName(fileName2);
+    String prefix3 = FileNameUtils.getPrefixFromFileName(fileName3);
+    String prefix4 = FileNameUtils.getPrefixFromFileName(fileName4);
+
+    // prefixes with topic name included won't match
+    assertThat(prefix1).isNotEqualTo(prefix2);
+    // but prefixes without topic name would match
+    assertThat(prefix3).isEqualTo(prefix4);
+  }
+
+  @Test
+  public void testFileNameWontSupportMoreThan32767Partitions() {
+    int partition = 0x8000;
+    long startOffset = 456L;
+    long endOffset = 789L;
+    String tableName = "test_table";
+    String topicName = "test_topic";
+    assertThatThrownBy(() -> FileNameUtils.fileName(
+                    TestUtils.TEST_CONNECTOR_NAME, tableName, topicName, partition, startOffset, endOffset))
+            .isInstanceOf(IllegalArgumentException.class);
+
+  }
+
 }

--- a/src/test/java/com/snowflake/kafka/connector/internal/IngestionServiceIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/IngestionServiceIT.java
@@ -36,7 +36,7 @@ public class IngestionServiceIT {
     String file = "{\"aa\":123}";
     // File Name Format: app/table/partition/start_end_timeStamp.fileFormat.gz
     // start offset = 0, end offset = 1
-    String fileName = FileNameUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, 0, 0, 1);
+    String fileName = FileNameUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, "topic", table, 0, 0, 1);
 
     conn.put(stage, fileName, file);
     ingestService.ingestFile(fileName);

--- a/src/test/java/com/snowflake/kafka/connector/internal/IngestionServiceIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/IngestionServiceIT.java
@@ -37,7 +37,7 @@ public class IngestionServiceIT {
     // File Name Format: app/table/partition/start_end_timeStamp.fileFormat.gz
     // start offset = 0, end offset = 1
     String fileName =
-        FileNameUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, "topic", table, 0, 0, 1);
+        FileNameTestUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, "topic", table, 0, 0, 1);
 
     conn.put(stage, fileName, file);
     ingestService.ingestFile(fileName);

--- a/src/test/java/com/snowflake/kafka/connector/internal/IngestionServiceIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/IngestionServiceIT.java
@@ -36,7 +36,8 @@ public class IngestionServiceIT {
     String file = "{\"aa\":123}";
     // File Name Format: app/table/partition/start_end_timeStamp.fileFormat.gz
     // start offset = 0, end offset = 1
-    String fileName = FileNameUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, "topic", table, 0, 0, 1);
+    String fileName =
+        FileNameUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, "topic", table, 0, 0, 1);
 
     conn.put(stage, fileName, file);
     ingestService.ingestFile(fileName);

--- a/src/test/java/com/snowflake/kafka/connector/internal/SinkServiceIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/SinkServiceIT.java
@@ -754,13 +754,13 @@ public class SinkServiceIT {
     long time = System.currentTimeMillis() - 2 * 60 * 60 * 1000L;
 
     String fileName1 =
-        FileNameUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, null, 0, 0, 0, time);
+        FileNameTestUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, null, 0, 0, 0, time);
     String fileName2 =
-        FileNameUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, null, 0, 1, 1, time);
+        FileNameTestUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, null, 0, 1, 1, time);
     String fileName3 =
-        FileNameUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, null, 0, 2, 3, time);
+        FileNameTestUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, null, 0, 2, 3, time);
     String fileName4 =
-        FileNameUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, null, 0, 4, 5, time);
+        FileNameTestUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, null, 0, 4, 5, time);
 
     conn.createStage(stage);
     conn.createTable(table);

--- a/src/test/java/com/snowflake/kafka/connector/internal/SinkServiceIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/SinkServiceIT.java
@@ -124,7 +124,11 @@ public class SinkServiceIT {
         () ->
             conn.listStage(
                         stage,
-                        FileNameUtils.filePrefix(TestUtils.TEST_CONNECTOR_NAME, table, topicFileNamePlaceholder, partition))
+                        FileNameUtils.filePrefix(
+                            TestUtils.TEST_CONNECTOR_NAME,
+                            table,
+                            topicFileNamePlaceholder,
+                            partition))
                     .size()
                 == 1,
         5,
@@ -132,7 +136,9 @@ public class SinkServiceIT {
     service.callAllGetOffset();
     List<String> files =
         conn.listStage(
-            stage, FileNameUtils.filePrefix(TestUtils.TEST_CONNECTOR_NAME, table, topicFileNamePlaceholder, partition));
+            stage,
+            FileNameUtils.filePrefix(
+                TestUtils.TEST_CONNECTOR_NAME, table, topicFileNamePlaceholder, partition));
     String fileName = files.get(0);
 
     assert FileNameUtils.fileNameToTimeIngested(fileName) < System.currentTimeMillis();
@@ -248,7 +254,8 @@ public class SinkServiceIT {
         () ->
             conn.listStage(
                         stage,
-                        FileNameUtils.filePrefix(TestUtils.TEST_CONNECTOR_NAME, table, "", partition))
+                        FileNameUtils.filePrefix(
+                            TestUtils.TEST_CONNECTOR_NAME, table, "", partition))
                     .size()
                 == 1,
         5,
@@ -434,7 +441,8 @@ public class SinkServiceIT {
         () ->
             conn.listStage(
                         stage,
-                        FileNameUtils.filePrefix(TestUtils.TEST_CONNECTOR_NAME, table, "", partition))
+                        FileNameUtils.filePrefix(
+                            TestUtils.TEST_CONNECTOR_NAME, table, "", partition))
                     .size()
                 == 1,
         5,
@@ -562,7 +570,8 @@ public class SinkServiceIT {
         () ->
             conn.listStage(
                         stage,
-                        FileNameUtils.filePrefix(TestUtils.TEST_CONNECTOR_NAME, table, null, partition))
+                        FileNameUtils.filePrefix(
+                            TestUtils.TEST_CONNECTOR_NAME, table, null, partition))
                     .size()
                 == 1,
         5,
@@ -744,10 +753,14 @@ public class SinkServiceIT {
     // Two hours ago                         h   m    s    milli
     long time = System.currentTimeMillis() - 2 * 60 * 60 * 1000L;
 
-    String fileName1 = FileNameUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, null, 0, 0, 0, time);
-    String fileName2 = FileNameUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, null, 0, 1, 1, time);
-    String fileName3 = FileNameUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, null,0, 2, 3, time);
-    String fileName4 = FileNameUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, null, 0, 4, 5, time);
+    String fileName1 =
+        FileNameUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, null, 0, 0, 0, time);
+    String fileName2 =
+        FileNameUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, null, 0, 1, 1, time);
+    String fileName3 =
+        FileNameUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, null, 0, 2, 3, time);
+    String fileName4 =
+        FileNameUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, null, 0, 4, 5, time);
 
     conn.createStage(stage);
     conn.createTable(table);
@@ -880,7 +893,8 @@ public class SinkServiceIT {
             spyConn
                     .listStage(
                         stage,
-                        FileNameUtils.filePrefix(TestUtils.TEST_CONNECTOR_NAME, table, topicName, partition))
+                        FileNameUtils.filePrefix(
+                            TestUtils.TEST_CONNECTOR_NAME, table, topicName, partition))
                     .size()
                 == 1,
         5,
@@ -908,7 +922,8 @@ public class SinkServiceIT {
             spyConn
                     .listStage(
                         stage,
-                        FileNameUtils.filePrefix(TestUtils.TEST_CONNECTOR_NAME, table, topicName, partition))
+                        FileNameUtils.filePrefix(
+                            TestUtils.TEST_CONNECTOR_NAME, table, topicName, partition))
                     .size()
                 == 0,
         30,
@@ -947,7 +962,8 @@ public class SinkServiceIT {
             spyConn
                     .listStage(
                         stage,
-                        FileNameUtils.filePrefix(TestUtils.TEST_CONNECTOR_NAME, table, null, partition))
+                        FileNameUtils.filePrefix(
+                            TestUtils.TEST_CONNECTOR_NAME, table, null, partition))
                     .size()
                 == 1,
         5,
@@ -971,7 +987,8 @@ public class SinkServiceIT {
             spyConn
                     .listStage(
                         stage,
-                        FileNameUtils.filePrefix(TestUtils.TEST_CONNECTOR_NAME, table, null, partition))
+                        FileNameUtils.filePrefix(
+                            TestUtils.TEST_CONNECTOR_NAME, table, null, partition))
                     .size()
                 == 0,
         60,

--- a/src/test/java/com/snowflake/kafka/connector/internal/SinkServiceIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/SinkServiceIT.java
@@ -25,6 +25,8 @@ import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.After;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class SinkServiceIT {
   private SnowflakeConnectionService conn = TestUtils.getConnectionService();
@@ -90,13 +92,21 @@ public class SinkServiceIT {
         });
   }
 
-  @Test
-  public void testIngestion() throws Exception {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testIngestion(boolean useMultipleTopicsToTable) throws Exception {
     conn.createTable(table);
     conn.createStage(stage);
+    Map<String, String> topic2Table = new HashMap<>();
+    final String topicFileNamePlaceholder = useMultipleTopicsToTable ? topic : "";
+    if (useMultipleTopicsToTable) {
+      topic2Table.put(topic, table);
+      topic2Table.put("dummy", table);
+    }
     SnowflakeSinkService service =
         SnowflakeSinkServiceFactory.builder(conn)
             .setRecordNumber(1)
+            .setTopic2TableMap(topic2Table)
             .addTask(table, new TopicPartition(topic, partition))
             .build();
 
@@ -114,7 +124,7 @@ public class SinkServiceIT {
         () ->
             conn.listStage(
                         stage,
-                        FileNameUtils.filePrefix(TestUtils.TEST_CONNECTOR_NAME, table, partition))
+                        FileNameUtils.filePrefix(TestUtils.TEST_CONNECTOR_NAME, table, topicFileNamePlaceholder, partition))
                     .size()
                 == 1,
         5,
@@ -122,7 +132,7 @@ public class SinkServiceIT {
     service.callAllGetOffset();
     List<String> files =
         conn.listStage(
-            stage, FileNameUtils.filePrefix(TestUtils.TEST_CONNECTOR_NAME, table, partition));
+            stage, FileNameUtils.filePrefix(TestUtils.TEST_CONNECTOR_NAME, table, topicFileNamePlaceholder, partition));
     String fileName = files.get(0);
 
     assert FileNameUtils.fileNameToTimeIngested(fileName) < System.currentTimeMillis();
@@ -238,7 +248,7 @@ public class SinkServiceIT {
         () ->
             conn.listStage(
                         stage,
-                        FileNameUtils.filePrefix(TestUtils.TEST_CONNECTOR_NAME, table, partition))
+                        FileNameUtils.filePrefix(TestUtils.TEST_CONNECTOR_NAME, table, "", partition))
                     .size()
                 == 1,
         5,
@@ -246,7 +256,7 @@ public class SinkServiceIT {
     service.callAllGetOffset();
     List<String> files =
         conn.listStage(
-            stage, FileNameUtils.filePrefix(TestUtils.TEST_CONNECTOR_NAME, table, partition));
+            stage, FileNameUtils.filePrefix(TestUtils.TEST_CONNECTOR_NAME, table, "", partition));
     String fileName = files.get(0);
 
     assert FileNameUtils.fileNameToTimeIngested(fileName) < System.currentTimeMillis();
@@ -424,7 +434,7 @@ public class SinkServiceIT {
         () ->
             conn.listStage(
                         stage,
-                        FileNameUtils.filePrefix(TestUtils.TEST_CONNECTOR_NAME, table, partition))
+                        FileNameUtils.filePrefix(TestUtils.TEST_CONNECTOR_NAME, table, "", partition))
                     .size()
                 == 1,
         5,
@@ -432,7 +442,7 @@ public class SinkServiceIT {
     service.callAllGetOffset();
     List<String> files =
         conn.listStage(
-            stage, FileNameUtils.filePrefix(TestUtils.TEST_CONNECTOR_NAME, table, partition));
+            stage, FileNameUtils.filePrefix(TestUtils.TEST_CONNECTOR_NAME, table, "", partition));
     String fileName = files.get(0);
 
     assert FileNameUtils.fileNameToTimeIngested(fileName) < System.currentTimeMillis();
@@ -552,7 +562,7 @@ public class SinkServiceIT {
         () ->
             conn.listStage(
                         stage,
-                        FileNameUtils.filePrefix(TestUtils.TEST_CONNECTOR_NAME, table, partition))
+                        FileNameUtils.filePrefix(TestUtils.TEST_CONNECTOR_NAME, table, null, partition))
                     .size()
                 == 1,
         5,
@@ -560,7 +570,7 @@ public class SinkServiceIT {
     service.callAllGetOffset();
     files =
         conn.listStage(
-            stage, FileNameUtils.filePrefix(TestUtils.TEST_CONNECTOR_NAME, table, partition));
+            stage, FileNameUtils.filePrefix(TestUtils.TEST_CONNECTOR_NAME, table, null, partition));
     String fileName = files.get(0);
 
     assert FileNameUtils.fileNameToTimeIngested(fileName) < System.currentTimeMillis();
@@ -734,10 +744,10 @@ public class SinkServiceIT {
     // Two hours ago                         h   m    s    milli
     long time = System.currentTimeMillis() - 2 * 60 * 60 * 1000L;
 
-    String fileName1 = FileNameUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, 0, 0, 0, time);
-    String fileName2 = FileNameUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, 0, 1, 1, time);
-    String fileName3 = FileNameUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, 0, 2, 3, time);
-    String fileName4 = FileNameUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, 0, 4, 5, time);
+    String fileName1 = FileNameUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, null, 0, 0, 0, time);
+    String fileName2 = FileNameUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, null, 0, 1, 1, time);
+    String fileName3 = FileNameUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, null,0, 2, 3, time);
+    String fileName4 = FileNameUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, null, 0, 4, 5, time);
 
     conn.createStage(stage);
     conn.createTable(table);
@@ -825,7 +835,7 @@ public class SinkServiceIT {
 
   int getStageSize(String stage, String table, int partition) {
     return conn.listStage(
-            stage, FileNameUtils.filePrefix(TestUtils.TEST_CONNECTOR_NAME, table, partition))
+            stage, FileNameUtils.filePrefix(TestUtils.TEST_CONNECTOR_NAME, table, null, partition))
         .size();
   }
 
@@ -834,15 +844,24 @@ public class SinkServiceIT {
    *
    * @throws Exception
    */
-  @Test
-  public void testCleanerRecover() throws Exception {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testCleanerRecover(boolean useMultipleTopicsToTable) throws Exception {
     conn.createTable(table);
     conn.createStage(stage);
     SnowflakeConnectionService spyConn = spy(conn);
 
+    final String topicName = useMultipleTopicsToTable ? topic : null;
+    Map<String, String> topic2Table = new HashMap<>();
+    if (useMultipleTopicsToTable) {
+      topic2Table.put(topic, table);
+      topic2Table.put("dummy", table);
+    }
+
     SnowflakeSinkService service =
         SnowflakeSinkServiceFactory.builder(spyConn)
             .setRecordNumber(1)
+            .setTopic2TableMap(topic2Table)
             .addTask(table, new TopicPartition(topic, partition))
             .build();
 
@@ -861,7 +880,7 @@ public class SinkServiceIT {
             spyConn
                     .listStage(
                         stage,
-                        FileNameUtils.filePrefix(TestUtils.TEST_CONNECTOR_NAME, table, partition))
+                        FileNameUtils.filePrefix(TestUtils.TEST_CONNECTOR_NAME, table, topicName, partition))
                     .size()
                 == 1,
         5,
@@ -889,7 +908,7 @@ public class SinkServiceIT {
             spyConn
                     .listStage(
                         stage,
-                        FileNameUtils.filePrefix(TestUtils.TEST_CONNECTOR_NAME, table, partition))
+                        FileNameUtils.filePrefix(TestUtils.TEST_CONNECTOR_NAME, table, topicName, partition))
                     .size()
                 == 0,
         30,
@@ -928,7 +947,7 @@ public class SinkServiceIT {
             spyConn
                     .listStage(
                         stage,
-                        FileNameUtils.filePrefix(TestUtils.TEST_CONNECTOR_NAME, table, partition))
+                        FileNameUtils.filePrefix(TestUtils.TEST_CONNECTOR_NAME, table, null, partition))
                     .size()
                 == 1,
         5,
@@ -952,7 +971,7 @@ public class SinkServiceIT {
             spyConn
                     .listStage(
                         stage,
-                        FileNameUtils.filePrefix(TestUtils.TEST_CONNECTOR_NAME, table, partition))
+                        FileNameUtils.filePrefix(TestUtils.TEST_CONNECTOR_NAME, table, null, partition))
                     .size()
                 == 0,
         60,

--- a/src/test/java/com/snowflake/kafka/connector/internal/SnowflakeTelemetryPipeStatusMetricsIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/SnowflakeTelemetryPipeStatusMetricsIT.java
@@ -94,7 +94,7 @@ public class SnowflakeTelemetryPipeStatusMetricsIT {
             conn.listStage(
                         stageName,
                         FileNameUtils.filePrefix(
-                            TestUtils.TEST_CONNECTOR_NAME, tableName, partition))
+                            TestUtils.TEST_CONNECTOR_NAME, tableName, null, partition))
                     .size()
                 == 0,
         30,

--- a/src/test/java/com/snowflake/kafka/connector/internal/StageFilesProcessorTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/StageFilesProcessorTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.anyMap;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -19,6 +20,7 @@ import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryPipeSt
 import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryService;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -257,8 +259,92 @@ class StageFilesProcessorTest {
     verify(ingestionService, times(50)).readOneHourHistory(anyList(), anyLong());
     // when files get to the 1 hour age, they will be automatically marked as failed and moved to
     // table stage
+    verify(conn, times(3)).moveToTableStage(anyString(), anyString(), failedFiles.capture());
+    assertThat(failedFiles.getAllValues().stream().flatMap(Collection::stream))
+        .containsOnly(file1, file2, file3);
+  }
+
+  @Test
+  void fileProcessor_WillMoveFailedFilesToStageEvenWhenOneFails() {
+    createFileProcessor(61);
+
+    String file1 = String.format("connector/topic/0/1_9_%d.json.gz", currentTime.get());
+    String file2 = String.format("connector/topic/0/10_19_%d.json.gz", currentTime.get());
+    String file3 = String.format("connector/topic/0/20_29_%d.json.gz", currentTime.get());
+    register.registerNewStageFile(file1);
+    register.registerNewStageFile(file2);
+    register.registerNewStageFile(file3);
+
+    when(conn.listStage(STAGE_NAME, PREFIX)).thenReturn(new ArrayList<>());
+    // no report for request files
+    when(ingestionService.readIngestHistoryForward(anyMap(), any(), any(), anyInt()))
+        .thenAnswer(
+            a -> {
+              Map<String, InternalUtils.IngestedFileStatus> report = a.getArgument(0);
+              report.put(file1, InternalUtils.IngestedFileStatus.FAILED);
+              report.put(file2, InternalUtils.IngestedFileStatus.FAILED);
+              report.put(file3, InternalUtils.IngestedFileStatus.FAILED);
+              return 3;
+            });
+    // ... nor any history entry in the past one hour
+    when(ingestionService.readOneHourHistory(anyList(), anyLong())).thenReturn(new HashMap<>());
+    // we should not purge stage when file is not LOADED
+    doNothing().when(conn).purgeStage(anyString(), anyList());
+    ArgumentCaptor<List<String>> failedFiles = ArgumentCaptor.forClass(List.class);
+    doThrow(new SnowflakeKafkaConnectorException("ups", "123"))
+        .doNothing()
+        .doNothing()
+        .when(conn)
+        .moveToTableStage(anyString(), anyString(), failedFiles.capture());
+
+    victim.trackFiles(register, telemetry);
+
+    verify(conn, times(1)).listStage(STAGE_NAME, PREFIX);
+    verify(ingestionService, times(1)).readIngestHistoryForward(anyMap(), any(), any(), anyInt());
+    verify(conn, times(0)).purgeStage(anyString(), anyList());
+    verify(ingestionService, times(0)).readOneHourHistory(anyList(), anyLong());
+    verify(conn, times(3)).moveToTableStage(anyString(), anyString(), failedFiles.capture());
+    assertThat(failedFiles.getAllValues().stream().flatMap(Collection::stream))
+        .containsOnly(file1, file2, file3);
+  }
+
+  @Test
+  void fileProcessor_WillTreatFreshStaleFileAsStageOne() {
+    createFileProcessor(61);
+
+    String file1 =
+        String.format(
+            "connector/topic/0/1_9_%d.json.gz",
+            currentTime.get() + Duration.ofSeconds(65L).toMillis());
+    register.registerNewStageFile(file1);
+    register.newOffset(Long.MIN_VALUE);
+    nextTickCallback.set(
+        (run, time) -> {
+          if (run == 1) {
+            register.newOffset(Long.MAX_VALUE);
+          }
+        });
+
+    when(conn.listStage(STAGE_NAME, PREFIX)).thenReturn(new ArrayList<>());
+    // no report for request files
+    when(ingestionService.readIngestHistoryForward(anyMap(), any(), any(), anyInt())).thenReturn(0);
+    // ... nor any history entry in the past one hour
+    when(ingestionService.readOneHourHistory(anyList(), anyLong())).thenReturn(new HashMap<>());
+    // we should not purge stage when file is not LOADED
+    doNothing().when(conn).purgeStage(anyString(), anyList());
+    ArgumentCaptor<List<String>> failedFiles = ArgumentCaptor.forClass(List.class);
+    doNothing().when(conn).moveToTableStage(anyString(), anyString(), failedFiles.capture());
+
+    victim.trackFiles(register, telemetry);
+
+    verify(conn, times(1)).listStage(STAGE_NAME, PREFIX);
+    verify(ingestionService, times(60)).readIngestHistoryForward(anyMap(), any(), any(), anyInt());
+    verify(conn, times(0)).purgeStage(anyString(), anyList());
+    verify(ingestionService, times(50)).readOneHourHistory(anyList(), anyLong());
+    // when files get to the 1 hour age, they will be automatically marked as failed and moved to
+    // table stage
     verify(conn, times(1)).moveToTableStage(anyString(), anyString(), failedFiles.capture());
-    assertThat(failedFiles.getValue()).containsOnly(file1, file2, file3);
+    assertThat(failedFiles.getValue()).containsOnly(file1);
   }
 
   @Test

--- a/src/test/java/com/snowflake/kafka/connector/internal/StageFilesProcessorTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/StageFilesProcessorTest.java
@@ -81,6 +81,8 @@ class StageFilesProcessorTest {
             TABLE_NAME,
             STAGE_NAME,
             PREFIX,
+            "topic",
+            0,
             conn,
             ingestionService,
             pipeTelemetry,

--- a/src/test/java/com/snowflake/kafka/connector/internal/StageFilesProcessor_FileCategorizerTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/StageFilesProcessor_FileCategorizerTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.base.Functions;
 import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -14,11 +16,15 @@ import java.util.stream.IntStream;
 import net.snowflake.client.jdbc.internal.joda.time.DateTime;
 import net.snowflake.client.jdbc.internal.joda.time.DateTimeZone;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class StageFilesProcessor_FileCategorizerTest {
   @Test
   void allFilesWillBeCategorizedAsStageFilesWhenNoInitialOffsetIsSupplied() {
     DateTime ts = new DateTime(2000, 1, 10, 12, 0, DateTimeZone.UTC);
+    StageFilesProcessor.FilteringPredicates filters =
+        new StageFilesProcessor.FilteringPredicates(() -> ts.toInstant().getMillis(), "");
     List<String> files =
         IntStream.rangeClosed(0, 9)
             .mapToObj(
@@ -31,7 +37,7 @@ class StageFilesProcessor_FileCategorizerTest {
             .collect(Collectors.toList());
 
     StageFilesProcessor.FileCategorizer victim =
-        StageFilesProcessor.FileCategorizer.build(files, Long.MAX_VALUE);
+        StageFilesProcessor.FileCategorizer.build(files, Long.MAX_VALUE, filters);
 
     assertThat(victim.hasDirtyFiles()).isFalse();
     assertThat(victim.hasStageFiles()).isTrue();
@@ -41,6 +47,8 @@ class StageFilesProcessor_FileCategorizerTest {
   @Test
   void filesOlderThen1MinuteWillBeCategorizedAsMature() {
     DateTime ts = new DateTime(2000, 1, 10, 12, 0, DateTimeZone.UTC);
+    StageFilesProcessor.FilteringPredicates filters =
+        new StageFilesProcessor.FilteringPredicates(() -> ts.toInstant().getMillis(), "");
     List<String> files = new ArrayList<>();
     String matureFile =
         String.format(
@@ -60,10 +68,7 @@ class StageFilesProcessor_FileCategorizerTest {
     files.add(toYoungFile);
 
     StageFilesProcessor.FileCategorizer victim =
-        StageFilesProcessor.FileCategorizer.build(files, Long.MAX_VALUE);
-
-    StageFilesProcessor.FilteringPredicates filters =
-        new StageFilesProcessor.FilteringPredicates(ts::getMillis, "");
+        StageFilesProcessor.FileCategorizer.build(files, Long.MAX_VALUE, filters);
 
     assertThat(victim.hasDirtyFiles()).isFalse();
     assertThat(victim.hasStageFiles()).isTrue();
@@ -74,6 +79,8 @@ class StageFilesProcessor_FileCategorizerTest {
   @Test
   void filesYoungerThen1MinuteWillNotBeCategorizedAsLoaded() {
     DateTime ts = new DateTime(2000, 1, 10, 12, 0, DateTimeZone.UTC);
+    StageFilesProcessor.FilteringPredicates filters =
+        new StageFilesProcessor.FilteringPredicates(() -> ts.toInstant().getMillis(), "");
     List<String> files = new ArrayList<>();
     String matureFile =
         String.format(
@@ -93,7 +100,7 @@ class StageFilesProcessor_FileCategorizerTest {
     files.add(toYoungFile);
 
     StageFilesProcessor.FileCategorizer victim =
-        StageFilesProcessor.FileCategorizer.build(files, Long.MAX_VALUE);
+        StageFilesProcessor.FileCategorizer.build(files, Long.MAX_VALUE, filters);
     Map<String, StageFilesProcessor.IngestEntry> statuses =
         files.stream()
             .collect(
@@ -103,9 +110,6 @@ class StageFilesProcessor_FileCategorizerTest {
                         new StageFilesProcessor.IngestEntry(
                             InternalUtils.IngestedFileStatus.LOADED, ts.getMillis())));
     victim.updateFileStatus(statuses);
-
-    StageFilesProcessor.FilteringPredicates filters =
-        new StageFilesProcessor.FilteringPredicates(ts::getMillis, "");
 
     assertThat(victim.hasDirtyFiles()).isFalse();
     assertThat(victim.hasStageFiles()).isTrue();
@@ -117,6 +121,8 @@ class StageFilesProcessor_FileCategorizerTest {
   @Test
   void filesYoungerThen1MinuteWillNotBeCategorizedAsFailed() {
     DateTime ts = new DateTime(2000, 1, 10, 12, 0, DateTimeZone.UTC);
+    StageFilesProcessor.FilteringPredicates filters =
+        new StageFilesProcessor.FilteringPredicates(() -> ts.toInstant().getMillis(), "");
     List<String> files = new ArrayList<>();
     String matureFile =
         String.format(
@@ -136,7 +142,7 @@ class StageFilesProcessor_FileCategorizerTest {
     files.add(toYoungFile);
 
     StageFilesProcessor.FileCategorizer victim =
-        StageFilesProcessor.FileCategorizer.build(files, Long.MAX_VALUE);
+        StageFilesProcessor.FileCategorizer.build(files, Long.MAX_VALUE, filters);
     Map<String, StageFilesProcessor.IngestEntry> statuses =
         files.stream()
             .collect(
@@ -147,9 +153,6 @@ class StageFilesProcessor_FileCategorizerTest {
                             InternalUtils.IngestedFileStatus.FAILED, ts.getMillis())));
     victim.updateFileStatus(statuses);
 
-    StageFilesProcessor.FilteringPredicates filters =
-        new StageFilesProcessor.FilteringPredicates(ts::getMillis, "");
-
     assertThat(victim.hasDirtyFiles()).isFalse();
     assertThat(victim.hasStageFiles()).isTrue();
     assertThat(victim.query(filters.failedFilesPredicate).collect(Collectors.toList())).isEmpty();
@@ -158,10 +161,36 @@ class StageFilesProcessor_FileCategorizerTest {
   }
 
   @Test
-  void allFilesWillBeCategorizedAsDirtyFilesIfOffsetIsSmallerThanLastSubmittedFile() {
+  void allMatureFilesWillBeCategorizedAsDirtyFilesIfOffsetIsSmallerThanLastSubmittedFile() {
     DateTime ts = new DateTime(2000, 1, 10, 12, 0, DateTimeZone.UTC);
+    StageFilesProcessor.FilteringPredicates filters =
+        new StageFilesProcessor.FilteringPredicates(() -> ts.toInstant().getMillis(), "");
     List<String> files =
-        IntStream.rangeClosed(0, 9)
+        IntStream.rangeClosed(1, 10)
+            .mapToObj(
+                i ->
+                    String.format(
+                        "connector/topic/0/%d_%d_%d.json.gz",
+                        i * 100,
+                        ((i + 1) * 100) - 1,
+                        ts.getMillis() - Duration.ofMinutes(i).toMillis()))
+            .collect(Collectors.toList());
+
+    StageFilesProcessor.FileCategorizer victim =
+        StageFilesProcessor.FileCategorizer.build(files, -1, filters);
+
+    assertThat(victim.hasDirtyFiles()).isTrue();
+    assertThat(victim.hasStageFiles()).isFalse();
+    assertThat(victim.query(t -> true).collect(Collectors.toList())).isEmpty();
+  }
+
+  @Test
+  void allFreshFilesWillBeCategorizedAsStageFilesIfTheyHaventMatured() {
+    DateTime ts = new DateTime(2000, 1, 10, 12, 0, DateTimeZone.UTC);
+    StageFilesProcessor.FilteringPredicates filters =
+        new StageFilesProcessor.FilteringPredicates(() -> ts.toInstant().getMillis(), "");
+    List<String> files =
+        IntStream.rangeClosed(1, 10)
             .mapToObj(
                 i ->
                     String.format(
@@ -172,11 +201,11 @@ class StageFilesProcessor_FileCategorizerTest {
             .collect(Collectors.toList());
 
     StageFilesProcessor.FileCategorizer victim =
-        StageFilesProcessor.FileCategorizer.build(files, -1);
+        StageFilesProcessor.FileCategorizer.build(files, -1, filters);
 
-    assertThat(victim.hasDirtyFiles()).isTrue();
-    assertThat(victim.hasStageFiles()).isFalse();
-    assertThat(victim.query(t -> true).collect(Collectors.toList())).isEmpty();
+    assertThat(victim.hasDirtyFiles()).isFalse();
+    assertThat(victim.hasStageFiles()).isTrue();
+    assertThat(victim.query(t -> true).collect(Collectors.toList())).hasSize(10).containsAll(files);
   }
 
   @Test
@@ -208,7 +237,7 @@ class StageFilesProcessor_FileCategorizerTest {
                             InternalUtils.IngestedFileStatus.LOADED, ts.getMillis())));
 
     StageFilesProcessor.FileCategorizer victim =
-        StageFilesProcessor.FileCategorizer.build(files, Long.MAX_VALUE);
+        StageFilesProcessor.FileCategorizer.build(files, Long.MAX_VALUE, filters);
     victim.updateFileStatus(statuses);
 
     assertThat(victim.query(filters.loadedFilesPredicate).collect(Collectors.toList()))
@@ -253,7 +282,7 @@ class StageFilesProcessor_FileCategorizerTest {
                             ts.getMillis())));
 
     StageFilesProcessor.FileCategorizer victim =
-        StageFilesProcessor.FileCategorizer.build(files, Long.MAX_VALUE);
+        StageFilesProcessor.FileCategorizer.build(files, Long.MAX_VALUE, filters);
     victim.updateFileStatus(statuses);
 
     assertThat(victim.query(filters.loadedFilesPredicate).collect(Collectors.toList())).isEmpty();
@@ -282,7 +311,7 @@ class StageFilesProcessor_FileCategorizerTest {
             .collect(Collectors.toList());
 
     StageFilesProcessor.FileCategorizer victim =
-        StageFilesProcessor.FileCategorizer.build(files, Long.MAX_VALUE);
+        StageFilesProcessor.FileCategorizer.build(files, Long.MAX_VALUE, filters);
 
     assertThat(victim.query(filters.loadedFilesPredicate).collect(Collectors.toList())).isEmpty();
     assertThat(victim.query(filters.failedFilesPredicate).collect(Collectors.toList()))
@@ -311,7 +340,7 @@ class StageFilesProcessor_FileCategorizerTest {
             .collect(Collectors.toList());
 
     StageFilesProcessor.FileCategorizer victim =
-        StageFilesProcessor.FileCategorizer.build(files, Long.MAX_VALUE);
+        StageFilesProcessor.FileCategorizer.build(files, Long.MAX_VALUE, filters);
 
     assertThat(victim.query(filters.loadedFilesPredicate).collect(Collectors.toList())).isEmpty();
     assertThat(victim.query(filters.failedFilesPredicate).collect(Collectors.toList())).isEmpty();
@@ -366,12 +395,51 @@ class StageFilesProcessor_FileCategorizerTest {
     statuses.put(files.get(0), InternalUtils.IngestedFileStatus.LOADED);
 
     StageFilesProcessor.FileCategorizer victim =
-        StageFilesProcessor.FileCategorizer.build(files, Long.MAX_VALUE);
+        StageFilesProcessor.FileCategorizer.build(files, Long.MAX_VALUE, filters);
     victim.stopTrackingFiles(files);
 
     assertThat(victim.query(filters.loadedFilesPredicate).collect(Collectors.toList())).isEmpty();
     assertThat(victim.query(filters.failedFilesPredicate).collect(Collectors.toList())).isEmpty();
     assertThat(victim.query(filters.staledFilesPredicate).collect(Collectors.toList())).isEmpty();
-    ;
+  }
+
+  @ParameterizedTest
+  @ValueSource(longs = {Long.MIN_VALUE, Long.MAX_VALUE})
+  void fileTestFor_SNOW_1642799(long offset) {
+    String fileTimestamp = "28 Aug 2024 @ 17:32:40.822 UTC";
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd MMM yyyy '@' HH:mm:ss.SSS z");
+    // Parse the string to a ZonedDateTime object
+    ZonedDateTime fileTs = ZonedDateTime.parse(fileTimestamp, formatter);
+    ArrayList<String> files = new ArrayList<>();
+    files.add(
+        String.format(
+            "lcc_odgzj_2129566559/EDGE_EVENTABLE_ADHOCAVROV1_PROD_PRIVATE/2/576942355_576942400_%d.json.gz",
+            fileTs.toInstant().toEpochMilli()));
+
+    Map<String, StageFilesProcessor.IngestEntry> statuses = new HashMap<>();
+
+    String cleanerExecutionTime = "28 Aug 2024 @ 17:32:58.118 UTC";
+    ZonedDateTime cleanerRunTime = ZonedDateTime.parse(cleanerExecutionTime, formatter);
+
+    StageFilesProcessor.TimeSupplier timeSupplier = () -> cleanerRunTime.toInstant().toEpochMilli();
+    StageFilesProcessor.FilteringPredicates filters =
+        new StageFilesProcessor.FilteringPredicates(timeSupplier, "lcc_odgzj_2129566559");
+    StageFilesProcessor.FileCategorizer victim =
+        StageFilesProcessor.FileCategorizer.build(files, offset, filters);
+
+    String fileUploadTime = "28 Aug 2024 @ 17:32:41.113 UTC";
+    statuses.put(
+        files.get(0),
+        new StageFilesProcessor.IngestEntry(
+            InternalUtils.IngestedFileStatus.NOT_FOUND,
+            ZonedDateTime.parse(fileUploadTime, formatter).toInstant().toEpochMilli()));
+    victim.updateFileStatus(statuses);
+
+    assertThat(victim.query(filters.trackableFilesPredicate).collect(Collectors.toList()))
+        .isNotEmpty();
+    assertThat(victim.query(filters.matureFilePredicate).collect(Collectors.toList())).isEmpty();
+    assertThat(victim.query(filters.loadedFilesPredicate).collect(Collectors.toList())).isEmpty();
+    assertThat(victim.query(filters.staledFilesPredicate).collect(Collectors.toList())).isEmpty();
+    assertThat(victim.hasDirtyFiles()).isFalse();
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
@@ -454,7 +454,9 @@ public class TestUtils {
     return randomName("pipe");
   }
 
-  public static String randomTopicName() { return randomName("topic");}
+  public static String randomTopicName() {
+    return randomName("topic");
+  }
 
   /**
    * retrieve one properties

--- a/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
@@ -454,6 +454,8 @@ public class TestUtils {
     return randomName("pipe");
   }
 
+  public static String randomTopicName() { return randomName("topic");}
+
   /**
    * retrieve one properties
    *


### PR DESCRIPTION
<!-- Text inside of HTML comment blocks will NOT appear in your pull request description -->
<!-- Formatting information can be found at https://www.markdownguide.org/basic-syntax/ -->
# Overview

SNOW-1642799

Based on the logs analysis - when failed file is handled, it should happen that file is moved to table stage. However, it may happen that the file was removed by external process (i.e. manually) - in such case - exception would interrupt file cleaner process, which in turn - could potentially delete freshly uploaded files upon trying to resume normal operation. 

This PR does 2 things:
- in case of error when moving file to table stage - the cleaning process is not interrupted - file could be removed manually, so we just log the error and continue operation. Worst case scenario - the file would be moved in subsequent cleanup cycles - it may occupy stage for some time. 
- in case of forced restart, the cleaner will not delete "fresh" files - if cleaner process is restarting, the file may be processed by pipe logic, so the file may end up being ingested - worst case scenario - file will stay on stage for 1 hour and eventually be deleted. 

<!--
Why is this review being requested?  The full details should be in the JIRA, but the review should focus on the fix/change being implemented.
If there are multiple steps in the Jira, which step is this?
-->

## Pre-review checklist
- [ ] This change should be part of a Behavior Change Release. See [go/behavior-change](http://go/behavior-change).
- [x] This change has passed Merge gate tests
- [ ] Snowpipe Changes
- [ ] Snowpipe Streaming Changes
- [ ] This change is TEST-ONLY
- [ ] This change is README/Javadocs only
- [x] This change is protected by a config parameter `snowflake.snowpipe.stageFileNameExtensionEnabled`.
    - [x] `Yes` - Added end to end and Unit Tests. 
    - [ ] `No` - Suggest why it is not param protected
- [ ] Is his change protected by parameter <PARAMETER_NAME> on the server side?
    - [ ] The parameter/feature is not yet active in production (partial rollout or PrPr, see [Changes for Unreleased Features and Fixes](http://go/ppp-prpr)).
    - [ ] If there is an issue, it can be safely mitigated by turning the parameter off. This is also verified by a test (See [go/ppp](http://go/ppp)).


<!--
## Urgency
This review is *normal* priority
This review is **high** priority
This review is ***URGENT*** priority
-->

<!--
Indicate any urgency for performing the review.  Perhaps it is a fix for a prod issue or is blocking a customer.
-->

<!--
## Risks
What are the risks associated to your change?
-->

<!--
## Backward and forward Compatible
Imagine customer upgrading to new version and rolling back to older version. Will there be any concerns?
[ ] Backward compatible
[ ] Forward compatible
-->

<!--
Suggested reading order:   Provide an order in which to read files, classes, and methods.  Without this your reader will spend lots of time reading code without understanding the context (imagine the top file references a new class in methods of a file below it).  You need to tell your reviewers how to learn your code.
-->

<!--
## Reviewer roles
Every reviewer must be told their role and what actions are expected of them.  Tell every reviewer what will happen if they don't complete the review.  If you aren't sure who the secondary owner is then work with a manager and/or tech lead to figure this out.
If there are specific items or subsets of the change that you want a particular reviewer to focus on, mention it here.  You can @-mention people using their github username
-->

<!--
Reviewers:  Every review must have at least two reviewers for bug fixes, GA'ed component. One reviewer is enough for test only, doc changes.
Example:
- Minimum # of Required Reviewers - **Two** for Improvements and Bugfixes - <@github alias> 
- Educational purposes - <@github alias>
- Manager/TL approval (If patch critical and requires a release) - <@github alias>
-->

