### PR TITLE
Log stage file offset ranges during purge or move

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/KCLogger.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/KCLogger.java
@@ -103,4 +103,11 @@ public class KCLogger {
 
     return Utils.formatLogMessage(format, vars);
   }
+
+  /**
+   * Check if DEBUG or TRACE logging is enabled
+   */
+  public boolean isDebugOrTraceEnabled() {
+    return this.logger.isDebugEnabled() || this.logger.isTraceEnabled();
+  }
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
@@ -2,6 +2,7 @@ package com.snowflake.kafka.connector.internal;
 
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWPIPE_SINGLE_TABLE_MULTIPLE_TOPICS_FIX_ENABLED;
 import static com.snowflake.kafka.connector.config.TopicToTableModeExtractor.determineTopic2TableMode;
+import static com.snowflake.kafka.connector.internal.FileNameUtils.prepareFilesOffsetsLogString;
 import static com.snowflake.kafka.connector.internal.metrics.MetricsUtil.BUFFER_RECORD_COUNT;
 import static com.snowflake.kafka.connector.internal.metrics.MetricsUtil.BUFFER_SIZE_BYTES;
 import static com.snowflake.kafka.connector.internal.metrics.MetricsUtil.BUFFER_SUB_DOMAIN;
@@ -1085,22 +1086,27 @@ class SnowflakeSinkServiceV1 implements SnowflakeSinkService {
 
     private void purge(List<String> files) {
       if (!files.isEmpty()) {
-        LOGGER.debug(
-            "Purging loaded files for pipe:{}, loadedFileCount:{}, loadedFiles:{}",
-            pipeName,
-            files.size(),
-            Arrays.toString(files.toArray()));
+        String logString = String.format(
+            "Purging loaded files for pipe: %s, loadedFileCount: %d", pipeName, files.size()
+        );
+        LOGGER.info(logString + prepareFilesOffsetsLogString(
+                files, "loadedFiles", LOGGER.isDebugOrTraceEnabled()
+            )
+        );
         conn.purgeStage(stageName, files);
       }
     }
 
     private void moveToTableStage(List<String> failedFiles) {
       if (!failedFiles.isEmpty()) {
-        LOGGER.debug(
-            "Moving failed files for pipe:{} to tableStage failedFileCount:{}, failedFiles:{}",
-            pipeName,
-            failedFiles.size(),
-            Arrays.toString(failedFiles.toArray()));
+        String logString = String.format(
+            "Moving failed files for pipe: %s to tableStage failedFileCount: %d",
+            pipeName, failedFiles.size()
+        );
+        LOGGER.info(logString + prepareFilesOffsetsLogString(
+                failedFiles, "failedFiles", LOGGER.isDebugOrTraceEnabled()
+            )
+        );
         conn.moveToTableStage(tableName, stageName, failedFiles);
       }
     }


### PR DESCRIPTION
# Overview
Problem : 
Investigating or verifying if all data has been delivered is difficult with current logging. 

Solution : 
Explicitly log offset-range of files that are either moved or purged. A single log during purge/move can now help us understand exact offsets that gets processed (or in unfortunate events, dropped). 


## Pre-review checklist
- [ ] This change should be part of a Behavior Change Release. See [go/behavior-change](http://go/behavior-change).
- [ ] This change has passed Merge gate tests
- [x] Snowpipe Changes
- [ ] Snowpipe Streaming Changes
- [ ] This change is TEST-ONLY
- [ ] This change is README/Javadocs only
- [ ] This change is protected by a config parameter <PARAMETER_NAME> eg `snowflake.ingestion.method`.
    - [ ] `Yes` - Added end to end and Unit Tests. 
    - [ ] `No` - Suggest why it is not param protected
- [ ] Is his change protected by parameter <PARAMETER_NAME> on the server side?
    - [ ] The parameter/feature is not yet active in production (partial rollout or PrPr, see [Changes for Unreleased Features and Fixes](http://go/ppp-prpr)).
    - [ ] If there is an issue, it can be safely mitigated by turning the parameter off. This is also verified by a test (See [go/ppp](http://go/ppp)).

## Urgency
This review is **high** priority
Customer raised a P1 incident, and wanted to know "what" data got lost (if any). It is not possible to do this easily with current logs. 
