### PR TITLE
[Snowpipe Streaming] Fix IndexOutOfBoundException thrown when offsets are not continous during schema-evolution

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/BufferedTopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/BufferedTopicPartitionChannel.java
@@ -1310,13 +1310,13 @@ public class BufferedTopicPartitionChannel implements TopicPartitionChannel {
     }
 
     /**
-     * Get all rows and their offsets. Each map corresponds to one row whose keys are column names
-     * and values are corresponding data in that column.
+     * Get all rows and corresponding SinkRecords. Each map corresponds to one row whose keys are
+     * column names and values are corresponding data in that column.
      *
      * <p>This goes over through all buffered kafka records and transforms into JsonSchema and
      * JsonNode Check {@link #handleNativeRecord(SinkRecord, boolean)}
      *
-     * @return A pair that contains the records and their corresponding offsets
+     * @return A pair that contains the records and their corresponding original sinkRecords
      */
     @Override
     public Pair<List<Map<String, Object>>, List<SinkRecord>> getData() {

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/BufferedTopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/BufferedTopicPartitionChannel.java
@@ -659,9 +659,9 @@ public class BufferedTopicPartitionChannel implements TopicPartitionChannel {
           // preserve the original order, for anything after the first schema mismatch error we will
           // retry after the evolution
           SinkRecord originalSinkRecord = originalSinkRecords.get(idx);
-          InsertValidationResponse response = this.channel.insertRow(
-              records.get(idx), Long.toString(originalSinkRecord.kafkaOffset())
-          );
+          InsertValidationResponse response =
+              this.channel.insertRow(
+                  records.get(idx), Long.toString(originalSinkRecord.kafkaOffset()));
           if (response.hasErrors()) {
             InsertValidationResponse.InsertError insertError = response.getInsertErrors().get(0);
             SchemaEvolutionTargetItems schemaEvolutionTargetItems =
@@ -686,9 +686,7 @@ public class BufferedTopicPartitionChannel implements TopicPartitionChannel {
             } else {
               LOGGER.info("Triggering schema evolution. Items: {}", schemaEvolutionTargetItems);
               schemaEvolutionService.evolveSchemaIfNeeded(
-                  schemaEvolutionTargetItems,
-                  originalSinkRecord,
-                  channel.getTableSchema());
+                  schemaEvolutionTargetItems, originalSinkRecord, channel.getTableSchema());
               // Offset reset needed since it's possible that we successfully ingested partial batch
               needToResetOffset = true;
               break;

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/BufferedTopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/BufferedTopicPartitionChannel.java
@@ -641,10 +641,10 @@ public class BufferedTopicPartitionChannel implements TopicPartitionChannel {
           "Invoking insertRows API for channel:{}, streamingBuffer:{}",
           this.channel.getFullyQualifiedName(),
           this.insertRowsStreamingBuffer);
-      Pair<List<Map<String, Object>>, List<Long>> recordsAndOffsets =
+      Pair<List<Map<String, Object>>, List<SinkRecord>> recordsAndOriginalSinkRecords =
           this.insertRowsStreamingBuffer.getData();
-      List<Map<String, Object>> records = recordsAndOffsets.getKey();
-      List<Long> offsets = recordsAndOffsets.getValue();
+      List<Map<String, Object>> records = recordsAndOriginalSinkRecords.getKey();
+      List<SinkRecord> originalSinkRecords = recordsAndOriginalSinkRecords.getValue();
       InsertValidationResponse finalResponse = new InsertValidationResponse();
       boolean needToResetOffset = false;
       if (!enableSchemaEvolution) {
@@ -658,16 +658,19 @@ public class BufferedTopicPartitionChannel implements TopicPartitionChannel {
           // For schema evolution, we need to call the insertRows API row by row in order to
           // preserve the original order, for anything after the first schema mismatch error we will
           // retry after the evolution
-          InsertValidationResponse response =
-              this.channel.insertRow(records.get(idx), Long.toString(offsets.get(idx)));
+          SinkRecord originalSinkRecord = originalSinkRecords.get(idx);
+          InsertValidationResponse response = this.channel.insertRow(
+              records.get(idx), Long.toString(originalSinkRecord.kafkaOffset())
+          );
           if (response.hasErrors()) {
             InsertValidationResponse.InsertError insertError = response.getInsertErrors().get(0);
             SchemaEvolutionTargetItems schemaEvolutionTargetItems =
                 insertErrorMapper.mapToSchemaEvolutionItems(
                     insertError, this.channel.getTableName());
 
+            // TODO : originalSinkRecordIdx can be replaced by idx
             long originalSinkRecordIdx =
-                offsets.get(idx) - this.insertRowsStreamingBuffer.getFirstOffset();
+                originalSinkRecord.kafkaOffset() - this.insertRowsStreamingBuffer.getFirstOffset();
 
             if (!schemaEvolutionTargetItems.hasDataForSchemaEvolution()) {
               InsertValidationResponse.InsertError newInsertError =
@@ -684,7 +687,7 @@ public class BufferedTopicPartitionChannel implements TopicPartitionChannel {
               LOGGER.info("Triggering schema evolution. Items: {}", schemaEvolutionTargetItems);
               schemaEvolutionService.evolveSchemaIfNeeded(
                   schemaEvolutionTargetItems,
-                  this.insertRowsStreamingBuffer.getSinkRecord(originalSinkRecordIdx),
+                  originalSinkRecord,
                   channel.getTableSchema());
               // Offset reset needed since it's possible that we successfully ingested partial batch
               needToResetOffset = true;
@@ -1282,7 +1285,7 @@ public class BufferedTopicPartitionChannel implements TopicPartitionChannel {
    * before calling insertRows API.
    */
   @VisibleForTesting
-  class StreamingBuffer extends PartitionBuffer<Pair<List<Map<String, Object>>, List<Long>>> {
+  class StreamingBuffer extends PartitionBuffer<Pair<List<Map<String, Object>>, List<SinkRecord>>> {
     // Records coming from Kafka
     private final List<SinkRecord> sinkRecords;
 
@@ -1316,9 +1319,9 @@ public class BufferedTopicPartitionChannel implements TopicPartitionChannel {
      * @return A pair that contains the records and their corresponding offsets
      */
     @Override
-    public Pair<List<Map<String, Object>>, List<Long>> getData() {
+    public Pair<List<Map<String, Object>>, List<SinkRecord>> getData() {
       final List<Map<String, Object>> records = new ArrayList<>();
-      final List<Long> offsets = new ArrayList<>();
+      final List<SinkRecord> filteredOriginalSinkRecords = new ArrayList<>();
 
       for (SinkRecord kafkaSinkRecord : sinkRecords) {
         SinkRecord snowflakeRecord = getSnowflakeSinkRecordFromKafkaRecord(kafkaSinkRecord);
@@ -1345,7 +1348,7 @@ public class BufferedTopicPartitionChannel implements TopicPartitionChannel {
             Map<String, Object> tableRow =
                 recordService.getProcessedRecordForStreamingIngest(snowflakeRecord);
             records.add(tableRow);
-            offsets.add(snowflakeRecord.kafkaOffset());
+            filteredOriginalSinkRecords.add(kafkaSinkRecord);
           } catch (JsonProcessingException e) {
             LOGGER.warn(
                 "Record has JsonProcessingException offset:{}, topic:{}",
@@ -1371,7 +1374,7 @@ public class BufferedTopicPartitionChannel implements TopicPartitionChannel {
           getBufferSizeBytes(),
           getFirstOffset(),
           getLastOffset());
-      return new Pair<>(records, offsets);
+      return new Pair<>(records, filteredOriginalSinkRecords);
     }
 
     @Override

--- a/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
@@ -723,9 +723,12 @@ public class TestUtils {
       final String topicName,
       final int partitionNo) {
     return createJsonRecords(
-        startOffset, noOfRecords, topicName, partitionNo, null,
-        Collections.singletonMap("schemas.enable", Boolean.toString(false))
-    );
+        startOffset,
+        noOfRecords,
+        topicName,
+        partitionNo,
+        null,
+        Collections.singletonMap("schemas.enable", Boolean.toString(false)));
   }
 
   /* Generate (noOfRecords - startOffset) for a given topic and partition. */
@@ -735,10 +738,12 @@ public class TestUtils {
       final String topicName,
       final int partitionNo) {
     return createJsonRecords(
-        startOffset, noOfRecords, topicName, partitionNo,
+        startOffset,
+        noOfRecords,
+        topicName,
+        partitionNo,
         TestUtils.JSON_WITH_SCHEMA.getBytes(StandardCharsets.UTF_8),
-        Collections.singletonMap("schemas.enable", Boolean.toString(true))
-    );
+        Collections.singletonMap("schemas.enable", Boolean.toString(true)));
   }
 
   private static List<SinkRecord> createJsonRecords(
@@ -747,8 +752,7 @@ public class TestUtils {
       final String topicName,
       final int partitionNo,
       byte[] value,
-      Map<String, String> converterConfig
-  ) {
+      Map<String, String> converterConfig) {
     JsonConverter converter = new JsonConverter();
     converter.configure(converterConfig, false);
     SchemaAndValue schemaInputValue = converter.toConnectData("test", value);

--- a/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
@@ -716,22 +716,44 @@ public class TestUtils {
     return records;
   }
 
+  /* Generate (noOfRecords - startOffset) blank records for a given topic and partition. */
+  public static List<SinkRecord> createBlankJsonSinkRecords(
+      final long startOffset,
+      final long noOfRecords,
+      final String topicName,
+      final int partitionNo) {
+    return createJsonRecords(
+        startOffset, noOfRecords, topicName, partitionNo, null,
+        Collections.singletonMap("schemas.enable", Boolean.toString(false))
+    );
+  }
+
   /* Generate (noOfRecords - startOffset) for a given topic and partition. */
   public static List<SinkRecord> createNativeJsonSinkRecords(
       final long startOffset,
       final long noOfRecords,
       final String topicName,
       final int partitionNo) {
-    ArrayList<SinkRecord> records = new ArrayList<>();
+    return createJsonRecords(
+        startOffset, noOfRecords, topicName, partitionNo,
+        TestUtils.JSON_WITH_SCHEMA.getBytes(StandardCharsets.UTF_8),
+        Collections.singletonMap("schemas.enable", Boolean.toString(true))
+    );
+  }
 
+  private static List<SinkRecord> createJsonRecords(
+      final long startOffset,
+      final long noOfRecords,
+      final String topicName,
+      final int partitionNo,
+      byte[] value,
+      Map<String, String> converterConfig
+  ) {
     JsonConverter converter = new JsonConverter();
-    HashMap<String, String> converterConfig = new HashMap<>();
-    converterConfig.put("schemas.enable", "true");
     converter.configure(converterConfig, false);
-    SchemaAndValue schemaInputValue =
-        converter.toConnectData(
-            "test", TestUtils.JSON_WITH_SCHEMA.getBytes(StandardCharsets.UTF_8));
+    SchemaAndValue schemaInputValue = converter.toConnectData("test", value);
 
+    ArrayList<SinkRecord> records = new ArrayList<>();
     for (long i = startOffset; i < startOffset + noOfRecords; ++i) {
       records.add(
           new SinkRecord(

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelIT.java
@@ -737,8 +737,7 @@ public class TopicPartitionChannelIT {
     SnowflakeSinkConnectorConfig.setDefaultValues(config);
     config.put(
         SnowflakeSinkConnectorConfig.ENABLE_SCHEMATIZATION_CONFIG,
-        Boolean.toString(withSchematization)
-    );
+        Boolean.toString(withSchematization));
 
     // create tpChannel
     SnowflakeSinkService service =

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelIT.java
@@ -1,5 +1,9 @@
 package com.snowflake.kafka.connector.internal.streaming;
 
+import static com.snowflake.kafka.connector.internal.streaming.ChannelMigrationResponseCode.SUCCESS;
+import static com.snowflake.kafka.connector.internal.streaming.ChannelMigrationResponseCode.isChannelMigrationResponseSuccessful;
+import static com.snowflake.kafka.connector.internal.streaming.channel.TopicPartitionChannel.NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE;
+
 import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
 import com.snowflake.kafka.connector.Utils;
 import com.snowflake.kafka.connector.dlq.InMemoryKafkaRecordErrorReporter;
@@ -7,10 +11,7 @@ import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
 import com.snowflake.kafka.connector.internal.SnowflakeSinkService;
 import com.snowflake.kafka.connector.internal.SnowflakeSinkServiceFactory;
 import com.snowflake.kafka.connector.internal.TestUtils;
-import static com.snowflake.kafka.connector.internal.streaming.ChannelMigrationResponseCode.SUCCESS;
-import static com.snowflake.kafka.connector.internal.streaming.ChannelMigrationResponseCode.isChannelMigrationResponseSuccessful;
 import com.snowflake.kafka.connector.internal.streaming.channel.TopicPartitionChannel;
-import static com.snowflake.kafka.connector.internal.streaming.channel.TopicPartitionChannel.NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE;
 import com.snowflake.kafka.connector.internal.streaming.schemaevolution.InsertErrorMapper;
 import com.snowflake.kafka.connector.internal.streaming.schemaevolution.snowflake.SnowflakeSchemaEvolutionService;
 import com.snowflake.kafka.connector.internal.streaming.telemetry.SnowflakeTelemetryServiceV2;
@@ -506,7 +507,8 @@ public class TopicPartitionChannelIT {
     final long secondBatchCount = 500;
 
     // create 18 blank records that do not kick off schematization
-    List<SinkRecord> firstBatch = TestUtils.createBlankJsonSinkRecords(0, firstBatchCount, topic, PARTITION);
+    List<SinkRecord> firstBatch =
+        TestUtils.createBlankJsonSinkRecords(0, firstBatchCount, topic, PARTITION);
     service.insert(firstBatch);
 
     // send batch with 500, should kick off a record based flush and schematization on record 19,
@@ -765,9 +767,7 @@ public class TopicPartitionChannelIT {
     }
 
     TestUtils.assertWithRetry(
-        () -> service.getOffset(new TopicPartition(topic, PARTITION)) == 302,
-        20, 5
-    );
+        () -> service.getOffset(new TopicPartition(topic, PARTITION)) == 302, 20, 5);
 
     assert TestUtils.tableSize(testTableName) == 4
         : "expected: " + 4 + " actual: " + TestUtils.tableSize(testTableName);


### PR DESCRIPTION
Connector Exception stacktrace  : 
```
org.apache.kafka.connect.errors.ConnectException: Exiting WorkerSinkTask due to unrecoverable exception.
at org.apache.kafka.connect.runtime.WorkerSinkTask.deliverMessages(WorkerSinkTask.java:657)
at org.apache.kafka.connect.runtime.WorkerSinkTask.poll(WorkerSinkTask.java:348)
at org.apache.kafka.connect.runtime.WorkerSinkTask.iteration(WorkerSinkTask.java:247)
at org.apache.kafka.connect.runtime.WorkerSinkTask.execute(WorkerSinkTask.java:216)
at org.apache.kafka.connect.runtime.WorkerTask.doRun(WorkerTask.java:247)
at org.apache.kafka.connect.runtime.WorkerTask.run(WorkerTask.java:302)
at org.apache.kafka.connect.runtime.isolation.Plugins.lambda$withClassLoader$7(Plugins.java:339)
at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: java.lang.IndexOutOfBoundsException: Index 4293 out of bounds for length 3159
at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:100)
at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:106)
at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:302)
at java.base/java.util.Objects.checkIndex(Objects.java:385)
at java.base/java.util.ArrayList.get(ArrayList.java:427)
at com.snowflake.kafka.connector.internal.streaming.TopicPartitionChannel$StreamingBuffer.getSinkRecord(TopicPartitionChannel.java:1341)
at com.snowflake.kafka.connector.internal.streaming.TopicPartitionChannel$InsertRowsApiResponseSupplier.get(TopicPartitionChannel.java:697)
at com.snowflake.kafka.connector.internal.streaming.TopicPartitionChannel$InsertRowsApiResponseSupplier.get(TopicPartitionChannel.java:625)
at dev.failsafe.Functions.lambda$toCtxSupplier$11(Functions.java:243)
at dev.failsafe.Functions.lambda$get$0(Functions.java:46)
at dev.failsafe.internal.FallbackExecutor.lambda$apply$0(FallbackExecutor.java:51)
at dev.failsafe.SyncExecutionImpl.executeSync(SyncExecutionImpl.java:182)
at dev.failsafe.FailsafeExecutor.call(FailsafeExecutor.java:438)
at dev.failsafe.FailsafeExecutor.get(FailsafeExecutor.java:115)
at com.snowflake.kafka.connector.internal.streaming.TopicPartitionChannel.insertRowsWithFallback(TopicPartitionChannel.java:619)
at com.snowflake.kafka.connector.internal.streaming.TopicPartitionChannel.insertBufferedRecords(TopicPartitionChannel.java:545)
at com.snowflake.kafka.connector.internal.streaming.TopicPartitionChannel.insertRecordToBuffer(TopicPartitionChannel.java:423)
at com.snowflake.kafka.connector.internal.streaming.SnowflakeSinkServiceV2.insert(SnowflakeSinkServiceV2.java:325)
at com.snowflake.kafka.connector.internal.streaming.SnowflakeSinkServiceV2.insert(SnowflakeSinkServiceV2.java:292)
at com.snowflake.kafka.connector.SnowflakeSinkTask.put(SnowflakeSinkTask.java:313)
at org.apache.kafka.connect.runtime.WorkerSinkTask.deliverMessages(WorkerSinkTask.java:623)
... 11 more
```
Due to this connector could not `evolve-schema` (even if `snowflake.role.name` had correct permissions)

Reproduction on ITs : https://github.com/snowflakedb/snowflake-kafka-connector/pull/1036

---

What was the bug ? 

[This computation](https://github.com/confluentinc/snowflake-kafka-connector/blob/c2ef3174bc57ad445ef437ce65b9ae08ed7aa5a8/src/main/java/com/snowflake/kafka/connector/internal/streaming/BufferedTopicPartitionChannel.java#L671-L673) is not right. 
When Offsets are continous, lets checkout [`records`](https://github.com/snowflakedb/snowflake-kafka-connector/blob/master/src/main/java/com/snowflake/kafka/connector/internal/streaming/BufferedTopicPartitionChannel.java#L646), [`offsets`](https://github.com/snowflakedb/snowflake-kafka-connector/blob/master/src/main/java/com/snowflake/kafka/connector/internal/streaming/BufferedTopicPartitionChannel.java#L647) and [`sinkRecords`](https://github.com/snowflakedb/snowflake-kafka-connector/blob/master/src/main/java/com/snowflake/kafka/connector/internal/streaming/BufferedTopicPartitionChannel.java#L1287) objects
sinkRecords : [SinkRecord<2000>, SinkRecord<2001> .... SinkRecord<2100>] (101 records)
records : [Map<2000>, .... Map<2100>]
offsets : [2000, ... 2100]. 

For `idx` = 10
```
long originalSinkRecordIdx = offsets.get(idx) - this.insertRowsStreamingBuffer.getFirstOffset();
```
=> long originalSinkRecordIdx = 2010 - 2000 = 10\

------------

If offsets are not continous (with gaps, like when using FilterSMT) -> 
sinkRecords : [SinkRecord<2000>, SinkRecord<2002> .... SinkRecord<2100>] (51 records)
records : [Map<2000>, Map<2002>, .... Map<2100>]
offsets : [2000, 2002,... 2100]. 

For `idx` = 10
```
long originalSinkRecordIdx = offsets.get(idx) - this.insertRowsStreamingBuffer.getFirstOffset();
```
=> long originalSinkRecordIdx = 2020 - 2000 = 20   (incorrect). 
[we want SinkRecord at 10th index]. 

----

## Pre-review checklist
- [ ] This change should be part of a Behavior Change Release. See [go/behavior-change](http://go/behavior-change).
- [ ] This change has passed Merge gate tests
- [ ] Snowpipe Changes
- [X] Snowpipe Streaming Changes
- [ ] This change is TEST-ONLY
- [ ] This change is README/Javadocs only
- [ ] This change is protected by a config parameter <PARAMETER_NAME> eg `snowflake.ingestion.method`.
    - [ ] `Yes` - Added end to end and Unit Tests. 
    - [x] `No` - Suggest why it is not param protected (This is a bug-fix)
- [ ] Is his change protected by parameter <PARAMETER_NAME> on the server side?
    - [ ] The parameter/feature is not yet active in production (partial rollout or PrPr, see [Changes for Unreleased Features and Fixes](http://go/ppp-prpr)).
    - [ ] If there is an issue, it can be safely mitigated by turning the parameter off. This is also verified by a test (See [go/ppp](http://go/ppp)).


## Urgency
This review is **high** priority
