### PR TITLE
Add support for config provider for any property

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnector.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnector.java
@@ -29,7 +29,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.regex.Pattern;
 import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.connect.connector.Task;
@@ -219,7 +218,7 @@ public class SnowflakeSinkConnector extends SinkConnector {
 
     // If using snowflake_jwt and authentication, and private key or private key passphrase is
     // provided through a config provider, skip validation
-    if (isUsingJWT(connectorConfigs) && isUsingConfigProvider(connectorConfigs)) {
+    if (Utils.isUsingJWT(connectorConfigs) && Utils.isUsingConfigProvider(connectorConfigs)) {
       return result;
     }
 
@@ -311,23 +310,6 @@ public class SnowflakeSinkConnector extends SinkConnector {
 
     LOGGER.info("Validated config with no error");
     return result;
-  }
-
-  private static boolean isUsingConfigProvider(Map<String, String> connectorConfigs) {
-    Pattern configProviderPrefix = Pattern.compile("[$][{][a-zA-Z]+:");
-
-    return configProviderPrefix
-            .matcher(connectorConfigs.getOrDefault(Utils.SF_PRIVATE_KEY, ""))
-            .find()
-        || configProviderPrefix
-            .matcher(connectorConfigs.getOrDefault(Utils.PRIVATE_KEY_PASSPHRASE, ""))
-            .find();
-  }
-
-  private static boolean isUsingJWT(Map<String, String> connectorConfigs) {
-    return connectorConfigs
-        .getOrDefault(Utils.SF_AUTHENTICATOR, Utils.SNOWFLAKE_JWT)
-        .equals(Utils.SNOWFLAKE_JWT);
   }
 
   /** @return connector version */


### PR DESCRIPTION
<!-- Text inside of HTML comment blocks will NOT appear in your pull request description -->
<!-- Formatting information can be found at https://www.markdownguide.org/basic-syntax/ -->
# Overview

SNOW-XXXXX

<!--
Why is this review being requested?  The full details should be in the JIRA, but the review should focus on the fix/change being implemented.
If there are multiple steps in the Jira, which step is this?
-->
Currently, config providers are allowed for connection-related properties only - for any other property, validation runs and fails, as it's run before the config provider resolves values.
This PR adds a check of validation error and if it's caused by configuration provider - removes the error.
Unfortunately - the way it's done is hacky(uses some bad encapsulation from KafkaConnect authors).
I can find a better way to do so(such as rewriting code to extend each validator from a config-aware one, so that the value is checked only if it's not supposed to be resolved by the config provider).
Please let me know if this improvement can be accepted on your side, and I'll adjust the code as you'd like.

The motivation is that likely user should be able to provide any config parameter using the config provider for whatever reason, and there should be no hidden assumptions about the secrecy of the parameters.
P.S. The true motivation in my case is that we are planning to consume from ~100 topics in one setup, and the connector's config is just too long for AWS MSK to handle(not sure whether this is MSK or KafkaConnect itself). The issue is exaggerated by an even bigger topic2table map(compared to a list of topics).
P.P.S. I was also considering why validation happens before config resolution, but cannot find meaningful results. Also I was considering to resolve these values by writing some code(it's possible 100%) - but didn't find existing KafkaConnect Connectors to do so(checked JDBC/S3 sinks).

## Pre-review checklist
- [ ] This change should be part of a Behavior Change Release. See [go/behavior-change](http://go/behavior-change).
- [ ] This change has passed Merge gate tests
- [ ] Snowpipe Changes
- [ ] Snowpipe Streaming Changes
- [ ] This change is TEST-ONLY
- [ ] This change is README/Javadocs only
- [ ] This change is protected by a config parameter <PARAMETER_NAME> eg `snowflake.ingestion.method`.
    - [ ] `Yes` - Added end to end and Unit Tests. 
    - [ ] `No` - Suggest why it is not param protected
- [ ] Is his change protected by parameter <PARAMETER_NAME> on the server side?
    - [ ] The parameter/feature is not yet active in production (partial rollout or PrPr, see [Changes for Unreleased Features and Fixes](http://go/ppp-prpr)).
    - [ ] If there is an issue, it can be safely mitigated by turning the parameter off. This is also verified by a test (See [go/ppp](http://go/ppp)).


<!--
## Urgency
This review is *normal* priority
-->

<!--
Indicate any urgency for performing the review.  Perhaps it is a fix for a prod issue or is blocking a customer.
-->

<!--
## Risks
What are the risks associated to your change?
-->
Likely no risks, as existing code will remain the same, while for some portion of users it may be useful.

<!--
## Backward and forward Compatible
Imagine customer upgrading to new version and rolling back to older version. Will there be any concerns?
[x] Backward compatible
[x] Forward compatible
-->

<!--
Suggested reading order:   Provide an order in which to read files, classes, and methods.  Without this your reader will spend lots of time reading code without understanding the context (imagine the top file references a new class in methods of a file below it).  You need to tell your reviewers how to learn your code.
-->

<!--
## Reviewer roles
Every reviewer must be told their role and what actions are expected of them.  Tell every reviewer what will happen if they don't complete the review.  If you aren't sure who the secondary owner is then work with a manager and/or tech lead to figure this out.
If there are specific items or subsets of the change that you want a particular reviewer to focus on, mention it here.  You can @-mention people using their github username
-->

<!--
Reviewers:  Every review must have at least two reviewers for bug fixes, GA'ed component. One reviewer is enough for test only, doc changes.
Example:
- Minimum # of Required Reviewers - **Two** for Improvements and Bugfixes - <@github alias> 
- Educational purposes - <@github alias>
- Manager/TL approval (If patch critical and requires a release) - <@github alias>
-->

