### PR TITLE
Add configuration to disable reprocess files cleanup by v1Cleaner

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/DefaultConnectorConfigValidator.java
+++ b/src/main/java/com/snowflake/kafka/connector/DefaultConnectorConfigValidator.java
@@ -3,6 +3,7 @@ package com.snowflake.kafka.connector;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.BehaviorOnNullValues.VALIDATOR;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.JMX_OPT;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWPIPE_DISABLE_REPROCESS_FILES_CLEANUP;
 import static com.snowflake.kafka.connector.Utils.*;
 
 import com.google.common.collect.ImmutableMap;
@@ -260,6 +261,17 @@ public class DefaultConnectorConfigValidator implements ConnectorConfigValidator
           || config.get(JMX_OPT).equalsIgnoreCase("false"))) {
         invalidConfigParams.put(
             JMX_OPT, Utils.formatString("Kafka config:{} should either be true or false", JMX_OPT));
+      }
+    }
+
+    if (config.containsKey(SNOWPIPE_DISABLE_REPROCESS_FILES_CLEANUP)) {
+      if (!(config.get(SNOWPIPE_DISABLE_REPROCESS_FILES_CLEANUP).equalsIgnoreCase("true")
+              || config.get(SNOWPIPE_DISABLE_REPROCESS_FILES_CLEANUP).equalsIgnoreCase("false"))) {
+        invalidConfigParams.put(
+                SNOWPIPE_DISABLE_REPROCESS_FILES_CLEANUP,
+                Utils.formatString(
+                        "Kafka config:{} should either be true or false",
+                        SNOWPIPE_DISABLE_REPROCESS_FILES_CLEANUP));
       }
     }
 

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -121,6 +121,10 @@ public class SnowflakeSinkConnectorConfig {
   public static final boolean SNOWPIPE_FILE_CLEANER_FIX_ENABLED_DEFAULT = true;
   public static final int SNOWPIPE_FILE_CLEANER_THREADS_DEFAULT = 1;
 
+  public static final String SNOWPIPE_DISABLE_REPROCESS_FILES_CLEANUP =
+          "snowflake.snowpipe.v1Cleaner.disable.reprocessFiles.cleanup";
+  public static final boolean SNOWPIPE_DISABLE_REPROCESS_FILES_CLEANUP_DEFAULT = false;
+
   public static final String SNOWPIPE_SINGLE_TABLE_MULTIPLE_TOPICS_FIX_ENABLED =
       "snowflake.snowpipe.stageFileNameExtensionEnabled";
   public static final boolean SNOWPIPE_SINGLE_TABLE_MULTIPLE_TOPICS_FIX_ENABLED_DEFAULT = true;

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceFactory.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceFactory.java
@@ -85,6 +85,18 @@ public class SnowflakeSinkServiceFactory {
                           .SNOWPIPE_SINGLE_TABLE_MULTIPLE_TOPICS_FIX_ENABLED));
         }
         svc.configureSingleTableLoadFromMultipleTopics(extendedStageFileNameFix);
+
+        boolean disableReprocessFilesCleanup =
+                SnowflakeSinkConnectorConfig.SNOWPIPE_DISABLE_REPROCESS_FILES_CLEANUP_DEFAULT;
+        if (connectorConfig != null
+                && connectorConfig.containsKey(
+                SnowflakeSinkConnectorConfig.SNOWPIPE_DISABLE_REPROCESS_FILES_CLEANUP)) {
+          disableReprocessFilesCleanup =
+                  Boolean.parseBoolean(
+                          connectorConfig.get(
+                                  SnowflakeSinkConnectorConfig.SNOWPIPE_DISABLE_REPROCESS_FILES_CLEANUP));
+        }
+        svc.configureDisableReprocessFilesCleanup(disableReprocessFilesCleanup);
       } else {
         this.service = new SnowflakeSinkServiceV2(conn, connectorConfig);
       }

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
@@ -99,6 +99,9 @@ class SnowflakeSinkServiceV1 implements SnowflakeSinkService {
   // data into a single table.
   private boolean enableStageFilePrefixExtension = false;
 
+  // CC-30278 if enabled cleaner won't delete reprocess files on stage
+  private boolean disableReprocessFilesCleanup = false;
+
   private final Set<String> perTableWarningNotifications = new HashSet<>();
 
   SnowflakeSinkServiceV1(SnowflakeConnectionService conn) {
@@ -450,6 +453,10 @@ class SnowflakeSinkServiceV1 implements SnowflakeSinkService {
     }
   }
 
+  public void configureDisableReprocessFilesCleanup(boolean disable) {
+    disableReprocessFilesCleanup = disable;
+  }
+
   private class ServiceContext {
     private final String tableName;
     private final String stageName;
@@ -641,7 +648,9 @@ class SnowflakeSinkServiceV1 implements SnowflakeSinkService {
       List<String> currentFilesOnStage = conn.listStage(stageName, prefix);
       List<String> reprocessFiles = new ArrayList<>();
 
-      filterFileReprocess(currentFilesOnStage, reprocessFiles, recordOffset);
+      if (!disableReprocessFilesCleanup) {
+        filterFileReprocess(currentFilesOnStage, reprocessFiles, recordOffset);
+      }
 
       // Telemetry
       pipeCreation.setFileCountRestart(currentFilesOnStage.size());
@@ -686,7 +695,7 @@ class SnowflakeSinkServiceV1 implements SnowflakeSinkService {
             }
           });
 
-      if (reprocessFiles.size() > 0) {
+      if (!disableReprocessFilesCleanup && reprocessFiles.size() > 0) {
         // After we start the cleaner thread, delay a while and start deleting files.
         reprocessCleanerExecutor.submit(
             () -> {

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigValidatorTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigValidatorTest.java
@@ -1025,10 +1025,10 @@ public class ConnectorConfigValidatorTest {
 
   @Test
   public void testDISABLE_REPROCESS_FILES_CLEANUP_invalid_value() {
-      Map<String, String> config = getConfig();
-      config.put(SnowflakeSinkConnectorConfig.SNOWPIPE_DISABLE_REPROCESS_FILES_CLEANUP, "INVALID");
+    Map<String, String> config = getConfig();
+    config.put(SnowflakeSinkConnectorConfig.SNOWPIPE_DISABLE_REPROCESS_FILES_CLEANUP, "INVALID");
     assertThatThrownBy(() -> connectorConfigValidator.validateConfig(config))
-            .isInstanceOf(SnowflakeKafkaConnectorException.class)
-            .hasMessageContaining(SnowflakeSinkConnectorConfig.SNOWPIPE_DISABLE_REPROCESS_FILES_CLEANUP);
+        .isInstanceOf(SnowflakeKafkaConnectorException.class)
+        .hasMessageContaining(SnowflakeSinkConnectorConfig.SNOWPIPE_DISABLE_REPROCESS_FILES_CLEANUP);
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigValidatorTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigValidatorTest.java
@@ -1013,4 +1013,22 @@ public class ConnectorConfigValidatorTest {
       }
     }
   }
+
+  @Test
+  public void testDISABLE_REPROCESS_FILES_CLEANUP_valid_value() {
+    Map<String, String> config = getConfig();
+    config.put(SnowflakeSinkConnectorConfig.SNOWPIPE_DISABLE_REPROCESS_FILES_CLEANUP, "true");
+    connectorConfigValidator.validateConfig(config);
+    config.put(SnowflakeSinkConnectorConfig.SNOWPIPE_DISABLE_REPROCESS_FILES_CLEANUP, "False");
+    connectorConfigValidator.validateConfig(config);
+  }
+
+  @Test
+  public void testDISABLE_REPROCESS_FILES_CLEANUP_invalid_value() {
+      Map<String, String> config = getConfig();
+      config.put(SnowflakeSinkConnectorConfig.SNOWPIPE_DISABLE_REPROCESS_FILES_CLEANUP, "INVALID");
+    assertThatThrownBy(() -> connectorConfigValidator.validateConfig(config))
+            .isInstanceOf(SnowflakeKafkaConnectorException.class)
+            .hasMessageContaining(SnowflakeSinkConnectorConfig.SNOWPIPE_DISABLE_REPROCESS_FILES_CLEANUP);
+  }
 }

--- a/src/test/java/com/snowflake/kafka/connector/internal/SinkServiceIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/SinkServiceIT.java
@@ -748,20 +748,20 @@ public class SinkServiceIT {
   @Test
   public void testRecoverReprocessFiles() throws Exception {
     String data =
-            "{\"content\":{\"name\":\"test\"},\"meta\":{\"offset\":0,"
-                    + "\"topic\":\"test\",\"partition\":0}}";
+        "{\"content\":{\"name\":\"test\"},\"meta\":{\"offset\":0,"
+            + "\"topic\":\"test\",\"partition\":0}}";
 
     // Two hours ago                         h   m    s    milli
     long time = System.currentTimeMillis() - 2 * 60 * 60 * 1000L;
 
     String fileName1 =
-            FileNameTestUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, null, 0, 0, 0, time);
+        FileNameTestUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, null, 0, 0, 0, time);
     String fileName2 =
-            FileNameTestUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, null, 0, 1, 1, time);
+        FileNameTestUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, null, 0, 1, 1, time);
     String fileName3 =
-            FileNameTestUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, null, 0, 2, 3, time);
+        FileNameTestUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, null, 0, 2, 3, time);
     String fileName4 =
-            FileNameTestUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, null, 0, 4, 5, time);
+        FileNameTestUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, null, 0, 4, 5, time);
 
     conn.createStage(stage);
     conn.createTable(table);
@@ -783,18 +783,18 @@ public class SinkServiceIT {
     assert getStageSize(stage, table, 0) == 4;
 
     SnowflakeSinkService service =
-            SnowflakeSinkServiceFactory.builder(conn)
-                    .addTask(table, new TopicPartition(topic, partition))
-                    .setRecordNumber(1) // immediate flush
-                    .build();
+        SnowflakeSinkServiceFactory.builder(conn)
+            .addTask(table, new TopicPartition(topic, partition))
+            .setRecordNumber(1) // immediate flush
+            .build();
 
     SnowflakeConverter converter = new SnowflakeJsonConverter();
     SchemaAndValue result =
-            converter.toConnectData(topic, "12321".getBytes(StandardCharsets.UTF_8));
+        converter.toConnectData(topic, "12321".getBytes(StandardCharsets.UTF_8));
     // This record is ingested as well.
     SinkRecord record =
-            new SinkRecord(
-                    topic, partition, Schema.STRING_SCHEMA, "test", result.schema(), result.value(), 3);
+        new SinkRecord(
+            topic, partition, Schema.STRING_SCHEMA, "test", result.schema(), result.value(), 3);
     // lazy init and recovery function
     service.insert(record);
     // wait for async put
@@ -814,20 +814,20 @@ public class SinkServiceIT {
   @Test
   public void testReprocessFilesCleanupDisabled() throws Exception {
     String data =
-            "{\"content\":{\"name\":\"test\"},\"meta\":{\"offset\":0,"
-                    + "\"topic\":\"test\",\"partition\":0}}";
+        "{\"content\":{\"name\":\"test\"},\"meta\":{\"offset\":0,"
+            + "\"topic\":\"test\",\"partition\":0}}";
 
     // Two hours ago                         h   m    s    milli
     long time = System.currentTimeMillis() - 2 * 60 * 60 * 1000L;
 
     String fileName1 =
-            FileNameTestUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, null, 0, 0, 0, time);
+        FileNameTestUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, null, 0, 0, 0, time);
     String fileName2 =
-            FileNameTestUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, null, 0, 1, 1, time);
+        FileNameTestUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, null, 0, 1, 1, time);
     String fileName3 =
-            FileNameTestUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, null, 0, 2, 3, time);
+        FileNameTestUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, null, 0, 2, 3, time);
     String fileName4 =
-            FileNameTestUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, null, 0, 4, 5, time);
+        FileNameTestUtils.fileName(TestUtils.TEST_CONNECTOR_NAME, table, null, 0, 4, 5, time);
 
     conn.createStage(stage);
     conn.createTable(table);
@@ -853,18 +853,18 @@ public class SinkServiceIT {
     connectorConfig.put(SnowflakeSinkConnectorConfig.SNOWPIPE_FILE_CLEANER_FIX_ENABLED, "false");
 
     SnowflakeSinkService service =
-            SnowflakeSinkServiceFactory.builder(conn, IngestionMethodConfig.SNOWPIPE, connectorConfig)
-                    .addTask(table, new TopicPartition(topic, partition))
-                    .setRecordNumber(1) // immediate flush
-                    .build();
+        SnowflakeSinkServiceFactory.builder(conn, IngestionMethodConfig.SNOWPIPE, connectorConfig)
+            .addTask(table, new TopicPartition(topic, partition))
+            .setRecordNumber(1) // immediate flush
+            .build();
 
     SnowflakeConverter converter = new SnowflakeJsonConverter();
     SchemaAndValue result =
-            converter.toConnectData(topic, "12321".getBytes(StandardCharsets.UTF_8));
+        converter.toConnectData(topic, "12321".getBytes(StandardCharsets.UTF_8));
     // This record is ingested as well.
     SinkRecord record =
-            new SinkRecord(
-                    topic, partition, Schema.STRING_SCHEMA, "test", result.schema(), result.value(), 3);
+        new SinkRecord(
+            topic, partition, Schema.STRING_SCHEMA, "test", result.schema(), result.value(), 3);
     // lazy init and recovery function
     service.insert(record);
     // wait for async put

--- a/src/test/java/com/snowflake/kafka/connector/internal/SinkServiceIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/SinkServiceIT.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
 import com.snowflake.kafka.connector.Utils;
+import com.snowflake.kafka.connector.internal.streaming.IngestionMethodConfig;
 import com.snowflake.kafka.connector.records.SnowflakeConverter;
 import com.snowflake.kafka.connector.records.SnowflakeJsonConverter;
 import io.confluent.connect.avro.AvroConverter;
@@ -26,6 +27,7 @@ import org.junit.After;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 public class SinkServiceIT {
@@ -744,8 +746,12 @@ public class SinkServiceIT {
     service.startPartition(table, new TopicPartition(topic, partition));
   }
 
-  @Test
-  public void testRecoverReprocessFiles() throws Exception {
+  @ParameterizedTest
+  @CsvSource({
+          "false, 2", // Scenario 1: SNOWPIPE_DISABLE_REPROCESS_FILES_CLEANUP = false, TableStage size 2
+          "true, 3"   // Scenario 2: SNOWPIPE_DISABLE_REPROCESS_FILES_CLEANUP = true, TableStage size 3
+  })
+  public void testRecoverReprocessFiles(String disableReprocessFilesCleanup, int expectedTableStageSize) throws Exception {
     String data =
         "{\"content\":{\"name\":\"test\"},\"meta\":{\"offset\":0,"
             + "\"topic\":\"test\",\"partition\":0}}";
@@ -781,8 +787,11 @@ public class SinkServiceIT {
 
     assert getStageSize(stage, table, 0) == 4;
 
+    Map<String, String> connectorConfig = new HashMap<>();
+    connectorConfig.put(SnowflakeSinkConnectorConfig.SNOWPIPE_DISABLE_REPROCESS_FILES_CLEANUP, disableReprocessFilesCleanup);
+
     SnowflakeSinkService service =
-        SnowflakeSinkServiceFactory.builder(conn)
+        SnowflakeSinkServiceFactory.builder(conn, IngestionMethodConfig.SNOWPIPE, connectorConfig)
             .addTask(table, new TopicPartition(topic, partition))
             .setRecordNumber(1) // immediate flush
             .build();
@@ -803,9 +812,11 @@ public class SinkServiceIT {
     // cleaner will remove previous files and ingested new file
     TestUtils.assertWithRetry(() -> getStageSize(stage, table, 0) == 0, 30, 10);
 
-    // verify that filename2 appears in table stage
+    // Verify that filename2 appears in the table stage
+    // When SNOWPIPE_DISABLE_REPROCESS_FILES_CLEANUP is set to True, files will not be removed from currentStage.
+    // As a result, fileName4 will eventually be added to the table stage, bringing the total count to 3.
     List<String> files = conn.listStage(table, "", true);
-    assert files.size() == 2;
+    assert files.size() == expectedTableStageSize;
 
     service.closeAll();
   }


### PR DESCRIPTION
<!-- Text inside of HTML comment blocks will NOT appear in your pull request description -->
<!-- Formatting information can be found at https://www.markdownguide.org/basic-syntax/ -->
# Overview

Issue: Missing records in Snowflake when streaming data using the Snowflake Sink Connector. Customers who have set up multiple topics to map to a single table might see data loss.

Cause: Cleaning up reprocessFiles may remove files that haven’t been fully loaded yet, leading to data loss.

Solution: To avoid this, enable the snowflake.snowpipe.v1Cleaner.disable.reprocessFiles.cleanup flag. This will stop the cleanup of reprocessFiles and help prevent any data loss during the process.

<!--
Why is this review being requested?  The full details should be in the JIRA, but the review should focus on the fix/change being implemented.
If there are multiple steps in the Jira, which step is this?
-->

## Pre-review checklist
- [ ] This change should be part of a Behavior Change Release. See [go/behavior-change](http://go/behavior-change).
- [ ] This change has passed Merge gate tests
- [ ] Snowpipe Changes
- [ ] Snowpipe Streaming Changes
- [ ] This change is TEST-ONLY
- [ ] This change is README/Javadocs only
- [ ] This change is protected by a config parameter <PARAMETER_NAME> eg `snowflake.ingestion.method`.
    - [ ] `Yes` - Added end to end and Unit Tests. 
    - [ ] `No` - Suggest why it is not param protected
- [ ] Is his change protected by parameter <PARAMETER_NAME> on the server side?
    - [ ] The parameter/feature is not yet active in production (partial rollout or PrPr, see [Changes for Unreleased Features and Fixes](http://go/ppp-prpr)).
    - [ ] If there is an issue, it can be safely mitigated by turning the parameter off. This is also verified by a test (See [go/ppp](http://go/ppp)).


<!--
## Urgency
This review is *normal* priority
This review is **high** priority
This review is ***URGENT*** priority
-->

<!--
Indicate any urgency for performing the review.  Perhaps it is a fix for a prod issue or is blocking a customer.
-->

<!--
## Risks
What are the risks associated to your change?
-->

<!--
## Backward and forward Compatible
Imagine customer upgrading to new version and rolling back to older version. Will there be any concerns?
[ ] Backward compatible
[ ] Forward compatible
-->

<!--
Suggested reading order:   Provide an order in which to read files, classes, and methods.  Without this your reader will spend lots of time reading code without understanding the context (imagine the top file references a new class in methods of a file below it).  You need to tell your reviewers how to learn your code.
-->

<!--
## Reviewer roles
Every reviewer must be told their role and what actions are expected of them.  Tell every reviewer what will happen if they don't complete the review.  If you aren't sure who the secondary owner is then work with a manager and/or tech lead to figure this out.
If there are specific items or subsets of the change that you want a particular reviewer to focus on, mention it here.  You can @-mention people using their github username
-->

<!--
Reviewers:  Every review must have at least two reviewers for bug fixes, GA'ed component. One reviewer is enough for test only, doc changes.
Example:
- Minimum # of Required Reviewers - **Two** for Improvements and Bugfixes - <@github alias> 
- Educational purposes - <@github alias>
- Manager/TL approval (If patch critical and requires a release) - <@github alias>
-->

