### PR TITLE
CASEC-9813 Bump protobuf in test-data to 3.25.5

### DIFF
--- a/test/test_data/protobuf/pom.xml
+++ b/test/test_data/protobuf/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>3.25.2</version>
+            <version>3.25.5</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
This subproject is only for test data generation, but some vulnerabilities scanners raise alerts regarding it.