### PR TITLE
SNOW-1904571 Add option to configure v2 cleaner interval

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -117,9 +117,17 @@ public class SnowflakeSinkConnectorConfig {
   public static final String SNOWPIPE_FILE_CLEANER_FIX_ENABLED =
       "snowflake.snowpipe.v2CleanerEnabled";
   public static final String SNOWPIPE_FILE_CLEANER_THREADS = "snowflake.snowpipe.v2CleanerThreads";
+  // how often to run v2 cleaner
+  // low value may cause hitting "too many requests - 429 status code" while querying the internal
+  // stage
+  // setting it higher may be cost-effective when no messages land on a partition
+  // (https://snowflakecomputing.atlassian.net/browse/SNOW-1904571)
+  public static final String SNOWPIPE_FILE_CLEANER_INTERVAL_SECONDS =
+      "snowflake.snowpipe.v2CleanerIntervalSeconds";
 
   public static final boolean SNOWPIPE_FILE_CLEANER_FIX_ENABLED_DEFAULT = true;
   public static final int SNOWPIPE_FILE_CLEANER_THREADS_DEFAULT = 1;
+  public static final long SNOWPIPE_FILE_CLEANER_INTERVAL_SECONDS_DEFAULT = 61;
 
   public static final String SNOWPIPE_ENABLE_REPROCESS_FILES_CLEANUP =
       "snowflake.snowpipe.v1Cleaner.enable.reprocessFiles.cleanup";

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceFactory.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceFactory.java
@@ -47,7 +47,18 @@ public class SnowflakeSinkServiceFactory {
         IngestionMethodConfig ingestionType,
         Map<String, String> connectorConfig) {
       if (ingestionType == IngestionMethodConfig.SNOWPIPE) {
-        SnowflakeSinkServiceV1 svc = new SnowflakeSinkServiceV1(conn);
+        long v2CleanerIntervalSeconds =
+            SnowflakeSinkConnectorConfig.SNOWPIPE_FILE_CLEANER_INTERVAL_SECONDS_DEFAULT;
+        if (connectorConfig != null
+            && connectorConfig.containsKey(
+                SnowflakeSinkConnectorConfig.SNOWPIPE_FILE_CLEANER_INTERVAL_SECONDS)) {
+          v2CleanerIntervalSeconds =
+              Long.parseLong(
+                  connectorConfig.get(
+                      SnowflakeSinkConnectorConfig.SNOWPIPE_FILE_CLEANER_INTERVAL_SECONDS));
+        }
+
+        SnowflakeSinkServiceV1 svc = new SnowflakeSinkServiceV1(conn, v2CleanerIntervalSeconds);
         this.service = svc;
         boolean useStageFilesProcessor =
             SnowflakeSinkConnectorConfig.SNOWPIPE_FILE_CLEANER_FIX_ENABLED_DEFAULT;

--- a/src/test/java/com/snowflake/kafka/connector/internal/StageFilesProcessorTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/StageFilesProcessorTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
 import com.snowflake.kafka.connector.internal.streaming.IngestionMethodConfig;
 import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryBasicInfo;
 import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryPipeCreation;
@@ -92,7 +93,8 @@ class StageFilesProcessorTest {
             pipeTelemetry,
             telemetryService,
             createTestScheduler(ticks, currentTime, nextTickCallback, scheduledFuture),
-            currentTime::get);
+            currentTime::get,
+            SnowflakeSinkConnectorConfig.SNOWPIPE_FILE_CLEANER_INTERVAL_SECONDS_DEFAULT);
     register = new StageFilesProcessor.ProgressRegisterImpl(victim);
   }
 

--- a/test/test_verify.py
+++ b/test/test_verify.py
@@ -84,7 +84,8 @@ class KafkaTest:
             }
         else:
             self.client_config = {
-                "bootstrap.servers": kafkaAddress
+                "bootstrap.servers": kafkaAddress,
+                "broker.address.family": "v4",
             }
 
         self.adminClient = AdminClient(self.client_config)


### PR DESCRIPTION
<!-- Text inside of HTML comment blocks will NOT appear in your pull request description -->
<!-- Formatting information can be found at https://www.markdownguide.org/basic-syntax/ -->
# Overview

SNOW-1904571

<!--
Why is this review being requested?  The full details should be in the JIRA, but the review should focus on the fix/change being implemented.
If there are multiple steps in the Jira, which step is this?
-->

For Snowpipe based connector when having a topic with multiple partitions with no data produced the cleaner is never started because pipe doe not exists. 
```
                // cleaner starts along with the partition task, but until table, stage and pipe
                // aren't created - there is no point in querying the stage.
                if (isFirstRun.get()
                    && checkPreRequisites() != CleanerPrerequisites.PIPE_COMPATIBLE) {
                  LOGGER.debug(
                      "neither table {} nor stage {} nor pipe {} have been initialized yet,"
                          + " skipping cycle...",
                      tableName,
                      stageName,
                      pipeName);
                  return;
                }
```

This generates additional `describe table / stage / pipe` calls that some users find costly and noisy. 

This PR adds `snowflake.snowpipe.v2CleanerIntervalSeconds` configuration options to run cleaner with a lower frequency.