### PR TITLE
SNOW-1933073 Add retry policy for channel migration

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/ChannelOffsetTokenMigrator.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/ChannelOffsetTokenMigrator.java
@@ -1,0 +1,67 @@
+package com.snowflake.kafka.connector.internal.streaming;
+
+import com.snowflake.kafka.connector.internal.KCLogger;
+import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
+import com.snowflake.kafka.connector.internal.SnowflakeConnectionServiceV1;
+import com.snowflake.kafka.connector.internal.SnowflakeErrors;
+import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryService;
+import dev.failsafe.Failsafe;
+import dev.failsafe.Fallback;
+import dev.failsafe.RetryPolicy;
+import java.time.Duration;
+
+/**
+ * Encapsulates logic around offset token migration that is required to avoid data duplication when
+ * upgrading the connector from version 2.1.0. (see PROD-39429 for details).
+ */
+public class ChannelOffsetTokenMigrator {
+
+  private static final KCLogger LOGGER = new KCLogger(ChannelOffsetTokenMigrator.class.getName());
+
+  private static final Duration CHANNEL_MIGRATION_RETRY_DELAY = Duration.ofSeconds(1);
+
+  private static final int CHANNEL_MIGRATION_RETRY_MAX_ATTEMPTS = 3;
+
+  private final SnowflakeConnectionService snowflakeConnectionService;
+
+  private final SnowflakeTelemetryService telemetryService;
+
+  public ChannelOffsetTokenMigrator(
+      SnowflakeConnectionService snowflakeConnectionService,
+      SnowflakeTelemetryService telemetryService) {
+    this.snowflakeConnectionService = snowflakeConnectionService;
+    this.telemetryService = telemetryService;
+  }
+
+  private static RetryPolicy<ChannelMigrateOffsetTokenResponseDTO> channelMigrationRetryPolicy() {
+    return RetryPolicy.<ChannelMigrateOffsetTokenResponseDTO>builder()
+        .handle(SnowflakeConnectionServiceV1.OffsetTokenMigrationRetryableException.class)
+        .withDelay(CHANNEL_MIGRATION_RETRY_DELAY)
+        .withMaxAttempts(CHANNEL_MIGRATION_RETRY_MAX_ATTEMPTS)
+        .onRetry(
+            event ->
+                LOGGER.warn(
+                    "Channel offset token migration retry no:{}, message:{}",
+                    event.getAttemptCount(),
+                    event.getLastException().getMessage()))
+        .build();
+  }
+
+  public void migrateChannelOffsetWithRetry(
+      String tableName, String sourceChannelName, String destinationChannelName) {
+    Fallback<ChannelMigrateOffsetTokenResponseDTO> fallback =
+        Fallback.ofException(
+            e -> {
+              LOGGER.error("Channel offset token migration - max retry attempts", e);
+              throw SnowflakeErrors.ERROR_5023.getException(
+                  e.getLastException().getMessage(), this.telemetryService);
+            });
+
+    Failsafe.with(fallback)
+        .compose(channelMigrationRetryPolicy())
+        .get(
+            () ->
+                snowflakeConnectionService.migrateStreamingChannelOffsetToken(
+                    tableName, sourceChannelName, destinationChannelName));
+  }
+}

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/DirectTopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/DirectTopicPartitionChannel.java
@@ -143,6 +143,8 @@ public class DirectTopicPartitionChannel implements TopicPartitionChannel {
 
   private final InsertErrorMapper insertErrorMapper;
 
+  private final ChannelOffsetTokenMigrator channelOffsetTokenMigrator;
+
   /**
    * Used to send telemetry to Snowflake. Currently, TelemetryClient created from a Snowflake
    * Connection Object, i.e. not a session-less Client
@@ -246,12 +248,14 @@ public class DirectTopicPartitionChannel implements TopicPartitionChannel {
     this.enableSchemaEvolution = this.enableSchematization && hasSchemaEvolutionPermission;
     this.schemaEvolutionService = schemaEvolutionService;
 
+    this.channelOffsetTokenMigrator = new ChannelOffsetTokenMigrator(conn, telemetryService);
+
     if (isEnableChannelOffsetMigration(sfConnectorConfig)) {
       /* Channel Name format V2 is computed from connector name, topic and partition */
       final String channelNameFormatV2 =
           TopicPartitionChannel.generateChannelNameFormatV2(
               this.channelNameFormatV1, this.conn.getConnectorName());
-      conn.migrateStreamingChannelOffsetToken(
+      channelOffsetTokenMigrator.migrateChannelOffsetWithRetry(
           this.tableName, channelNameFormatV2, this.channelNameFormatV1);
     }
 

--- a/src/test/java/com/snowflake/kafka/connector/internal/ConnectionServiceIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/ConnectionServiceIT.java
@@ -465,7 +465,7 @@ public class ConnectionServiceIT {
       channelMigrateOffsetTokenResponseDTO =
           conn.migrateStreamingChannelOffsetToken(
               tableName + "_Table_DOESNT_EXIST", sourceChannelName, destinationChannelName);
-    } catch (SnowflakeKafkaConnectorException ex) {
+    } catch (SnowflakeConnectionServiceV1.OffsetTokenMigrationRetryableException ex) {
       assert ex.getMessage()
           .contains(
               ChannelMigrationResponseCode.ERR_TABLE_DOES_NOT_EXIST_NOT_AUTHORIZED.getMessage());


### PR DESCRIPTION
SNOW-1933073

Offset token migration is called for every channel at startup. Even a single failure results in a fatal error that cause connector restart which then cause another batch of requests to be called. Massive number of offset migration requests has recently caused problems on the GS side.

Thanks to the retry policy we can retry just one request that failed which is better for both backend and connector.
