### PR TITLE
SNOW-2034182 [Data loss fix] Change OnErrorOption from CONTINUE to SKIP_BATCH

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/DirectTopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/DirectTopicPartitionChannel.java
@@ -255,7 +255,7 @@ public class DirectTopicPartitionChannel implements TopicPartitionChannel {
     }
 
     // Open channel and reset the offset in kafka
-    this.channel = Preconditions.checkNotNull(openChannelForTable());
+    this.channel = Preconditions.checkNotNull(openChannelForTable(this.enableSchemaEvolution));
     final long lastCommittedOffsetToken = fetchOffsetTokenWithRetry();
     this.offsetPersistedInSnowflake.set(lastCommittedOffsetToken);
     this.processedOffset.set(lastCommittedOffsetToken);
@@ -755,7 +755,7 @@ public class DirectTopicPartitionChannel implements TopicPartitionChannel {
       final StreamingApiFallbackInvoker streamingApiFallbackInvoker) {
     LOGGER.warn(
         "{} Re-opening channel:{}", streamingApiFallbackInvoker, this.getChannelNameFormatV1());
-    return Preconditions.checkNotNull(openChannelForTable());
+    return Preconditions.checkNotNull(openChannelForTable(this.enableSchemaEvolution));
   }
 
   /**
@@ -808,13 +808,19 @@ public class DirectTopicPartitionChannel implements TopicPartitionChannel {
    *
    * @return new channel which was fetched after open/reopen
    */
-  private SnowflakeStreamingIngestChannel openChannelForTable() {
+  private SnowflakeStreamingIngestChannel openChannelForTable(boolean schemaEvolutionEnabled) {
+    // SKIP_BATCH is necessary to avoid race condition in the schematization flow
+    OpenChannelRequest.OnErrorOption onErrorOption =
+        schemaEvolutionEnabled
+            ? OpenChannelRequest.OnErrorOption.SKIP_BATCH
+            : OpenChannelRequest.OnErrorOption.CONTINUE;
+
     OpenChannelRequest channelRequest =
         OpenChannelRequest.builder(this.channelNameFormatV1)
             .setDBName(this.sfConnectorConfig.get(Utils.SF_DATABASE))
             .setSchemaName(this.sfConnectorConfig.get(Utils.SF_SCHEMA))
             .setTableName(this.tableName)
-            .setOnErrorOption(OpenChannelRequest.OnErrorOption.SKIP_BATCH)
+            .setOnErrorOption(onErrorOption)
             .setOffsetTokenVerificationFunction(StreamingUtils.offsetTokenVerificationFunction)
             .build();
     LOGGER.info(

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/DirectTopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/DirectTopicPartitionChannel.java
@@ -814,7 +814,7 @@ public class DirectTopicPartitionChannel implements TopicPartitionChannel {
             .setDBName(this.sfConnectorConfig.get(Utils.SF_DATABASE))
             .setSchemaName(this.sfConnectorConfig.get(Utils.SF_SCHEMA))
             .setTableName(this.tableName)
-            .setOnErrorOption(OpenChannelRequest.OnErrorOption.CONTINUE)
+            .setOnErrorOption(OpenChannelRequest.OnErrorOption.SKIP_BATCH)
             .setOffsetTokenVerificationFunction(StreamingUtils.offsetTokenVerificationFunction)
             .build();
     LOGGER.info(

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -68,7 +68,7 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
   private final IcebergTableSchemaValidator icebergTableSchemaValidator;
   private final IcebergInitService icebergInitService;
 
-  private final SchemaEvolutionService schemaEvolutionService;
+  private SchemaEvolutionService schemaEvolutionService;
 
   private Map<String, String> topicToTableMap;
 
@@ -119,12 +119,14 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
       KafkaRecordErrorReporter recordErrorReporter,
       SinkTaskContext sinkTaskContext,
       boolean enableCustomJMXMonitoring,
-      Map<String, String> topicToTableMap) {
+      Map<String, String> topicToTableMap,
+      SchemaEvolutionService schemaEvolutionService) {
     this(conn, connectorConfig);
     this.kafkaRecordErrorReporter = recordErrorReporter;
     this.sinkTaskContext = sinkTaskContext;
     this.enableCustomJMXMonitoring = enableCustomJMXMonitoring;
     this.topicToTableMap = topicToTableMap;
+    this.schemaEvolutionService = schemaEvolutionService;
   }
 
   @Deprecated

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/DelayedSchemaEvolutionService.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/DelayedSchemaEvolutionService.java
@@ -1,0 +1,32 @@
+package com.snowflake.kafka.connector.internal.streaming;
+
+import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
+import com.snowflake.kafka.connector.internal.streaming.schemaevolution.SchemaEvolutionTargetItems;
+import com.snowflake.kafka.connector.internal.streaming.schemaevolution.snowflake.SnowflakeSchemaEvolutionService;
+import java.util.Map;
+import net.snowflake.ingest.streaming.internal.ColumnProperties;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+/** This fake class simulates a delay in running ALTER TABLE statement */
+public class DelayedSchemaEvolutionService extends SnowflakeSchemaEvolutionService {
+
+  private final long delayedInMillis;
+
+  public DelayedSchemaEvolutionService(SnowflakeConnectionService conn, long delayedInMillis) {
+    super(conn);
+    this.delayedInMillis = delayedInMillis;
+  }
+
+  @Override
+  public void evolveSchemaIfNeeded(
+      SchemaEvolutionTargetItems targetItems,
+      SinkRecord record,
+      Map<String, ColumnProperties> existingSchema) {
+    try {
+      Thread.sleep(delayedInMillis);
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+    super.evolveSchemaIfNeeded(targetItems, record, existingSchema);
+  }
+}

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingSinkServiceBuilder.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingSinkServiceBuilder.java
@@ -3,6 +3,8 @@ package com.snowflake.kafka.connector.internal.streaming;
 import com.snowflake.kafka.connector.dlq.InMemoryKafkaRecordErrorReporter;
 import com.snowflake.kafka.connector.dlq.KafkaRecordErrorReporter;
 import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
+import com.snowflake.kafka.connector.internal.streaming.schemaevolution.SchemaEvolutionService;
+import com.snowflake.kafka.connector.internal.streaming.schemaevolution.snowflake.SnowflakeSchemaEvolutionService;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -17,6 +19,7 @@ public class StreamingSinkServiceBuilder {
   private SinkTaskContext sinkTaskContext = new InMemorySinkTaskContext(Collections.emptySet());
   private boolean enableCustomJMXMonitoring = false;
   private Map<String, String> topicToTableMap = new HashMap<>();
+  private SchemaEvolutionService schemaEvolutionService;
 
   public static StreamingSinkServiceBuilder builder(
       SnowflakeConnectionService conn, Map<String, String> connectorConfig) {
@@ -30,7 +33,10 @@ public class StreamingSinkServiceBuilder {
         errorReporter,
         sinkTaskContext,
         enableCustomJMXMonitoring,
-        topicToTableMap);
+        topicToTableMap,
+        schemaEvolutionService == null
+            ? new SnowflakeSchemaEvolutionService(conn)
+            : schemaEvolutionService);
   }
 
   private StreamingSinkServiceBuilder(
@@ -57,6 +63,12 @@ public class StreamingSinkServiceBuilder {
 
   public StreamingSinkServiceBuilder withTopicToTableMap(Map<String, String> topic2TableMap) {
     topicToTableMap = topic2TableMap;
+    return this;
+  }
+
+  public StreamingSinkServiceBuilder withSchemaEvolutionService(
+      SchemaEvolutionService schemaEvolutionService) {
+    this.schemaEvolutionService = schemaEvolutionService;
     return this;
   }
 }


### PR DESCRIPTION
<!-- Text inside of HTML comment blocks will NOT appear in your pull request description -->
<!-- Formatting information can be found at https://www.markdownguide.org/basic-syntax/ -->
# Overview

SNOW-2034182

<!--
Why is this review being requested?  The full details should be in the JIRA, but the review should focus on the fix/change being implemented.
If there are multiple steps in the Jira, which step is this?
-->

When schematization is enabled it is possible for the connector to lose a single message that triggers changing a table schema due to a race condition. Assuming that `offset=n` triggers the schema evolution:
1. `this.channel.insertRow(transformedRecord, Long.toString(offset))` is called for offset=n-1 (no schema evolution)
2. `this.channel.insertRow(transformedRecord, Long.toString(offset))` is called for offset=n
3. [Race condition] The background ingest sdk flush thread sends and commits the data with offsets up to n (inclusive) into Snowflake. Record n is considered as error and is skipped due to `OnErrorOption.CONTINUE` client setting.
4. The channel is invalidated and reopened. Connector reports offset n+1 as the next starting point for Kafka Connect

Note that data won't be loss if step 4 happens before step 3.