### PR TITLE
CONN-10472 Separate SnowflakeSinkServiceV1 and SnowflakeSinkServiceV2 creation

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
@@ -251,7 +251,7 @@ public class SnowflakeSinkTask extends SinkTask {
               this.context,
               enableCustomJMXMonitoring,
               topic2table,
-              SnowflakeSinkConnectorConfig.BehaviorOnNullValues.DEFAULT,
+              behavior,
               schemaEvolutionService);
     }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkService.java
@@ -2,9 +2,7 @@ package com.snowflake.kafka.connector.internal;
 
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.annotations.VisibleForTesting;
-import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
 import com.snowflake.kafka.connector.dlq.KafkaRecordErrorReporter;
-import com.snowflake.kafka.connector.records.SnowflakeMetadataConfig;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
@@ -87,57 +85,6 @@ public interface SnowflakeSinkService {
    * @return true is closed
    */
   boolean isClosed();
-
-  /**
-   * change maximum number of record cached in buffer to control the flush rate, 0 for unlimited
-   *
-   * @param num a non negative long number represents number of record limitation
-   */
-  void setRecordNumber(long num);
-
-  /**
-   * change data size of buffer to control the flush rate, the minimum file size is controlled by
-   * {@link SnowflakeSinkConnectorConfig#BUFFER_SIZE_BYTES_MIN}
-   *
-   * <p>Please note: The buffer size for Streaming and snowpipe doesnt necessarily translate to same
-   * file size in Snowflake.
-   *
-   * <p>There is Java to UTF conversion followed by file compression in gzip.
-   *
-   * @param size a non negative long number represents data size limitation
-   */
-  void setFileSize(long size);
-
-  /**
-   * pass topic to table map to sink service
-   *
-   * @param topic2TableMap a String to String Map represents topic to table map
-   */
-  void setTopic2TableMap(Map<String, String> topic2TableMap);
-
-  /**
-   * change flush rate of sink service the minimum flush time is controlled by {@link
-   * SnowflakeSinkConnectorConfig#BUFFER_FLUSH_TIME_SEC_MIN}
-   *
-   * @param time a non negative long number represents service flush time in seconds
-   */
-  void setFlushTime(long time);
-
-  /**
-   * set the metadata config to let user control what metadata to be collected into SF db
-   *
-   * @param configMap a String to String Map
-   */
-  void setMetadataConfig(SnowflakeMetadataConfig configMap);
-
-  /* Set the behavior on what action to perform when this( @see com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig#BEHAVIOR_ON_NULL_VALUES_CONFIG ) config is set. */
-  void setBehaviorOnNullValuesConfig(SnowflakeSinkConnectorConfig.BehaviorOnNullValues behavior);
-
-  /* Should we emit Custom SF JMX Metrics to Mbean Server? If true (Default), we emit in form of SimpleMbeans */
-  void setCustomJMXMetrics(boolean enableJMX);
-
-  /* Only used in testing and verifying what was the passed value of this behavior from config to sink service*/
-  SnowflakeSinkConnectorConfig.BehaviorOnNullValues getBehaviorOnNullValuesConfig();
 
   /* Set Error reporter which can be used to send records to DLQ (Dead Letter Queue) */
   default void setErrorReporter(KafkaRecordErrorReporter kafkaRecordErrorReporter) {}

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkServiceV1.java
@@ -350,7 +350,6 @@ class SnowflakeSinkServiceV1 implements SnowflakeSinkService {
     return this.isStopped;
   }
 
-  @Override
   public void setRecordNumber(final long num) {
     if (num < 0) {
       LOGGER.error("number of record in each file is {}, it is negative, reset to" + " 0");
@@ -361,7 +360,6 @@ class SnowflakeSinkServiceV1 implements SnowflakeSinkService {
     }
   }
 
-  @Override
   public void setFileSize(final long size) {
     if (size < SnowflakeSinkConnectorConfig.BUFFER_SIZE_BYTES_MIN) {
       LOGGER.error(
@@ -376,7 +374,6 @@ class SnowflakeSinkServiceV1 implements SnowflakeSinkService {
     }
   }
 
-  @Override
   public void setFlushTime(final long time) {
     if (time < SnowflakeSinkConnectorConfig.BUFFER_FLUSH_TIME_SEC_MIN) {
       LOGGER.error(
@@ -391,12 +388,10 @@ class SnowflakeSinkServiceV1 implements SnowflakeSinkService {
     }
   }
 
-  @Override
   public void setTopic2TableMap(Map<String, String> topic2TableMap) {
     this.topic2TableMap = topic2TableMap;
   }
 
-  @Override
   public void setMetadataConfig(SnowflakeMetadataConfig configMap) {
     this.recordService.setMetadataConfig(configMap);
   }
@@ -413,7 +408,6 @@ class SnowflakeSinkServiceV1 implements SnowflakeSinkService {
     return this.fileSize;
   }
 
-  @Override
   public void setBehaviorOnNullValuesConfig(
       SnowflakeSinkConnectorConfig.BehaviorOnNullValues behavior) {
     this.behaviorOnNullValues = behavior;
@@ -427,14 +421,8 @@ class SnowflakeSinkServiceV1 implements SnowflakeSinkService {
     cleanerServiceExecutor = new ScheduledThreadPoolExecutor(Math.max(1, threadCount));
   }
 
-  @Override
   public void setCustomJMXMetrics(boolean enableJMX) {
     this.enableCustomJMXMonitoring = enableJMX;
-  }
-
-  @Override
-  public SnowflakeSinkConnectorConfig.BehaviorOnNullValues getBehaviorOnNullValuesConfig() {
-    return this.behaviorOnNullValues;
   }
 
   /**

--- a/src/test/java/com/snowflake/kafka/connector/internal/SinkServiceIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/SinkServiceIT.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.*;
 
 import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
 import com.snowflake.kafka.connector.Utils;
-import com.snowflake.kafka.connector.internal.streaming.IngestionMethodConfig;
 import com.snowflake.kafka.connector.records.SnowflakeConverter;
 import com.snowflake.kafka.connector.records.SnowflakeJsonConverter;
 import io.confluent.connect.avro.AvroConverter;
@@ -803,7 +802,7 @@ public class SinkServiceIT {
     connectorConfig.put(SnowflakeSinkConnectorConfig.SNOWPIPE_FILE_CLEANER_FIX_ENABLED, "false");
 
     SnowflakeSinkService service =
-        SnowflakeSinkServiceFactory.builder(conn, IngestionMethodConfig.SNOWPIPE, connectorConfig)
+        SnowflakeSinkServiceFactory.builder(conn, connectorConfig)
             .addTask(table, new TopicPartition(topic, partition))
             .setRecordNumber(1) // immediate flush
             .build();

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2AvroSchematizationIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2AvroSchematizationIT.java
@@ -5,10 +5,8 @@ import static com.snowflake.kafka.connector.internal.streaming.channel.TopicPart
 import static org.awaitility.Awaitility.await;
 
 import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
-import com.snowflake.kafka.connector.dlq.InMemoryKafkaRecordErrorReporter;
 import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
 import com.snowflake.kafka.connector.internal.SnowflakeSinkService;
-import com.snowflake.kafka.connector.internal.SnowflakeSinkServiceFactory;
 import com.snowflake.kafka.connector.internal.TestUtils;
 import io.confluent.connect.avro.AvroConverter;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
@@ -149,12 +147,12 @@ public class SnowflakeSinkServiceV2AvroSchematizationIT {
 
   private SnowflakeSinkService createService() {
     Map<String, String> config = prepareConfig();
-    return SnowflakeSinkServiceFactory.builder(
-            conn, IngestionMethodConfig.SNOWPIPE_STREAMING, config)
-        .setErrorReporter(new InMemoryKafkaRecordErrorReporter())
-        .setSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(topicPartition)))
-        .addTask(table, new TopicPartition(topic, PARTITION))
-        .build();
+    SnowflakeSinkService service =
+        StreamingSinkServiceBuilder.builder(conn, config)
+            .withSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(topicPartition)))
+            .build();
+    service.startPartition(table, new TopicPartition(topic, PARTITION));
+    return service;
   }
 
   private SinkRecord createSinkRecord() {

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2IT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2IT.java
@@ -17,7 +17,6 @@ import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
 import com.snowflake.kafka.connector.internal.SnowflakeConnectionServiceFactory;
 import com.snowflake.kafka.connector.internal.SnowflakeErrors;
 import com.snowflake.kafka.connector.internal.SnowflakeSinkService;
-import com.snowflake.kafka.connector.internal.SnowflakeSinkServiceFactory;
 import com.snowflake.kafka.connector.internal.TestUtils;
 import com.snowflake.kafka.connector.internal.metrics.MetricsUtil;
 import com.snowflake.kafka.connector.internal.streaming.telemetry.SnowflakeTelemetryChannelCreation;
@@ -989,11 +988,10 @@ public class SnowflakeSinkServiceV2IT {
 
     // initialize a new sink service
     SnowflakeSinkService service2 =
-        SnowflakeSinkServiceFactory.builder(conn, IngestionMethodConfig.SNOWPIPE_STREAMING, config)
-            .setErrorReporter(new InMemoryKafkaRecordErrorReporter())
-            .setSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(topicPartition)))
-            .addTask(table, new TopicPartition(topic, partition))
+        StreamingSinkServiceBuilder.builder(conn, config)
+            .withSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(topicPartition)))
             .build();
+    service2.startPartition(table, new TopicPartition(topic, partition));
     offset = 1;
     // Create sink record
     SinkRecord record2 =

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2StopIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2StopIT.java
@@ -1,9 +1,7 @@
 package com.snowflake.kafka.connector.internal.streaming;
 
 import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
-import com.snowflake.kafka.connector.dlq.InMemoryKafkaRecordErrorReporter;
 import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
-import com.snowflake.kafka.connector.internal.SnowflakeSinkServiceFactory;
 import com.snowflake.kafka.connector.internal.TestUtils;
 import java.util.Collections;
 import java.util.Map;
@@ -45,14 +43,11 @@ public class SnowflakeSinkServiceV2StopIT {
 
     // opens a channel for partition 0, table and topic
     SnowflakeSinkServiceV2 service =
-        (SnowflakeSinkServiceV2)
-            SnowflakeSinkServiceFactory.builder(
-                    conn, IngestionMethodConfig.SNOWPIPE_STREAMING, config)
-                .setErrorReporter(new InMemoryKafkaRecordErrorReporter())
-                .setSinkTaskContext(
-                    new InMemorySinkTaskContext(Collections.singleton(topicPartition)))
-                .addTask(topicAndTableName, topicPartition)
-                .build();
+        StreamingSinkServiceBuilder.builder(conn, config)
+            .withSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(topicPartition)))
+            .build();
+    service.startPartition(topicAndTableName, topicPartition);
+
     SnowflakeStreamingIngestClient client = service.getStreamingIngestClient();
 
     // when

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingSinkServiceBuilder.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingSinkServiceBuilder.java
@@ -1,5 +1,6 @@
 package com.snowflake.kafka.connector.internal.streaming;
 
+import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
 import com.snowflake.kafka.connector.dlq.InMemoryKafkaRecordErrorReporter;
 import com.snowflake.kafka.connector.dlq.KafkaRecordErrorReporter;
 import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
@@ -19,6 +20,8 @@ public class StreamingSinkServiceBuilder {
   private SinkTaskContext sinkTaskContext = new InMemorySinkTaskContext(Collections.emptySet());
   private boolean enableCustomJMXMonitoring = false;
   private Map<String, String> topicToTableMap = new HashMap<>();
+  private SnowflakeSinkConnectorConfig.BehaviorOnNullValues behaviorOnNullValues =
+      SnowflakeSinkConnectorConfig.BehaviorOnNullValues.DEFAULT;
   private SchemaEvolutionService schemaEvolutionService;
 
   public static StreamingSinkServiceBuilder builder(
@@ -34,6 +37,7 @@ public class StreamingSinkServiceBuilder {
         sinkTaskContext,
         enableCustomJMXMonitoring,
         topicToTableMap,
+        behaviorOnNullValues,
         schemaEvolutionService == null
             ? new SnowflakeSchemaEvolutionService(conn)
             : schemaEvolutionService);
@@ -63,6 +67,12 @@ public class StreamingSinkServiceBuilder {
 
   public StreamingSinkServiceBuilder withTopicToTableMap(Map<String, String> topic2TableMap) {
     topicToTableMap = topic2TableMap;
+    return this;
+  }
+
+  public StreamingSinkServiceBuilder withBehaviorOnNullValues(
+      SnowflakeSinkConnectorConfig.BehaviorOnNullValues behavior) {
+    behaviorOnNullValues = behavior;
     return this;
   }
 

--- a/src/test/java/com/snowflake/kafka/connector/streaming/iceberg/IcebergIngestionIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/streaming/iceberg/IcebergIngestionIT.java
@@ -9,6 +9,7 @@ import com.snowflake.kafka.connector.internal.SnowflakeSinkService;
 import com.snowflake.kafka.connector.internal.TestUtils;
 import com.snowflake.kafka.connector.internal.streaming.InMemorySinkTaskContext;
 import com.snowflake.kafka.connector.internal.streaming.StreamingSinkServiceBuilder;
+import com.snowflake.kafka.connector.internal.streaming.schemaevolution.iceberg.IcebergSchemaEvolutionService;
 import com.snowflake.kafka.connector.streaming.iceberg.sql.ComplexJsonRecord;
 import com.snowflake.kafka.connector.streaming.iceberg.sql.MetadataRecord.RecordWithMetadata;
 import com.snowflake.kafka.connector.streaming.iceberg.sql.PrimitiveJsonRecord;
@@ -67,6 +68,7 @@ public abstract class IcebergIngestionIT extends BaseIcebergIT {
             .withErrorReporter(kafkaRecordErrorReporter)
             .withSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(topicPartition)))
             .withTopicToTableMap(topic2Table)
+            .withSchemaEvolutionService(new IcebergSchemaEvolutionService(conn))
             .build();
     service.startPartition(tableName, topicPartition);
   }

--- a/src/test/java/com/snowflake/kafka/connector/streaming/iceberg/IcebergIngestionIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/streaming/iceberg/IcebergIngestionIT.java
@@ -6,10 +6,9 @@ import static com.snowflake.kafka.connector.internal.TestUtils.getConfForStreami
 import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
 import com.snowflake.kafka.connector.dlq.InMemoryKafkaRecordErrorReporter;
 import com.snowflake.kafka.connector.internal.SnowflakeSinkService;
-import com.snowflake.kafka.connector.internal.SnowflakeSinkServiceFactory;
 import com.snowflake.kafka.connector.internal.TestUtils;
 import com.snowflake.kafka.connector.internal.streaming.InMemorySinkTaskContext;
-import com.snowflake.kafka.connector.internal.streaming.IngestionMethodConfig;
+import com.snowflake.kafka.connector.internal.streaming.StreamingSinkServiceBuilder;
 import com.snowflake.kafka.connector.streaming.iceberg.sql.ComplexJsonRecord;
 import com.snowflake.kafka.connector.streaming.iceberg.sql.MetadataRecord.RecordWithMetadata;
 import com.snowflake.kafka.connector.streaming.iceberg.sql.PrimitiveJsonRecord;
@@ -64,12 +63,11 @@ public abstract class IcebergIngestionIT extends BaseIcebergIT {
 
     kafkaRecordErrorReporter = new InMemoryKafkaRecordErrorReporter();
     service =
-        SnowflakeSinkServiceFactory.builder(conn, IngestionMethodConfig.SNOWPIPE_STREAMING, config)
-            .setErrorReporter(kafkaRecordErrorReporter)
-            .setSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(topicPartition)))
-            .setTopic2TableMap(topic2Table)
-            .addTask(tableName, topicPartition)
+        StreamingSinkServiceBuilder.builder(conn, config)
+            .withSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(topicPartition)))
+            .withTopicToTableMap(topic2Table)
             .build();
+    service.startPartition(tableName, topicPartition);
   }
 
   @AfterEach

--- a/src/test/java/com/snowflake/kafka/connector/streaming/iceberg/IcebergIngestionIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/streaming/iceberg/IcebergIngestionIT.java
@@ -64,6 +64,7 @@ public abstract class IcebergIngestionIT extends BaseIcebergIT {
     kafkaRecordErrorReporter = new InMemoryKafkaRecordErrorReporter();
     service =
         StreamingSinkServiceBuilder.builder(conn, config)
+            .withErrorReporter(kafkaRecordErrorReporter)
             .withSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(topicPartition)))
             .withTopicToTableMap(topic2Table)
             .build();


### PR DESCRIPTION
<!-- Text inside of HTML comment blocks will NOT appear in your pull request description -->
<!-- Formatting information can be found at https://www.markdownguide.org/basic-syntax/ -->
# Overview

CONN-10472

<!--
Why is this review being requested?  The full details should be in the JIRA, but the review should focus on the fix/change being implemented.
If there are multiple steps in the Jira, which step is this?
-->

This is the last part of the refactoring effort started after double buffer removal 💪 Intentions behind this PR:
- Creation of `SnowflakeSinkServiceV1` and `SnowflakeSinkServiceV2` is completely separated
- `SnowflakeSinkServiceV2` has a single constructor and all final fields
- `SnowflakeSinkService` interface no longer contains buffer related methods as they are Snowpipe specific
- `SnowflakeSinkServiceFactory` is used only to construct instances of `SnowflakeSinkServiceV1`