### PR TITLE
CONN-10463 ExposingInternalsTopicPartitionChannel refactor

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/DirectTopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/DirectTopicPartitionChannel.java
@@ -943,23 +943,9 @@ public class DirectTopicPartitionChannel implements TopicPartitionChannel {
     return this.currentConsumerGroupOffset.get();
   }
 
-  @Override
-  @VisibleForTesting
-  @Deprecated
-  public boolean isPartitionBufferEmpty() {
-    return true;
-  }
-
-  @Override
   @VisibleForTesting
   public SnowflakeStreamingIngestChannel getChannel() {
     return this.channel;
-  }
-
-  @Override
-  @VisibleForTesting
-  public SnowflakeTelemetryService getTelemetryServiceV2() {
-    return this.telemetryServiceV2;
   }
 
   @Override

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/channel/ExposingInternalsTopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/channel/ExposingInternalsTopicPartitionChannel.java
@@ -2,9 +2,7 @@ package com.snowflake.kafka.connector.internal.streaming.channel;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.snowflake.kafka.connector.internal.streaming.telemetry.SnowflakeTelemetryChannelStatus;
-import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryService;
 import dev.failsafe.Fallback;
-import net.snowflake.ingest.streaming.SnowflakeStreamingIngestChannel;
 
 public interface ExposingInternalsTopicPartitionChannel {
 
@@ -16,15 +14,6 @@ public interface ExposingInternalsTopicPartitionChannel {
 
   @VisibleForTesting
   long getLatestConsumerOffset();
-
-  @VisibleForTesting
-  boolean isPartitionBufferEmpty();
-
-  @VisibleForTesting
-  SnowflakeStreamingIngestChannel getChannel();
-
-  @VisibleForTesting
-  SnowflakeTelemetryService getTelemetryServiceV2();
 
   @VisibleForTesting
   SnowflakeTelemetryChannelStatus getSnowflakeTelemetryChannelStatus();

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelIT.java
@@ -12,7 +12,6 @@ import com.snowflake.kafka.connector.internal.TestUtils;
 import com.snowflake.kafka.connector.internal.streaming.channel.TopicPartitionChannel;
 import com.snowflake.kafka.connector.internal.streaming.schemaevolution.InsertErrorMapper;
 import com.snowflake.kafka.connector.internal.streaming.schemaevolution.snowflake.SnowflakeSchemaEvolutionService;
-import com.snowflake.kafka.connector.internal.streaming.telemetry.SnowflakeTelemetryServiceV2;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -205,9 +204,6 @@ public class TopicPartitionChannelIT {
         service.getTopicPartitionChannelFromCacheKey(testChannelName).get();
 
     Assertions.assertNotNull(topicPartitionChannel);
-
-    Assertions.assertTrue(
-        topicPartitionChannel.getTelemetryServiceV2() instanceof SnowflakeTelemetryServiceV2);
 
     // close channel
     topicPartitionChannel.closeChannel();

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelTest.java
@@ -133,8 +133,7 @@ public class TopicPartitionChannelTest {
         mockKafkaRecordErrorReporter,
         mockSinkTaskContext,
         mockSnowflakeConnectionService,
-        mockTelemetryService,
-        this.schemaEvolutionService);
+        mockTelemetryService);
   }
 
   @Test
@@ -151,8 +150,7 @@ public class TopicPartitionChannelTest {
             mockKafkaRecordErrorReporter,
             mockSinkTaskContext,
             mockSnowflakeConnectionService,
-            mockTelemetryService,
-            this.schemaEvolutionService);
+            mockTelemetryService);
 
     Assert.assertEquals(-1L, topicPartitionChannel.fetchOffsetTokenWithRetry());
   }
@@ -172,8 +170,7 @@ public class TopicPartitionChannelTest {
             mockKafkaRecordErrorReporter,
             mockSinkTaskContext,
             mockSnowflakeConnectionService,
-            mockTelemetryService,
-            this.schemaEvolutionService);
+            mockTelemetryService);
 
     Assert.assertEquals(100L, topicPartitionChannel.fetchOffsetTokenWithRetry());
   }
@@ -202,8 +199,7 @@ public class TopicPartitionChannelTest {
             mockKafkaRecordErrorReporter,
             mockSinkTaskContext,
             mockSnowflakeConnectionService,
-            mockTelemetryService,
-            this.schemaEvolutionService);
+            mockTelemetryService);
 
     JsonConverter converter = new JsonConverter();
     HashMap<String, String> converterConfig = new HashMap<String, String>();
@@ -226,8 +222,6 @@ public class TopicPartitionChannelTest {
     topicPartitionChannel.insertRecord(record1, true);
 
     Assert.assertEquals(-1l, topicPartitionChannel.getOffsetPersistedInSnowflake());
-
-    Assert.assertTrue(topicPartitionChannel.isPartitionBufferEmpty());
   }
 
   @Test
@@ -252,8 +246,7 @@ public class TopicPartitionChannelTest {
             RecordServiceFactory.createRecordService(false, false),
             mockTelemetryService,
             false,
-            null,
-            this.schemaEvolutionService);
+            null);
 
     topicPartitionChannel.closeChannel();
   }
@@ -281,8 +274,7 @@ public class TopicPartitionChannelTest {
             RecordServiceFactory.createRecordService(false, false),
             mockTelemetryService,
             false,
-            null,
-            this.schemaEvolutionService);
+            null);
 
     // when
     assertDoesNotThrow(topicPartitionChannel::closeChannel);
@@ -312,8 +304,7 @@ public class TopicPartitionChannelTest {
             RecordServiceFactory.createRecordService(false, false),
             mockTelemetryService,
             false,
-            null,
-            this.schemaEvolutionService);
+            null);
 
     // when
     assertDoesNotThrow(topicPartitionChannel::closeChannel);
@@ -348,8 +339,7 @@ public class TopicPartitionChannelTest {
             RecordServiceFactory.createRecordService(false, false),
             mockTelemetryService,
             false,
-            null,
-            this.schemaEvolutionService);
+            null);
 
     // when
     ExecutionException ex =
@@ -386,8 +376,7 @@ public class TopicPartitionChannelTest {
             RecordServiceFactory.createRecordService(false, false),
             mockTelemetryService,
             false,
-            null,
-            this.schemaEvolutionService);
+            null);
 
     // when
     assertDoesNotThrow(() -> topicPartitionChannel.closeChannelAsync().get());
@@ -417,8 +406,7 @@ public class TopicPartitionChannelTest {
             RecordServiceFactory.createRecordService(false, false),
             mockTelemetryService,
             false,
-            null,
-            this.schemaEvolutionService);
+            null);
 
     // when
     assertDoesNotThrow(() -> topicPartitionChannel.closeChannelAsync().get());
@@ -452,8 +440,7 @@ public class TopicPartitionChannelTest {
             RecordServiceFactory.createRecordService(false, false),
             mockTelemetryService,
             false,
-            null,
-            this.schemaEvolutionService);
+            null);
     Mockito.verify(mockSnowflakeConnectionService, Mockito.times(1))
         .migrateStreamingChannelOffsetToken(anyString(), anyString(), anyString());
 
@@ -474,8 +461,7 @@ public class TopicPartitionChannelTest {
             RecordServiceFactory.createRecordService(false, false),
             mockTelemetryService,
             false,
-            null,
-            this.schemaEvolutionService);
+            null);
     Mockito.verify(mockSnowflakeConnectionService, Mockito.times(2))
         .migrateStreamingChannelOffsetToken(anyString(), anyString(), anyString());
 
@@ -497,8 +483,7 @@ public class TopicPartitionChannelTest {
             RecordServiceFactory.createRecordService(false, false),
             mockTelemetryService,
             false,
-            null,
-            this.schemaEvolutionService);
+            null);
     Mockito.verify(anotherMockForParamDisabled, Mockito.times(0))
         .migrateStreamingChannelOffsetToken(anyString(), anyString(), anyString());
   }
@@ -527,8 +512,7 @@ public class TopicPartitionChannelTest {
               RecordServiceFactory.createRecordService(false, false),
               mockTelemetryService,
               false,
-              null,
-              this.schemaEvolutionService);
+              null);
       Assert.fail("Should throw an exception:");
     } catch (Exception e) {
       Mockito.verify(mockSnowflakeConnectionService, Mockito.times(1))
@@ -542,7 +526,7 @@ public class TopicPartitionChannelTest {
   public void testFetchOffsetTokenWithRetry_SFException() {
     Mockito.when(mockStreamingChannel.getLatestCommittedOffsetToken()).thenThrow(SF_EXCEPTION);
 
-    TopicPartitionChannel topicPartitionChannel =
+    DirectTopicPartitionChannel topicPartitionChannel =
         createTopicPartitionChannel(
             mockStreamingClient,
             topicPartition,
@@ -552,8 +536,7 @@ public class TopicPartitionChannelTest {
             mockKafkaRecordErrorReporter,
             mockSinkTaskContext,
             mockSnowflakeConnectionService,
-            mockTelemetryService,
-            this.schemaEvolutionService);
+            mockTelemetryService);
 
     try {
       Assert.assertEquals(-1L, topicPartitionChannel.fetchOffsetTokenWithRetry());
@@ -577,7 +560,7 @@ public class TopicPartitionChannelTest {
         .thenThrow(SF_EXCEPTION)
         .thenReturn(offsetTokenAfterMaxAttempts);
 
-    TopicPartitionChannel topicPartitionChannel =
+    DirectTopicPartitionChannel topicPartitionChannel =
         createTopicPartitionChannel(
             mockStreamingClient,
             topicPartition,
@@ -587,8 +570,7 @@ public class TopicPartitionChannelTest {
             mockKafkaRecordErrorReporter,
             mockSinkTaskContext,
             mockSnowflakeConnectionService,
-            mockTelemetryService,
-            this.schemaEvolutionService);
+            mockTelemetryService);
 
     int expectedRetries = MAX_GET_OFFSET_TOKEN_RETRIES;
     Mockito.verify(mockStreamingClient, Mockito.times(2)).openChannel(ArgumentMatchers.any());
@@ -608,7 +590,7 @@ public class TopicPartitionChannelTest {
 
     Mockito.when(mockStreamingChannel.getLatestCommittedOffsetToken()).thenReturn("invalidNo");
 
-    TopicPartitionChannel topicPartitionChannel =
+    DirectTopicPartitionChannel topicPartitionChannel =
         createTopicPartitionChannel(
             mockStreamingClient,
             topicPartition,
@@ -618,8 +600,7 @@ public class TopicPartitionChannelTest {
             mockKafkaRecordErrorReporter,
             mockSinkTaskContext,
             mockSnowflakeConnectionService,
-            mockTelemetryService,
-            this.schemaEvolutionService);
+            mockTelemetryService);
 
     try {
       topicPartitionChannel.fetchOffsetTokenWithRetry();
@@ -641,7 +622,7 @@ public class TopicPartitionChannelTest {
     NullPointerException exception = new NullPointerException("NPE");
     Mockito.when(mockStreamingChannel.getLatestCommittedOffsetToken()).thenThrow(exception);
 
-    TopicPartitionChannel topicPartitionChannel =
+    DirectTopicPartitionChannel topicPartitionChannel =
         createTopicPartitionChannel(
             mockStreamingClient,
             topicPartition,
@@ -651,8 +632,7 @@ public class TopicPartitionChannelTest {
             mockKafkaRecordErrorReporter,
             mockSinkTaskContext,
             mockSnowflakeConnectionService,
-            mockTelemetryService,
-            this.schemaEvolutionService);
+            mockTelemetryService);
 
     try {
       Assert.assertEquals(-1L, topicPartitionChannel.fetchOffsetTokenWithRetry());
@@ -670,7 +650,7 @@ public class TopicPartitionChannelTest {
     RuntimeException exception = new RuntimeException("runtime exception");
     Mockito.when(mockStreamingChannel.getLatestCommittedOffsetToken()).thenThrow(exception);
 
-    TopicPartitionChannel topicPartitionChannel =
+    DirectTopicPartitionChannel topicPartitionChannel =
         createTopicPartitionChannel(
             mockStreamingClient,
             topicPartition,
@@ -680,8 +660,7 @@ public class TopicPartitionChannelTest {
             mockKafkaRecordErrorReporter,
             mockSinkTaskContext,
             mockSnowflakeConnectionService,
-            mockTelemetryService,
-            this.schemaEvolutionService);
+            mockTelemetryService);
 
     try {
       Assert.assertEquals(-1L, topicPartitionChannel.fetchOffsetTokenWithRetry());
@@ -719,7 +698,7 @@ public class TopicPartitionChannelTest {
         .thenReturn(Long.toString(noOfRecords - 1));
 
     // create tpchannel
-    TopicPartitionChannel topicPartitionChannel =
+    DirectTopicPartitionChannel topicPartitionChannel =
         createTopicPartitionChannel(
             mockStreamingClient,
             topicPartition,
@@ -729,8 +708,7 @@ public class TopicPartitionChannelTest {
             mockKafkaRecordErrorReporter,
             mockSinkTaskContext,
             mockSnowflakeConnectionService,
-            mockTelemetryService,
-            this.schemaEvolutionService);
+            mockTelemetryService);
     expectedOpenChannelCount++;
     expectedGetOffsetCount++;
 
@@ -838,8 +816,7 @@ public class TopicPartitionChannelTest {
               RecordServiceFactory.createRecordService(false, false),
               mockTelemetryService,
               false,
-              null,
-              this.schemaEvolutionService);
+              null);
 
       final int noOfRecords = 2;
       List<SinkRecord> records =
@@ -850,7 +827,6 @@ public class TopicPartitionChannelTest {
       }
 
       // Verify that the buffer is cleaned up and one record is in the DLQ
-      Assert.assertTrue(topicPartitionChannel.isPartitionBufferEmpty());
       Assert.assertEquals(1, kafkaRecordErrorReporter.getReportedRecords().size());
     }
   }
@@ -892,8 +868,7 @@ public class TopicPartitionChannelTest {
             RecordServiceFactory.createRecordService(false, false),
             this.mockTelemetryService,
             true,
-            metricsJmxReporter,
-            this.schemaEvolutionService);
+            metricsJmxReporter);
 
     // insert records
     List<SinkRecord> records =
@@ -965,8 +940,7 @@ public class TopicPartitionChannelTest {
             RecordServiceFactory.createRecordService(false, false),
             this.mockTelemetryService,
             true,
-            null,
-            this.schemaEvolutionService);
+            null);
 
     // insert records
     List<SinkRecord> records =
@@ -984,7 +958,7 @@ public class TopicPartitionChannelTest {
     assert resultStatus.getMetricsJmxReporter() == null;
   }
 
-  public TopicPartitionChannel createTopicPartitionChannel(
+  public DirectTopicPartitionChannel createTopicPartitionChannel(
       SnowflakeStreamingIngestClient streamingIngestClient,
       TopicPartition topicPartition,
       final String channelNameFormatV1,
@@ -993,8 +967,7 @@ public class TopicPartitionChannelTest {
       KafkaRecordErrorReporter kafkaRecordErrorReporter,
       SinkTaskContext sinkTaskContext,
       SnowflakeConnectionService conn,
-      SnowflakeTelemetryService telemetryService,
-      SchemaEvolutionService schemaEvolutionService) {
+      SnowflakeTelemetryService telemetryService) {
     return new DirectTopicPartitionChannel(
         streamingIngestClient,
         topicPartition,
@@ -1009,7 +982,7 @@ public class TopicPartitionChannelTest {
         new InsertErrorMapper());
   }
 
-  public TopicPartitionChannel createTopicPartitionChannel(
+  public DirectTopicPartitionChannel createTopicPartitionChannel(
       SnowflakeStreamingIngestClient streamingIngestClient,
       TopicPartition topicPartition,
       final String channelNameFormatV1,
@@ -1022,8 +995,7 @@ public class TopicPartitionChannelTest {
       RecordService recordService,
       SnowflakeTelemetryService telemetryService,
       boolean enableCustomJMXMonitoring,
-      MetricsJmxReporter metricsJmxReporter,
-      SchemaEvolutionService schemaEvolutionService) {
+      MetricsJmxReporter metricsJmxReporter) {
     return new DirectTopicPartitionChannel(
         streamingIngestClient,
         topicPartition,
@@ -1077,7 +1049,7 @@ public class TopicPartitionChannelTest {
     Mockito.when(mockStreamingClient.openChannel(any(OpenChannelRequest.class)))
         .thenReturn(channel1, channel2);
 
-    TopicPartitionChannel topicPartitionChannel =
+    DirectTopicPartitionChannel topicPartitionChannel =
         createTopicPartitionChannel(
             this.mockStreamingClient,
             this.topicPartition,
@@ -1091,8 +1063,7 @@ public class TopicPartitionChannelTest {
             RecordServiceFactory.createRecordService(false, false),
             this.mockTelemetryService,
             true,
-            null,
-            this.schemaEvolutionService);
+            null);
 
     // expect
     Assert.assertThrows(
@@ -1129,7 +1100,7 @@ public class TopicPartitionChannelTest {
     Mockito.when(mockStreamingClient.openChannel(any(OpenChannelRequest.class)))
         .thenReturn(originalChannel, reopenedChannel);
 
-    TopicPartitionChannel topicPartitionChannel =
+    DirectTopicPartitionChannel topicPartitionChannel =
         createTopicPartitionChannel(
             this.mockStreamingClient,
             this.topicPartition,
@@ -1143,8 +1114,7 @@ public class TopicPartitionChannelTest {
             RecordServiceFactory.createRecordService(false, false),
             this.mockTelemetryService,
             true,
-            null,
-            this.schemaEvolutionService);
+            null);
 
     // when
     topicPartitionChannel.getOffsetSafeToCommitToKafka();


### PR DESCRIPTION
<!-- Text inside of HTML comment blocks will NOT appear in your pull request description -->
<!-- Formatting information can be found at https://www.markdownguide.org/basic-syntax/ -->
# Overview

CONN-10463

Another small refactor discovered while creating a PoC:
- `SnowflakeStreamingIngestChannel getChannel();` is moved to the `DirectTopicPartitionChannel` class. This is crucial because a new implementation of the channel will not use a v1 channel at all.
- `boolean isPartitionBufferEmpty();` is simply deleted after double buffer removal
- `SnowflakeTelemetryService getTelemetryServiceV2();` - is also deleted because its only usage doesn't bring any value
