### PR TITLE
CONN-10486 Failsafe logic separation

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/LatestCommitedOffsetTokenExecutor.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/LatestCommitedOffsetTokenExecutor.java
@@ -1,0 +1,74 @@
+package com.snowflake.kafka.connector.internal.streaming;
+
+import static java.time.temporal.ChronoUnit.SECONDS;
+
+import com.snowflake.kafka.connector.internal.KCLogger;
+import dev.failsafe.Failsafe;
+import dev.failsafe.FailsafeExecutor;
+import dev.failsafe.Fallback;
+import dev.failsafe.RetryPolicy;
+import dev.failsafe.function.CheckedSupplier;
+import java.time.Duration;
+
+/**
+ * Class that separates Failsafe specific logic (retries and fallback) from the actual channel logic
+ */
+public class LatestCommitedOffsetTokenExecutor {
+
+  private static final KCLogger LOGGER =
+      new KCLogger(LatestCommitedOffsetTokenExecutor.class.getName());
+
+  private static final Duration DURATION_BETWEEN_GET_OFFSET_TOKEN_RETRY = Duration.ofSeconds(1);
+  protected static final int MAX_GET_OFFSET_TOKEN_RETRIES = 3;
+
+  public static FailsafeExecutor<Long> getExecutor(
+      String channelName,
+      Class<? extends Throwable> exceptionClass,
+      CheckedSupplier<Long> fallbackSupplier) {
+    RetryPolicy<Long> retryPolicy = createRetryPolicy(exceptionClass);
+    Fallback<Long> fallback = createFallback(channelName, exceptionClass, fallbackSupplier);
+
+    return Failsafe.with(fallback)
+        .onFailure(
+            event ->
+                LOGGER.error(
+                    "[OFFSET_TOKEN_RETRY_FAILSAFE] Failure to fetch offsetToken even after retry"
+                        + " and fallback from snowflake for channel:{}, elapsedTimeSeconds:{}",
+                    channelName,
+                    event.getElapsedTime().get(SECONDS),
+                    event.getException()))
+        .compose(retryPolicy);
+  }
+
+  private static RetryPolicy<Long> createRetryPolicy(
+      Class<? extends Throwable> retryExceptionClass) {
+    return RetryPolicy.<Long>builder()
+        .handle(retryExceptionClass)
+        .withDelay(DURATION_BETWEEN_GET_OFFSET_TOKEN_RETRY)
+        .withMaxAttempts(MAX_GET_OFFSET_TOKEN_RETRIES)
+        .onRetry(
+            event ->
+                LOGGER.warn(
+                    "[OFFSET_TOKEN_RETRY_POLICY] retry for getLatestCommittedOffsetToken. Retry"
+                        + " no:{}, message:{}",
+                    event.getAttemptCount(),
+                    event.getLastException().getMessage()))
+        .build();
+  }
+
+  private static Fallback<Long> createFallback(
+      String channelName,
+      Class<? extends Throwable> exceptionClass,
+      CheckedSupplier<Long> fallbackSupplier) {
+    return Fallback.builder(fallbackSupplier)
+        .handle(exceptionClass)
+        .onFailure(
+            event ->
+                LOGGER.error(
+                    "[OFFSET_TOKEN_FALLBACK] Failed to open Channel/fetch offsetToken for"
+                        + " channel:{}, exception:{}",
+                    channelName,
+                    event.getException().toString()))
+        .build();
+  }
+}

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingUtils.java
@@ -11,38 +11,11 @@ import java.util.Map;
 import java.util.Properties;
 import net.snowflake.ingest.streaming.OffsetTokenVerificationFunction;
 import net.snowflake.ingest.utils.Constants;
-import org.apache.kafka.common.record.DefaultRecord;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /* Utility class/Helper methods for streaming related ingestion. */
 public class StreamingUtils {
-  private static final Logger LOGGER = LoggerFactory.getLogger(StreamingUtils.class);
-
-  // Streaming Ingest API related fields
-
-  protected static final Duration DURATION_BETWEEN_GET_OFFSET_TOKEN_RETRY = Duration.ofSeconds(1);
-
-  protected static final int MAX_GET_OFFSET_TOKEN_RETRIES = 3;
-
   public static final long STREAMING_BUFFER_FLUSH_TIME_MINIMUM_SEC =
       Duration.ofSeconds(1).getSeconds();
-
-  /**
-   * Keeping this default as ~ 20MB.
-   *
-   * <p>Logic behind this optimium value is we will do gzip compression and json to UTF conversion
-   * which will account to almost 95% compression.
-   *
-   * <p>1 MB is an ideal size for streaming ingestion so 95% if 20MB = 1MB
-   */
-  protected static final long STREAMING_BUFFER_BYTES_DEFAULT = 20_000_000;
-
-  // excluding key, value and headers: 5 bytes length + 10 bytes timestamp + 5 bytes offset + 1
-  // byte attributes. (This is not for record metadata, this is before we transform to snowflake
-  // understood JSON)
-  // This is overhead size for calculating while buffering Kafka records.
-  public static final int MAX_RECORD_OVERHEAD_BYTES = DefaultRecord.MAX_RECORD_OVERHEAD;
 
   // TODO: Modify STREAMING_CONSTANT to Constants. after SNOW-352846 is released
   public static final String STREAMING_CONSTANT_AUTHORIZATION_TYPE = "authorization_type";

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelTest.java
@@ -4,7 +4,7 @@ import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ERRORS_TOLERANCE_CONFIG;
 import static com.snowflake.kafka.connector.internal.TestUtils.TEST_CONNECTOR_NAME;
-import static com.snowflake.kafka.connector.internal.streaming.StreamingUtils.MAX_GET_OFFSET_TOKEN_RETRIES;
+import static com.snowflake.kafka.connector.internal.streaming.LatestCommitedOffsetTokenExecutor.MAX_GET_OFFSET_TOKEN_RETRIES;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;


### PR DESCRIPTION
Failsafe logic is shared across Snowpipe Streaming v1 and v2 so it's worth extracting to a separate class.