### PR TITLE
CONN-10486 SnowflakeSinkServiceV2IT refactor

### DIFF
--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2BaseIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2BaseIT.java
@@ -1,0 +1,16 @@
+package com.snowflake.kafka.connector.internal.streaming;
+
+import com.snowflake.kafka.connector.internal.TestUtils;
+import org.apache.kafka.common.TopicPartition;
+
+public abstract class SnowflakeSinkServiceV2BaseIT {
+
+  protected final String table = TestUtils.randomTableName();
+
+  protected final int partition = 0;
+  protected final int partition2 = 1;
+
+  // Topic name should be same as table name. (Only for testing, not necessarily in real deployment)
+  protected String topic = table;
+  protected TopicPartition topicPartition = new TopicPartition(topic, partition);
+}

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2LegacyIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2LegacyIT.java
@@ -1,0 +1,59 @@
+package com.snowflake.kafka.connector.internal.streaming;
+
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_MAX_CLIENT_LAG;
+import static com.snowflake.kafka.connector.internal.streaming.channel.TopicPartitionChannel.NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE;
+
+import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
+import com.snowflake.kafka.connector.internal.SnowflakeSinkService;
+import com.snowflake.kafka.connector.internal.TestUtils;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class SnowflakeSinkServiceV2LegacyIT extends SnowflakeSinkServiceV2BaseIT {
+
+  private final SnowflakeConnectionService conn = TestUtils.getConnectionServiceForStreaming();
+
+  @BeforeEach
+  public void setup() {
+    conn.createTable(table);
+  }
+
+  @AfterEach
+  public void afterEach() {
+    TestUtils.dropTable(table);
+  }
+
+  @Test
+  public void testStreamingIngestionValidClientLag() throws Exception {
+    Map<String, String> config = TestUtils.getConfForStreaming();
+    config.put(SNOWPIPE_STREAMING_MAX_CLIENT_LAG, "7");
+
+    SnowflakeSinkService service =
+        StreamingSinkServiceBuilder.builder(conn, config)
+            .withSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(topicPartition)))
+            .build();
+    service.startPartition(table, topicPartition);
+
+    final long noOfRecords = 50;
+    List<SinkRecord> sinkRecords =
+        TestUtils.createJsonStringSinkRecords(0, noOfRecords, topic, partition);
+
+    service.insert(sinkRecords);
+
+    // Wait 5 seconds here and no flush should happen since the max client lag is 7 seconds
+    Thread.sleep(5 * 1000);
+    Assertions.assertEquals(
+        NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE, service.getOffset(topicPartition));
+
+    // Wait for enough time, the rows should be flushed
+    TestUtils.assertWithRetry(() -> service.getOffset(topicPartition) == noOfRecords, 3, 5);
+
+    service.closeAll();
+  }
+}

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2OAuthIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2OAuthIT.java
@@ -1,0 +1,66 @@
+package com.snowflake.kafka.connector.internal.streaming;
+
+import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
+import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
+import com.snowflake.kafka.connector.internal.SnowflakeSinkService;
+import com.snowflake.kafka.connector.internal.TestUtils;
+import com.snowflake.kafka.connector.records.SnowflakeConverter;
+import com.snowflake.kafka.connector.records.SnowflakeJsonConverter;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Map;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class SnowflakeSinkServiceV2OAuthIT extends SnowflakeSinkServiceV2BaseIT {
+
+  private final SnowflakeConnectionService conn = TestUtils.getOAuthConnectionServiceForStreaming();
+
+  @BeforeEach
+  public void setup() {
+    conn.createTable(table);
+  }
+
+  @AfterEach
+  public void afterEach() {
+    TestUtils.dropTable(table);
+  }
+
+  @Test
+  void shouldIngestDataWithOAuth() throws Exception {
+    Map<String, String> config = TestUtils.getConfForStreamingWithOAuth();
+    SnowflakeSinkConnectorConfig.setDefaultValues(config);
+
+    // opens a channel for partition 0, table and topic
+    SnowflakeSinkService service =
+        StreamingSinkServiceBuilder.builder(conn, config)
+            .withSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(topicPartition)))
+            .build();
+    service.startPartition(table, new TopicPartition(topic, partition));
+
+    SnowflakeConverter converter = new SnowflakeJsonConverter();
+    SchemaAndValue input =
+        converter.toConnectData(topic, "{\"name\":\"test\"}".getBytes(StandardCharsets.UTF_8));
+    long offset = 0;
+
+    SinkRecord record1 =
+        new SinkRecord(
+            topic,
+            partition,
+            Schema.STRING_SCHEMA,
+            "test_key" + offset,
+            input.schema(),
+            input.value(),
+            offset);
+
+    service.insert(record1);
+
+    TestUtils.assertWithRetry(
+        () -> service.getOffset(new TopicPartition(topic, partition)) == 1, 20, 5);
+  }
+}

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2SchematizationIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2SchematizationIT.java
@@ -1,0 +1,282 @@
+package com.snowflake.kafka.connector.internal.streaming;
+
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_SCHEMATIZATION_CONFIG;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_MAX_CLIENT_LAG;
+import static com.snowflake.kafka.connector.internal.streaming.channel.TopicPartitionChannel.NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE;
+import static org.awaitility.Awaitility.await;
+
+import com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig;
+import com.snowflake.kafka.connector.internal.SchematizationTestUtils;
+import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
+import com.snowflake.kafka.connector.internal.SnowflakeErrors;
+import com.snowflake.kafka.connector.internal.SnowflakeSinkService;
+import com.snowflake.kafka.connector.internal.TestUtils;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.json.JsonConverter;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class SnowflakeSinkServiceV2SchematizationIT extends SnowflakeSinkServiceV2BaseIT {
+
+  private final SnowflakeConnectionService conn = TestUtils.getConnectionServiceForStreaming();
+  private Map<String, String> config;
+
+  @BeforeEach
+  public void setup() {
+    config = TestUtils.getConfForStreaming();
+    config.put(ENABLE_SCHEMATIZATION_CONFIG, "true");
+  }
+
+  @Test
+  public void testSchematizationWithTableCreationAndJsonInput() throws Exception {
+    config.put(
+        SnowflakeSinkConnectorConfig.VALUE_CONVERTER_CONFIG_FIELD,
+        "org.apache.kafka.connect.json.JsonConverter");
+    config.put(SnowflakeSinkConnectorConfig.VALUE_SCHEMA_REGISTRY_CONFIG_FIELD, "http://fake-url");
+    config.put("schemas.enable", "false");
+    // get rid of these at the end
+    SnowflakeSinkConnectorConfig.setDefaultValues(config);
+
+    SchemaBuilder schemaBuilder =
+        SchemaBuilder.struct()
+            .field("id_int8", Schema.INT8_SCHEMA)
+            .field("id_int8_optional", Schema.OPTIONAL_INT8_SCHEMA)
+            .field("id_int16", Schema.INT16_SCHEMA)
+            .field("\"id_int32_double_quotes\"", Schema.INT32_SCHEMA)
+            .field("id_int64", Schema.INT64_SCHEMA)
+            .field("first_name", Schema.STRING_SCHEMA)
+            .field("rating_float32", Schema.FLOAT32_SCHEMA)
+            .field("rating_float64", Schema.FLOAT64_SCHEMA)
+            .field("approval", Schema.BOOLEAN_SCHEMA)
+            .field("info_array", SchemaBuilder.array(Schema.STRING_SCHEMA).build())
+            .field(
+                "info_map", SchemaBuilder.map(Schema.STRING_SCHEMA, Schema.INT32_SCHEMA).build());
+
+    Struct original =
+        new Struct(schemaBuilder.build())
+            .put("id_int8", (byte) 0)
+            .put("id_int16", (short) 42)
+            .put("\"id_int32_double_quotes\"", 42)
+            .put("id_int64", 42L)
+            .put("first_name", "zekai")
+            .put("rating_float32", 0.99f)
+            .put("rating_float64", 0.99d)
+            .put("approval", true)
+            .put("info_array", Arrays.asList("a", "b"))
+            .put("info_map", Collections.singletonMap("field", 3));
+
+    JsonConverter jsonConverter = new JsonConverter();
+    jsonConverter.configure(config, false);
+    byte[] converted = jsonConverter.fromConnectData(topic, original.schema(), original);
+    conn.createTableWithOnlyMetadataColumn(table);
+
+    SchemaAndValue jsonInputValue = jsonConverter.toConnectData(topic, converted);
+
+    long startOffset = 0;
+
+    SinkRecord jsonRecordValue =
+        new SinkRecord(
+            topic,
+            partition,
+            Schema.STRING_SCHEMA,
+            "test",
+            jsonInputValue.schema(),
+            jsonInputValue.value(),
+            startOffset);
+
+    SnowflakeSinkService service =
+        StreamingSinkServiceBuilder.builder(conn, config)
+            .withSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(topicPartition)))
+            .build();
+    service.startPartition(table, topicPartition);
+
+    // The first insert should fail and schema evolution will kick in to update the schema
+    service.insert(Collections.singletonList(jsonRecordValue));
+    TestUtils.assertWithRetry(
+        () -> service.getOffset(topicPartition) == NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE, 20, 5);
+    TestUtils.checkTableSchema(table, SchematizationTestUtils.SF_JSON_SCHEMA_FOR_TABLE_CREATION);
+
+    // Retry the insert should succeed now with the updated schema
+    service.insert(Collections.singletonList(jsonRecordValue));
+    TestUtils.assertWithRetry(() -> service.getOffset(topicPartition) == startOffset + 1, 20, 5);
+
+    TestUtils.checkTableContentOneRow(
+        table, SchematizationTestUtils.CONTENT_FOR_JSON_TABLE_CREATION);
+
+    service.closeAll();
+  }
+
+  @Test
+  public void testSchematizationSchemaEvolutionWithNonNullableColumn() throws Exception {
+    config.put(
+        SnowflakeSinkConnectorConfig.VALUE_CONVERTER_CONFIG_FIELD,
+        "org.apache.kafka.connect.json.JsonConverter");
+    config.put(SnowflakeSinkConnectorConfig.VALUE_SCHEMA_REGISTRY_CONFIG_FIELD, "http://fake-url");
+    config.put("schemas.enable", "false");
+    // get rid of these at the end
+
+    Schema schema =
+        SchemaBuilder.struct()
+            .field("id_int8", Schema.INT8_SCHEMA)
+            .field("id_int8_non_nullable_null_value", Schema.OPTIONAL_INT8_SCHEMA)
+            .build();
+    Struct original =
+        new Struct(schema).put("id_int8", (byte) 0).put("id_int8_non_nullable_null_value", null);
+
+    JsonConverter jsonConverter = new JsonConverter();
+    jsonConverter.configure(config, false);
+    byte[] converted = jsonConverter.fromConnectData(topic, original.schema(), original);
+    conn.createTableWithOnlyMetadataColumn(table);
+    createNonNullableColumn(table, "id_int8_non_nullable_missing_value");
+    createNonNullableColumn(table, "id_int8_non_nullable_null_value");
+
+    SchemaAndValue jsonInputValue = jsonConverter.toConnectData(topic, converted);
+
+    long startOffset = 0;
+
+    SinkRecord jsonRecordValue =
+        new SinkRecord(
+            topic,
+            partition,
+            Schema.STRING_SCHEMA,
+            "test",
+            jsonInputValue.schema(),
+            jsonInputValue.value(),
+            startOffset);
+
+    SnowflakeSinkService service =
+        StreamingSinkServiceBuilder.builder(conn, config)
+            .withSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(topicPartition)))
+            .build();
+    service.startPartition(table, topicPartition);
+
+    // The first insert should fail and schema evolution will kick in to add the column
+    service.insert(Collections.singletonList(jsonRecordValue));
+    TestUtils.assertWithRetry(
+        () -> service.getOffset(topicPartition) == NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE, 20, 5);
+
+    // The second insert should fail again and schema evolution will kick in to update the
+    // first not-nullable column nullability
+    service.insert(Collections.singletonList(jsonRecordValue));
+    TestUtils.assertWithRetry(
+        () -> service.getOffset(topicPartition) == NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE, 20, 5);
+
+    // The third insert should fail again and schema evolution will kick in to update the
+    // second not-nullable column nullability
+    service.insert(Collections.singletonList(jsonRecordValue));
+    TestUtils.assertWithRetry(
+        () -> service.getOffset(topicPartition) == NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE, 20, 5);
+
+    // Retry the insert should succeed now with the updated schema
+    service.insert(Collections.singletonList(jsonRecordValue));
+    TestUtils.assertWithRetry(() -> service.getOffset(topicPartition) == startOffset + 1, 20, 5);
+
+    service.closeAll();
+  }
+
+  @Test
+  void testSkippingOffsetsInSchemaEvolution() throws Exception {
+    long maxClientLagSeconds = 1L;
+    long schemaEvolutionDelayMs = 3 * 1000L; // must be enough for sdk to flush and commit
+    long assertionSleepTimeMs = 6 * 1000L;
+
+    config.put(ENABLE_SCHEMATIZATION_CONFIG, "true");
+    config.put(
+        SnowflakeSinkConnectorConfig.VALUE_CONVERTER_CONFIG_FIELD,
+        "org.apache.kafka.connect.json.JsonConverter");
+    config.put(SnowflakeSinkConnectorConfig.VALUE_SCHEMA_REGISTRY_CONFIG_FIELD, "http://fake-url");
+    config.put("schemas.enable", "false");
+    config.put(SNOWPIPE_STREAMING_MAX_CLIENT_LAG, String.valueOf(maxClientLagSeconds));
+
+    // setup a table with a single field
+    conn.createTableWithOnlyMetadataColumn(table);
+    createNonNullableColumn(table, "id_int8");
+
+    SnowflakeSinkService service =
+        StreamingSinkServiceBuilder.builder(conn, config)
+            .withSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(topicPartition)))
+            .withSchemaEvolutionService(
+                new DelayedSchemaEvolutionService(conn, schemaEvolutionDelayMs))
+            .build();
+    service.startPartition(table, topicPartition);
+
+    service.insert(
+        Arrays.asList(
+            recordWithSingleField(0),
+            recordWithSingleField(1),
+            recordWithTwoFields(2),
+            recordWithTwoFields(3)));
+
+    // wait for processing all records and running ingest sdk thread
+    Thread.sleep(assertionSleepTimeMs);
+
+    // records 0 and 1 are ingested, 2 triggers schema evolution, 3 is skipped
+    // getOffset() result is returned from preCommit() so Kafka will send next record starting from
+    // this offset
+    await().atMost(10, TimeUnit.SECONDS).until(() -> service.getOffset(topicPartition) == 2);
+
+    // Kafka sends remaining messages
+    service.insert(Arrays.asList(recordWithTwoFields(2), recordWithTwoFields(3)));
+
+    await().atMost(10, TimeUnit.SECONDS).until(() -> service.getOffset(topicPartition) == 4);
+  }
+
+  private SinkRecord recordWithSingleField(long offset) {
+    Schema schema = SchemaBuilder.struct().field("id_int8", Schema.INT8_SCHEMA).build();
+    Struct struct = new Struct(schema).put("id_int8", (byte) 0);
+    return getSinkRecord(offset, struct);
+  }
+
+  private SinkRecord recordWithTwoFields(long offset) {
+    Schema schema =
+        SchemaBuilder.struct()
+            .field("id_int8", Schema.INT8_SCHEMA)
+            .field("id_int8_2", Schema.INT8_SCHEMA)
+            .build();
+    Struct struct = new Struct(schema).put("id_int8", (byte) 0).put("id_int8_2", (byte) 0);
+    return getSinkRecord(offset, struct);
+  }
+
+  private SinkRecord getSinkRecord(long offset, Struct struct) {
+    JsonConverter jsonConverter = new JsonConverter();
+    Map<String, String> config = new HashMap<>();
+    config.put("schemas.enable", "false");
+    jsonConverter.configure(config, false);
+    byte[] converted = jsonConverter.fromConnectData(topic, struct.schema(), struct);
+    SchemaAndValue jsonInputValue = jsonConverter.toConnectData(topic, converted);
+
+    return new SinkRecord(
+        topic,
+        partition,
+        Schema.STRING_SCHEMA,
+        "test",
+        jsonInputValue.schema(),
+        jsonInputValue.value(),
+        offset);
+  }
+
+  private void createNonNullableColumn(String tableName, String colName) {
+    String createTableQuery = "alter table identifier(?) add " + colName + " int not null";
+
+    try {
+      PreparedStatement stmt = conn.getConnection().prepareStatement(createTableQuery);
+      stmt.setString(1, tableName);
+      stmt.setString(2, colName);
+      stmt.execute();
+      stmt.close();
+    } catch (SQLException e) {
+      throw SnowflakeErrors.ERROR_2007.getException(e);
+    }
+  }
+}


### PR DESCRIPTION
In order to ensure that SSv2 works I would like to test the same ITs as we have for SSv1. This PR fixes a couple of problems with the existing ITs:
- All tests were run twice for password and oAuth authentication. This is fundamentally wrong because authentication method doesn't change anything in the service logic. I extracted a single oAuth test and left rest of them as password based.
- Configuration validation tests were inappropiate for IT level testing so I decided to delete it. It's just to heavy.
- Some of the tests were strongly connected with double buffering logic that was removed recently
- Schematization tests were moved to a a separate file

Of course it is faaar from being perfect but it is good enough to continue development of SSv2.