### PR TITLE
CONN-10478 Java 11 migration

### DIFF
--- a/.github/workflows/End2EndTestApache.yml
+++ b/.github/workflows/End2EndTestApache.yml
@@ -14,15 +14,15 @@ jobs:
       matrix:
         apache_kafka_version: [ '2.8.2', '3.7.2' ]
         snowflake_cloud: [ 'AWS', 'AZURE', 'GCP' ]
-        java_test_version: [ '8', '11', '17' ]
+        java_test_version: [ '11', '17' ]
     steps:
     - name: Checkout Code
       uses: actions/checkout@v4
-    - name: "Install Java 8"
+    - name: "Install Java 11"
       uses: actions/setup-java@v3
       with:
         distribution: 'zulu'
-        java-version: 8
+        java-version: 11
     - name: "Cache local Maven repository"
       uses: actions/cache@v4
       with:

--- a/.github/workflows/End2EndTestConfluent.yml
+++ b/.github/workflows/End2EndTestConfluent.yml
@@ -14,15 +14,15 @@ jobs:
       matrix:
         confluent_version: [ '6.2.15', '7.8.2' ]
         snowflake_cloud: [ 'AWS', 'AZURE', 'GCP' ]
-        java_test_version: [ '8', '11', '17' ]
+        java_test_version: [ '11', '17' ]
     steps:
     - name: Checkout Code
       uses: actions/checkout@v4
-    - name: "Install Java 8"
+    - name: "Install Java 11"
       uses: actions/setup-java@v3
       with:
         distribution: 'zulu'
-        java-version: 8
+        java-version: 11
     - name: "Cache local Maven repository"
       uses: actions/cache@v4
       with:

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -16,10 +16,10 @@ jobs:
     steps:
     - name: Checkout Code
       uses: actions/checkout@v4
-    - name: "Install Java 8"
+    - name: "Install Java 11"
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
     - name: "Cache local Maven repository"
       uses: actions/cache@v4
       with:

--- a/.github/workflows/StressTest.yml
+++ b/.github/workflows/StressTest.yml
@@ -20,11 +20,11 @@ jobs:
     steps:
     - name: Checkout Code
       uses: actions/checkout@v4
-    - name: "Install Java 8"
+    - name: "Install Java 11"
       uses: actions/setup-java@v3
       with:
         distribution: 'zulu'
-        java-version: 8
+        java-version: 11
     - name: Install Python
       uses: actions/setup-python@v4
       with:

--- a/pom.xml
+++ b/pom.xml
@@ -42,10 +42,10 @@
         <url>https://github.com/snowflakedb/snowflake-kafka-connector</url>
     </scm>
 
-    <!-- Set our Language Level to Java 8 -->
+    <!-- Set our Language Level to Java 11 -->
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <skipTests>false</skipTests>
         <skipUnitTests>${skipTests}</skipUnitTests>
         <skipIntegrationTests>${skipTests}</skipIntegrationTests>

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -42,10 +42,10 @@
         <url>https://github.com/snowflakedb/snowflake-kafka-connector</url>
     </scm>
 
-    <!-- Set our Language Level to Java 8 -->
+    <!-- Set our Language Level to Java 11 -->
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <skipTests>false</skipTests>
         <skipUnitTests>${skipTests}</skipUnitTests>
         <skipIntegrationTests>${skipTests}</skipIntegrationTests>

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigValidatorTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigValidatorTest.java
@@ -1,7 +1,6 @@
 package com.snowflake.kafka.connector;
 
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.*;
-import static com.snowflake.kafka.connector.Utils.HTTP_NON_PROXY_HOSTS;
 import static com.snowflake.kafka.connector.internal.TestUtils.getConfig;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.assertEquals;
@@ -20,7 +19,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.apache.kafka.connect.storage.Converter;
-import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -141,33 +139,6 @@ public class ConnectorConfigValidatorTest {
     assertThatThrownBy(() -> connectorConfigValidator.validateConfig(config))
         .isInstanceOf(SnowflakeKafkaConnectorException.class)
         .hasMessageContaining(JVM_PROXY_PORT);
-  }
-
-  @Test
-  public void testNonProxyHosts() {
-    String oldNonProxyHosts =
-        (System.getProperty(HTTP_NON_PROXY_HOSTS) != null)
-            ? System.getProperty(HTTP_NON_PROXY_HOSTS)
-            : null;
-
-    System.setProperty(HTTP_NON_PROXY_HOSTS, "host1.com|host2.com|localhost");
-    Map<String, String> config = getConfig();
-    config.put(JVM_PROXY_HOST, "127.0.0.1");
-    config.put(JVM_PROXY_PORT, "3128");
-    config.put(
-        SnowflakeSinkConnectorConfig.JVM_NON_PROXY_HOSTS,
-        "*.snowflakecomputing.com|*.amazonaws.com");
-    Utils.enableJVMProxy(config);
-    String mergedNonProxyHosts = System.getProperty(HTTP_NON_PROXY_HOSTS);
-    Assert.assertTrue(
-        mergedNonProxyHosts.equals(
-            "host1.com|host2.com|localhost|*.snowflakecomputing.com|*.amazonaws.com"));
-
-    if (oldNonProxyHosts != null) {
-      System.setProperty(HTTP_NON_PROXY_HOSTS, oldNonProxyHosts);
-    } else {
-      System.clearProperty(HTTP_NON_PROXY_HOSTS);
-    }
   }
 
   @Test

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigValidatorTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigValidatorTest.java
@@ -1,6 +1,10 @@
 package com.snowflake.kafka.connector;
 
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.*;
+import static com.snowflake.kafka.connector.Utils.HTTP_NON_PROXY_HOSTS;
+import static com.snowflake.kafka.connector.Utils.HTTP_PROXY_HOST;
+import static com.snowflake.kafka.connector.Utils.HTTP_PROXY_PORT;
+import static com.snowflake.kafka.connector.Utils.HTTP_USE_PROXY;
 import static com.snowflake.kafka.connector.internal.TestUtils.getConfig;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.Assert.assertEquals;
@@ -19,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.apache.kafka.connect.storage.Converter;
+import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -139,6 +144,38 @@ public class ConnectorConfigValidatorTest {
     assertThatThrownBy(() -> connectorConfigValidator.validateConfig(config))
         .isInstanceOf(SnowflakeKafkaConnectorException.class)
         .hasMessageContaining(JVM_PROXY_PORT);
+  }
+
+  @Test
+  public void testNonProxyHosts() {
+    String oldNonProxyHosts =
+        (System.getProperty(HTTP_NON_PROXY_HOSTS) != null)
+            ? System.getProperty(HTTP_NON_PROXY_HOSTS)
+            : null;
+
+    System.setProperty(HTTP_NON_PROXY_HOSTS, "host1.com|host2.com|localhost");
+    Map<String, String> config = getConfig();
+    config.put(JVM_PROXY_HOST, "127.0.0.1");
+    config.put(JVM_PROXY_PORT, "3128");
+    config.put(
+        SnowflakeSinkConnectorConfig.JVM_NON_PROXY_HOSTS,
+        "*.snowflakecomputing.com|*.amazonaws.com");
+    Utils.enableJVMProxy(config);
+    String mergedNonProxyHosts = System.getProperty(HTTP_NON_PROXY_HOSTS);
+    Assert.assertTrue(
+        mergedNonProxyHosts.equals(
+            "host1.com|host2.com|localhost|*.snowflakecomputing.com|*.amazonaws.com"));
+
+    if (oldNonProxyHosts != null) {
+      System.setProperty(HTTP_NON_PROXY_HOSTS, oldNonProxyHosts);
+    } else {
+      System.clearProperty(HTTP_NON_PROXY_HOSTS);
+    }
+
+    // clear properties to prevent other tests from failing
+    System.clearProperty(HTTP_USE_PROXY);
+    System.clearProperty(HTTP_PROXY_HOST);
+    System.clearProperty(HTTP_PROXY_PORT);
   }
 
   @Test


### PR DESCRIPTION
Migration to JDK 11 including removal of JDK 8 testing.

The main reasons for the migration are:
- enable support for Snowpipe Streaming v2
- long-lasting deprecation and upcoming removal of JDK 8 from Kafka / Kafka Connect environment