### PR TITLE
CONN-10496 Record data mapping for SSv2

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/records/SnowflakeTableStreamingRecordMapper.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/SnowflakeTableStreamingRecordMapper.java
@@ -23,22 +23,75 @@ class SnowflakeTableStreamingRecordMapper extends StreamingRecordMapper {
   public Map<String, Object> processSnowflakeRecord(
       RecordService.SnowflakeTableRow row, boolean includeAllMetadata)
       throws JsonProcessingException {
-    final Map<String, Object> streamingIngestRow = new HashMap<>();
-    for (JsonNode node : row.getContent().getData()) {
-      if (schematizationEnabled) {
-        streamingIngestRow.putAll(getMapFromJsonNodeForStreamingIngest(node));
-      } else {
-        streamingIngestRow.put(TABLE_COLUMN_CONTENT, mapper.writeValueAsString(node));
-      }
-    }
+    final Map<String, Object> streamingIngestRow = new HashMap<>(getContent(row));
     if (includeAllMetadata) {
-      streamingIngestRow.put(TABLE_COLUMN_METADATA, mapper.writeValueAsString(row.getMetadata()));
+      streamingIngestRow.put(TABLE_COLUMN_METADATA, getMetadata(row));
     }
     return streamingIngestRow;
   }
 
-  private Map<String, Object> getMapFromJsonNodeForStreamingIngest(JsonNode node)
+  private Map<String, Object> getContent(RecordService.SnowflakeTableRow row)
       throws JsonProcessingException {
+    if (ssv2Enabled) {
+      return getContentForSSv2(row);
+    } else {
+      return getContentForSSv1(row);
+    }
+  }
+
+  private Map<String, Object> getContentForSSv2(RecordService.SnowflakeTableRow row) {
+    try {
+      if (schematizationEnabled) {
+        return getContentForSchematizedSSv2(row);
+      } else {
+        return getContentForNonSchematizedSSv2(row);
+      }
+    } catch (Exception e) {
+      throw SnowflakeErrors.ERROR_0010.getException(e);
+    }
+  }
+
+  private Map<String, Object> getContentForNonSchematizedSSv2(RecordService.SnowflakeTableRow row) {
+    Map<String, Object> result = new HashMap<>();
+    for (JsonNode node : row.getContent().getData()) {
+      switch (node.getNodeType()) {
+        case OBJECT:
+          result.put(TABLE_COLUMN_CONTENT, mapper.convertValue(node, OBJECTS_MAP_TYPE_REFERENCE));
+          break;
+        case ARRAY:
+          result.put(TABLE_COLUMN_CONTENT, mapper.convertValue(node, OBJECTS_LIST_TYPE_REFERENCE));
+          break;
+        default:
+          result.put(TABLE_COLUMN_CONTENT, node.asText());
+      }
+    }
+    return result;
+  }
+
+  private Map<String, Object> getContentForSchematizedSSv2(RecordService.SnowflakeTableRow row)
+      throws JsonProcessingException {
+    Map<String, Object> result = new HashMap<>();
+    for (JsonNode node : row.getContent().getData()) {
+      result.putAll(getMapFromJsonNodeForStreamingIngest(node, false));
+    }
+    return result;
+  }
+
+  private Map<String, Object> getContentForSSv1(RecordService.SnowflakeTableRow row)
+      throws JsonProcessingException {
+    Map<String, Object> result = new HashMap<>();
+    for (JsonNode node : row.getContent().getData()) {
+      if (schematizationEnabled) {
+        result.putAll(getMapFromJsonNodeForStreamingIngest(node, true));
+      } else {
+        result.put(TABLE_COLUMN_CONTENT, mapper.writeValueAsString(node));
+      }
+    }
+    return result;
+  }
+
+  private Map<String, Object> getMapFromJsonNodeForStreamingIngest(
+      JsonNode node, boolean nestedObjectsAsString) throws JsonProcessingException {
     final Map<String, Object> streamingIngestRow = new HashMap<>();
 
     // return empty if tombstone record
@@ -51,6 +104,14 @@ class SnowflakeTableStreamingRecordMapper extends StreamingRecordMapper {
       String columnName = columnNames.next();
       JsonNode columnNode = node.get(columnName);
       Object columnValue = getTextualValue(columnNode);
+      if (!nestedObjectsAsString) {
+        if (columnNode.isObject()) {
+          columnValue = mapper.convertValue(columnNode, OBJECTS_MAP_TYPE_REFERENCE);
+        }
+        if (columnNode.isArray()) {
+          columnValue = mapper.convertValue(columnNode, OBJECTS_LIST_TYPE_REFERENCE);
+        }
+      }
       // while the value is always dumped into a string, the Streaming Ingest SDK
       // will transform the value according to its type in the table
       streamingIngestRow.put(Utils.quoteNameIfNeeded(columnName), columnValue);
@@ -61,5 +122,14 @@ class SnowflakeTableStreamingRecordMapper extends StreamingRecordMapper {
           "Not able to convert node to Snowpipe Streaming input format");
     }
     return streamingIngestRow;
+  }
+
+  private Object getMetadata(RecordService.SnowflakeTableRow row) throws JsonProcessingException {
+    if (ssv2Enabled) {
+      Map<String, Object> mapForMetadata = getMapForMetadata(row.getMetadata());
+      return metadataFromMap(mapForMetadata);
+    } else {
+      return mapper.writeValueAsString(row.getMetadata());
+    }
   }
 }

--- a/src/main/java/com/snowflake/kafka/connector/records/StreamingRecordMapper.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/StreamingRecordMapper.java
@@ -1,15 +1,33 @@
 package com.snowflake.kafka.connector.records;
 
+import static com.snowflake.kafka.connector.records.RecordService.HEADERS;
+import static com.snowflake.kafka.connector.records.RecordService.KEY;
+import static com.snowflake.kafka.connector.records.RecordService.KEY_SCHEMA_ID;
+import static com.snowflake.kafka.connector.records.RecordService.OFFSET;
+import static com.snowflake.kafka.connector.records.RecordService.PARTITION;
+import static com.snowflake.kafka.connector.records.RecordService.SCHEMA_ID;
+import static com.snowflake.kafka.connector.records.RecordService.TOPIC;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.DoubleNode;
 import com.fasterxml.jackson.databind.node.FloatNode;
 import com.fasterxml.jackson.databind.node.NumericNode;
 import com.snowflake.kafka.connector.records.RecordService.SnowflakeTableRow;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 abstract class StreamingRecordMapper {
+
+  protected static final TypeReference<Map<String, Object>> OBJECTS_MAP_TYPE_REFERENCE =
+      new TypeReference<>() {};
+
+  protected static final TypeReference<List<Object>> OBJECTS_LIST_TYPE_REFERENCE =
+      new TypeReference<>() {};
 
   protected final ObjectMapper mapper;
   protected final boolean schematizationEnabled;
@@ -65,5 +83,56 @@ abstract class StreamingRecordMapper {
     } else {
       return mapper.writeValueAsString(columnNode);
     }
+  }
+
+  protected static Long getNullSafeLong(Map<String, Object> mapForMetadata, String key) {
+    return mapForMetadata.get(key) == null ? null : ((Number) mapForMetadata.get(key)).longValue();
+  }
+
+  protected static String getNullSafeString(Map<String, Object> mapForMetadata, String key) {
+    Object object = mapForMetadata.get(key);
+    return object == null ? null : object.toString();
+  }
+
+  protected Map<String, Object> getMapForMetadata(JsonNode metadataNode)
+      throws JsonProcessingException {
+    Map<String, Object> values = mapper.convertValue(metadataNode, OBJECTS_MAP_TYPE_REFERENCE);
+    // we don't want headers to be serialized as Map<String, Object> so we overwrite it as
+    // Map<String, String>
+    Map<String, String> headers = convertHeaders(metadataNode.findValue(HEADERS));
+    values.put(HEADERS, headers);
+    return values;
+  }
+
+  protected Map<String, String> convertHeaders(JsonNode headersNode)
+      throws JsonProcessingException {
+    final Map<String, String> headers = new HashMap<>();
+
+    if (headersNode == null || headersNode.isNull() || headersNode.isEmpty()) {
+      return headers;
+    }
+
+    Iterator<String> fields = headersNode.fieldNames();
+    while (fields.hasNext()) {
+      String key = fields.next();
+      JsonNode valueNode = headersNode.get(key);
+      String value = getTextualValue(valueNode);
+      headers.put(key, value);
+    }
+    return headers;
+  }
+
+  protected MetadataRecord metadataFromMap(Map<String, Object> mapForMetadata) {
+    return new MetadataRecord(
+        getNullSafeLong(mapForMetadata, OFFSET),
+        (String) mapForMetadata.get(TOPIC),
+        (Integer) mapForMetadata.get(PARTITION),
+        getNullSafeString(mapForMetadata, KEY),
+        (Integer) mapForMetadata.get(SCHEMA_ID),
+        (Integer) mapForMetadata.get(KEY_SCHEMA_ID),
+        getNullSafeLong(mapForMetadata, "CreateTime"),
+        getNullSafeLong(mapForMetadata, "LogAppendTime"),
+        getNullSafeLong(mapForMetadata, "SnowflakeConnectorPushTime"),
+        (Map<String, String>) mapForMetadata.get(HEADERS));
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/records/IcebergTableStreamingRecordMapperTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/records/IcebergTableStreamingRecordMapperTest.java
@@ -4,7 +4,6 @@ import static com.snowflake.kafka.connector.streaming.iceberg.sql.PrimitiveJsonR
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.snowflake.kafka.connector.Utils;
@@ -17,8 +16,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-class IcebergTableStreamingRecordMapperTest {
-  private static final ObjectMapper objectMapper = new ObjectMapper();
+class IcebergTableStreamingRecordMapperTest extends StreamingRecordMapperTest {
 
   private static final ImmutableMap<String, Object> primitiveJsonAsMap =
       ImmutableMap.of(
@@ -38,25 +36,6 @@ class IcebergTableStreamingRecordMapperTest {
           0.25,
           "approval",
           true);
-
-  private static final String fullMetadataJsonExample =
-      "{"
-          + "\"offset\": 10,"
-          + "\"topic\": \"topic\","
-          + "\"partition\": 0,"
-          + "\"key\": \"key\","
-          + "\"schema_id\": 1,"
-          + "\"key_schema_id\": 2,"
-          + "\"CreateTime\": 3,"
-          + "\"LogAppendTime\": 4,"
-          + "\"SnowflakeConnectorPushTime\": 5,"
-          + "\"headers\": {\"objectAsJsonStringHeader\": {"
-          + "\"key1\": \"value1\","
-          + "\"key2\": \"value2\""
-          + "},"
-          + "\"header2\": \"testheaderstring\","
-          + "\"header3\": 3.5}"
-          + "}";
 
   private static final Map<String, Object> fullMetadataJsonAsMap =
       ImmutableMap.of(
@@ -104,24 +83,6 @@ class IcebergTableStreamingRecordMapperTest {
   private static final MetadataRecord nestedHeaderRecordMetadata =
       new MetadataRecord(
           null, null, null, null, null, null, null, null, null, Map.of("key", "{\"key2\":null}"));
-  private static final MetadataRecord fullRecordMetadata =
-      new MetadataRecord(
-          10L,
-          "topic",
-          0,
-          "key",
-          1,
-          2,
-          3L,
-          4L,
-          5L,
-          Map.of(
-              "header3",
-              "3.5",
-              "header2",
-              "testheaderstring",
-              "objectAsJsonStringHeader",
-              "{\"key1\":\"value1\",\"key2\":\"value2\"}"));
 
   @ParameterizedTest(name = "{0}")
   @MethodSource("prepareSchematizationData")
@@ -439,16 +400,5 @@ class IcebergTableStreamingRecordMapperTest {
     map.put(key, value);
     map.put(key2, value2);
     return map;
-  }
-
-  private static SnowflakeTableRow buildRow(String content) throws JsonProcessingException {
-    return buildRow(content, fullMetadataJsonExample);
-  }
-
-  private static SnowflakeTableRow buildRow(String content, String metadata)
-      throws JsonProcessingException {
-    return new SnowflakeTableRow(
-        new SnowflakeRecordContent(objectMapper.readTree(content)),
-        objectMapper.readTree(metadata));
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/records/IcebergTableStreamingRecordMapperTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/records/IcebergTableStreamingRecordMapperTest.java
@@ -126,7 +126,7 @@ class IcebergTableStreamingRecordMapperTest extends StreamingRecordMapperTest {
   @Test
   void shouldSkipMapMetadata() throws JsonProcessingException {
     // Given
-    SnowflakeTableRow row = buildRow(primitiveJsonExample);
+    SnowflakeTableRow row = buildRowWithDefaultMetadata(primitiveJsonExample);
 
     // When
     IcebergTableStreamingRecordMapper mapper =
@@ -159,26 +159,26 @@ class IcebergTableStreamingRecordMapperTest extends StreamingRecordMapperTest {
     return Stream.of(
         Arguments.of(
             "Empty JSON",
-            buildRow("{}"),
+            buildRowWithDefaultMetadata("{}"),
             ImmutableMap.of(Utils.TABLE_COLUMN_METADATA, fullMetadataJsonAsMap)),
         Arguments.of(
             "Simple JSON",
-            buildRow("{\"key\": \"value\"}"),
+            buildRowWithDefaultMetadata("{\"key\": \"value\"}"),
             ImmutableMap.of(
                 "\"KEY\"", "value", Utils.TABLE_COLUMN_METADATA, fullMetadataJsonAsMap)),
         Arguments.of(
             "Already quoted key JSON",
-            buildRow("{\"\\\"key\\\"\": \"value\"}"),
+            buildRowWithDefaultMetadata("{\"\\\"key\\\"\": \"value\"}"),
             ImmutableMap.of(
                 "\"key\"", "value", Utils.TABLE_COLUMN_METADATA, fullMetadataJsonAsMap)),
         Arguments.of(
             "Already quoted UPPERCASE key JSON",
-            buildRow("{\"\\\"KEY\\\"\": \"value\"}"),
+            buildRowWithDefaultMetadata("{\"\\\"KEY\\\"\": \"value\"}"),
             ImmutableMap.of(
                 "\"KEY\"", "value", Utils.TABLE_COLUMN_METADATA, fullMetadataJsonAsMap)),
         Arguments.of(
             "JSON with different primitive types",
-            buildRow(primitiveJsonExample),
+            buildRowWithDefaultMetadata(primitiveJsonExample),
             ImmutableMap.of(
                 "\"ID_INT8\"",
                 8,
@@ -200,7 +200,8 @@ class IcebergTableStreamingRecordMapperTest extends StreamingRecordMapperTest {
                 fullMetadataJsonAsMap)),
         Arguments.of(
             "Nested array",
-            buildRow("{\"key\": [" + primitiveJsonExample + ", " + primitiveJsonExample + "]}"),
+            buildRowWithDefaultMetadata(
+                "{\"key\": [" + primitiveJsonExample + ", " + primitiveJsonExample + "]}"),
             ImmutableMap.of(
                 "\"KEY\"",
                 ImmutableList.of(primitiveJsonAsMap, primitiveJsonAsMap),
@@ -208,22 +209,22 @@ class IcebergTableStreamingRecordMapperTest extends StreamingRecordMapperTest {
                 fullMetadataJsonAsMap)),
         Arguments.of(
             "Empty nested array",
-            buildRow("{\"key\": []}"),
+            buildRowWithDefaultMetadata("{\"key\": []}"),
             ImmutableMap.of(
                 "\"KEY\"", ImmutableList.of(), Utils.TABLE_COLUMN_METADATA, fullMetadataJsonAsMap)),
         Arguments.of(
             "Empty object",
-            buildRow("{\"key\": {}}"),
+            buildRowWithDefaultMetadata("{\"key\": {}}"),
             ImmutableMap.of(
                 "\"KEY\"", ImmutableMap.of(), Utils.TABLE_COLUMN_METADATA, fullMetadataJsonAsMap)),
         Arguments.of(
             "Nested object",
-            buildRow("{\"key\":" + primitiveJsonExample + "}"),
+            buildRowWithDefaultMetadata("{\"key\":" + primitiveJsonExample + "}"),
             ImmutableMap.of(
                 "\"KEY\"", primitiveJsonAsMap, Utils.TABLE_COLUMN_METADATA, fullMetadataJsonAsMap)),
         Arguments.of(
             "Double nested object",
-            buildRow("{\"key\":{\"key2\":" + primitiveJsonExample + "}}"),
+            buildRowWithDefaultMetadata("{\"key\":{\"key2\":" + primitiveJsonExample + "}}"),
             ImmutableMap.of(
                 "\"KEY\"",
                 ImmutableMap.of("key2", primitiveJsonAsMap),
@@ -231,7 +232,7 @@ class IcebergTableStreamingRecordMapperTest extends StreamingRecordMapperTest {
                 fullMetadataJsonAsMap)),
         Arguments.of(
             "Nested objects and primitive types",
-            buildRow(
+            buildRowWithDefaultMetadata(
                 primitiveJsonExample.replaceFirst("}", "")
                     + ",\"key\":"
                     + primitiveJsonExample
@@ -261,7 +262,11 @@ class IcebergTableStreamingRecordMapperTest extends StreamingRecordMapperTest {
 
   private static Stream<Arguments> prepareMetadataData() throws JsonProcessingException {
     return Stream.of(
-        Arguments.of("Full metadata", buildRow("{}"), fullMetadataJsonAsMap, fullRecordMetadata),
+        Arguments.of(
+            "Full metadata",
+            buildRowWithDefaultMetadata("{}"),
+            fullMetadataJsonAsMap,
+            fullRecordMetadata),
         Arguments.of(
             "Empty metadata",
             buildRow("{}", "{}"),
@@ -298,7 +303,7 @@ class IcebergTableStreamingRecordMapperTest extends StreamingRecordMapperTest {
     return Stream.of(
         Arguments.of(
             "Empty JSON",
-            buildRow("{}"),
+            buildRowWithDefaultMetadata("{}"),
             ImmutableMap.of(
                 Utils.TABLE_COLUMN_CONTENT,
                 ImmutableMap.of(),
@@ -306,7 +311,7 @@ class IcebergTableStreamingRecordMapperTest extends StreamingRecordMapperTest {
                 fullMetadataJsonAsMap)),
         Arguments.of(
             "Simple JSON",
-            buildRow("{\"key\": \"value\"}"),
+            buildRowWithDefaultMetadata("{\"key\": \"value\"}"),
             ImmutableMap.of(
                 Utils.TABLE_COLUMN_CONTENT,
                 ImmutableMap.of("key", "value"),
@@ -314,7 +319,7 @@ class IcebergTableStreamingRecordMapperTest extends StreamingRecordMapperTest {
                 fullMetadataJsonAsMap)),
         Arguments.of(
             "UPPERCASE key JSON",
-            buildRow("{\"KEY\": \"value\"}"),
+            buildRowWithDefaultMetadata("{\"KEY\": \"value\"}"),
             ImmutableMap.of(
                 Utils.TABLE_COLUMN_CONTENT,
                 ImmutableMap.of("KEY", "value"),
@@ -322,7 +327,7 @@ class IcebergTableStreamingRecordMapperTest extends StreamingRecordMapperTest {
                 fullMetadataJsonAsMap)),
         Arguments.of(
             "JSON with different primitive types",
-            buildRow(primitiveJsonExample),
+            buildRowWithDefaultMetadata(primitiveJsonExample),
             ImmutableMap.of(
                 Utils.TABLE_COLUMN_CONTENT,
                 primitiveJsonAsMap,
@@ -330,7 +335,8 @@ class IcebergTableStreamingRecordMapperTest extends StreamingRecordMapperTest {
                 fullMetadataJsonAsMap)),
         Arguments.of(
             "Nested array",
-            buildRow("{\"key\": [" + primitiveJsonExample + ", " + primitiveJsonExample + "]}"),
+            buildRowWithDefaultMetadata(
+                "{\"key\": [" + primitiveJsonExample + ", " + primitiveJsonExample + "]}"),
             ImmutableMap.of(
                 Utils.TABLE_COLUMN_CONTENT,
                 ImmutableMap.of("key", ImmutableList.of(primitiveJsonAsMap, primitiveJsonAsMap)),
@@ -338,7 +344,7 @@ class IcebergTableStreamingRecordMapperTest extends StreamingRecordMapperTest {
                 fullMetadataJsonAsMap)),
         Arguments.of(
             "Empty nested array",
-            buildRow("{\"key\": []}"),
+            buildRowWithDefaultMetadata("{\"key\": []}"),
             ImmutableMap.of(
                 Utils.TABLE_COLUMN_CONTENT,
                 ImmutableMap.of("key", ImmutableList.of()),
@@ -346,7 +352,7 @@ class IcebergTableStreamingRecordMapperTest extends StreamingRecordMapperTest {
                 fullMetadataJsonAsMap)),
         Arguments.of(
             "Empty object",
-            buildRow("{\"key\": {}}"),
+            buildRowWithDefaultMetadata("{\"key\": {}}"),
             ImmutableMap.of(
                 Utils.TABLE_COLUMN_CONTENT,
                 ImmutableMap.of("key", ImmutableMap.of()),
@@ -354,7 +360,7 @@ class IcebergTableStreamingRecordMapperTest extends StreamingRecordMapperTest {
                 fullMetadataJsonAsMap)),
         Arguments.of(
             "Nested object",
-            buildRow("{\"key\":" + primitiveJsonExample + "}"),
+            buildRowWithDefaultMetadata("{\"key\":" + primitiveJsonExample + "}"),
             ImmutableMap.of(
                 Utils.TABLE_COLUMN_CONTENT,
                 ImmutableMap.of("key", primitiveJsonAsMap),
@@ -362,7 +368,7 @@ class IcebergTableStreamingRecordMapperTest extends StreamingRecordMapperTest {
                 fullMetadataJsonAsMap)),
         Arguments.of(
             "Double nested object",
-            buildRow("{\"key\":{\"key2\":" + primitiveJsonExample + "}}"),
+            buildRowWithDefaultMetadata("{\"key\":{\"key2\":" + primitiveJsonExample + "}}"),
             ImmutableMap.of(
                 Utils.TABLE_COLUMN_CONTENT,
                 ImmutableMap.of("key", ImmutableMap.of("key2", primitiveJsonAsMap)),
@@ -370,7 +376,7 @@ class IcebergTableStreamingRecordMapperTest extends StreamingRecordMapperTest {
                 fullMetadataJsonAsMap)),
         Arguments.of(
             "Nested objects and primitive types",
-            buildRow(
+            buildRowWithDefaultMetadata(
                 primitiveJsonExample.replaceFirst("}", "")
                     + ",\"key\":"
                     + primitiveJsonExample

--- a/src/test/java/com/snowflake/kafka/connector/records/SnowflakeTableStreamingRecordMapperTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/records/SnowflakeTableStreamingRecordMapperTest.java
@@ -1,0 +1,152 @@
+package com.snowflake.kafka.connector.records;
+
+import static com.snowflake.kafka.connector.Utils.TABLE_COLUMN_CONTENT;
+import static com.snowflake.kafka.connector.Utils.TABLE_COLUMN_METADATA;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class SnowflakeTableStreamingRecordMapperTest extends StreamingRecordMapperTest {
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+
+  @ParameterizedTest
+  @MethodSource("ssv1NoSchematizationData")
+  public void shouldMapDataForSsv1(
+      RecordService.SnowflakeTableRow row, Map<String, Object> expected)
+      throws JsonProcessingException {
+    // given
+    SnowflakeTableStreamingRecordMapper mapper =
+        new SnowflakeTableStreamingRecordMapper(objectMapper, false, false);
+
+    // when
+    Map<String, Object> result = mapper.processSnowflakeRecord(row, true);
+
+    // then
+    assertThat(result).isEqualTo(expected);
+  }
+
+  @ParameterizedTest
+  @MethodSource("ssv1SchematizationData")
+  public void shouldMapDataForSsv1Schematization(
+      RecordService.SnowflakeTableRow row, Map<String, Object> expected)
+      throws JsonProcessingException {
+    // given
+    SnowflakeTableStreamingRecordMapper mapper =
+        new SnowflakeTableStreamingRecordMapper(objectMapper, true, false);
+
+    // when
+    Map<String, Object> result = mapper.processSnowflakeRecord(row, true);
+
+    // then
+    assertThat(result).isEqualTo(expected);
+  }
+
+  @ParameterizedTest
+  @MethodSource("ssv2NoSchematizationData")
+  public void shouldMapDataForSsv2(
+      RecordService.SnowflakeTableRow row, Map<String, Object> expected)
+      throws JsonProcessingException {
+    // given
+    SnowflakeTableStreamingRecordMapper mapper =
+        new SnowflakeTableStreamingRecordMapper(objectMapper, false, true);
+
+    // when
+    Map<String, Object> result = mapper.processSnowflakeRecord(row, true);
+
+    // then
+    assertThat(result).isEqualTo(expected);
+  }
+
+  @ParameterizedTest
+  @MethodSource("ssv2SchematizationData")
+  public void shouldMapDataForSsv2Schematization(
+      RecordService.SnowflakeTableRow row, Map<String, Object> expected)
+      throws JsonProcessingException {
+    // given
+    SnowflakeTableStreamingRecordMapper mapper =
+        new SnowflakeTableStreamingRecordMapper(objectMapper, true, true);
+
+    // when
+    Map<String, Object> result = mapper.processSnowflakeRecord(row, true);
+
+    // then
+    assertThat(result).isEqualTo(expected);
+  }
+
+  public static Stream<Arguments> ssv1NoSchematizationData() throws JsonProcessingException {
+    return Stream.of(
+        Arguments.of(
+            buildRow("{}", "{}"), Map.of(TABLE_COLUMN_METADATA, "{}", TABLE_COLUMN_CONTENT, "{}")),
+        Arguments.of(
+            buildRow("{}"),
+            Map.of(
+                TABLE_COLUMN_METADATA, fullMetadataWithoutWhitespace, TABLE_COLUMN_CONTENT, "{}")),
+        Arguments.of(
+            buildRow("{\"key\": \"value\"}"),
+            Map.of(
+                TABLE_COLUMN_METADATA,
+                fullMetadataWithoutWhitespace,
+                TABLE_COLUMN_CONTENT,
+                "{\"key\":\"value\"}")));
+  }
+
+  public static Stream<Arguments> ssv1SchematizationData() throws JsonProcessingException {
+    return Stream.of(
+        Arguments.of(buildRow("{}", "{}"), Map.of(TABLE_COLUMN_METADATA, "{}")),
+        Arguments.of(buildRow("{}"), Map.of(TABLE_COLUMN_METADATA, fullMetadataWithoutWhitespace)),
+        Arguments.of(
+            buildRow("{\"key\": \"value\"}"),
+            Map.of(TABLE_COLUMN_METADATA, fullMetadataWithoutWhitespace, "\"KEY\"", "value")),
+        Arguments.of(
+            buildRow("{\"key\": []}"),
+            Map.of(
+                TABLE_COLUMN_METADATA, fullMetadataJsonExampleWithoutWhitespace, "\"KEY\"", "[]")));
+  }
+
+  public static Stream<Arguments> ssv2NoSchematizationData() throws JsonProcessingException {
+    return Stream.of(
+        Arguments.of(
+            buildRow("{}", "{}"),
+            Map.of(
+                TABLE_COLUMN_METADATA,
+                new MetadataRecord(null, null, null, null, null, null, null, null, null, Map.of()),
+                TABLE_COLUMN_CONTENT,
+                new HashMap<>())),
+        Arguments.of(
+            buildRow("{}"),
+            Map.of(
+                TABLE_COLUMN_METADATA, fullRecordMetadata, TABLE_COLUMN_CONTENT, new HashMap<>())),
+        Arguments.of(
+            buildRow("{\"key\": \"value\"}"),
+            Map.of(
+                TABLE_COLUMN_METADATA,
+                fullRecordMetadata,
+                TABLE_COLUMN_CONTENT,
+                Map.of("key", "value"))));
+  }
+
+  public static Stream<Arguments> ssv2SchematizationData() throws JsonProcessingException {
+    return Stream.of(
+        Arguments.of(
+            buildRow("{}", "{}"),
+            Map.of(
+                TABLE_COLUMN_METADATA,
+                new MetadataRecord(
+                    null, null, null, null, null, null, null, null, null, Map.of()))),
+        Arguments.of(buildRow("{}"), Map.of(TABLE_COLUMN_METADATA, fullRecordMetadata)),
+        Arguments.of(
+            buildRow("{\"key\": \"value\"}"),
+            Map.of(TABLE_COLUMN_METADATA, fullRecordMetadata, "\"KEY\"", "value")),
+        Arguments.of(
+            buildRow("{\"key\": []}"),
+            Map.of(TABLE_COLUMN_METADATA, fullRecordMetadata, "\"KEY\"", List.of())));
+  }
+}

--- a/src/test/java/com/snowflake/kafka/connector/records/SnowflakeTableStreamingRecordMapperTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/records/SnowflakeTableStreamingRecordMapperTest.java
@@ -86,11 +86,11 @@ public class SnowflakeTableStreamingRecordMapperTest extends StreamingRecordMapp
         Arguments.of(
             buildRow("{}", "{}"), Map.of(TABLE_COLUMN_METADATA, "{}", TABLE_COLUMN_CONTENT, "{}")),
         Arguments.of(
-            buildRow("{}"),
+            buildRowWithDefaultMetadata("{}"),
             Map.of(
                 TABLE_COLUMN_METADATA, fullMetadataWithoutWhitespace, TABLE_COLUMN_CONTENT, "{}")),
         Arguments.of(
-            buildRow("{\"key\": \"value\"}"),
+            buildRowWithDefaultMetadata("{\"key\": \"value\"}"),
             Map.of(
                 TABLE_COLUMN_METADATA,
                 fullMetadataWithoutWhitespace,
@@ -101,14 +101,15 @@ public class SnowflakeTableStreamingRecordMapperTest extends StreamingRecordMapp
   public static Stream<Arguments> ssv1SchematizationData() throws JsonProcessingException {
     return Stream.of(
         Arguments.of(buildRow("{}", "{}"), Map.of(TABLE_COLUMN_METADATA, "{}")),
-        Arguments.of(buildRow("{}"), Map.of(TABLE_COLUMN_METADATA, fullMetadataWithoutWhitespace)),
         Arguments.of(
-            buildRow("{\"key\": \"value\"}"),
+            buildRowWithDefaultMetadata("{}"),
+            Map.of(TABLE_COLUMN_METADATA, fullMetadataWithoutWhitespace)),
+        Arguments.of(
+            buildRowWithDefaultMetadata("{\"key\": \"value\"}"),
             Map.of(TABLE_COLUMN_METADATA, fullMetadataWithoutWhitespace, "\"KEY\"", "value")),
         Arguments.of(
-            buildRow("{\"key\": []}"),
-            Map.of(
-                TABLE_COLUMN_METADATA, fullMetadataJsonExampleWithoutWhitespace, "\"KEY\"", "[]")));
+            buildRowWithDefaultMetadata("{\"key\": []}"),
+            Map.of(TABLE_COLUMN_METADATA, fullMetadataWithoutWhitespace, "\"KEY\"", "[]")));
   }
 
   public static Stream<Arguments> ssv2NoSchematizationData() throws JsonProcessingException {
@@ -121,11 +122,11 @@ public class SnowflakeTableStreamingRecordMapperTest extends StreamingRecordMapp
                 TABLE_COLUMN_CONTENT,
                 new HashMap<>())),
         Arguments.of(
-            buildRow("{}"),
+            buildRowWithDefaultMetadata("{}"),
             Map.of(
                 TABLE_COLUMN_METADATA, fullRecordMetadata, TABLE_COLUMN_CONTENT, new HashMap<>())),
         Arguments.of(
-            buildRow("{\"key\": \"value\"}"),
+            buildRowWithDefaultMetadata("{\"key\": \"value\"}"),
             Map.of(
                 TABLE_COLUMN_METADATA,
                 fullRecordMetadata,
@@ -141,12 +142,13 @@ public class SnowflakeTableStreamingRecordMapperTest extends StreamingRecordMapp
                 TABLE_COLUMN_METADATA,
                 new MetadataRecord(
                     null, null, null, null, null, null, null, null, null, Map.of()))),
-        Arguments.of(buildRow("{}"), Map.of(TABLE_COLUMN_METADATA, fullRecordMetadata)),
         Arguments.of(
-            buildRow("{\"key\": \"value\"}"),
+            buildRowWithDefaultMetadata("{}"), Map.of(TABLE_COLUMN_METADATA, fullRecordMetadata)),
+        Arguments.of(
+            buildRowWithDefaultMetadata("{\"key\": \"value\"}"),
             Map.of(TABLE_COLUMN_METADATA, fullRecordMetadata, "\"KEY\"", "value")),
         Arguments.of(
-            buildRow("{\"key\": []}"),
+            buildRowWithDefaultMetadata("{\"key\": []}"),
             Map.of(TABLE_COLUMN_METADATA, fullRecordMetadata, "\"KEY\"", List.of())));
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/records/StreamingRecordMapperTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/records/StreamingRecordMapperTest.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Map;
 
-public class StreamingRecordMapperTest {
+abstract class StreamingRecordMapperTest {
 
   protected static final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -26,9 +26,6 @@ public class StreamingRecordMapperTest {
           + "\"header2\": \"testheaderstring\","
           + "\"header3\": 3.5}"
           + "}";
-
-  protected static final String fullMetadataJsonExampleWithoutWhitespace =
-      fullMetadataJsonExample.replaceAll("\\s+", "");
 
   protected static final String fullMetadataWithoutWhitespace =
       fullMetadataJsonExample.replaceAll("\\s+", "");
@@ -52,7 +49,7 @@ public class StreamingRecordMapperTest {
               "objectAsJsonStringHeader",
               "{\"key1\":\"value1\",\"key2\":\"value2\"}"));
 
-  protected static RecordService.SnowflakeTableRow buildRow(String content)
+  protected static RecordService.SnowflakeTableRow buildRowWithDefaultMetadata(String content)
       throws JsonProcessingException {
     return buildRow(content, fullMetadataJsonExample);
   }

--- a/src/test/java/com/snowflake/kafka/connector/records/StreamingRecordMapperTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/records/StreamingRecordMapperTest.java
@@ -1,0 +1,66 @@
+package com.snowflake.kafka.connector.records;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+
+public class StreamingRecordMapperTest {
+
+  protected static final ObjectMapper objectMapper = new ObjectMapper();
+
+  protected static final String fullMetadataJsonExample =
+      "{"
+          + "\"offset\": 10,"
+          + "\"topic\": \"topic\","
+          + "\"partition\": 0,"
+          + "\"key\": \"key\","
+          + "\"schema_id\": 1,"
+          + "\"key_schema_id\": 2,"
+          + "\"CreateTime\": 3,"
+          + "\"LogAppendTime\": 4,"
+          + "\"SnowflakeConnectorPushTime\": 5,"
+          + "\"headers\": {\"objectAsJsonStringHeader\": {"
+          + "\"key1\": \"value1\","
+          + "\"key2\": \"value2\""
+          + "},"
+          + "\"header2\": \"testheaderstring\","
+          + "\"header3\": 3.5}"
+          + "}";
+
+  protected static final String fullMetadataJsonExampleWithoutWhitespace =
+      fullMetadataJsonExample.replaceAll("\\s+", "");
+
+  protected static final String fullMetadataWithoutWhitespace =
+      fullMetadataJsonExample.replaceAll("\\s+", "");
+
+  protected static final MetadataRecord fullRecordMetadata =
+      new MetadataRecord(
+          10L,
+          "topic",
+          0,
+          "key",
+          1,
+          2,
+          3L,
+          4L,
+          5L,
+          Map.of(
+              "header3",
+              "3.5",
+              "header2",
+              "testheaderstring",
+              "objectAsJsonStringHeader",
+              "{\"key1\":\"value1\",\"key2\":\"value2\"}"));
+
+  protected static RecordService.SnowflakeTableRow buildRow(String content)
+      throws JsonProcessingException {
+    return buildRow(content, fullMetadataJsonExample);
+  }
+
+  protected static RecordService.SnowflakeTableRow buildRow(String content, String metadata)
+      throws JsonProcessingException {
+    return new RecordService.SnowflakeTableRow(
+        new SnowflakeRecordContent(objectMapper.readTree(content)),
+        objectMapper.readTree(metadata));
+  }
+}


### PR DESCRIPTION
<!-- Text inside of HTML comment blocks will NOT appear in your pull request description -->
<!-- Formatting information can be found at https://www.markdownguide.org/basic-syntax/ -->
# Overview

CONN-10496 Record data mapping for SSv2

In SSv1 Objects and Arrays were converted into Strings containing JSON.

In SSv2 it would be problematic because it would require placing additional logic within the pipe e.g. `PARSE_JSON($1) AS RECORD_CONTENT`. To keep pipe simple and avoid its recreation when schema change the data is mapped into `Map<String, Object>`.