### PR TITLE
CONN-10496 Creating pipe for SSv2

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/DefaultPipeDefinitionProvider.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/DefaultPipeDefinitionProvider.java
@@ -1,0 +1,20 @@
+package com.snowflake.kafka.connector.internal.streaming.v2;
+
+/** Default implementation does not perform any transformations on pipe level */
+public class DefaultPipeDefinitionProvider implements PipeDefinitionProvider {
+
+  private static final String CREATE_PIPE_IF_NOT_EXISTS_STATEMENT =
+      "CREATE PIPE IF NOT EXISTS identifier(?) AS COPY INTO %s FROM TABLE (DATA_SOURCE(TYPE =>"
+          + " 'STREAMING')) MATCH_BY_COLUMN_NAME=CASE_SENSITIVE";
+
+  private static final String CREATE_OR_REPLACE_PIPE_STATEMENT =
+      "CREATE OR REPLACE PIPE identifier(?) AS COPY INTO %s FROM TABLE (DATA_SOURCE(TYPE =>"
+          + " 'STREAMING')) MATCH_BY_COLUMN_NAME=CASE_SENSITIVE";
+
+  @Override
+  public String getPipeDefinition(String tableName, boolean recreate) {
+    String sqlTemplate =
+        recreate ? CREATE_OR_REPLACE_PIPE_STATEMENT : CREATE_PIPE_IF_NOT_EXISTS_STATEMENT;
+    return String.format(sqlTemplate, tableName);
+  }
+}

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/PipeDefinitionProvider.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/PipeDefinitionProvider.java
@@ -1,0 +1,6 @@
+package com.snowflake.kafka.connector.internal.streaming.v2;
+
+/** Construct CREATE PIPE sql statement */
+public interface PipeDefinitionProvider {
+  String getPipeDefinition(String tableName, boolean recreate);
+}

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/DefaultPipeDefinitionProviderTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/DefaultPipeDefinitionProviderTest.java
@@ -1,0 +1,35 @@
+package com.snowflake.kafka.connector.internal.streaming.v2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class DefaultPipeDefinitionProviderTest {
+
+  private static final PipeDefinitionProvider provider = new DefaultPipeDefinitionProvider();
+
+  @ParameterizedTest
+  @MethodSource("testParams")
+  void shouldCreatePipeDefinition(boolean recreate, String expected) {
+    // when
+    String result = provider.getPipeDefinition("foo", recreate);
+
+    // then
+    assertThat(result).isEqualTo(expected);
+  }
+
+  public static Stream<Arguments> testParams() {
+    return Stream.of(
+        Arguments.of(
+            true,
+            "CREATE OR REPLACE PIPE identifier(?) AS COPY INTO foo FROM TABLE (DATA_SOURCE(TYPE =>"
+                + " 'STREAMING')) MATCH_BY_COLUMN_NAME=CASE_SENSITIVE"),
+        Arguments.of(
+            false,
+            "CREATE PIPE IF NOT EXISTS identifier(?) AS COPY INTO foo FROM TABLE (DATA_SOURCE(TYPE"
+                + " => 'STREAMING')) MATCH_BY_COLUMN_NAME=CASE_SENSITIVE"));
+  }
+}


### PR DESCRIPTION
<!-- Text inside of HTML comment blocks will NOT appear in your pull request description -->
<!-- Formatting information can be found at https://www.markdownguide.org/basic-syntax/ -->
# Overview

CONN-10496 Creating pipe for SSv2

<!--
Why is this review being requested?  The full details should be in the JIRA, but the review should focus on the fix/change being implemented.
If there are multiple steps in the Jira, which step is this?
-->

Initially this interface was more complicated but after [recent changes](https://github.com/snowflakedb/snowflake-kafka-connector/pull/1114) that's all left. `create if not exists` is called at channel/partition startup and `create or replace` when schema evolution happens.