### PR TITLE
CONN-10458 Disable schema evolution for ssv2

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/SSv2PipeCreator.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/SSv2PipeCreator.java
@@ -3,7 +3,7 @@ package com.snowflake.kafka.connector.internal.streaming.v2;
 import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
 
 /** Creates pipe without any transformations */
-class SSv2PipeCreator {
+public class SSv2PipeCreator {
 
   private static final String CREATE_PIPE_IF_NOT_EXISTS_STATEMENT =
       "CREATE PIPE IF NOT EXISTS identifier(?) AS COPY INTO %s FROM TABLE (DATA_SOURCE(TYPE =>"
@@ -17,7 +17,7 @@ class SSv2PipeCreator {
   private final String pipeName;
   private final String tableName;
 
-  SSv2PipeCreator(SnowflakeConnectionService conn, String pipeName, String tableName) {
+  public SSv2PipeCreator(SnowflakeConnectionService conn, String pipeName, String tableName) {
     this.conn = conn;
     this.pipeName = pipeName;
     this.tableName = tableName;

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2IT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2IT.java
@@ -945,7 +945,7 @@ public class SnowflakeSinkServiceV2IT extends SnowflakeSinkServiceV2BaseIT {
   // note this test relies on testrole_kafka and testrole_kafka_1 roles being granted to test_kafka
   // user
   @ParameterizedTest
-  @ValueSource(booleans = {true, false})
+  @ValueSource(booleans = {false})
   public void testStreamingIngest_multipleChannel_distinctClients(boolean ssv2Enabled)
       throws Exception {
     config.put(SNOWPIPE_STREAMING_V2_ENABLED, String.valueOf(ssv2Enabled));

--- a/test/rest_request_template/schema_evolution_nullable_values_after_smt.json
+++ b/test/rest_request_template/schema_evolution_nullable_values_after_smt.json
@@ -15,7 +15,6 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
-    "snowflake.streaming.v2.enabled": "$SNOWFLAKE_STREAMING_V2_ENABLED",
     "snowflake.streaming.max.client.lag": 10,
     "snowflake.enable.schematization": true,
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",

--- a/test/rest_request_template/snowpipe_streaming_schema_mapping_dlq.json
+++ b/test/rest_request_template/snowpipe_streaming_schema_mapping_dlq.json
@@ -14,7 +14,6 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
-    "snowflake.streaming.v2.enabled": "$SNOWFLAKE_STREAMING_V2_ENABLED",
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",
     "value.converter": "org.apache.kafka.connect.json.JsonConverter",
     "value.converter.schemas.enable": "false",

--- a/test/rest_request_template/test_schema_evolution_json_ignore_tombstone.json
+++ b/test/rest_request_template/test_schema_evolution_json_ignore_tombstone.json
@@ -15,7 +15,6 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
-    "snowflake.streaming.v2.enabled": "$SNOWFLAKE_STREAMING_V2_ENABLED",
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",
     "value.converter": "org.apache.kafka.connect.json.JsonConverter",
     "value.converter.schemas.enable": "false",

--- a/test/rest_request_template/test_schema_evolution_w_random_row_count.json
+++ b/test/rest_request_template/test_schema_evolution_w_random_row_count.json
@@ -15,7 +15,6 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
-    "snowflake.streaming.v2.enabled": "$SNOWFLAKE_STREAMING_V2_ENABLED",
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",
     "value.converter": "org.apache.kafka.connect.json.JsonConverter",
     "value.converter.schemas.enable": "false",

--- a/test/rest_request_template/travis_correct_auto_table_creation.json
+++ b/test/rest_request_template/travis_correct_auto_table_creation.json
@@ -14,7 +14,6 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
-    "snowflake.streaming.v2.enabled": "$SNOWFLAKE_STREAMING_V2_ENABLED",
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",
     "value.converter": "io.confluent.connect.avro.AvroConverter",
     "value.converter.schema.registry.url": "CONFLUENT_SCHEMA_REGISTRY",

--- a/test/rest_request_template/travis_correct_auto_table_creation_topic2table.json
+++ b/test/rest_request_template/travis_correct_auto_table_creation_topic2table.json
@@ -15,7 +15,6 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
-    "snowflake.streaming.v2.enabled": "$SNOWFLAKE_STREAMING_V2_ENABLED",
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",
     "value.converter": "io.confluent.connect.avro.AvroConverter",
     "value.converter.schema.registry.url": "CONFLUENT_SCHEMA_REGISTRY",

--- a/test/rest_request_template/travis_correct_schema_evolution_avro_sr.json
+++ b/test/rest_request_template/travis_correct_schema_evolution_avro_sr.json
@@ -15,7 +15,6 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
-    "snowflake.streaming.v2.enabled": "$SNOWFLAKE_STREAMING_V2_ENABLED",
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",
     "value.converter":"io.confluent.connect.avro.AvroConverter",
     "value.converter.schema.registry.url":"CONFLUENT_SCHEMA_REGISTRY",

--- a/test/rest_request_template/travis_correct_schema_evolution_avro_sr_logical_types.json
+++ b/test/rest_request_template/travis_correct_schema_evolution_avro_sr_logical_types.json
@@ -15,7 +15,6 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
-    "snowflake.streaming.v2.enabled": "$SNOWFLAKE_STREAMING_V2_ENABLED",
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",
     "value.converter":"io.confluent.connect.avro.AvroConverter",
     "value.converter.schema.registry.url":"CONFLUENT_SCHEMA_REGISTRY",

--- a/test/rest_request_template/travis_correct_schema_evolution_json.json
+++ b/test/rest_request_template/travis_correct_schema_evolution_json.json
@@ -15,7 +15,6 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
-    "snowflake.streaming.v2.enabled": "$SNOWFLAKE_STREAMING_V2_ENABLED",
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",
     "value.converter": "org.apache.kafka.connect.json.JsonConverter",
     "value.converter.schemas.enable": "false",

--- a/test/rest_request_template/travis_correct_schema_evolution_nonnullable_json.json
+++ b/test/rest_request_template/travis_correct_schema_evolution_nonnullable_json.json
@@ -15,7 +15,6 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
-    "snowflake.streaming.v2.enabled": "$SNOWFLAKE_STREAMING_V2_ENABLED",
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",
     "value.converter": "org.apache.kafka.connect.json.JsonConverter",
     "value.converter.schemas.enable": "false",

--- a/test/rest_request_template/travis_correct_schema_evolution_w_auto_table_creation_avro_sr.json
+++ b/test/rest_request_template/travis_correct_schema_evolution_w_auto_table_creation_avro_sr.json
@@ -15,7 +15,6 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
-    "snowflake.streaming.v2.enabled": "$SNOWFLAKE_STREAMING_V2_ENABLED",
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",
     "value.converter":"io.confluent.connect.avro.AvroConverter",
     "value.converter.schema.registry.url":"CONFLUENT_SCHEMA_REGISTRY",

--- a/test/rest_request_template/travis_correct_schema_evolution_w_auto_table_creation_json.json
+++ b/test/rest_request_template/travis_correct_schema_evolution_w_auto_table_creation_json.json
@@ -15,7 +15,6 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
-    "snowflake.streaming.v2.enabled": "$SNOWFLAKE_STREAMING_V2_ENABLED",
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",
     "value.converter": "org.apache.kafka.connect.json.JsonConverter",
     "value.converter.schemas.enable": "false",

--- a/test/rest_request_template/travis_correct_schema_mapping.json
+++ b/test/rest_request_template/travis_correct_schema_mapping.json
@@ -14,7 +14,6 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
-    "snowflake.streaming.v2.enabled": "$SNOWFLAKE_STREAMING_V2_ENABLED",
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",
     "value.converter": "org.apache.kafka.connect.json.JsonConverter",
     "value.converter.schemas.enable": "false",

--- a/test/rest_request_template/travis_correct_schema_not_supported_converter.json
+++ b/test/rest_request_template/travis_correct_schema_not_supported_converter.json
@@ -14,7 +14,6 @@
     "snowflake.schema.name": "SNOWFLAKE_SCHEMA",
     "snowflake.role.name": "SNOWFLAKE_ROLE",
     "snowflake.ingestion.method": "SNOWPIPE_STREAMING",
-    "snowflake.streaming.v2.enabled": "$SNOWFLAKE_STREAMING_V2_ENABLED",
     "key.converter": "org.apache.kafka.connect.storage.StringConverter",
     "value.converter": "org.apache.kafka.connect.storage.StringConverter",
     "value.converter.schemas.enable": "false",


### PR DESCRIPTION
Schema evolution in the current SSv2 architecture will lose data. The reason is that multiple nodes share the same pipe object and when it is recreated from one worker node, other nodes cannot synchronize.

This PR block the ability to evolve schema. If schema doesn't match, the connector will either send record to DLQ or stop (depending on the user configuration).