### PR TITLE
FLOW-4165 Bump confluent packages to 7.9.2 / Release 3.2.2

### DIFF
--- a/.github/workflows/GoogleJavaFormat.yml
+++ b/.github/workflows/GoogleJavaFormat.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: GoogleJavaFormat
         id: googlejavaformat
-        uses: axel-op/googlejavaformat-action@v3
+        uses: axel-op/googlejavaformat-action@v4
         with:
           skipCommit: true
           version: 1.10.0

--- a/.github/workflows/GoogleJavaFormat.yml
+++ b/.github/workflows/GoogleJavaFormat.yml
@@ -13,8 +13,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: GoogleJavaFormat
         id: googlejavaformat
-        uses: axel-op/googlejavaformat-action@v4
+        uses: axel-op/googlejavaformat-action@v3
         with:
-          skipCommit: true
+          skip-commit: true
           version: 1.10.0
           args: "-n --set-exit-if-changed"

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.snowflake</groupId>
     <artifactId>snowflake-kafka-connector</artifactId>
-    <version>3.2.1</version>
+    <version>3.2.2</version>
     <packaging>jar</packaging>
     <name>Snowflake Kafka Connector</name>
     <description>Snowflake Kafka Connect Sink Connector</description>
@@ -53,7 +53,7 @@
         <kafka.version>3.9.0</kafka.version>
         <awaitility.version>4.2.2</awaitility.version>
         <assertj-core.version>3.26.3</assertj-core.version>
-        <confluent.version>7.9.0</confluent.version>
+        <confluent.version>7.9.2</confluent.version>
         <!--Compatible protobuf version https://github.com/confluentinc/common/blob/v7.7.0/pom.xml#L91 -->
         <protobuf.version>3.25.5</protobuf.version>
         <guava.version>33.4.0-jre</guava.version>

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.snowflake</groupId>
     <artifactId>snowflake-kafka-connector</artifactId>
-    <version>3.2.1</version>
+    <version>3.2.2</version>
     <packaging>jar</packaging>
     <name>Snowflake Kafka Connector</name>
     <description>Snowflake Kafka Connect Sink Connector</description>
@@ -63,7 +63,7 @@
         <kafka.version>3.9.0</kafka.version>
         <awaitility.version>4.2.2</awaitility.version>
         <assertj-core.version>3.26.3</assertj-core.version>
-        <confluent.version>7.9.0</confluent.version>
+        <confluent.version>7.9.2</confluent.version>
         <!--Compatible protobuf version https://github.com/confluentinc/common/blob/v7.7.0/pom.xml#L91 -->
         <protobuf.version>3.25.5</protobuf.version>
         <guava.version>33.4.0-jre</guava.version>

--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -65,7 +65,7 @@ import org.apache.kafka.common.config.ConfigValue;
 public class Utils {
 
   // Connector version, change every release
-  public static final String VERSION = "3.2.1";
+  public static final String VERSION = "3.2.2";
 
   // connector parameter list
   public static final String NAME = "name";


### PR DESCRIPTION
<!-- Text inside of HTML comment blocks will NOT appear in your pull request description -->
<!-- Formatting information can be found at https://www.markdownguide.org/basic-syntax/ -->
# Overview

FLOW-4165

Bumping Confluent packages to 7.9.2 in order to fix vulnerability.
This commit marks 3.2.2 release.