### PR TITLE
FLOW-4165 Bump Confluent packages to 8.0.0

### DIFF
--- a/.github/workflows/GoogleJavaFormat.yml
+++ b/.github/workflows/GoogleJavaFormat.yml
@@ -15,6 +15,6 @@ jobs:
         id: googlejavaformat
         uses: axel-op/googlejavaformat-action@v3
         with:
-          skipCommit: true
+          skip-commit: true
           version: 1.10.0
           args: "-n --set-exit-if-changed"

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <kafka.version>3.9.1</kafka.version>
         <awaitility.version>4.2.2</awaitility.version>
         <assertj-core.version>3.26.3</assertj-core.version>
-        <confluent.version>7.9.0</confluent.version>
+        <confluent.version>8.0.0</confluent.version>
         <!--Compatible protobuf version https://github.com/confluentinc/common/blob/v7.7.0/pom.xml#L91 -->
         <protobuf.version>3.25.5</protobuf.version>
         <guava.version>33.4.0-jre</guava.version>

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -63,7 +63,7 @@
         <kafka.version>3.9.1</kafka.version>
         <awaitility.version>4.2.2</awaitility.version>
         <assertj-core.version>3.26.3</assertj-core.version>
-        <confluent.version>7.9.0</confluent.version>
+        <confluent.version>8.0.0</confluent.version>
         <!--Compatible protobuf version https://github.com/confluentinc/common/blob/v7.7.0/pom.xml#L91 -->
         <protobuf.version>3.25.5</protobuf.version>
         <guava.version>33.4.0-jre</guava.version>


### PR DESCRIPTION
<!-- Text inside of HTML comment blocks will NOT appear in your pull request description -->
<!-- Formatting information can be found at https://www.markdownguide.org/basic-syntax/ -->
# Overview

FLOW-4165 Bump Confluent packages to 8.0.0

Similar to 3.x branch: https://github.com/snowflakedb/snowflake-kafka-connector/pull/1123
On master (4.x) we already require Java 11 so we can go straight to Confluent 8.0.0 packages that drops Java 8 support as well.
