### PR TITLE
CONN-10463 SSv2 config and mini-refactors

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkConnectorConfig.java
@@ -156,6 +156,9 @@ public class SnowflakeSinkConnectorConfig {
   public static final String ICEBERG_ENABLED = "snowflake.streaming.iceberg.enabled";
   public static final boolean ICEBERG_ENABLED_DEFAULT_VALUE = false;
 
+  public static final String SNOWPIPE_STREAMING_V2_ENABLED = "snowflake.streaming.v2.enabled";
+  public static final boolean SNOWPIPE_STREAMING_V2_ENABLED_DEFAULT_VALUE = false;
+
   // TESTING
   public static final String REBALANCING = "snowflake.test.rebalancing";
   public static final boolean REBALANCING_DEFAULT = false;

--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -18,6 +18,7 @@ package com.snowflake.kafka.connector;
 
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ICEBERG_ENABLED;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_V2_ENABLED_DEFAULT_VALUE;
 
 import com.google.common.collect.ImmutableMap;
 import com.snowflake.kafka.connector.internal.InternalUtils;
@@ -43,7 +44,7 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Random;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -115,8 +116,6 @@ public class Utils {
 
   // jdbc log dir
   public static final String JAVA_IO_TMPDIR = "java.io.tmpdir";
-
-  private static final Random random = new Random();
 
   // mvn repo
   private static final String MVN_REPO =
@@ -412,8 +411,10 @@ public class Utils {
   }
 
   public static boolean isSnowpipeStreamingV2Enabled(Map<String, String> config) {
-    return Boolean.parseBoolean(
-        config.get(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_V2_ENABLED));
+    return Optional.ofNullable(
+            config.get(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_V2_ENABLED))
+        .map(Boolean::parseBoolean)
+        .orElse(SNOWPIPE_STREAMING_V2_ENABLED_DEFAULT_VALUE);
   }
 
   /**

--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -74,7 +74,6 @@ public class Utils {
   public static final String SF_USER = "snowflake.user.name";
   public static final String SF_PRIVATE_KEY = "snowflake.private.key";
   public static final String SF_URL = "snowflake.url.name";
-  public static final String SF_SSL = "sfssl"; // for test only
   public static final String SF_WAREHOUSE = "sfwarehouse"; // for test only
   public static final String PRIVATE_KEY_PASSPHRASE = "snowflake.private.key" + ".passphrase";
   public static final String SF_AUTHENTICATOR =
@@ -412,12 +411,25 @@ public class Utils {
         config.get(SnowflakeSinkConnectorConfig.ENABLE_SCHEMATIZATION_CONFIG));
   }
 
+  public static boolean isSnowpipeStreamingV2Enabled(Map<String, String> config) {
+    return Boolean.parseBoolean(
+        config.get(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_V2_ENABLED));
+  }
+
   /**
    * @param config config with applied default values
    * @return role specified in rhe config
    */
   public static String role(Map<String, String> config) {
     return config.get(SF_ROLE);
+  }
+
+  public static String database(Map<String, String> config) {
+    return config.get(SF_DATABASE);
+  }
+
+  public static String schema(Map<String, String> config) {
+    return config.get(SF_SCHEMA);
   }
 
   /**

--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -425,11 +425,11 @@ public class Utils {
     return config.get(SF_ROLE);
   }
 
-  public static String database(Map<String, String> config) {
+  public static String getDatabase(Map<String, String> config) {
     return config.get(SF_DATABASE);
   }
 
-  public static String schema(Map<String, String> config) {
+  public static String getSchema(Map<String, String> config) {
     return config.get(SF_SCHEMA);
   }
 

--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -421,7 +421,7 @@ public class Utils {
    * @param config config with applied default values
    * @return role specified in rhe config
    */
-  public static String role(Map<String, String> config) {
+  public static String getRole(Map<String, String> config) {
     return config.get(SF_ROLE);
   }
 
@@ -443,7 +443,7 @@ public class Utils {
     return !isSnowpipeIngestion(config);
   }
 
-  public static String user(Map<String, String> config) {
+  public static String getUser(Map<String, String> config) {
     return config.get(SF_USER);
   }
 

--- a/src/main/java/com/snowflake/kafka/connector/config/ConnectorConfigDefinition.java
+++ b/src/main/java/com/snowflake/kafka/connector/config/ConnectorConfigDefinition.java
@@ -483,6 +483,12 @@ public class ConnectorConfigDefinition {
             "When set to true the connector will ingest data into the Iceberg table. Check the"
                 + " official Snowflake documentation for the prerequisites.")
         .define(
+            SNOWPIPE_STREAMING_V2_ENABLED,
+            ConfigDef.Type.BOOLEAN,
+            SNOWPIPE_STREAMING_V2_ENABLED_DEFAULT_VALUE,
+            ConfigDef.Importance.HIGH,
+            "When set to true the connector will ingest data using Snowpipe Streaming v2.")
+        .define(
             ENABLE_CHANNEL_OFFSET_TOKEN_VERIFICATION_FUNCTION_CONFIG,
             ConfigDef.Type.BOOLEAN,
             ENABLE_CHANNEL_OFFSET_TOKEN_VERIFICATION_FUNCTION_DEFAULT,

--- a/src/main/java/com/snowflake/kafka/connector/config/IcebergConfigValidator.java
+++ b/src/main/java/com/snowflake/kafka/connector/config/IcebergConfigValidator.java
@@ -4,6 +4,7 @@ import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.*;
 import static com.snowflake.kafka.connector.internal.streaming.IngestionMethodConfig.SNOWPIPE_STREAMING;
 
 import com.google.common.collect.ImmutableMap;
+import com.snowflake.kafka.connector.Utils;
 import com.snowflake.kafka.connector.internal.streaming.IngestionMethodConfig;
 import com.snowflake.kafka.connector.internal.streaming.StreamingConfigValidator;
 import java.util.HashMap;
@@ -13,6 +14,9 @@ import java.util.Map;
 public class IcebergConfigValidator implements StreamingConfigValidator {
   private static final String INCOMPATIBLE_INGESTION_METHOD =
       "Ingestion to Iceberg table is supported only for Snowpipe Streaming";
+
+  private static final String ICEBERG_NOT_SUPPORTED_IN_SSV2 =
+      "Ingestion to Iceberg table is not supported by Snowpipe Streaming v2";
 
   @Override
   public ImmutableMap<String, String> validate(Map<String, String> inputConfig) {
@@ -29,6 +33,10 @@ public class IcebergConfigValidator implements StreamingConfigValidator {
 
     if (ingestionMethod != SNOWPIPE_STREAMING) {
       validationErrors.put(INGESTION_METHOD_OPT, INCOMPATIBLE_INGESTION_METHOD);
+    }
+
+    if (Utils.isSnowpipeStreamingV2Enabled(inputConfig)) {
+      validationErrors.put(SNOWPIPE_STREAMING_V2_ENABLED, ICEBERG_NOT_SUPPORTED_IN_SSV2);
     }
 
     return ImmutableMap.copyOf(validationErrors);

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeErrors.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeErrors.java
@@ -144,6 +144,11 @@ public enum SnowflakeErrors {
       "0032",
       "Iceberg table does not exist or is in invalid format",
       "Check Snowflake Kafka Connector docs for details"),
+  ERROR_0033(
+      "0033",
+      "Iceberg ingestion not supported by Snowpipe Streaming v2",
+      "Use Snowpipe Streaming v1 instead"),
+
   // Snowflake connection issues 1---
   ERROR_1001(
       "1001",

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/DefaultStreamingConfigValidator.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/DefaultStreamingConfigValidator.java
@@ -126,8 +126,9 @@ public class DefaultStreamingConfigValidator implements StreamingConfigValidator
     if (inputConfig.containsKey(Utils.SF_ROLE)) {
       String rolePresentForSSv2 =
           String.format(
-              "'%s' must not be present when '%s' is enabled",
-              Utils.SF_ROLE, SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_V2_ENABLED);
+              "The default role is used when '%s' is enabled. Delete '%s' parameter from the"
+                  + " connector config and make sure that default role is set properly.",
+              SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_V2_ENABLED, Utils.SF_ROLE);
       return Optional.of(Map.entry(Utils.SF_ROLE, rolePresentForSSv2));
     }
     return Optional.empty();

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/DefaultStreamingConfigValidator.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/DefaultStreamingConfigValidator.java
@@ -21,6 +21,7 @@ import com.snowflake.kafka.connector.Utils;
 import com.snowflake.kafka.connector.internal.KCLogger;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import org.apache.kafka.common.config.ConfigException;
 
@@ -49,16 +50,9 @@ public class DefaultStreamingConfigValidator implements StreamingConfigValidator
           invalidParams.putAll(validateConfigConverters(KEY_CONVERTER_CONFIG_FIELD, inputConfig));
           invalidParams.putAll(validateConfigConverters(VALUE_CONVERTER_CONFIG_FIELD, inputConfig));
 
-          // Validate if snowflake role is present
-          if (!inputConfig.containsKey(Utils.SF_ROLE)
-              || Strings.isNullOrEmpty(inputConfig.get(Utils.SF_ROLE))) {
-            invalidParams.put(
-                Utils.SF_ROLE,
-                Utils.formatString(
-                    "Config:{} should be present if ingestionMethod is:{}",
-                    Utils.SF_ROLE,
-                    inputConfig.get(INGESTION_METHOD_OPT)));
-          }
+          validateRole(inputConfig)
+              .ifPresent(
+                  errorEntry -> invalidParams.put(errorEntry.getKey(), errorEntry.getValue()));
 
           /**
            * Only checking in streaming since we are utilizing the values before we send it to
@@ -104,6 +98,39 @@ public class DefaultStreamingConfigValidator implements StreamingConfigValidator
     }
 
     return ImmutableMap.copyOf(invalidParams);
+  }
+
+  private static Optional<Map.Entry<String, String>> validateRole(Map<String, String> inputConfig) {
+    if (Utils.isSnowpipeStreamingV2Enabled(inputConfig)) {
+      return validateRoleForSSv2(inputConfig);
+    } else {
+      return validateRoleForSSv1(inputConfig);
+    }
+  }
+
+  private static Optional<Map.Entry<String, String>> validateRoleForSSv1(
+      Map<String, String> inputConfig) {
+    if (!inputConfig.containsKey(Utils.SF_ROLE)
+        || Strings.isNullOrEmpty(inputConfig.get(Utils.SF_ROLE))) {
+      String roleMissingForSSv1 =
+          String.format(
+              "Config:%s should be present if ingestionMethod is:%s",
+              Utils.SF_ROLE, inputConfig.get(INGESTION_METHOD_OPT));
+      return Optional.of(Map.entry(Utils.SF_ROLE, roleMissingForSSv1));
+    }
+    return Optional.empty();
+  }
+
+  private static Optional<Map.Entry<String, String>> validateRoleForSSv2(
+      Map<String, String> inputConfig) {
+    if (inputConfig.containsKey(Utils.SF_ROLE)) {
+      String rolePresentForSSv2 =
+          String.format(
+              "'%s' must not be present when '%s' is enabled",
+              Utils.SF_ROLE, SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_V2_ENABLED);
+      return Optional.of(Map.entry(Utils.SF_ROLE, rolePresentForSSv2));
+    }
+    return Optional.empty();
   }
 
   private static void ensureValidLong(

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/DirectTopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/DirectTopicPartitionChannel.java
@@ -2,8 +2,8 @@ package com.snowflake.kafka.connector.internal.streaming;
 
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_CHANNEL_OFFSET_TOKEN_MIGRATION_CONFIG;
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.ENABLE_CHANNEL_OFFSET_TOKEN_MIGRATION_DEFAULT;
-import static com.snowflake.kafka.connector.Utils.database;
-import static com.snowflake.kafka.connector.Utils.schema;
+import static com.snowflake.kafka.connector.Utils.getDatabase;
+import static com.snowflake.kafka.connector.Utils.getSchema;
 import static java.util.stream.Collectors.toMap;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -642,8 +642,8 @@ public class DirectTopicPartitionChannel implements TopicPartitionChannel {
 
     OpenChannelRequest channelRequest =
         OpenChannelRequest.builder(this.channelNameFormatV1)
-            .setDBName(database(sfConnectorConfig))
-            .setSchemaName(schema(sfConnectorConfig))
+            .setDBName(getDatabase(sfConnectorConfig))
+            .setSchemaName(getSchema(sfConnectorConfig))
             .setTableName(this.tableName)
             .setOnErrorOption(onErrorOption)
             .setOffsetTokenVerificationFunction(StreamingUtils.offsetTokenVerificationFunction)

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -239,6 +239,9 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
     StreamingRecordService streamingRecordService =
         new StreamingRecordService(this.recordService, this.kafkaRecordErrorReporter);
 
+    boolean schemaEvolutionEnabled =
+        Utils.isSchematizationEnabled(connectorConfig) && hasSchemaEvolutionPermission;
+
     StreamingErrorHandler streamingErrorHandler =
         new StreamingErrorHandler(
             connectorConfig, kafkaRecordErrorReporter, this.conn.getTelemetryClient());
@@ -248,7 +251,7 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
         topicPartition,
         partitionChannelKey, // Streaming channel name
         tableName,
-        hasSchemaEvolutionPermission,
+        schemaEvolutionEnabled,
         this.connectorConfig,
         this.sinkTaskContext,
         this.conn,

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -218,29 +218,24 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
    * presented or not.
    */
   private void createStreamingChannelForTopicPartition(
-      final String tableName,
-      final TopicPartition topicPartition,
-      boolean hasSchemaEvolutionPermission) {
+      final String tableName, final TopicPartition topicPartition, boolean schemaEvolutionEnabled) {
     final String partitionChannelKey =
         partitionChannelKey(topicPartition.topic(), topicPartition.partition());
     // Create new instance of TopicPartitionChannel which will always open the channel.
     partitionsToChannel.put(
         partitionChannelKey,
         createTopicPartitionChannel(
-            tableName, topicPartition, hasSchemaEvolutionPermission, partitionChannelKey));
+            tableName, topicPartition, schemaEvolutionEnabled, partitionChannelKey));
   }
 
   private TopicPartitionChannel createTopicPartitionChannel(
       String tableName,
       TopicPartition topicPartition,
-      boolean hasSchemaEvolutionPermission,
+      boolean schemaEvolutionEnabled,
       String partitionChannelKey) {
 
     StreamingRecordService streamingRecordService =
         new StreamingRecordService(this.recordService, this.kafkaRecordErrorReporter);
-
-    boolean schemaEvolutionEnabled =
-        Utils.isSchematizationEnabled(connectorConfig) && hasSchemaEvolutionPermission;
 
     StreamingErrorHandler streamingErrorHandler =
         new StreamingErrorHandler(

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -203,7 +203,9 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
   private void tableActionsOnStartPartition(String tableName) {
     if (Utils.isIcebergEnabled(connectorConfig)) {
       icebergTableSchemaValidator.validateTable(
-          tableName, Utils.role(connectorConfig), Utils.isSchematizationEnabled(connectorConfig));
+          tableName,
+          Utils.getRole(connectorConfig),
+          Utils.isSchematizationEnabled(connectorConfig));
       icebergInitService.initializeIcebergTableProperties(tableName);
       populateSchemaEvolutionPermissions(tableName);
     } else {

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/validation/JWTManagerProvider.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/validation/JWTManagerProvider.java
@@ -23,7 +23,7 @@ class JWTManagerProvider {
     SnowflakeURL snowflakeURL = new SnowflakeURL(config.get(Utils.SF_URL));
     PrivateKey privateKey = parsePrivateKey(config.get(Utils.SF_PRIVATE_KEY));
     KeyPair keyPair = getKeyPair(privateKey);
-    return new JWTManager(snowflakeURL.getAccount(), Utils.user(config), keyPair, null);
+    return new JWTManager(snowflakeURL.getAccount(), Utils.getUser(config), keyPair, null);
   }
 
   private static KeyPair getKeyPair(PrivateKey privateKey) {

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/validation/RowsetApiRowSchemaProvider.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/validation/RowsetApiRowSchemaProvider.java
@@ -1,8 +1,9 @@
 package com.snowflake.kafka.connector.internal.streaming.validation;
 
 import static com.snowflake.kafka.connector.Utils.SF_URL;
+import static com.snowflake.kafka.connector.Utils.database;
+import static com.snowflake.kafka.connector.Utils.schema;
 
-import com.snowflake.kafka.connector.Utils;
 import com.snowflake.kafka.connector.internal.KCLogger;
 import java.io.IOException;
 import java.net.URLEncoder;
@@ -88,8 +89,8 @@ public class RowsetApiRowSchemaProvider implements RowSchemaProvider {
             + connectorConfig.get(SF_URL)
             + String.format(
                 TABLE_COLUMNS_ENDPOINT,
-                URLEncoder.encode(connectorConfig.get(Utils.SF_DATABASE), StandardCharsets.UTF_8),
-                URLEncoder.encode(connectorConfig.get(Utils.SF_SCHEMA), StandardCharsets.UTF_8),
+                URLEncoder.encode(database(connectorConfig), StandardCharsets.UTF_8),
+                URLEncoder.encode(schema(connectorConfig), StandardCharsets.UTF_8),
                 URLEncoder.encode(tableName, StandardCharsets.UTF_8));
 
     HttpPost tableInfoRequest = new HttpPost(destinationUrl);

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/validation/RowsetApiRowSchemaProvider.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/validation/RowsetApiRowSchemaProvider.java
@@ -1,8 +1,8 @@
 package com.snowflake.kafka.connector.internal.streaming.validation;
 
 import static com.snowflake.kafka.connector.Utils.SF_URL;
-import static com.snowflake.kafka.connector.Utils.database;
-import static com.snowflake.kafka.connector.Utils.schema;
+import static com.snowflake.kafka.connector.Utils.getDatabase;
+import static com.snowflake.kafka.connector.Utils.getSchema;
 
 import com.snowflake.kafka.connector.internal.KCLogger;
 import java.io.IOException;
@@ -89,8 +89,8 @@ public class RowsetApiRowSchemaProvider implements RowSchemaProvider {
             + connectorConfig.get(SF_URL)
             + String.format(
                 TABLE_COLUMNS_ENDPOINT,
-                URLEncoder.encode(database(connectorConfig), StandardCharsets.UTF_8),
-                URLEncoder.encode(schema(connectorConfig), StandardCharsets.UTF_8),
+                URLEncoder.encode(getDatabase(connectorConfig), StandardCharsets.UTF_8),
+                URLEncoder.encode(getSchema(connectorConfig), StandardCharsets.UTF_8),
                 URLEncoder.encode(tableName, StandardCharsets.UTF_8));
 
     HttpPost tableInfoRequest = new HttpPost(destinationUrl);

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigValidatorTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigValidatorTest.java
@@ -919,6 +919,31 @@ public class ConnectorConfigValidatorTest {
         .hasMessageContaining(SnowflakeSinkConnectorConfig.OAUTH_REFRESH_TOKEN);
   }
 
+  @Test
+  public void shouldValidateSSv2Config() {
+    Map<String, String> config =
+        SnowflakeSinkConnectorConfigBuilder.streamingConfig()
+            .withSnowpipeStreamingV2Enabled()
+            .withoutRole()
+            .build();
+
+    assertThatCode(() -> connectorConfigValidator.validateConfig(config))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  public void shouldThrowExceptionWhenRoleDefinedForSSv2() {
+    Map<String, String> config =
+        SnowflakeSinkConnectorConfigBuilder.streamingConfig()
+            .withSnowpipeStreamingV2Enabled()
+            .withRole("someRole")
+            .build();
+
+    assertThatThrownBy(() -> connectorConfigValidator.validateConfig(config))
+        .isInstanceOf(SnowflakeKafkaConnectorException.class)
+        .hasMessageContaining(SNOWFLAKE_ROLE);
+  }
+
   private void invalidConfigRunner(List<String> paramsToRemove) {
     Map<String, String> config = getConfig();
     for (String configParam : paramsToRemove) {

--- a/src/test/java/com/snowflake/kafka/connector/config/IcebergConfigValidationTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/config/IcebergConfigValidationTest.java
@@ -1,6 +1,7 @@
 package com.snowflake.kafka.connector.config;
 
 import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.INGESTION_METHOD_OPT;
+import static com.snowflake.kafka.connector.SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_V2_ENABLED;
 
 import com.google.common.collect.ImmutableMap;
 import com.snowflake.kafka.connector.internal.streaming.IngestionMethodConfig;
@@ -52,6 +53,11 @@ public class IcebergConfigValidationTest {
             SnowflakeSinkConnectorConfigBuilder.icebergConfig()
                 .withIngestionMethod(IngestionMethodConfig.SNOWPIPE)
                 .build(),
-            INGESTION_METHOD_OPT));
+            INGESTION_METHOD_OPT),
+        Arguments.of(
+            SnowflakeSinkConnectorConfigBuilder.icebergConfig()
+                .withSnowpipeStreamingV2Enabled()
+                .build(),
+            SNOWPIPE_STREAMING_V2_ENABLED));
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/config/SnowflakeSinkConnectorConfigBuilder.java
+++ b/src/test/java/com/snowflake/kafka/connector/config/SnowflakeSinkConnectorConfigBuilder.java
@@ -149,6 +149,11 @@ public class SnowflakeSinkConnectorConfigBuilder {
     return this;
   }
 
+  public SnowflakeSinkConnectorConfigBuilder withSnowpipeStreamingV2Enabled() {
+    config.put(SnowflakeSinkConnectorConfig.SNOWPIPE_STREAMING_V2_ENABLED, "true");
+    return this;
+  }
+
   public Map<String, String> build() {
     return config;
   }

--- a/src/test/java/com/snowflake/kafka/connector/config/SnowflakeSinkConnectorConfigBuilder.java
+++ b/src/test/java/com/snowflake/kafka/connector/config/SnowflakeSinkConnectorConfigBuilder.java
@@ -113,6 +113,11 @@ public class SnowflakeSinkConnectorConfigBuilder {
     return this;
   }
 
+  public SnowflakeSinkConnectorConfigBuilder withoutRole() {
+    config.remove(SF_ROLE);
+    return this;
+  }
+
   public SnowflakeSinkConnectorConfigBuilder withSchematizationEnabled(boolean enabled) {
     config.put(ENABLE_SCHEMATIZATION_CONFIG, Boolean.toString(enabled));
     return this;

--- a/test/apache_properties/server.properties
+++ b/test/apache_properties/server.properties
@@ -28,7 +28,8 @@ broker.id=0
 #     listeners = listener_name://host_name:port
 #   EXAMPLE:
 #     listeners = PLAINTEXT://your.host.name:9092
-#listeners=PLAINTEXT://:9092
+# Uncomment the following line to run tests on local Mac
+#listeners=PLAINTEXT://localhost:9092
 
 # Hostname and port the broker will advertise to producers and consumers. If not set, 
 # it uses the value for "listeners" if configured.  Otherwise, it will use the value

--- a/test/connect-log4j.properties
+++ b/test/connect-log4j.properties
@@ -42,6 +42,7 @@ log4j.appender.connectAppender.layout.ConversionPattern=${connect.log.pattern}
 log4j.logger.org.apache.zookeeper=ERROR
 log4j.logger.org.reflections=ERROR
 
-# enable debug level logging for SF KC and Ingest SDK
 log4j.logger.com.snowflake.kafka.connector=DEBUG
-log4j.logger.net.snowflake=DEBUG
+
+# DEBUG produce tons of logs - use carefully
+log4j.logger.net.snowflake=INFO

--- a/test/test_verify.py
+++ b/test/test_verify.py
@@ -65,7 +65,7 @@ class KafkaTest:
 
         self.SEND_INTERVAL = 0.01  # send a record every 10 ms
         self.VERIFY_INTERVAL = 60  # verify every 60 secs
-        self.MAX_RETRY = 30  # max wait time 30 mins
+        self.MAX_RETRY = 10 # max wait time 10 mins
         self.MAX_FLUSH_BUFFER_SIZE = 5000  # flush buffer when 10000 data was in the queue
 
         self.kafkaConnectAddress = kafkaConnectAddress


### PR DESCRIPTION
To make review of the main SSv2 PR easier I extracted the part related to the parameter management:
- Adding parameter `snowflake.streaming.v2.enabled`
- Iceberg not supported in SSv2 validation
- SSv2 in PuPr supports only the default role - `snowflake.role.name` cannot be provided in SSv2
- a couple of one-liners