### PR TITLE
SNOW-2184975 Remove kafka-schema-rules dependency / fix Iceberg tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -443,12 +443,6 @@
 
         <dependency>
             <groupId>io.confluent</groupId>
-            <artifactId>kafka-schema-rules</artifactId>
-            <version>${confluent.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>io.confluent</groupId>
             <artifactId>kafka-schema-registry-client-encryption</artifactId>
             <version>${confluent.version}</version>
         </dependency>

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -601,12 +601,6 @@
 
         <dependency>
             <groupId>io.confluent</groupId>
-            <artifactId>kafka-schema-rules</artifactId>
-            <version>${confluent.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>io.confluent</groupId>
             <artifactId>kafka-schema-registry-client-encryption</artifactId>
             <version>${confluent.version}</version>
         </dependency>

--- a/src/test/java/com/snowflake/kafka/connector/streaming/iceberg/IcebergIngestionSchemaEvolutionIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/streaming/iceberg/IcebergIngestionSchemaEvolutionIT.java
@@ -26,11 +26,11 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class IcebergIngestionSchemaEvolutionIT extends IcebergIngestionIT {
 
   private static final String RECORD_METADATA_TYPE =
-      "OBJECT(offset NUMBER(19,0), topic VARCHAR(16777216), partition NUMBER(10,0), key"
-          + " VARCHAR(16777216), schema_id NUMBER(10,0), key_schema_id NUMBER(10,0),"
+      "OBJECT(offset NUMBER(19,0), topic VARCHAR(134217728), partition NUMBER(10,0), key"
+          + " VARCHAR(134217728), schema_id NUMBER(10,0), key_schema_id NUMBER(10,0),"
           + " CreateTime NUMBER(19,0), LogAppendTime NUMBER(19,0),"
-          + " SnowflakeConnectorPushTime NUMBER(19,0), headers MAP(VARCHAR(16777216),"
-          + " VARCHAR(16777216)))";
+          + " SnowflakeConnectorPushTime NUMBER(19,0), headers MAP(VARCHAR(134217728),"
+          + " VARCHAR(134217728)))";
 
   @Override
   protected Boolean isSchemaEvolutionEnabled() {
@@ -80,7 +80,7 @@ public class IcebergIngestionSchemaEvolutionIT extends IcebergIngestionIT {
     service.insert(Collections.singletonList(createKafkaRecord(simpleRecordJson, 2, false)));
 
     rows = describeTable(tableName);
-    assertThat(rows).hasSize(10).contains(new DescribeTableRow("SIMPLE", "VARCHAR(16777216)"));
+    assertThat(rows).hasSize(10).contains(new DescribeTableRow("SIMPLE", "VARCHAR(134217728)"));
 
     // reinsert record with extra field
     service.insert(Collections.singletonList(createKafkaRecord(simpleRecordJson, 2, false)));
@@ -99,7 +99,7 @@ public class IcebergIngestionSchemaEvolutionIT extends IcebergIngestionIT {
               new DescribeTableRow("ID_INT16", "NUMBER(10,0)"),
               new DescribeTableRow("ID_INT32", "NUMBER(10,0)"),
               new DescribeTableRow("ID_INT64", "NUMBER(19,0)"),
-              new DescribeTableRow("DESCRIPTION", "VARCHAR(16777216)"),
+              new DescribeTableRow("DESCRIPTION", "VARCHAR(134217728)"),
               new DescribeTableRow("RATING_FLOAT32", "FLOAT"),
               new DescribeTableRow("RATING_FLOAT64", "FLOAT"),
               new DescribeTableRow("APPROVAL", "BOOLEAN")
@@ -113,7 +113,7 @@ public class IcebergIngestionSchemaEvolutionIT extends IcebergIngestionIT {
               new DescribeTableRow("ID_INT16", "NUMBER(19,0)"),
               new DescribeTableRow("ID_INT32", "NUMBER(19,0)"),
               new DescribeTableRow("ID_INT64", "NUMBER(19,0)"),
-              new DescribeTableRow("DESCRIPTION", "VARCHAR(16777216)"),
+              new DescribeTableRow("DESCRIPTION", "VARCHAR(134217728)"),
               new DescribeTableRow("RATING_FLOAT32", "FLOAT"),
               new DescribeTableRow("RATING_FLOAT64", "FLOAT"),
               new DescribeTableRow("APPROVAL", "BOOLEAN")
@@ -143,7 +143,7 @@ public class IcebergIngestionSchemaEvolutionIT extends IcebergIngestionIT {
     List<DescribeTableRow> columns = describeTable(tableName);
     assertEquals(
         columns.get(1).getType(),
-        "OBJECT(k1 NUMBER(19,0), k2 NUMBER(19,0), k3 VARCHAR(16777216), k4 FLOAT)");
+        "OBJECT(k1 NUMBER(19,0), k2 NUMBER(19,0), k3 VARCHAR(134217728), k4 FLOAT)");
 
     // k2, k3, k4
     String testStruct4 = "{ \"testStruct\": { \"k2\" : 2, \"k3\" : 3, \"k4\" : 4.34 } }";
@@ -152,7 +152,7 @@ public class IcebergIngestionSchemaEvolutionIT extends IcebergIngestionIT {
     columns = describeTable(tableName);
     assertEquals(
         columns.get(1).getType(),
-        "OBJECT(k1 NUMBER(19,0), k2 NUMBER(19,0), k3 VARCHAR(16777216), k4 FLOAT)");
+        "OBJECT(k1 NUMBER(19,0), k2 NUMBER(19,0), k3 VARCHAR(134217728), k4 FLOAT)");
 
     // k5, k6
     String testStruct5 = "{ \"testStruct\": { \"k5\" : 2, \"k6\" : 3 } }";
@@ -162,7 +162,7 @@ public class IcebergIngestionSchemaEvolutionIT extends IcebergIngestionIT {
     columns = describeTable(tableName);
     assertEquals(
         columns.get(1).getType(),
-        "OBJECT(k1 NUMBER(19,0), k2 NUMBER(19,0), k3 VARCHAR(16777216), k4 FLOAT, k5 NUMBER(19,0),"
+        "OBJECT(k1 NUMBER(19,0), k2 NUMBER(19,0), k3 VARCHAR(134217728), k4 FLOAT, k5 NUMBER(19,0),"
             + " k6 NUMBER(19,0))");
     assertEquals(columns.size(), 2);
   }
@@ -213,24 +213,24 @@ public class IcebergIngestionSchemaEvolutionIT extends IcebergIngestionIT {
           new DescribeTableRow("ID_INT16", "NUMBER(10,0)"),
           new DescribeTableRow("ID_INT32", "NUMBER(10,0)"),
           new DescribeTableRow("ID_INT64", "NUMBER(19,0)"),
-          new DescribeTableRow("DESCRIPTION", "VARCHAR(16777216)"),
+          new DescribeTableRow("DESCRIPTION", "VARCHAR(134217728)"),
           new DescribeTableRow("RATING_FLOAT32", "FLOAT"),
           new DescribeTableRow("RATING_FLOAT64", "FLOAT"),
           new DescribeTableRow("APPROVAL", "BOOLEAN"),
           new DescribeTableRow("ARRAY1", "ARRAY(NUMBER(10,0))"),
-          new DescribeTableRow("ARRAY2", "ARRAY(VARCHAR(16777216))"),
+          new DescribeTableRow("ARRAY2", "ARRAY(VARCHAR(134217728))"),
           new DescribeTableRow("ARRAY3", "ARRAY(BOOLEAN)"),
           new DescribeTableRow("ARRAY4", "ARRAY(NUMBER(10,0))"),
           new DescribeTableRow("ARRAY5", "ARRAY(ARRAY(NUMBER(10,0)))"),
           new DescribeTableRow(
               "NESTEDRECORD",
               "OBJECT(id_int8 NUMBER(10,0), id_int16 NUMBER(10,0), id_int32 NUMBER(10,0), id_int64"
-                  + " NUMBER(19,0), description VARCHAR(16777216), rating_float32 FLOAT,"
+                  + " NUMBER(19,0), description VARCHAR(134217728), rating_float32 FLOAT,"
                   + " rating_float64 FLOAT, approval BOOLEAN)"),
           new DescribeTableRow(
               "NESTEDRECORD2",
               "OBJECT(id_int8 NUMBER(10,0), id_int16 NUMBER(10,0), id_int32 NUMBER(10,0), id_int64"
-                  + " NUMBER(19,0), description VARCHAR(16777216), rating_float32 FLOAT,"
+                  + " NUMBER(19,0), description VARCHAR(134217728), rating_float32 FLOAT,"
                   + " rating_float64 FLOAT, approval BOOLEAN)"),
         };
     assertThat(columns).containsExactlyInAnyOrder(expectedSchema);
@@ -251,12 +251,12 @@ public class IcebergIngestionSchemaEvolutionIT extends IcebergIngestionIT {
           new DescribeTableRow("ID_INT16", "NUMBER(19,0)"),
           new DescribeTableRow("ID_INT32", "NUMBER(19,0)"),
           new DescribeTableRow("ID_INT64", "NUMBER(19,0)"),
-          new DescribeTableRow("DESCRIPTION", "VARCHAR(16777216)"),
+          new DescribeTableRow("DESCRIPTION", "VARCHAR(134217728)"),
           new DescribeTableRow("RATING_FLOAT32", "FLOAT"),
           new DescribeTableRow("RATING_FLOAT64", "FLOAT"),
           new DescribeTableRow("APPROVAL", "BOOLEAN"),
           new DescribeTableRow("ARRAY1", "ARRAY(NUMBER(19,0))"),
-          new DescribeTableRow("ARRAY2", "ARRAY(VARCHAR(16777216))"),
+          new DescribeTableRow("ARRAY2", "ARRAY(VARCHAR(134217728))"),
           new DescribeTableRow("ARRAY3", "ARRAY(BOOLEAN)"),
           new DescribeTableRow("ARRAY4", "ARRAY(NUMBER(19,0))"),
           new DescribeTableRow("ARRAY5", "ARRAY(ARRAY(NUMBER(19,0)))"),
@@ -264,12 +264,12 @@ public class IcebergIngestionSchemaEvolutionIT extends IcebergIngestionIT {
               "NESTEDRECORD",
               "OBJECT(id_int8 NUMBER(19,0), id_int16 NUMBER(19,0), rating_float32 FLOAT,"
                   + " rating_float64 FLOAT, approval BOOLEAN, id_int32 NUMBER(19,0), description"
-                  + " VARCHAR(16777216), id_int64 NUMBER(19,0))"),
+                  + " VARCHAR(134217728), id_int64 NUMBER(19,0))"),
           new DescribeTableRow(
               "NESTEDRECORD2",
               "OBJECT(id_int8 NUMBER(19,0), id_int16 NUMBER(19,0), rating_float32 FLOAT,"
                   + " rating_float64 FLOAT, approval BOOLEAN, id_int32 NUMBER(19,0), description"
-                  + " VARCHAR(16777216), id_int64 NUMBER(19,0))"),
+                  + " VARCHAR(134217728), id_int64 NUMBER(19,0))"),
         };
     assertThat(columns).containsExactlyInAnyOrder(expectedSchema);
   }
@@ -295,14 +295,14 @@ public class IcebergIngestionSchemaEvolutionIT extends IcebergIngestionIT {
         Arguments.of(
             nestedObjectWithSchema(),
             "OBJECT_WITH_NESTED_OBJECTS",
-            "OBJECT(nestedStruct OBJECT(description VARCHAR(16777216)))"),
+            "OBJECT(nestedStruct OBJECT(description VARCHAR(134217728)))"),
         Arguments.of(
-            simpleMapWithSchema(), "SIMPLE_TEST_MAP", "MAP(VARCHAR(16777216), NUMBER(10,0))"),
+            simpleMapWithSchema(), "SIMPLE_TEST_MAP", "MAP(VARCHAR(134217728), NUMBER(10,0))"),
         Arguments.of(simpleArrayWithSchema(), "SIMPLE_ARRAY", "ARRAY(NUMBER(10,0))"),
         Arguments.of(
             complexPayloadWithSchema(),
             "OBJECT",
-            "OBJECT(arrayOfMaps ARRAY(MAP(VARCHAR(16777216), FLOAT)))"));
+            "OBJECT(arrayOfMaps ARRAY(MAP(VARCHAR(134217728), FLOAT)))"));
   }
 
   @ParameterizedTest
@@ -366,7 +366,7 @@ public class IcebergIngestionSchemaEvolutionIT extends IcebergIngestionIT {
           new DescribeTableRow("TEST_INT16", SMALL_INT),
           new DescribeTableRow("TEST_INT32", SMALL_INT),
           new DescribeTableRow("TEST_INT64", "NUMBER(19,0)"),
-          new DescribeTableRow("TEST_STRING", "VARCHAR(16777216)"),
+          new DescribeTableRow("TEST_STRING", "VARCHAR(134217728)"),
           new DescribeTableRow("TEST_FLOAT", "FLOAT"),
           new DescribeTableRow("TEST_DOUBLE", "FLOAT")
         };
@@ -405,7 +405,7 @@ public class IcebergIngestionSchemaEvolutionIT extends IcebergIngestionIT {
     // verify number of columns, datatype and column name
     assertEquals(2, columns.size());
     assertEquals("OBJECT", columns.get(1).getColumn());
-    assertEquals("OBJECT(test_string VARCHAR(16777216))", columns.get(1).getType());
+    assertEquals("OBJECT(test_string VARCHAR(134217728))", columns.get(1).getType());
 
     // evolution
     insertWithRetry(objectWithNestedObject, 1, withSchema);
@@ -414,8 +414,8 @@ public class IcebergIngestionSchemaEvolutionIT extends IcebergIngestionIT {
     assertEquals(2, columns.size());
     assertEquals("OBJECT", columns.get(1).getColumn());
     assertEquals(
-        "OBJECT(test_string VARCHAR(16777216), nested_object OBJECT(test_string"
-            + " VARCHAR(16777216)))",
+        "OBJECT(test_string VARCHAR(134217728), nested_object OBJECT(test_string"
+            + " VARCHAR(134217728)))",
         columns.get(1).getType());
 
     // evolution
@@ -426,13 +426,13 @@ public class IcebergIngestionSchemaEvolutionIT extends IcebergIngestionIT {
     // 1st column
     assertEquals("OBJECT", columns.get(1).getColumn());
     assertEquals(
-        "OBJECT(test_string VARCHAR(16777216), nested_object OBJECT(test_string"
-            + " VARCHAR(16777216)))",
+        "OBJECT(test_string VARCHAR(134217728), nested_object OBJECT(test_string"
+            + " VARCHAR(134217728)))",
         columns.get(1).getType());
     // 2nd column
     assertEquals("OBJECT_WITH_NESTED_OBJECTS", columns.get(2).getColumn());
     assertEquals(
-        "OBJECT(nestedStruct OBJECT(description VARCHAR(16777216)))", columns.get(2).getType());
+        "OBJECT(nestedStruct OBJECT(description VARCHAR(134217728)))", columns.get(2).getType());
 
     // evolution
     insertWithRetry(twoObjectsExtendedWithMapAndArray, 3, withSchema);
@@ -445,15 +445,15 @@ public class IcebergIngestionSchemaEvolutionIT extends IcebergIngestionIT {
     if (withSchema) {
       // MAP is not supported without schema, execute this assertion only when there is a schema,
       assertEquals(
-          "OBJECT(test_string VARCHAR(16777216), nested_object OBJECT(test_string"
-              + " VARCHAR(16777216)), Test_Map MAP(VARCHAR(16777216), OBJECT(test_string"
-              + " VARCHAR(16777216))))",
+          "OBJECT(test_string VARCHAR(134217728), nested_object OBJECT(test_string"
+              + " VARCHAR(134217728)), Test_Map MAP(VARCHAR(134217728), OBJECT(test_string"
+              + " VARCHAR(134217728))))",
           columns.get(1).getType());
     }
     // 2nd column
     assertEquals("OBJECT_WITH_NESTED_OBJECTS", columns.get(2).getColumn());
     assertEquals(
-        "OBJECT(nestedStruct OBJECT(description VARCHAR(16777216), test_array ARRAY(FLOAT)))",
+        "OBJECT(nestedStruct OBJECT(description VARCHAR(134217728), test_array ARRAY(FLOAT)))",
         columns.get(2).getType());
   }
 

--- a/src/test/java/com/snowflake/kafka/connector/streaming/iceberg/IcebergInitServiceIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/streaming/iceberg/IcebergInitServiceIT.java
@@ -42,16 +42,16 @@ public class IcebergInitServiceIT extends BaseIcebergIT {
     assertThat(describeRecordMetadataType(tableName))
         .isEqualTo(
             "OBJECT(offset NUMBER(19,0), "
-                + "topic VARCHAR(16777216), "
+                + "topic VARCHAR(134217728), "
                 + "partition NUMBER(10,0), "
-                + "key VARCHAR(16777216), "
+                + "key VARCHAR(134217728), "
                 + "schema_id NUMBER(10,0), "
                 + "key_schema_id NUMBER(10,0), "
                 + "CreateTime NUMBER(19,0), "
                 + "LogAppendTime NUMBER(19,0), "
                 + "SnowflakeConnectorPushTime NUMBER(19,0), "
-                + "headers MAP(VARCHAR(16777216), "
-                + "VARCHAR(16777216)))");
+                + "headers MAP(VARCHAR(134217728), "
+                + "VARCHAR(134217728)))");
   }
 
   @Test
@@ -70,16 +70,16 @@ public class IcebergInitServiceIT extends BaseIcebergIT {
     assertThat(describeRecordMetadataType(tableName))
         .isEqualTo(
             "OBJECT(offset NUMBER(19,0), "
-                + "topic VARCHAR(16777216), "
+                + "topic VARCHAR(134217728), "
                 + "partition NUMBER(10,0), "
-                + "key VARCHAR(16777216), "
+                + "key VARCHAR(134217728), "
                 + "schema_id NUMBER(10,0), "
                 + "key_schema_id NUMBER(10,0), "
                 + "CreateTime NUMBER(19,0), "
                 + "LogAppendTime NUMBER(19,0), "
                 + "SnowflakeConnectorPushTime NUMBER(19,0), "
-                + "headers MAP(VARCHAR(16777216), "
-                + "VARCHAR(16777216)))");
+                + "headers MAP(VARCHAR(134217728), "
+                + "VARCHAR(134217728)))");
   }
 
   @Test
@@ -100,15 +100,15 @@ public class IcebergInitServiceIT extends BaseIcebergIT {
     assertThat(describeRecordMetadataType(tableName))
         .isEqualTo(
             "OBJECT(offset NUMBER(19,0), "
-                + "topic VARCHAR(16777216), "
+                + "topic VARCHAR(134217728), "
                 + "partition NUMBER(10,0), "
-                + "key VARCHAR(16777216), "
+                + "key VARCHAR(134217728), "
                 + "schema_id NUMBER(10,0), "
                 + "key_schema_id NUMBER(10,0), "
                 + "CreateTime NUMBER(19,0), "
                 + "LogAppendTime NUMBER(19,0), "
                 + "SnowflakeConnectorPushTime NUMBER(19,0), "
-                + "headers MAP(VARCHAR(16777216), "
-                + "VARCHAR(16777216)))");
+                + "headers MAP(VARCHAR(134217728), "
+                + "VARCHAR(134217728)))");
   }
 }


### PR DESCRIPTION
1. `kafka-schema-rules` dependency was added during update of Confluent packages to 7.6.0 as a result of e2e test failure. With the current version it is no longer needed which is very convenient in terms of vulnerability present in the transitive dependency.

2. Iceberg tests needs adjustment after latest Snowflake BCR that changed the size of VARCHAR columns.