### PR TITLE
SNOW-2197881 OSSRH migration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
     <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://ossrh-staging-api.central.sonatype.com/content/repositories/snapshots</url>
         </snapshotRepository>
     </distributionManagement>
     <build>

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -100,7 +100,7 @@
     <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://ossrh-staging-api.central.sonatype.com/content/repositories/snapshots</url>
         </snapshotRepository>
     </distributionManagement>
     <build>


### PR DESCRIPTION
SNOW-2197881 OSSRH migration

On June 30 OSSRH, which was the method we used to publish artifacts into maven, was shut down  https://central.sonatype.org/pages/ossrh-eol/

The simplest migration path is to use ossrh staging api: https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/