### PR TITLE
SNOW-2197881 Change OSSRH link for nexus-staging-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                    <nexusUrl>https://ossrh-staging-api.central.sonatype.com/</nexusUrl>
                     <autoReleaseAfterClose>true</autoReleaseAfterClose>
                 </configuration>
             </plugin>

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -318,7 +318,7 @@
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                    <nexusUrl>https://ossrh-staging-api.central.sonatype.com/</nexusUrl>
                     <autoReleaseAfterClose>true</autoReleaseAfterClose>
                 </configuration>
             </plugin>


### PR DESCRIPTION
In the previous PR I changed OSSRH link in the`distributionManagement` section but missed out that it was also declared for the `nexus-staging-maven-plugin`  https://github.com/snowflakedb/snowflake-kafka-connector/pull/1137