### PR TITLE
SNOW-2197881 Change OSSRH link for nexus-staging-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                    <nexusUrl>https://ossrh-staging-api.central.sonatype.com/</nexusUrl>
                     <autoReleaseAfterClose>true</autoReleaseAfterClose>
                 </configuration>
             </plugin>

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -319,7 +319,7 @@
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                    <nexusUrl>https://ossrh-staging-api.central.sonatype.com/</nexusUrl>
                     <autoReleaseAfterClose>true</autoReleaseAfterClose>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Cherry-picking from `3.2.x` to master: https://github.com/snowflakedb/snowflake-kafka-connector/pull/1139

With `3.2.3` finally released we know that it works!