### PR TITLE
CONN-10463 Leftovers after abandoning Jackson serialization

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingV2PartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingV2PartitionChannel.java
@@ -256,8 +256,6 @@ public class SnowpipeStreamingV2PartitionChannel implements TopicPartitionChanne
 
   private Optional<RowSchema.Error> validateRecord(Map<String, Object> transformedRecord) {
     Map<String, Object> fieldsToValidate = new HashMap<>(transformedRecord);
-    // skip RECORD_METADATA cause SSv1 validations don't accept POJOs
-    fieldsToValidate.remove("RECORD_METADATA");
     return Optional.ofNullable(
         rowSchemaManager.get(tableName, connectorConfig).validate(fieldsToValidate));
   }

--- a/src/test/java/com/snowflake/kafka/connector/streaming/iceberg/sql/MetadataRecord.java
+++ b/src/test/java/com/snowflake/kafka/connector/streaming/iceberg/sql/MetadataRecord.java
@@ -58,27 +58,22 @@ public class MetadataRecord {
     return key;
   }
 
-  @JsonProperty("schema_id")
   public Integer getSchemaId() {
     return schemaId;
   }
 
-  @JsonProperty("key_schema_id")
   public Integer getKeySchemaId() {
     return keySchemaId;
   }
 
-  @JsonProperty("CreateTime")
   public Long getCreateTime() {
     return createTime;
   }
 
-  @JsonProperty("LogAppendTime")
   public Long getLogAppendTime() {
     return logAppendTime;
   }
 
-  @JsonProperty("SnowflakeConnectorPushTime")
   public Long getSnowflakeConnectorPushTime() {
     return snowflakeConnectorPushTime;
   }


### PR DESCRIPTION
Addressing comments from: https://github.com/snowflakedb/snowflake-kafka-connector/pull/1117
- Jackson serialization is no longer used
- No need to skip RECORD_METADATA validation anymore (it failed when POJO was passed)