### PR TITLE
SNOW-2193898 Recreate streaming ingest client on CLIENT_CLOSED error

### DIFF
--- a/profile.json.example
+++ b/profile.json.example
@@ -1,7 +1,8 @@
 {
   "user": "user name",
+  "role": "user role",
   "private_key": "private key",
-  "host": "acountname.snowflakecomputing.com:443",
+  "host": "account_identifier.snowflakecomputing.com:443",
   "schema": "schema name",
   "database": "database name",
   "warehouse": "warehouse name"

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/DirectTopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/DirectTopicPartitionChannel.java
@@ -414,9 +414,8 @@ public class DirectTopicPartitionChannel implements TopicPartitionChannel {
   private void insertRowFallbackSupplier(Throwable ex)
       throws TopicPartitionChannelInsertionException {
     if (isClientInvalidError(ex)) {
-      this.streamingIngestClient =
-          StreamingClientProvider.getStreamingClientProviderInstance()
-              .recreateClient(sfConnectorConfig);
+      LOGGER.warn("Client is invalid, recreating client for channel: {}", getChannelNameFormatV1());
+      this.streamingIngestClient = StreamingClientProvider.getStreamingClientProviderInstance().getClient(sfConnectorConfig);
     }
     final long offsetRecoveredFromSnowflake =
         streamingApiFallbackSupplier(StreamingApiFallbackInvoker.INSERT_ROWS_FALLBACK);
@@ -676,11 +675,9 @@ public class DirectTopicPartitionChannel implements TopicPartitionChannel {
     try {
       return OpenChannelRetryPolicy.executeWithRetry(
           () -> {
-            // Recreate client if invalid before each attempt
             if (!StreamingClientHandler.isClientValid(streamingIngestClient)) {
-              this.streamingIngestClient =
-                  StreamingClientProvider.getStreamingClientProviderInstance()
-                      .recreateClient(sfConnectorConfig);
+              LOGGER.warn("Client is invalid, recreating client for channel: {}", getChannelNameFormatV1());
+              this.streamingIngestClient = StreamingClientProvider.getStreamingClientProviderInstance().getClient(sfConnectorConfig);
             }
             return streamingIngestClient.openChannel(channelRequest);
           },

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/DirectTopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/DirectTopicPartitionChannel.java
@@ -415,7 +415,8 @@ public class DirectTopicPartitionChannel implements TopicPartitionChannel {
       throws TopicPartitionChannelInsertionException {
     if (isClientInvalidError(ex)) {
       LOGGER.warn("Client is invalid, recreating client for channel: {}", getChannelNameFormatV1());
-      this.streamingIngestClient = StreamingClientProvider.getStreamingClientProviderInstance().getClient(sfConnectorConfig);
+      this.streamingIngestClient =
+          StreamingClientProvider.getStreamingClientProviderInstance().getClient(sfConnectorConfig);
     }
     final long offsetRecoveredFromSnowflake =
         streamingApiFallbackSupplier(StreamingApiFallbackInvoker.INSERT_ROWS_FALLBACK);
@@ -676,8 +677,11 @@ public class DirectTopicPartitionChannel implements TopicPartitionChannel {
       return OpenChannelRetryPolicy.executeWithRetry(
           () -> {
             if (!StreamingClientHandler.isClientValid(streamingIngestClient)) {
-              LOGGER.warn("Client is invalid, recreating client for channel: {}", getChannelNameFormatV1());
-              this.streamingIngestClient = StreamingClientProvider.getStreamingClientProviderInstance().getClient(sfConnectorConfig);
+              LOGGER.warn(
+                  "Client is invalid, recreating client for channel: {}", getChannelNameFormatV1());
+              this.streamingIngestClient =
+                  StreamingClientProvider.getStreamingClientProviderInstance()
+                      .getClient(sfConnectorConfig);
             }
             return streamingIngestClient.openChannel(channelRequest);
           },

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/DirectTopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/DirectTopicPartitionChannel.java
@@ -40,6 +40,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import net.snowflake.ingest.streaming.*;
+import net.snowflake.ingest.utils.ErrorCode;
 import net.snowflake.ingest.utils.SFException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.errors.ConnectException;
@@ -76,7 +77,7 @@ public class DirectTopicPartitionChannel implements TopicPartitionChannel {
   // should be skipped
   private boolean needToSkipCurrentBatch = false;
 
-  private final SnowflakeStreamingIngestClient streamingIngestClient;
+  private SnowflakeStreamingIngestClient streamingIngestClient;
 
   // Topic partition Object from connect consisting of topic and partition
   private final TopicPartition topicPartition;
@@ -412,6 +413,11 @@ public class DirectTopicPartitionChannel implements TopicPartitionChannel {
    */
   private void insertRowFallbackSupplier(Throwable ex)
       throws TopicPartitionChannelInsertionException {
+    if (isClientInvalidError(ex)) {
+      this.streamingIngestClient =
+          StreamingClientProvider.getStreamingClientProviderInstance()
+              .recreateClient(sfConnectorConfig);
+    }
     final long offsetRecoveredFromSnowflake =
         streamingApiFallbackSupplier(StreamingApiFallbackInvoker.INSERT_ROWS_FALLBACK);
     throw new TopicPartitionChannelInsertionException(
@@ -476,6 +482,19 @@ public class DirectTopicPartitionChannel implements TopicPartitionChannel {
   @VisibleForTesting
   public long fetchOffsetTokenWithRetry() {
     return offsetTokenExecutor.get(this::fetchLatestCommittedOffsetFromSnowflake);
+  }
+
+  /**
+   * Checks if the exception indicates a client invalidation error.
+   *
+   * @param e the exception to check
+   * @return true if the exception is a CLOSED_CLIENT error
+   */
+  private boolean isClientInvalidError(Throwable e) {
+    if (!(e instanceof SFException)) {
+      return false;
+    }
+    return ErrorCode.CLOSED_CLIENT.getMessageCode().equals(((SFException) e).getVendorCode());
   }
 
   /**

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -403,7 +403,8 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
     partitionsToChannel.clear();
 
     SnowflakeStreamingIngestClient client =
-        StreamingClientProvider.getStreamingClientProviderInstance().getClient(this.connectorConfig);
+        StreamingClientProvider.getStreamingClientProviderInstance()
+            .getClient(this.connectorConfig);
     StreamingClientProvider.getStreamingClientProviderInstance()
         .closeClient(this.connectorConfig, client);
   }

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProvider.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProvider.java
@@ -139,9 +139,12 @@ public class StreamingClientProvider {
 
   /**
    * Gets the current client or creates a new one from the given connector config.
-   * If optimization is enabled, gets or recreates the client in the shared provider cache.
-   * If optimization is disabled, creates a new streaming client and the caller
-   * is responsible for closing it.
+   *
+   * <ul>
+   *   <li>If optimization is enabled, gets or recreates the client using the shared provider cache.
+   *   <li>If optimization is disabled, creates a new streaming client and the caller is responsible
+   *       for closing it.
+   * </ul>
    *
    * @param connectorConfig The connector config
    * @return A streaming client
@@ -178,8 +181,10 @@ public class StreamingClientProvider {
    * @param clientProperties The client properties for cache lookup
    * @return A valid client (either cached or newly created)
    */
-  public SnowflakeStreamingIngestClient getOrRecreateClient(StreamingClientProperties clientProperties) {
-    // ConcurrentHashMap.compute() ensures that only one thread recreates a client for the specified key at a time.
+  public SnowflakeStreamingIngestClient getOrRecreateClient(
+      StreamingClientProperties clientProperties) {
+    // ConcurrentHashMap.compute() ensures that only one thread recreates a client for the specified
+    // key at a time.
     return this.registeredClients
         .asMap()
         .compute(

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProvider.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProvider.java
@@ -188,15 +188,20 @@ public class StreamingClientProvider {
   public SnowflakeStreamingIngestClient recreateClient(Map<String, String> connectorConfig) {
     StreamingClientProperties clientProperties = new StreamingClientProperties(connectorConfig);
 
-    // ConcurrentHashMap.compute() ensures that only one thread recreates a client for the specified key.
-    return this.registeredClients.asMap().compute(clientProperties, (key, client) -> {
-      if (StreamingClientHandler.isClientValid(client)) {
-        LOGGER.info("Client was already recreated by another thread: {}", client.getName());
-        return client;
-      }
-      LOGGER.info("Recreating client: {}", clientProperties.toString());
-      return this.streamingClientHandler.createClient(clientProperties);
-    });
+    // ConcurrentHashMap.compute() ensures that only one thread recreates a client for the specified
+    // key.
+    return this.registeredClients
+        .asMap()
+        .compute(
+            clientProperties,
+            (key, client) -> {
+              if (StreamingClientHandler.isClientValid(client)) {
+                LOGGER.info("Client was already recreated by another thread: {}", client.getName());
+                return client;
+              }
+              LOGGER.info("Recreating client: {}", clientProperties.toString());
+              return this.streamingClientHandler.createClient(clientProperties);
+            });
   }
 
   /**

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/StreamingIngestClientV2Provider.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/StreamingIngestClientV2Provider.java
@@ -58,7 +58,8 @@ public class StreamingIngestClientV2Provider {
         LOGGER.warn("Client is invalid, recreating client for pipe: {}", pipeName);
         oldClient.close();
       }
-      pipeToClientMap.put(pipeName, createClient(connectorConfig, pipeName, streamingClientProperties));
+      pipeToClientMap.put(
+          pipeName, createClient(connectorConfig, pipeName, streamingClientProperties));
     }
   }
 

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelIT.java
@@ -65,12 +65,14 @@ public class TopicPartitionChannelIT {
 
   /**
    * Tests that when a client is closed, the connector:
+   *
    * <ol>
    *   <li>Detects the client closed error
    *   <li>Recreates the client
    *   <li>Reopens the channel with the new client
    *   <li>Successfully inserts data
    * </ol>
+   *
    * @param ssv2Enabled whether to test SSv1 or SSv2
    */
   @ParameterizedTest

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/TopicPartitionChannelIT.java
@@ -65,11 +65,12 @@ public class TopicPartitionChannelIT {
 
   /**
    * Tests that when a client is closed, the connector:
-   * 1. Detects the client closed error
-   * 2. Recreates the client
-   * 3. Reopens the channel with the new client
-   * 4. Successfully inserts data
-   *
+   * <ol>
+   *   <li>Detects the client closed error
+   *   <li>Recreates the client
+   *   <li>Reopens the channel with the new client
+   *   <li>Successfully inserts data
+   * </ol>
    * @param ssv2Enabled whether to test SSv1 or SSv2
    */
   @ParameterizedTest
@@ -90,8 +91,7 @@ public class TopicPartitionChannelIT {
     service.startPartition(testTableName, topicPartition);
 
     // Insert initial records to verify setup
-    List<SinkRecord> initialRecords =
-        TestUtils.createJsonStringSinkRecords(0, 5, topic, PARTITION);
+    List<SinkRecord> initialRecords = TestUtils.createJsonStringSinkRecords(0, 5, topic, PARTITION);
     service.insert(initialRecords);
 
     TestUtils.assertWithRetry(() -> service.getOffset(topicPartition) == 5);


### PR DESCRIPTION
<!-- Text inside of HTML comment blocks will NOT appear in your pull request description -->

<!-- Formatting information can be found at https://www.markdownguide.org/basic-syntax/ -->

# Overview

SNOW-2193898 Support transparent failover with [Client Redirect](https://docs.snowflake.com/en/user-guide/client-redirect) in streaming mode

## Problem

When Streaming Ingest SDK returns a `CLOSED_CLIENT` error, Kafka Connector will attempt to reopen channels with the same closed client, leading to repeated failures.

Customers are currently required to manually restart their KC after changing deployment: https://docs.snowflake.com/en/user-guide/snowpipe-streaming/snowpipe-streaming-classic-kafka#failover-limitations

## Solution

Implement automatic client recreation when a `CLOSED_CLIENT` error is detected. Streaming Ingest SDK will separately be updated to close the client when it detects a change to the primary deployment.

## Changes

### SSv1

- `DirectTopicPartitionChannel`
    - Make `streamingIngestClient` field non-final to allow updates
    - Update `insertRowFallbackSupplier()` to call `StreamingClientProvider.recreateClient()` when client is closed

### SSv2

- `SnowpipeStreamingV2PartitionChannel`
    - Add `CLIENT_CLOSED_ERROR_CODE` constant with TODO (SSv2 SDK does not yet return structured error codes)
    - Update `insertRowFallbackSupplier()` to call `StreamingIngestClientV2Provider.recreateClient()`

### Client optimization

Be mindful to support both optimized and unoptimized path. To summarize:

- If optimization is **enabled**, all client with the same client properties will share a single client, managed by the `StreamingClientProvider`​. In this case, the `SinkService`​ **does not** cache the client.
- If optimization is **disabled**, every `SinkService`​ manages its own client and the shared cache managed by StreamingClientProvider is not used. In this case, `SinkService`​ **must** maintain its own reference to the client object and handle closing (which in the optimized path is done by the provider cache eviction policy).

## Testing

- [x] Added IT `testClientRecreationOn_ClosedClientError()` that validates:
    1. Client is closed (simulating CLOSED_CLIENT error)
    2. New client is created on next operation
    3. Data continues to be inserted successfully
    4. Works for both SSv1 and SSv2

## Urgency

This review is **high** priority. Customer requesting KC streaming ingest support for Client Redirect.

## Risks

Client recreate is an expensive operation. However:

1. The current response of reopening channel without fixing the underlying issue is wasteful.
2. A well-behaved customer following documentation will already be performing this action automatically when changing primary deployments.

## Backward/forward compatible

[x] This change does not introduce any breaking API or data format changes.

## Pre-review checklist

- [ ] This change should be part of a Behavior Change Release. See [go/behavior-change](http://go/behavior-change).
- [ ] This change has passed Merge gate tests
- [ ] Snowpipe Changes
- [x] Snowpipe Streaming Changes
- [ ] This change is TEST-ONLY
- [ ] This change is README/Javadocs only
- [ ] This change is protected by a config parameter \<PARAMETER_NAME> eg `snowflake.ingestion.method`.
    - [ ] `Yes` - Added end to end and Unit Tests.
    - [x] `No` - This change should be enabled on all KC instances.
- [ ] Is this change protected by parameter \<PARAMETER_NAME> on the server side?
    - [ ] The parameter/feature is not yet active in production (partial rollout or PrPr, see [Changes for Unreleased Features and Fixes](http://go/ppp-prpr)).
    - [ ] If there is an issue, it can be safely mitigated by turning the parameter off. This is also verified by a test (See [go/ppp](http://go/ppp)).