### PR TITLE
Change Confluent manifest to publish as the same listing

### DIFF
--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -188,7 +188,7 @@
                             <goal>kafka-connect</goal>
                         </goals>
                         <configuration>
-                            <title>Snowflake High Performance Sink Connector</title>
+                            <title>Snowflake Sink Connector</title>
                             <documentationUrl>
                                 https://docs.snowflake.com/en/connectors/kafkahp/about
                             </documentationUrl>
@@ -209,7 +209,6 @@
                                 in production, please contact Snowflake Support
                                 before doing so.
                             </supportSummary>
-                            <name>snowflake-kafka-connector-hp</name>
                             <ownerUsername>snowflakeinc</ownerUsername>
                             <ownerType>organization</ownerType>
                             <ownerName>Snowflake Inc.</ownerName>


### PR DESCRIPTION
This PR reverts some changes in manifest that have been done in #1253 to publish connector as a new listing on Confluent. We changed that decision and now the connector will be published as a new version of existing connector. 