### PR TITLE
Add JVM profiling infrastructure for CPU and memory analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ CLAUDE.md
 .mcp.json
 profile.txt
 profile_qa3.json
+profiling-results*/

--- a/test/docker/docker-compose.profile-apache.yml
+++ b/test/docker/docker-compose.profile-apache.yml
@@ -1,0 +1,40 @@
+# Profiling overlay for Apache Kafka (single-container mode).
+# Layers JFR, GC logging, JMX, and async-profiler support onto the kafka service.
+#
+# Usage:
+#   docker compose -f docker-compose.base.yml -f docker-compose.apache.yml \
+#                  -f docker-compose.profile-apache.yml up
+#
+# Or via run_tests.sh:
+#   ./run_tests.sh --platform=apache --platform-version=3.7.0 --profile [--keep] -- ...
+#
+# Note: KAFKA_HEAP_OPTS applies to all JVMs in the container (ZK, broker, Connect).
+# The 2g heap is shared across ZK + broker + Connect, which may be tight for
+# large-scale profiling workloads. Use the Confluent platform for heavy tests.
+# JFR and GC logs capture the Connect worker process specifically because
+# connect-distributed.sh is the last process started and inherits these flags.
+
+services:
+  kafka:
+    cap_add:
+      - SYS_PTRACE
+    ports:
+      - "127.0.0.1:9999:9999"
+    environment:
+      KAFKA_HEAP_OPTS: >-
+        -Xms512m -Xmx2g
+        -XX:StartFlightRecording=name=profile,filename=/tmp/profile/kc-profile.jfr,settings=profile,maxsize=500m,dumponexit=true
+        -XX:FlightRecorderOptions=stackdepth=256
+        -Xlog:gc*:file=/tmp/profile/gc.log:time,uptime,level,tags:filecount=5,filesize=50m
+        -XX:+HeapDumpOnOutOfMemoryError
+        -XX:HeapDumpPath=/tmp/profile/heapdump.hprof
+        -Dcom.sun.management.jmxremote
+        -Dcom.sun.management.jmxremote.port=9999
+        -Dcom.sun.management.jmxremote.rmi.port=9999
+        -Dcom.sun.management.jmxremote.authenticate=false
+        -Dcom.sun.management.jmxremote.ssl=false
+        -Djava.rmi.server.hostname=localhost
+    tmpfs:
+      - /tmp/profile:uid=1000,gid=1000
+    volumes:
+      - ${ASYNC_PROFILER_PATH:-/dev/null}:/opt/async-profiler:ro

--- a/test/docker/docker-compose.profile-confluent.yml
+++ b/test/docker/docker-compose.profile-confluent.yml
@@ -1,0 +1,45 @@
+# Profiling overlay for Confluent Platform.
+# Layers JFR, GC logging, JMX, and async-profiler support onto kafka-connect.
+#
+# Usage:
+#   docker compose -f docker-compose.base.yml -f docker-compose.confluent.yml \
+#                  -f docker-compose.profile-confluent.yml up
+#
+# Or via run_tests.sh:
+#   ./run_tests.sh --platform=confluent --platform-version=7.8.0 --profile [--keep] -- ...
+#
+# Collecting results:
+#   - JFR recording:  test/scripts/profile_connect.sh jfr-dump
+#   - GC logs:        test/scripts/profile_connect.sh collect ./results
+#   - Heap dumps:     test/scripts/profile_connect.sh heap-dump
+#   - Flame graphs:   test/scripts/profile_connect.sh async-cpu 60
+#
+# Analysis:
+#   - JFR:  jfr summary kc-profile.jfr  OR  open in JDK Mission Control
+#   - GC:   https://gceasy.io
+#   - Heap: Eclipse MAT
+
+services:
+  kafka-connect:
+    cap_add:
+      - SYS_PTRACE
+    ports:
+      - "9999:9999"
+    environment:
+      KAFKA_HEAP_OPTS: >-
+        -Xms512m -Xmx6g
+        -XX:StartFlightRecording=name=profile,filename=/tmp/profile/kc-profile.jfr,settings=profile,maxsize=500m,dumponexit=true
+        -XX:FlightRecorderOptions=stackdepth=256
+        -Xlog:gc*:file=/tmp/profile/gc.log:time,uptime,level,tags:filecount=5,filesize=50m
+        -XX:+HeapDumpOnOutOfMemoryError
+        -XX:HeapDumpPath=/tmp/profile/heapdump.hprof
+        -Dcom.sun.management.jmxremote
+        -Dcom.sun.management.jmxremote.port=9999
+        -Dcom.sun.management.jmxremote.rmi.port=9999
+        -Dcom.sun.management.jmxremote.authenticate=false
+        -Dcom.sun.management.jmxremote.ssl=false
+        -Djava.rmi.server.hostname=localhost
+    tmpfs:
+      - /tmp/profile:uid=1000,gid=1000
+    volumes:
+      - ${ASYNC_PROFILER_PATH:-/dev/null}:/opt/async-profiler:ro

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -63,6 +63,7 @@ usage() {
     echo "  --cloud=CLOUD        Snowflake cloud platform: AWS, GCP, or AZURE"
     echo "  --java-version=VER   Java version for Apache Kafka (default: 11)"
     echo "  --jmx                Enable JMX metrics scraping via Jolokia"
+    echo "  --profile            Enable JVM profiling (JFR, GC logs, JMX, async-profiler)"
     echo "  --keep               Keep containers running after tests"
     echo "  -i, --interactive    Start infra, then drop into a bash shell in the test-runner"
     echo "  --rebuild            Force rebuild of images"
@@ -83,6 +84,7 @@ usage() {
     echo "  $0 --platform=confluent --platform-version=7.8.0 -- -k test_string_json"
     echo "  $0 --platform=apache --platform-version=3.7.0 --keep -- -m pressure"
     echo "  $0 --platform=confluent --platform-version=7.8.0 -i   # interactive shell"
+    echo "  $0 --platform=confluent --platform-version=7.8.0 --profile --keep -- -m pressure"
     echo "  $0 --platform=confluent --platform-version=7.8.0 --logs-dir=/tmp/test-logs"
     exit 1
 }
@@ -92,6 +94,7 @@ PLATFORM="confluent"
 PLATFORM_VERSION="7.8.0"
 JAVA_VERSION="11"
 JMX_ENABLED="false"
+PROFILE_ENABLED="false"
 KEEP_RUNNING="false"
 INTERACTIVE="false"
 FORCE_REBUILD="false"
@@ -118,6 +121,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --jmx)
             JMX_ENABLED="true"
+            shift
+            ;;
+        --profile)
+            PROFILE_ENABLED="true"
             shift
             ;;
         --keep)
@@ -218,6 +225,13 @@ case $PLATFORM in
         error_exit "Unknown platform: $PLATFORM (supported: confluent, apache)"
         ;;
 esac
+
+# Layer profiling overlay (platform-specific to avoid undefined service errors)
+if [ "$PROFILE_ENABLED" = "true" ]; then
+    COMPOSE_FILES="$COMPOSE_FILES -f docker-compose.profile-${PLATFORM}.yml"
+    info "Profiling enabled: JFR, GC logs, JMX (port 9999), heap dump on OOM"
+    info "Use test/scripts/profile_connect.sh to interact with the profiler"
+fi
 
 # Check prerequisites
 command -v docker >/dev/null 2>&1 || error_exit "Docker is not installed"
@@ -369,6 +383,14 @@ if [ "$PLATFORM" = "apache" ]; then
     fi
 fi
 
+# When profiling, force-remove stale containers from prior --keep runs.
+# Bind mounts (plugin JARs) become stale if the host directory was recreated
+# while a kept container still held the old mount inode.
+if [ "$PROFILE_ENABLED" = "true" ]; then
+    info "Cleaning stale containers for fresh profiling..."
+    docker compose $COMPOSE_FILES down -v --remove-orphans 2>/dev/null || true
+fi
+
 # Start services
 info "Starting services: $START_SERVICES"
 docker compose $COMPOSE_FILES up -d $START_SERVICES
@@ -391,6 +413,24 @@ echo ""
 
 if [ $ELAPSED -ge $TIMEOUT ]; then
     error_exit "Services failed to become healthy within ${TIMEOUT}s"
+fi
+
+# Reset profiling to a clean slate (discard startup/warmup data from prior runs)
+if [ "$PROFILE_ENABLED" = "true" ]; then
+    PROFILE_CONTAINER=$(docker compose $COMPOSE_FILES ps -q $HEALTH_CHECK_SERVICE)
+    if [ -n "$PROFILE_CONTAINER" ]; then
+        info "Resetting JFR recording to clean slate..."
+        docker exec "$PROFILE_CONTAINER" sh -c '
+            rm -f /tmp/profile/kc-profile-*.jfr /tmp/profile/flamegraph-*.html 2>/dev/null
+            PID=$(jcmd 2>/dev/null | grep -v jcmd | head -1 | awk "{print \$1}")
+            if [ -n "$PID" ]; then
+                jcmd "$PID" JFR.stop name=profile 2>/dev/null || true
+                jcmd "$PID" JFR.start name=profile filename=/tmp/profile/kc-profile.jfr \
+                    settings=profile maxsize=500m dumponexit=true 2>/dev/null || true
+            fi
+        ' 2>/dev/null || warn "JFR reset failed — profiling data may include startup noise"
+        info "JFR recording restarted — clean slate for this test run"
+    fi
 fi
 
 # Start JMX metrics scraper in the background
@@ -498,6 +538,15 @@ if [ "$JMX_ENABLED" = "true" ]; then
     if [ "$METRICS_LINES" -gt 0 ] 2>/dev/null; then
         echo -e "${GREEN}  Analyze: ${PROJECT_ROOT}/test/scripts/analyze_metrics.sh ${METRICS_FILE}${NC}"
     fi
+    echo -e "${GREEN}========================================${NC}"
+fi
+
+if [ "$PROFILE_ENABLED" = "true" ]; then
+    echo ""
+    echo -e "${GREEN}========================================${NC}"
+    echo -e "${GREEN}  Profiling artifacts in container${NC}"
+    echo -e "${GREEN}  Collect: $PROJECT_ROOT/test/scripts/profile_connect.sh collect [DIR]${NC}"
+    echo -e "${GREEN}  Status:  $PROJECT_ROOT/test/scripts/profile_connect.sh status${NC}"
     echo -e "${GREEN}========================================${NC}"
 fi
 

--- a/test/scripts/profile_connect.sh
+++ b/test/scripts/profile_connect.sh
@@ -1,0 +1,219 @@
+#!/bin/bash
+#
+# Profile the Kafka Connect worker running in Docker.
+#
+# Wraps JFR and async-profiler commands against the Kafka Connect container.
+# Requires the profiling overlay (docker-compose.profile-confluent.yml or
+# docker-compose.profile-apache.yml) to be active.
+#
+# Usage:
+#   ./profile_connect.sh <command> [options]
+#
+# Commands:
+#   jfr-dump                    Dump the continuous JFR recording to a file
+#   jfr-stop                    Stop JFR and dump final recording
+#   heap-dump                   Take a heap dump (hprof)
+#   thread-dump                 Print thread dump to stdout
+#   async-cpu [DURATION]        CPU flame graph via async-profiler (default: 60s)
+#   async-alloc [DURATION]      Allocation flame graph via async-profiler (default: 60s)
+#   async-wall [DURATION]       Wall-clock flame graph via async-profiler (default: 60s)
+#   collect [OUTPUT_DIR]        Collect all profiling artifacts from the container
+#   status                      Show JFR recording status and JVM info
+#
+# Examples:
+#   ./profile_connect.sh status
+#   ./profile_connect.sh async-cpu 30
+#   ./profile_connect.sh jfr-dump
+#   ./profile_connect.sh heap-dump
+#   ./profile_connect.sh collect ./profiling-results
+#
+# Prerequisites:
+#   - Containers running with docker-compose.profile.yml overlay
+#   - For async-* commands: async-profiler mounted via ASYNC_PROFILER_PATH env var
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DOCKER_DIR="$SCRIPT_DIR/../docker"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+error_exit() { echo -e "${RED}ERROR: $1${NC}" >&2; exit 1; }
+info() { echo -e "${GREEN}INFO: $1${NC}"; }
+warn() { echo -e "${YELLOW}WARN: $1${NC}"; }
+
+# Detect which container is running Kafka Connect
+detect_container() {
+    local project_root
+    project_root="$(cd "$SCRIPT_DIR/../.." && pwd)"
+    local project_name
+    project_name="$(basename "$project_root")"
+
+    # Try confluent kafka-connect first, then apache kafka
+    local container
+    container=$(docker ps --filter "name=${project_name}.*kafka-connect" --format '{{.Names}}' | head -1)
+    if [ -z "$container" ]; then
+        container=$(docker ps --filter "name=${project_name}.*kafka" --format '{{.Names}}' | head -1)
+    fi
+
+    if [ -z "$container" ]; then
+        error_exit "No Kafka Connect container found. Is the test environment running?"
+    fi
+    echo "$container"
+}
+
+# Find the Kafka Connect JVM PID inside the container
+find_kc_pid() {
+    local container="$1"
+    # Kafka Connect main class
+    local pid
+    pid=$(docker exec "$container" jcmd 2>/dev/null \
+        | grep -i "ConnectDistributed\|connect-distributed" \
+        | awk '{print $1}' | head -1)
+
+    if [ -z "$pid" ]; then
+        # Fallback: find any java process
+        pid=$(docker exec "$container" jcmd 2>/dev/null \
+            | grep -v "^$\|jcmd" | head -1 | awk '{print $1}')
+    fi
+
+    if [ -z "$pid" ]; then
+        error_exit "Cannot find Kafka Connect JVM PID in container $container"
+    fi
+    echo "$pid"
+}
+
+COMMAND="${1:-help}"
+shift || true
+
+case "$COMMAND" in
+    status)
+        CONTAINER=$(detect_container)
+        PID=$(find_kc_pid "$CONTAINER")
+        info "Container: $CONTAINER"
+        info "Kafka Connect PID: $PID"
+        echo ""
+        echo "=== JFR Recordings ==="
+        docker exec "$CONTAINER" jcmd "$PID" JFR.check 2>/dev/null || echo "(no JFR recordings)"
+        echo ""
+        echo "=== VM Info ==="
+        docker exec "$CONTAINER" jcmd "$PID" VM.info 2>/dev/null | head -20
+        echo ""
+        echo "=== Heap Usage ==="
+        docker exec "$CONTAINER" jcmd "$PID" GC.heap_info 2>/dev/null || true
+        ;;
+
+    jfr-dump)
+        CONTAINER=$(detect_container)
+        PID=$(find_kc_pid "$CONTAINER")
+        OUTFILE="/tmp/profile/kc-profile-$(date +%Y%m%d-%H%M%S).jfr"
+        info "Dumping JFR recording to $OUTFILE..."
+        docker exec "$CONTAINER" jcmd "$PID" JFR.dump name=profile filename="$OUTFILE"
+        info "Done. Retrieve with: docker cp $CONTAINER:$OUTFILE ."
+        ;;
+
+    jfr-stop)
+        CONTAINER=$(detect_container)
+        PID=$(find_kc_pid "$CONTAINER")
+        OUTFILE="/tmp/profile/kc-profile-final.jfr"
+        info "Stopping JFR recording..."
+        docker exec "$CONTAINER" jcmd "$PID" JFR.stop name=profile filename="$OUTFILE"
+        info "Final recording at $OUTFILE"
+        info "Retrieve with: docker cp $CONTAINER:$OUTFILE ."
+        ;;
+
+    heap-dump)
+        CONTAINER=$(detect_container)
+        PID=$(find_kc_pid "$CONTAINER")
+        OUTFILE="/tmp/profile/heap-$(date +%Y%m%d-%H%M%S).hprof"
+        info "Taking heap dump (this may pause the JVM briefly)..."
+        docker exec "$CONTAINER" jcmd "$PID" GC.heap_dump "$OUTFILE"
+        info "Heap dump at $OUTFILE"
+        info "Retrieve with: docker cp $CONTAINER:$OUTFILE ."
+        ;;
+
+    thread-dump)
+        CONTAINER=$(detect_container)
+        PID=$(find_kc_pid "$CONTAINER")
+        docker exec "$CONTAINER" jcmd "$PID" Thread.print
+        ;;
+
+    async-cpu|async-alloc|async-wall)
+        CONTAINER=$(detect_container)
+        PID=$(find_kc_pid "$CONTAINER")
+        DURATION="${1:-60}"
+        EVENT="${COMMAND#async-}"
+
+        # Locate async-profiler (prefer /opt mount, fall back to /tmp copy)
+        ASPROF=""
+        for candidate in /opt/async-profiler/bin/asprof /tmp/async-profiler/bin/asprof; do
+            if docker exec "$CONTAINER" test -f "$candidate" 2>/dev/null; then
+                ASPROF="$candidate"
+                break
+            fi
+        done
+        if [ -z "$ASPROF" ]; then
+            error_exit "async-profiler not found in container. Set ASYNC_PROFILER_PATH or docker cp it to /tmp/async-profiler/."
+        fi
+
+        # Use itimer for cpu profiling — perf_event_open is typically restricted
+        # in containers even with SYS_PTRACE. itimer uses SIGPROF instead.
+        if [ "$EVENT" = "cpu" ]; then
+            EVENT="itimer"
+        fi
+
+        OUTFILE="/tmp/profile/flamegraph-${COMMAND#async-}-$(date +%Y%m%d-%H%M%S).html"
+        info "Profiling $EVENT for ${DURATION}s (PID $PID)..."
+        docker exec "$CONTAINER" "$ASPROF" \
+            -d "$DURATION" -f "$OUTFILE" -e "$EVENT" "$PID"
+        info "Flame graph at $OUTFILE"
+        info "Retrieve with: docker cp $CONTAINER:$OUTFILE ."
+        ;;
+
+    collect)
+        CONTAINER=$(detect_container)
+        OUTPUT_DIR="${1:-./profiling-results-$(date +%Y%m%d-%H%M%S)}"
+        mkdir -p "$OUTPUT_DIR"
+
+        info "Collecting profiling artifacts from $CONTAINER into $OUTPUT_DIR/"
+
+        # Dump JFR before collecting
+        PID=$(find_kc_pid "$CONTAINER")
+        docker exec "$CONTAINER" jcmd "$PID" JFR.dump name=profile \
+            filename="/tmp/profile/kc-profile-collected.jfr" 2>/dev/null || true
+
+        # Copy via tar pipe — docker cp cannot read from tmpfs mounts
+        if ! docker exec "$CONTAINER" test -d /tmp/profile 2>/dev/null; then
+            warn "/tmp/profile does not exist in container. Was --profile enabled?"
+        elif [ "$(docker exec "$CONTAINER" find /tmp/profile -maxdepth 1 -type f | wc -l)" -eq 0 ]; then
+            warn "/tmp/profile is empty — no profiling artifacts to collect."
+        else
+            docker exec "$CONTAINER" tar cf - -C /tmp/profile . \
+                | tar xf - -C "$OUTPUT_DIR/"
+        fi
+
+        info "Collected artifacts:"
+        ls -lh "$OUTPUT_DIR/"
+
+        # Print analysis hints
+        echo ""
+        echo "=== Analysis ==="
+        echo "  JFR:    jfr summary $OUTPUT_DIR/kc-profile-collected.jfr"
+        echo "          jfr print --events jdk.ExecutionSample $OUTPUT_DIR/*.jfr | head -100"
+        echo "          jfr print --events jdk.ObjectAllocationSample $OUTPUT_DIR/*.jfr | head -100"
+        echo "  GC:     Upload $OUTPUT_DIR/gc.log to https://gceasy.io"
+        echo "  Heap:   Open $OUTPUT_DIR/*.hprof in Eclipse MAT"
+        echo "  Flames: Open $OUTPUT_DIR/flamegraph-*.html in a browser"
+        ;;
+
+    help|--help|-h)
+        head -30 "$0" | grep "^#" | sed 's/^# \?//'
+        ;;
+
+    *)
+        error_exit "Unknown command: $COMMAND. Run '$0 help' for usage."
+        ;;
+esac

--- a/test/tests/pressure/test_perf_backlog_drain.py
+++ b/test/tests/pressure/test_perf_backlog_drain.py
@@ -1,0 +1,211 @@
+"""
+P1 Backlog Drain — profiling-friendly performance test.
+
+Defaults: 4 partitions × 1M records × ~250 bytes = 4M rows (~1 GB).
+All parameters are tunable via environment variables (see below).
+
+Scenario:
+  1. Create a single topic with DRAIN_PARTITIONS partitions (default 4).
+  2. Loader phase: pre-populate the topic with DRAIN_RECORDS_PER_PARTITION
+     records per partition.  Each message is a ~250-byte JSON row.
+  3. KC phase: start a Snowflake Streaming connector with DRAIN_TASKS_MAX
+     tasks (default 8) to drain the full topic from offset 0 ("cold start").
+     Runs for up to DRAIN_KC_TIMEOUT seconds (default 900).
+  4. Post-run: log final offsets, row counts, and drain time.
+
+Usage:
+  ./run_tests.sh --platform=confluent --platform-version=7.8.0 --profile --keep \\
+      -- tests/pressure/test_perf_backlog_drain.py
+
+  # Larger run (e.g. ~144M rows / ~38 GB):
+  DRAIN_PARTITIONS=4 DRAIN_RECORDS_PER_PARTITION=36000000 \\
+  ./run_tests.sh ... -- tests/pressure/test_perf_backlog_drain.py
+"""
+
+import json
+import logging
+import os
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+import pytest
+
+from lib.config_migration import V4_CONFIG_TEMPLATE
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Tunables — override via environment variables for quick profiling runs
+# ---------------------------------------------------------------------------
+PARTITION_COUNT = int(os.environ.get("DRAIN_PARTITIONS", "4"))
+TASKS_MAX = int(os.environ.get("DRAIN_TASKS_MAX", "8"))
+RECORDS_PER_PARTITION = int(os.environ.get("DRAIN_RECORDS_PER_PARTITION", "1_000_000"))
+LOADER_THREADS = int(os.environ.get("DRAIN_LOADER_THREADS", "4"))
+BATCH_SIZE = int(os.environ.get("DRAIN_BATCH_SIZE", "50_000"))
+KC_TIMEOUT = int(os.environ.get("DRAIN_KC_TIMEOUT", "900"))
+ROW_SIZE_APPROX = 250  # bytes per JSON message
+
+
+def _make_row(partition: int, id: int) -> bytes:
+    """Build a single JSON message (~250 bytes)."""
+    return json.dumps(
+        {
+            "MESSAGE": f"p{partition}-{id}",
+            "TIMESTAMP": int(time.time() * 1000),
+            "ID": id,
+            "PARTITION": partition,
+            "ROW_SIZE_IN_BYTES": ROW_SIZE_APPROX,
+        }
+    ).encode("utf-8")
+
+
+def _load_partition(driver, topic: str, partition: int, total: int, batch: int):
+    """Send `total` records to a single partition in batches."""
+    sent = 0
+    while sent < total:
+        chunk = min(batch, total - sent)
+        values = [_make_row(partition, sent + i) for i in range(chunk)]
+        driver.sendBytesData(topic, values, key=None, partition=partition)
+        sent += chunk
+        if sent % 200_000 == 0 or sent == total:
+            logger.info(
+                "Loader p%d: %d / %d (%.1f%%)",
+                partition,
+                sent,
+                total,
+                100 * sent / total,
+            )
+    return sent
+
+
+@pytest.mark.pressure
+@pytest.mark.parametrize("connector_version", ["v4"], indirect=True)
+def test_perf_backlog_drain(
+    driver,
+    name_salt,
+    create_topics,
+    create_custom_connector,
+    wait_for_rows,
+):
+    total_records = PARTITION_COUNT * RECORDS_PER_PARTITION
+    total_bytes = total_records * ROW_SIZE_APPROX
+    logger.info(
+        "=== P1 Backlog Drain: %d partitions × %d records = %d total (%.1f GB) ===",
+        PARTITION_COUNT,
+        RECORDS_PER_PARTITION,
+        total_records,
+        total_bytes / 1e9,
+    )
+
+    # -----------------------------------------------------------------------
+    # 1. Topic setup
+    # -----------------------------------------------------------------------
+    topic_unsalted = "perf_backlog_drain"
+    topics = create_topics(
+        [topic_unsalted],
+        num_partitions=PARTITION_COUNT,
+    )
+    topic = topics[0]
+    logger.info("Topic created: %s (%d partitions)", topic, PARTITION_COUNT)
+
+    # -----------------------------------------------------------------------
+    # 2. Loader phase — fill the topic before starting KC
+    # -----------------------------------------------------------------------
+    logger.info(
+        "=== Loader phase: %d threads, %d records/partition, batch=%d ===",
+        LOADER_THREADS,
+        RECORDS_PER_PARTITION,
+        BATCH_SIZE,
+    )
+    load_start = time.time()
+    with ThreadPoolExecutor(max_workers=LOADER_THREADS) as pool:
+        futures = {
+            pool.submit(
+                _load_partition,
+                driver,
+                topic,
+                p,
+                RECORDS_PER_PARTITION,
+                BATCH_SIZE,
+            ): p
+            for p in range(PARTITION_COUNT)
+        }
+        for fut in as_completed(futures):
+            p = futures[fut]
+            count = fut.result()
+            logger.info("Partition %d loaded: %d records", p, count)
+
+    load_elapsed = time.time() - load_start
+    load_throughput = total_bytes / load_elapsed / 1e6
+    logger.info(
+        "=== Loader done: %.1fs, %.1f MB/s ===",
+        load_elapsed,
+        load_throughput,
+    )
+
+    # -----------------------------------------------------------------------
+    # 3. KC phase — connector starts cold against a full topic
+    # -----------------------------------------------------------------------
+    logger.info(
+        "=== KC phase: %d tasks, timeout=%ds ===",
+        TASKS_MAX,
+        KC_TIMEOUT,
+    )
+    kc_start = time.time()
+
+    connector = create_custom_connector(
+        "perf_backlog_drain",
+        {
+            **V4_CONFIG_TEMPLATE,
+            "tasks.max": str(TASKS_MAX),
+            "topics": topic,
+            "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+            "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+            "value.converter.schemas.enable": "false",
+            "snowflake.validation": os.environ.get("DRAIN_VALIDATION", "server_side"),
+            "consumer.override.max.poll.interval.ms": "600000",
+            "consumer.override.auto.offset.reset": "earliest",
+        },
+    )
+
+    driver.wait_for_connector_running(connector.name, timeout=120)
+    logger.info("Connector %s is RUNNING", connector.name)
+
+    # -----------------------------------------------------------------------
+    # 4. Wait for all rows to land in Snowflake
+    # -----------------------------------------------------------------------
+    table_name = topic
+    wait_for_rows(
+        table_name,
+        total_records,
+        timeout=KC_TIMEOUT,
+        interval=10,
+        connector_name=connector.name,
+    )
+
+    kc_elapsed = time.time() - kc_start
+    drain_throughput = total_bytes / kc_elapsed / 1e6
+    logger.info(
+        "=== KC drain complete: %.1fs, %.1f MB/s ===",
+        kc_elapsed,
+        drain_throughput,
+    )
+
+    # -----------------------------------------------------------------------
+    # 5. Post-run stats
+    # -----------------------------------------------------------------------
+    logger.info("=== Post-run stats ===")
+    logger.info("  Total records:      %d", total_records)
+    logger.info(
+        "  Load time:          %.1fs (%.1f MB/s)", load_elapsed, load_throughput
+    )
+    logger.info("  Drain time:         %.1fs (%.1f MB/s)", kc_elapsed, drain_throughput)
+    logger.info(
+        "  Rows/sec (drain):   %.0f",
+        total_records / kc_elapsed if kc_elapsed > 0 else 0,
+    )
+    row_count = driver.select_number_of_records(table_name)
+    logger.info("  Snowflake rows:     %s", row_count)
+    assert row_count == total_records, (
+        f"Expected {total_records} rows but got {row_count}"
+    )


### PR DESCRIPTION
## Summary
- Add docker-compose profiling overlays (JFR, GC logging, JMX remote, async-profiler) for both Confluent and Apache platforms
- Add `--profile` flag to `run_tests.sh` that layers the profiling overlay
- Add `profile_connect.sh` helper CLI for JFR dumps, heap dumps, thread dumps, flame graphs, and artifact collection
- Add `test_perf_backlog_drain.py` — a controlled P1 backlog drain test (1 topic, 4 partitions, configurable record count, 8 tasks)

## Test plan
- [x] Validated compose config for Confluent, Apache, and KRaft+profile combinations
- [x] Ran backlog drain test with profiling on Confluent 7.8.0
- [x] Captured CPU + allocation flame graphs via async-profiler (itimer engine)
- [x] Captured JFR recordings (9 files, 876MB total)
- [x] Analyzed JFR for CPU hotspots, allocation sites, GC behavior
- [x] Findings documented in SNOW-3356559

Jira: SNOW-3356559
