### PR TITLE
Replace O(N) metric scan with targeted removal in channel registration

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/metrics/MetricsJmxReporter.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/metrics/MetricsJmxReporter.java
@@ -103,6 +103,14 @@ public class MetricsJmxReporter {
   }
 
   /**
+   * Remove a single metric by its exact registered name. O(1) lookup vs the O(N) scan of {@link
+   * #removeMetricsFromRegistry}.
+   */
+  public boolean removeMetric(final String exactName) {
+    return metricRegistry.remove(exactName);
+  }
+
+  /**
    * Create JMXReporter Instance, which internally handles the mbean server fetching and
    * registration of Mbeans. We use codehale metrics library to achieve this. More details
    * here: @see <a href="https://metrics.dropwizard.io/4.2.0/getting-started.html">DropWizard</a>

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/telemetry/SnowflakeTelemetryChannelStatus.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/telemetry/SnowflakeTelemetryChannelStatus.java
@@ -18,7 +18,6 @@
 package com.snowflake.kafka.connector.internal.streaming.telemetry;
 
 import static com.snowflake.kafka.connector.internal.metrics.MetricsUtil.channelMetricName;
-import static com.snowflake.kafka.connector.internal.metrics.MetricsUtil.channelMetricPrefix;
 import static com.snowflake.kafka.connector.internal.streaming.channel.TopicPartitionChannel.NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE;
 
 import com.codahale.metrics.Gauge;
@@ -89,6 +88,8 @@ public class SnowflakeTelemetryChannelStatus extends SnowflakeTelemetryBasicInfo
   private final AtomicLong backpressureRetryCount = new AtomicLong(0);
   private final AtomicLong appendRowFallbackCount = new AtomicLong(0);
   private final AtomicLong schemaEvolutionFailureCount = new AtomicLong(0);
+
+  private volatile String[] registeredMetricNames;
 
   /**
    * Creates a new object tracking {@link
@@ -168,52 +169,59 @@ public class SnowflakeTelemetryChannelStatus extends SnowflakeTelemetryBasicInfo
   }
 
   private void registerChannelJMXMetrics(MetricsJmxReporter reporter) {
-    LOGGER.debug(
-        "Registering new metrics for channel:{}, removing existing metrics:{}",
-        this.channelName,
-        reporter.getMetricRegistry().getMetrics().keySet().toString());
-    reporter.removeMetricsFromRegistry(channelMetricPrefix(this.channelName));
-
     MetricRegistry currentMetricRegistry = reporter.getMetricRegistry();
 
-    try {
-      currentMetricRegistry.register(
+    registeredMetricNames =
+        new String[] {
           channelMetricName(
               this.channelName,
               MetricsUtil.OFFSET_SUB_DOMAIN,
               MetricsUtil.OFFSET_PERSISTED_IN_SNOWFLAKE),
-          (Gauge<Long>) this.offsetPersistedInSnowflake::get);
-
-      currentMetricRegistry.register(
           channelMetricName(
               this.channelName, MetricsUtil.OFFSET_SUB_DOMAIN, MetricsUtil.PROCESSED_OFFSET),
-          (Gauge<Long>) this.processedOffset::get);
-
-      currentMetricRegistry.register(
           channelMetricName(
               this.channelName, MetricsUtil.OFFSET_SUB_DOMAIN, MetricsUtil.LATEST_CONSUMER_OFFSET),
-          (Gauge<Long>) this.latestConsumerOffset::get);
-
-      currentMetricRegistry.register(
           channelMetricName(
               this.channelName, MetricsUtil.OFFSET_SUB_DOMAIN, CHANNEL_RECOVERY_COUNT),
-          (Gauge<Long>) this.recoveryCount::get);
-    } catch (IllegalArgumentException ex) {
-      LOGGER.warn("Metrics already present:{}", ex.getMessage());
+        };
+
+    @SuppressWarnings("unchecked")
+    Gauge<Long>[] gauges =
+        new Gauge[] {
+          (Gauge<Long>) this.offsetPersistedInSnowflake::get,
+          (Gauge<Long>) this.processedOffset::get,
+          (Gauge<Long>) this.latestConsumerOffset::get,
+          (Gauge<Long>) this.recoveryCount::get,
+        };
+
+    for (int i = 0; i < registeredMetricNames.length; i++) {
+      try {
+        currentMetricRegistry.register(registeredMetricNames[i], gauges[i]);
+      } catch (IllegalArgumentException ex) {
+        // Safe: channel registration is serialized per task within open()
+        LOGGER.warn(
+            "Metric already present for channel {}, replacing: {}",
+            this.channelName,
+            registeredMetricNames[i]);
+        reporter.removeMetric(registeredMetricNames[i]);
+        currentMetricRegistry.register(registeredMetricNames[i], gauges[i]);
+      }
     }
 
-    reporter.start();
+    // JmxReporter is started once at task level (SnowflakeSinkTaskMetrics constructor).
+    // Its MetricRegistryListener auto-registers new MBeans as metrics are added.
+    // Calling start() per-channel would re-process ALL metrics: O(N) unregister + register.
   }
 
   /** Unregisters the JMX metrics if possible */
   public void tryUnregisterChannelJMXMetrics() {
     metricsJmxReporter.ifPresent(
         reporter -> {
-          LOGGER.debug(
-              "Removing metrics for channel:{}, existing metrics:{}",
-              this.channelName,
-              reporter.getMetricRegistry().getMetrics().keySet().toString());
-          reporter.removeMetricsFromRegistry(channelMetricPrefix(this.channelName));
+          if (registeredMetricNames != null) {
+            for (String name : registeredMetricNames) {
+              reporter.removeMetric(name);
+            }
+          }
         });
   }
 

--- a/src/test/java/com/snowflake/kafka/connector/internal/metrics/MetricsJmxReporterTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/metrics/MetricsJmxReporterTest.java
@@ -1,0 +1,54 @@
+package com.snowflake.kafka.connector.internal.metrics;
+
+import static org.junit.Assert.*;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricRegistry;
+import org.junit.Before;
+import org.junit.Test;
+
+public class MetricsJmxReporterTest {
+  private MetricRegistry metricRegistry;
+  private MetricsJmxReporter reporter;
+
+  @Before
+  public void setUp() {
+    metricRegistry = new MetricRegistry();
+    reporter = new MetricsJmxReporter(metricRegistry, "testConnector");
+  }
+
+  @Test
+  public void testRemoveMetricByExactName() {
+    metricRegistry.register("channel:ch1/offsets/processed-offset", (Gauge<Long>) () -> 42L);
+    metricRegistry.register("channel:ch1/offsets/persisted-offset", (Gauge<Long>) () -> 10L);
+    metricRegistry.register("channel:ch2/offsets/processed-offset", (Gauge<Long>) () -> 99L);
+
+    assertEquals(3, metricRegistry.getMetrics().size());
+
+    reporter.removeMetric("channel:ch1/offsets/processed-offset");
+
+    assertEquals(2, metricRegistry.getMetrics().size());
+    assertNull(metricRegistry.getGauges().get("channel:ch1/offsets/processed-offset"));
+    assertNotNull(metricRegistry.getGauges().get("channel:ch1/offsets/persisted-offset"));
+    assertNotNull(metricRegistry.getGauges().get("channel:ch2/offsets/processed-offset"));
+  }
+
+  @Test
+  public void testRemoveMetricNonexistentIsNoOp() {
+    metricRegistry.register("channel:ch1/offsets/processed-offset", (Gauge<Long>) () -> 42L);
+    reporter.removeMetric("channel:nonexistent/offsets/foo");
+    assertEquals(1, metricRegistry.getMetrics().size());
+  }
+
+  @Test
+  public void testRemoveMetricsFromRegistryStillWorks() {
+    metricRegistry.register("channel:ch1/offsets/a", (Gauge<Long>) () -> 1L);
+    metricRegistry.register("channel:ch1/offsets/b", (Gauge<Long>) () -> 2L);
+    metricRegistry.register("channel:ch2/offsets/a", (Gauge<Long>) () -> 3L);
+
+    reporter.removeMetricsFromRegistry("channel:ch1");
+
+    assertEquals(1, metricRegistry.getMetrics().size());
+    assertNotNull(metricRegistry.getGauges().get("channel:ch2/offsets/a"));
+  }
+}

--- a/src/test/java/com/snowflake/kafka/connector/internal/telemetry/SnowflakeTelemetryChannelStatusTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/telemetry/SnowflakeTelemetryChannelStatusTest.java
@@ -27,7 +27,7 @@ public class SnowflakeTelemetryChannelStatusTest {
     MetricsJmxReporter metricsJmxReporter =
         Mockito.spy(new MetricsJmxReporter(metricRegistry, TEST_CONNECTOR_NAME));
 
-    SnowflakeTelemetryChannelStatus snowflakeTelemetryChannelStatus =
+    SnowflakeTelemetryChannelStatus status =
         new SnowflakeTelemetryChannelStatus(
             tableName,
             connectorName,
@@ -37,15 +37,19 @@ public class SnowflakeTelemetryChannelStatusTest {
             new AtomicLong(-1),
             new AtomicLong(-1),
             new AtomicLong(-1));
-    verify(metricsJmxReporter, times(1)).start();
+
+    // Registration: 4 metrics registered, start() NOT called (handled at task level)
+    verify(metricsJmxReporter, times(0)).start();
     verify(metricRegistry, times((int) SnowflakeTelemetryChannelStatus.NUM_METRICS))
         .register(Mockito.anyString(), Mockito.any());
-    verify(metricsJmxReporter, times(1))
-        .removeMetricsFromRegistry(channelMetricPrefix(channelName));
 
-    snowflakeTelemetryChannelStatus.tryUnregisterChannelJMXMetrics();
-    verify(metricsJmxReporter, times(2))
-        .removeMetricsFromRegistry(channelMetricPrefix(channelName));
+    // No removeMatching scan should have been called during registration
+    verify(metricsJmxReporter, times(0)).removeMetricsFromRegistry(Mockito.anyString());
+
+    // Unregister: uses targeted removal (4 individual remove calls)
+    status.tryUnregisterChannelJMXMetrics();
+    verify(metricRegistry, times((int) SnowflakeTelemetryChannelStatus.NUM_METRICS))
+        .remove(Mockito.anyString());
   }
 
   @Test


### PR DESCRIPTION
## Summary
Eliminate 43.6% CPU bottleneck in `SnowflakeTelemetryChannelStatus.registerChannelJMXMetrics()` during channel creation.

**Root cause:** Two issues in the per-channel JMX metric registration path:
1. `removeMetricsFromRegistry()` did an O(N) scan of all metrics via `MetricFilter.startsWith(prefix)`, then unregistered matching MBeans
2. `reporter.start()` was called per-channel, causing JmxReporter to re-process ALL metrics (unregister + register MBeans for every metric in the registry)

**Fix:**
- Replace prefix scan with targeted `MetricRegistry.remove(exactName)` for the 4 known metric names
- Remove per-channel `reporter.start()` — JmxReporter is started once at task level (`SnowflakeSinkTaskMetrics` constructor), its `MetricRegistryListener` auto-registers new MBeans as metrics are added
- Store metric names in array for O(1) cleanup during `tryUnregisterChannelJMXMetrics()`

## Profiling results (before vs after)

Backlog drain workload: 1 topic, 4 partitions, 4M records, 8 tasks

| Component | Before (samples / %) | After (samples / %) | Change |
|-----------|---------------------|---------------------|--------|
| SF-Connector | 10,725 / 51.8% | 316 / 8.5% | -81% |
| - PartitionChannelMgr | 9,680 / 46.7% | 7 / 0.2% | **-99.9%** |
| Kafka-Connect | 1,247 / 6.0% | 1,400 / 37.8% | Now dominant (actual work) |
| JVM-Other | 3,566 / 17.2% | 1,570 / 42.4% | Normal (startup/JIT) |

## Test plan
- [x] Unit tests: `SnowflakeTelemetryChannelStatusTest` (3/3), `MetricsJmxReporterTest` (3/3), `SnowflakeSinkTaskMetricsTest` (13/13) — all pass
- [x] JFR profiling confirms `PartitionChannelManager.buildChannel` CPU dropped from 46.7% to 0.2%
- [x] async-profiler flame graphs confirm MBean registration/unregistration overhead eliminated

Jira: SNOW-3356560
