### PR TITLE
Fix data type normalization in RowValidator for v3/v4-compat parity

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/validation/DataValidationUtil.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/validation/DataValidationUtil.java
@@ -274,6 +274,42 @@ class DataValidationUtil {
   }
 
   /**
+   * Validates and parses input for VARIANT columns, returning a native Java object (Map, List, or
+   * primitive) instead of a JSON string. For String inputs this avoids the serialize→re-parse
+   * roundtrip of {@link #validateAndParseVariant}.
+   *
+   * @param input Object to validate
+   * @param insertRowIndex
+   * @return Native Java object (Map, List, String, Number, Boolean, or null for missing nodes)
+   */
+  static Object validateAndParseVariantAsObject(
+      String columnName, Object input, long insertRowIndex) {
+    JsonNode node =
+        validateAndParseSemiStructuredAsJsonTree(columnName, input, "VARIANT", insertRowIndex);
+
+    if (node.isMissingNode()) {
+      return null;
+    }
+
+    String output = node.toString();
+    int stringLength = output.getBytes(StandardCharsets.UTF_8).length;
+    if (stringLength > MAX_SEMI_STRUCTURED_LENGTH) {
+      throw valueFormatNotAllowedException(
+          columnName,
+          "VARIANT",
+          String.format(
+              "Variant too long: length=%d maxLength=%d", stringLength, MAX_SEMI_STRUCTURED_LENGTH),
+          insertRowIndex);
+    }
+    try {
+      return objectMapper.treeToValue(node, Object.class);
+    } catch (JsonProcessingException e) {
+      // Should never happen: node was already validated by validateAndParseSemiStructuredAsJsonTree
+      throw new IllegalStateException("Failed to convert validated JsonNode to Object", e);
+    }
+  }
+
+  /**
    * Validates and parses input as JSON. All types in the object tree must be valid variant types,
    * see {@link DataValidationUtil#isAllowedSemiStructuredType}.
    *
@@ -433,6 +469,43 @@ class DataValidationUtil {
           insertRowIndex);
     }
     return output;
+  }
+
+  /**
+   * Validates and parses input for ARRAY columns, returning a native Java List instead of a JSON
+   * string. For String inputs this avoids the serialize→re-parse roundtrip of {@link
+   * #validateAndParseArray}.
+   *
+   * @param input Object to validate
+   * @param insertRowIndex
+   * @return Native Java List
+   */
+  @SuppressWarnings("unchecked")
+  static List<Object> validateAndParseArrayAsList(
+      String columnName, Object input, long insertRowIndex) {
+    JsonNode jsonNode =
+        validateAndParseSemiStructuredAsJsonTree(columnName, input, "ARRAY", insertRowIndex);
+
+    if (!jsonNode.isArray()) {
+      jsonNode = objectMapper.createArrayNode().add(jsonNode);
+    }
+
+    String output = jsonNode.toString();
+    int stringLength = output.getBytes(StandardCharsets.UTF_8).length;
+    if (stringLength > MAX_SEMI_STRUCTURED_LENGTH) {
+      throw valueFormatNotAllowedException(
+          columnName,
+          "ARRAY",
+          String.format(
+              "Array too large. length=%d maxLength=%d", stringLength, MAX_SEMI_STRUCTURED_LENGTH),
+          insertRowIndex);
+    }
+    try {
+      return objectMapper.treeToValue(jsonNode, List.class);
+    } catch (JsonProcessingException e) {
+      // Should never happen: node was already validated by validateAndParseSemiStructuredAsJsonTree
+      throw new IllegalStateException("Failed to convert validated JsonNode to List", e);
+    }
   }
 
   /**
@@ -682,6 +755,52 @@ class DataValidationUtil {
               insertRowIndex, columnName, offsetDateTime));
     }
     return new TimestampWrapper(offsetDateTime, scale);
+  }
+
+  /**
+   * Validates a timestamp value and returns an ISO-formatted string. Unlike {@link
+   * #validateAndParseTimestamp} (which returns a {@link TimestampWrapper} for Parquet
+   * serialization), this method returns a human-readable ISO string suitable for passing to the
+   * SSv2 SDK.
+   *
+   * <p>This is used by RowValidator to normalize Integer/Long epoch values into unambiguous ISO
+   * strings, so the Snowflake backend interprets them correctly regardless of channel timezone.
+   *
+   * <p>Note: Unlike {@link #validateAndParseTimestamp}, this method omits the {@code scale}
+   * parameter because it only handles Integer/Long epoch inputs which have no fractional seconds.
+   *
+   * @param columnName Column name, used in error messages
+   * @param input Timestamp value (Integer, Long, String, or java.time.* object)
+   * @param defaultTimezone Timezone for inputs without timezone info
+   * @param trimTimezone true for TIMESTAMP_NTZ (strip timezone), false for LTZ/TZ
+   * @param insertRowIndex Row index for error messages
+   * @return ISO timestamp string (e.g., "2024-01-15T10:00" for NTZ, "2024-01-15T10:00Z" for LTZ)
+   */
+  static String validateAndFormatTimestamp(
+      String columnName,
+      Object input,
+      ZoneId defaultTimezone,
+      boolean trimTimezone,
+      long insertRowIndex) {
+    if (input instanceof Integer || input instanceof Long) {
+      input = input.toString();
+    }
+
+    OffsetDateTime offsetDateTime =
+        inputToOffsetDateTime(columnName, "TIMESTAMP", input, defaultTimezone, insertRowIndex);
+
+    if (trimTimezone) {
+      offsetDateTime = offsetDateTime.withOffsetSameLocal(ZoneOffset.UTC);
+    }
+    if (offsetDateTime.getYear() < 1 || offsetDateTime.getYear() > 9999) {
+      throw new SFExceptionValidation(
+          ErrorCode.INVALID_VALUE_ROW,
+          String.format(
+              "Timestamp out of representable inclusive range of years between 1 and 9999,"
+                  + " rowIndex:%d, column:%s, value:%s",
+              insertRowIndex, columnName, offsetDateTime));
+    }
+    return trimTimezone ? offsetDateTime.toLocalDateTime().toString() : offsetDateTime.toString();
   }
 
   /**
@@ -1120,7 +1239,8 @@ class DataValidationUtil {
    * @param rowIndex Index of the Input row primarily for debugging purposes.
    * @return SFExceptionValidation is thrown
    */
-  private static SFExceptionValidation valueFormatNotAllowedException(
+  // Package-private: used by RowValidator for consistent error formatting
+  static SFExceptionValidation valueFormatNotAllowedException(
       String columnName, String snowflakeType, String reason, final long rowIndex) {
     return new SFExceptionValidation(
         ErrorCode.INVALID_VALUE_ROW,

--- a/src/main/java/com/snowflake/kafka/connector/internal/validation/RowValidator.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/validation/RowValidator.java
@@ -6,13 +6,18 @@
 
 package com.snowflake.kafka.connector.internal.validation;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.snowflake.kafka.connector.Utils;
+import java.math.BigDecimal;
 import java.time.ZoneId;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,6 +32,7 @@ import org.slf4j.LoggerFactory;
  */
 public class RowValidator {
   private static final Logger logger = LoggerFactory.getLogger(RowValidator.class);
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   private final Map<String, ColumnSchema> columnSchemaMap;
 
   /**
@@ -138,8 +144,22 @@ public class RowValidator {
 
     switch (col.getLogicalType()) {
       case BOOLEAN:
-        DataValidationUtil.validateAndParseBoolean(col.getName(), value, insertRowIndex);
-        break;
+        // SSv2 SDK only accepts Boolean — normalize to avoid silent drops.
+        // Pre-reject non-0/1 Numbers for KC v3 parity: KC v3's StreamingRecordMapper stringified
+        // all values, and SSv1's convertStringToBoolean rejects e.g. "42".
+        if (value instanceof Number && !(value instanceof Boolean)) {
+          BigDecimal bd = new BigDecimal(value.toString());
+          if (bd.compareTo(BigDecimal.ZERO) != 0 && bd.compareTo(BigDecimal.ONE) != 0) {
+            throw DataValidationUtil.valueFormatNotAllowedException(
+                col.getName(),
+                "BOOLEAN",
+                "Only 0 and 1 are accepted for numeric boolean values",
+                insertRowIndex);
+          }
+        }
+        return DataValidationUtil.validateAndParseBoolean(col.getName(), value, insertRowIndex) == 1
+            ? Boolean.TRUE
+            : Boolean.FALSE;
 
       case FIXED:
         // Note: DataValidationUtil.validateAndParseBigDecimal doesn't check precision/scale
@@ -154,8 +174,26 @@ public class RowValidator {
 
       case TEXT:
       case CHAR:
+        // DVU.validateAndParseString only accepts String, Number, boolean, char — it rejects
+        // Map/Collection.  However, KC v3's StreamingRecordMapper serialized all non-textual
+        // JsonNodes to JSON strings via Jackson before the SDK saw them.  We replicate that
+        // pipeline-level serialization so v4-compat handles Map/Collection inputs the same way.
+        if (value instanceof Map || value instanceof Collection) {
+          try {
+            String json = OBJECT_MAPPER.writeValueAsString(value);
+            DataValidationUtil.validateAndParseString(
+                col.getName(), json, Optional.ofNullable(col.getLength()), insertRowIndex);
+            return json;
+          } catch (JsonProcessingException e) {
+            throw DataValidationUtil.valueFormatNotAllowedException(
+                col.getName(),
+                "STRING",
+                "Cannot serialize " + value.getClass().getSimpleName() + " to JSON",
+                insertRowIndex);
+          }
+        }
         DataValidationUtil.validateAndParseString(
-            col.getName(), value, java.util.Optional.ofNullable(col.getLength()), insertRowIndex);
+            col.getName(), value, Optional.ofNullable(col.getLength()), insertRowIndex);
         break;
 
       case BINARY:
@@ -164,10 +202,7 @@ public class RowValidator {
         // Returning byte[] sidesteps this ambiguity: byte[] is accepted uniformly regardless of
         // how that parameter is set.
         return DataValidationUtil.validateAndParseBinary(
-            col.getName(),
-            value,
-            java.util.Optional.ofNullable(col.getByteLength()),
-            insertRowIndex);
+            col.getName(), value, Optional.ofNullable(col.getByteLength()), insertRowIndex);
 
       case DATE:
         DataValidationUtil.validateAndParseDate(col.getName(), value, insertRowIndex);
@@ -179,26 +214,38 @@ public class RowValidator {
         break;
 
       case TIMESTAMP_NTZ:
-        validateTimestamp(col, value, insertRowIndex, true);
-        break;
+        return validateAndNormalizeTimestamp(col, value, /* trimTimezone= */ true, insertRowIndex);
 
       case TIMESTAMP_LTZ:
-        validateTimestamp(col, value, insertRowIndex, false);
-        break;
-
       case TIMESTAMP_TZ:
-        validateTimestamp(col, value, insertRowIndex, false);
-        break;
+        return validateAndNormalizeTimestamp(col, value, /* trimTimezone= */ false, insertRowIndex);
 
       case VARIANT:
+        // When input is a String, the SSv2 SDK stores it as a JSON-quoted string (e.g.
+        // '{"a":1}' → '"{\\"a\\":1}"'), whereas SSv1 stored the parsed native object.
+        // validateAndParseVariantAsObject returns a native Java object (Map/List/primitive)
+        // so the SDK receives the right type.
+        if (value instanceof String) {
+          return DataValidationUtil.validateAndParseVariantAsObject(
+              col.getName(), value, insertRowIndex);
+        }
         DataValidationUtil.validateAndParseVariant(col.getName(), value, insertRowIndex);
         break;
 
       case ARRAY:
+        // SSv2 SDK wraps a String value for an ARRAY column as a single-element array (e.g.
+        // "[1,2,3]" → ["[1,2,3]"]), while SSv1 parsed the string into a proper array.
+        // validateAndParseArrayAsList returns a native List so the SDK gets the right type.
+        if (value instanceof String) {
+          return DataValidationUtil.validateAndParseArrayAsList(
+              col.getName(), value, insertRowIndex);
+        }
         DataValidationUtil.validateAndParseArray(col.getName(), value, insertRowIndex);
         break;
 
       case OBJECT:
+        // No normalization needed: SSv2 SDK correctly parses JSON strings for OBJECT columns
+        // (unlike VARIANT/ARRAY). Passing the original String value through is safe.
         DataValidationUtil.validateAndParseObject(col.getName(), value, insertRowIndex);
         break;
 
@@ -210,16 +257,16 @@ public class RowValidator {
   }
 
   /**
-   * Validate a timestamp column value.
-   *
-   * @param col Column schema
-   * @param value Value to validate
-   * @param insertRowIndex Row index for error messages
-   * @param trimTimezone Whether to trim timezone (true for NTZ, false for LTZ/TZ)
+   * Validate and optionally normalize a timestamp value. Integer/Long epoch values are converted to
+   * ISO strings so the SSv2 SDK interprets them correctly; other types are validated in place.
    */
-  private void validateTimestamp(
-      ColumnSchema col, Object value, long insertRowIndex, boolean trimTimezone)
+  private Object validateAndNormalizeTimestamp(
+      ColumnSchema col, Object value, boolean trimTimezone, long insertRowIndex)
       throws SFExceptionValidation {
+    if (value instanceof Integer || value instanceof Long) {
+      return DataValidationUtil.validateAndFormatTimestamp(
+          col.getName(), value, defaultTimezone, trimTimezone, insertRowIndex);
+    }
     DataValidationUtil.validateAndParseTimestamp(
         col.getName(),
         value,
@@ -227,6 +274,7 @@ public class RowValidator {
         defaultTimezone,
         trimTimezone,
         insertRowIndex);
+    return value;
   }
 
   /** Detect columns in the row that don't exist in the table schema. */

--- a/src/test/java/com/snowflake/kafka/connector/internal/validation/DataValidationUtilTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/validation/DataValidationUtilTest.java
@@ -1551,6 +1551,121 @@ public class DataValidationUtilTest {
         () -> validateAndParseObject("COL", "}{", 0));
   }
 
+  // ================ validateAndParseVariantAsObject ================
+
+  @Test
+  public void testValidateAndParseVariantAsObject_jsonObject() {
+    Object result =
+        DataValidationUtil.validateAndParseVariantAsObject("COL", "{\"a\":1,\"b\":true}", 0);
+    Assert.assertTrue(result instanceof Map);
+    Map<?, ?> map = (Map<?, ?>) result;
+    assertEquals(1, map.get("a"));
+    assertEquals(true, map.get("b"));
+  }
+
+  @Test
+  public void testValidateAndParseVariantAsObject_jsonArray() {
+    Object result = DataValidationUtil.validateAndParseVariantAsObject("COL", "[1,2,3]", 0);
+    Assert.assertTrue(result instanceof java.util.List);
+    assertEquals(Arrays.asList(1, 2, 3), result);
+  }
+
+  @Test
+  public void testValidateAndParseVariantAsObject_primitive() {
+    assertEquals(42, DataValidationUtil.validateAndParseVariantAsObject("COL", "42", 0));
+    assertEquals(true, DataValidationUtil.validateAndParseVariantAsObject("COL", "true", 0));
+    assertEquals(
+        "hello", DataValidationUtil.validateAndParseVariantAsObject("COL", "\"hello\"", 0));
+  }
+
+  @Test
+  public void testValidateAndParseVariantAsObject_missingNode() {
+    assertNull(DataValidationUtil.validateAndParseVariantAsObject("COL", "", 0));
+    assertNull(DataValidationUtil.validateAndParseVariantAsObject("COL", "  ", 0));
+  }
+
+  @Test
+  public void testValidateAndParseVariantAsObject_invalidJson() {
+    expectError(
+        ErrorCode.INVALID_VALUE_ROW,
+        () -> DataValidationUtil.validateAndParseVariantAsObject("COL", "not_json", 0));
+  }
+
+  @Test
+  public void testValidateAndParseVariantAsObject_nativePassthrough() {
+    Map<String, Object> nativeMap = Collections.singletonMap("key", "value");
+    Object result = DataValidationUtil.validateAndParseVariantAsObject("COL", nativeMap, 0);
+    Assert.assertTrue(result instanceof Map);
+    assertEquals("value", ((Map<?, ?>) result).get("key"));
+  }
+
+  // ================ validateAndParseArrayAsList ================
+
+  @Test
+  public void testValidateAndParseArrayAsList_jsonArray() {
+    java.util.List<?> result = DataValidationUtil.validateAndParseArrayAsList("COL", "[1,2,3]", 0);
+    assertEquals(Arrays.asList(1, 2, 3), result);
+  }
+
+  @Test
+  public void testValidateAndParseArrayAsList_nonArrayWrapped() {
+    java.util.List<?> result =
+        DataValidationUtil.validateAndParseArrayAsList("COL", "\"hello\"", 0);
+    assertEquals(Collections.singletonList("hello"), result);
+  }
+
+  @Test
+  public void testValidateAndParseArrayAsList_nativeList() {
+    java.util.List<?> result =
+        DataValidationUtil.validateAndParseArrayAsList("COL", Arrays.asList(10, 20), 0);
+    assertEquals(Arrays.asList(10, 20), result);
+  }
+
+  @Test
+  public void testValidateAndParseArrayAsList_invalidJson() {
+    expectError(
+        ErrorCode.INVALID_VALUE_ROW,
+        () -> DataValidationUtil.validateAndParseArrayAsList("COL", "not_json", 0));
+  }
+
+  // ================ validateAndFormatTimestamp ================
+
+  @Test
+  public void testValidateAndFormatTimestamp_integerEpochNtz() {
+    // 1705312800 seconds = 2024-01-15T10:00:00 UTC
+    String result = DataValidationUtil.validateAndFormatTimestamp("COL", 1705312800, UTC, true, 0);
+    assertEquals("2024-01-15T10:00", result);
+  }
+
+  @Test
+  public void testValidateAndFormatTimestamp_longEpochNtz() {
+    String result = DataValidationUtil.validateAndFormatTimestamp("COL", 1705312800L, UTC, true, 0);
+    assertEquals("2024-01-15T10:00", result);
+  }
+
+  @Test
+  public void testValidateAndFormatTimestamp_integerEpochLtz() {
+    String result = DataValidationUtil.validateAndFormatTimestamp("COL", 1705312800, UTC, false, 0);
+    assertEquals("2024-01-15T10:00Z", result);
+  }
+
+  @Test
+  public void testValidateAndFormatTimestamp_stringPassthrough() {
+    // String input with explicit timezone
+    String result =
+        DataValidationUtil.validateAndFormatTimestamp(
+            "COL", "2024-01-15T13:45:30+05:00", UTC, false, 0);
+    assertEquals("2024-01-15T13:45:30+05:00", result);
+  }
+
+  @Test
+  public void testValidateAndFormatTimestamp_invalidString() {
+    expectError(
+        ErrorCode.INVALID_VALUE_ROW,
+        () ->
+            DataValidationUtil.validateAndFormatTimestamp("COL", "not_a_timestamp", UTC, true, 0));
+  }
+
   private JsonNode readTree(String value) {
     try {
       return objectMapper.readTree(value);

--- a/src/test/java/com/snowflake/kafka/connector/internal/validation/RowValidatorTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/validation/RowValidatorTest.java
@@ -910,6 +910,432 @@ public class RowValidatorTest {
         (byte[]) row.get("BIN_COL"));
   }
 
+  // ================ VARCHAR Map/List serialization Tests ================
+
+  /**
+   * Map sent to a VARCHAR column is serialized to JSON string, matching SSv1/SSv2 SDK behavior.
+   * Both SDKs serialize complex objects via Jackson inside appendRow(); RowValidator must
+   * replicate.
+   */
+  @Test
+  public void testValidateRowVarcharMapSerializedToJson() {
+    Map<String, ColumnSchema> schema = new HashMap<>();
+    schema.put(
+        "STR_COL", createColumnSchema("STR_COL", ColumnLogicalType.TEXT, true, null, null, null));
+
+    RowValidator validator = new RowValidator(schema);
+
+    Map<String, Object> inputMap = new LinkedHashMap<>();
+    inputMap.put("key", "value");
+
+    Map<String, Object> row = new HashMap<>();
+    row.put("STR_COL", inputMap);
+
+    ValidationResult result = validator.validateRow(row);
+    assertTrue(result.isValid());
+    assertEquals("{\"key\":\"value\"}", row.get("STR_COL"));
+  }
+
+  /** List sent to a VARCHAR column is serialized to JSON array string. */
+  @Test
+  public void testValidateRowVarcharListSerializedToJson() {
+    Map<String, ColumnSchema> schema = new HashMap<>();
+    schema.put(
+        "STR_COL", createColumnSchema("STR_COL", ColumnLogicalType.TEXT, true, null, null, null));
+
+    RowValidator validator = new RowValidator(schema);
+
+    Map<String, Object> row = new HashMap<>();
+    row.put("STR_COL", Arrays.asList(1, 2, 3));
+
+    ValidationResult result = validator.validateRow(row);
+    assertTrue(result.isValid());
+    assertEquals("[1,2,3]", row.get("STR_COL"));
+  }
+
+  /** Nested Map sent to VARCHAR is serialized recursively. */
+  @Test
+  public void testValidateRowVarcharNestedMapSerializedToJson() {
+    Map<String, ColumnSchema> schema = new HashMap<>();
+    schema.put(
+        "STR_COL", createColumnSchema("STR_COL", ColumnLogicalType.TEXT, true, null, null, null));
+
+    RowValidator validator = new RowValidator(schema);
+
+    Map<String, Object> nested = new LinkedHashMap<>();
+    nested.put("b", 1);
+    Map<String, Object> inputMap = new LinkedHashMap<>();
+    inputMap.put("a", nested);
+
+    Map<String, Object> row = new HashMap<>();
+    row.put("STR_COL", inputMap);
+
+    ValidationResult result = validator.validateRow(row);
+    assertTrue(result.isValid());
+    assertEquals("{\"a\":{\"b\":1}}", row.get("STR_COL"));
+  }
+
+  /** Map serialized to JSON that exceeds VARCHAR(N) length limit produces a type error. */
+  @Test
+  public void testValidateRowVarcharMapExceedsLengthLimit() {
+    Map<String, ColumnSchema> schema = new HashMap<>();
+    schema.put(
+        "STR_COL", createColumnSchema("STR_COL", ColumnLogicalType.TEXT, true, null, null, 5));
+
+    RowValidator validator = new RowValidator(schema);
+
+    Map<String, Object> inputMap = new LinkedHashMap<>();
+    inputMap.put("key", "value"); // {"key":"value"} = 15 chars, exceeds 5
+
+    Map<String, Object> row = new HashMap<>();
+    row.put("STR_COL", inputMap);
+
+    ValidationResult result = validator.validateRow(row);
+    assertFalse(result.isValid());
+    assertTrue(result.hasTypeError());
+  }
+
+  // ================ Boolean Normalization Tests ================
+
+  /**
+   * Integer 0/1 must be normalized to Boolean before reaching the SSv2 SDK. The SDK only accepts
+   * Boolean for BOOLEAN columns — Integer inputs are silently dropped without this normalization.
+   */
+  @Test
+  public void testValidateRowBooleanIntegerZeroNormalizedToFalse() {
+    Map<String, ColumnSchema> schema = new HashMap<>();
+    schema.put(
+        "BOOL_COL",
+        createColumnSchema("BOOL_COL", ColumnLogicalType.BOOLEAN, true, null, null, null));
+
+    RowValidator validator = new RowValidator(schema);
+
+    Map<String, Object> row = new HashMap<>();
+    row.put("BOOL_COL", 0);
+
+    ValidationResult result = validator.validateRow(row);
+    assertTrue(result.isValid());
+    assertEquals(Boolean.FALSE, row.get("BOOL_COL"));
+  }
+
+  @Test
+  public void testValidateRowBooleanIntegerOneNormalizedToTrue() {
+    Map<String, ColumnSchema> schema = new HashMap<>();
+    schema.put(
+        "BOOL_COL",
+        createColumnSchema("BOOL_COL", ColumnLogicalType.BOOLEAN, true, null, null, null));
+
+    RowValidator validator = new RowValidator(schema);
+
+    Map<String, Object> row = new HashMap<>();
+    row.put("BOOL_COL", 1);
+
+    ValidationResult result = validator.validateRow(row);
+    assertTrue(result.isValid());
+    assertEquals(Boolean.TRUE, row.get("BOOL_COL"));
+  }
+
+  /** Native Boolean values must also be normalized (no-op in effect, but consistent). */
+  @Test
+  public void testValidateRowBooleanNativeBooleanPassthrough() {
+    Map<String, ColumnSchema> schema = new HashMap<>();
+    schema.put(
+        "BOOL_COL",
+        createColumnSchema("BOOL_COL", ColumnLogicalType.BOOLEAN, true, null, null, null));
+
+    RowValidator validator = new RowValidator(schema);
+
+    for (Object input : Arrays.asList(Boolean.TRUE, Boolean.FALSE)) {
+      Map<String, Object> row = new HashMap<>();
+      row.put("BOOL_COL", input);
+      ValidationResult result = validator.validateRow(row);
+      assertTrue(result.isValid());
+      assertInstanceOf(Boolean.class, row.get("BOOL_COL"));
+      assertEquals(input, row.get("BOOL_COL"));
+    }
+  }
+
+  /** String tokens are normalized to Boolean (previously accepted as String by SDK). */
+  @Test
+  public void testValidateRowBooleanStringTokensNormalizedToBoolean() {
+    Map<String, ColumnSchema> schema = new HashMap<>();
+    schema.put(
+        "BOOL_COL",
+        createColumnSchema("BOOL_COL", ColumnLogicalType.BOOLEAN, true, null, null, null));
+
+    RowValidator validator = new RowValidator(schema);
+
+    Map<String, Object> trueInputs = new LinkedHashMap<>();
+    trueInputs.put("true", Boolean.TRUE);
+    trueInputs.put("yes", Boolean.TRUE);
+    trueInputs.put("on", Boolean.TRUE);
+
+    Map<String, Object> falseInputs = new LinkedHashMap<>();
+    falseInputs.put("false", Boolean.FALSE);
+    falseInputs.put("no", Boolean.FALSE);
+    falseInputs.put("off", Boolean.FALSE);
+
+    for (Map.Entry<String, Object> entry : trueInputs.entrySet()) {
+      Map<String, Object> row = new HashMap<>();
+      row.put("BOOL_COL", entry.getKey());
+      ValidationResult result = validator.validateRow(row);
+      assertTrue(result.isValid(), "Expected valid for input: " + entry.getKey());
+      assertEquals(entry.getValue(), row.get("BOOL_COL"), "Expected TRUE for: " + entry.getKey());
+    }
+
+    for (Map.Entry<String, Object> entry : falseInputs.entrySet()) {
+      Map<String, Object> row = new HashMap<>();
+      row.put("BOOL_COL", entry.getKey());
+      ValidationResult result = validator.validateRow(row);
+      assertTrue(result.isValid(), "Expected valid for input: " + entry.getKey());
+      assertEquals(entry.getValue(), row.get("BOOL_COL"), "Expected FALSE for: " + entry.getKey());
+    }
+  }
+
+  /** Invalid inputs for BOOLEAN still produce a type error. */
+  @Test
+  public void testValidateRowBooleanInvalidInputProducesTypeError() {
+    Map<String, ColumnSchema> schema = new HashMap<>();
+    schema.put(
+        "BOOL_COL",
+        createColumnSchema("BOOL_COL", ColumnLogicalType.BOOLEAN, true, null, null, null));
+
+    RowValidator validator = new RowValidator(schema);
+
+    for (Object invalid : Arrays.asList(new HashMap<>(), new ArrayList<>(), "not_a_bool")) {
+      Map<String, Object> row = new HashMap<>();
+      row.put("BOOL_COL", invalid);
+      ValidationResult result = validator.validateRow(row);
+      assertFalse(result.isValid(), "Expected type error for input: " + invalid);
+      assertTrue(result.hasTypeError(), "Expected type error for input: " + invalid);
+      assertEquals("BOOL_COL", result.getColumnName());
+    }
+  }
+
+  /**
+   * Non-0/1 numeric values for BOOLEAN produce a type error. Although SSv1 SDK's
+   * DataValidationUtil.validateAndParseBoolean accepts any Number directly, in KC v3 the record
+   * mapper converts all values to Strings first — and SSv1's convertStringToBoolean only accepts
+   * "0"/"1"/"true"/"false"/"yes"/"no"/"on"/"off". "42" is not in that set, so it's rejected.
+   * RowValidator pre-rejects non-0/1 Numbers to match end-to-end KC v3 behavior.
+   */
+  @Test
+  public void testValidateRowBooleanNonZeroOneIntegerProducesTypeError() {
+    Map<String, ColumnSchema> schema = new HashMap<>();
+    schema.put(
+        "BOOL_COL",
+        createColumnSchema("BOOL_COL", ColumnLogicalType.BOOLEAN, true, null, null, null));
+
+    RowValidator validator = new RowValidator(schema);
+
+    for (Object input : Arrays.asList(42, -1, 999, 2L, -100L)) {
+      Map<String, Object> row = new HashMap<>();
+      row.put("BOOL_COL", input);
+      ValidationResult result = validator.validateRow(row);
+      assertFalse(result.isValid(), "Expected type error for numeric input: " + input);
+      assertTrue(result.hasTypeError(), "Expected type error for numeric input: " + input);
+      assertEquals("BOOL_COL", result.getColumnName());
+    }
+  }
+
+  // ================ VARIANT normalization (String → native object) ================
+
+  /**
+   * JSON object string sent to VARIANT is parsed back to a Map so the SSv2 SDK stores it as a
+   * native VARIANT object, not a JSON-quoted string.
+   */
+  @Test
+  public void testValidateRowVariantJsonObjectStringNormalizedToMap() {
+    Map<String, ColumnSchema> schema = new HashMap<>();
+    schema.put("V", createColumnSchema("V", ColumnLogicalType.VARIANT, true, null, null, null));
+    RowValidator validator = new RowValidator(schema);
+
+    Map<String, Object> row = new HashMap<>();
+    row.put("V", "{\"a\":1}");
+    ValidationResult result = validator.validateRow(row);
+
+    assertTrue(result.isValid());
+    Object normalized = row.get("V");
+    assertTrue(normalized instanceof Map, "Expected Map but got: " + normalized.getClass());
+    assertEquals(1, ((Map<?, ?>) normalized).size());
+    assertEquals(1, ((Map<?, ?>) normalized).get("a"));
+  }
+
+  /**
+   * JSON array string sent to VARIANT is parsed back to a List so the SSv2 SDK stores it as a
+   * native array.
+   */
+  @Test
+  public void testValidateRowVariantJsonArrayStringNormalizedToList() {
+    Map<String, ColumnSchema> schema = new HashMap<>();
+    schema.put("V", createColumnSchema("V", ColumnLogicalType.VARIANT, true, null, null, null));
+    RowValidator validator = new RowValidator(schema);
+
+    Map<String, Object> row = new HashMap<>();
+    row.put("V", "[1,2,3]");
+    ValidationResult result = validator.validateRow(row);
+
+    assertTrue(result.isValid());
+    Object normalized = row.get("V");
+    assertTrue(normalized instanceof List, "Expected List but got: " + normalized.getClass());
+    assertEquals(Arrays.asList(1, 2, 3), normalized);
+  }
+
+  /** Non-String native objects passed to VARIANT are returned unchanged. */
+  @Test
+  public void testValidateRowVariantNativeObjectPassthrough() {
+    Map<String, ColumnSchema> schema = new HashMap<>();
+    schema.put("V", createColumnSchema("V", ColumnLogicalType.VARIANT, true, null, null, null));
+    RowValidator validator = new RowValidator(schema);
+
+    Map<String, Object> nativeMap = new HashMap<>();
+    nativeMap.put("key", "value");
+    Map<String, Object> row = new HashMap<>();
+    row.put("V", nativeMap);
+
+    ValidationResult result = validator.validateRow(row);
+    assertTrue(result.isValid());
+    assertSame(nativeMap, row.get("V"), "Native Map should not be replaced");
+  }
+
+  /** Invalid (non-JSON) string sent to VARIANT produces a type error. */
+  @Test
+  public void testValidateRowVariantInvalidJsonStringProducesTypeError() {
+    Map<String, ColumnSchema> schema = new HashMap<>();
+    schema.put("V", createColumnSchema("V", ColumnLogicalType.VARIANT, true, null, null, null));
+    RowValidator validator = new RowValidator(schema);
+
+    Map<String, Object> row = new HashMap<>();
+    row.put("V", "not valid json");
+    ValidationResult result = validator.validateRow(row);
+
+    assertFalse(result.isValid());
+    assertTrue(result.hasTypeError());
+    assertEquals("V", result.getColumnName());
+  }
+
+  // ================ ARRAY normalization (String → List) ================
+
+  /**
+   * JSON array string sent to ARRAY is parsed back to a List so the SSv2 SDK stores it as a proper
+   * array, not a single-element array wrapping the literal string.
+   */
+  @Test
+  public void testValidateRowArrayJsonStringNormalizedToList() {
+    Map<String, ColumnSchema> schema = new HashMap<>();
+    schema.put("A", createColumnSchema("A", ColumnLogicalType.ARRAY, true, null, null, null));
+    RowValidator validator = new RowValidator(schema);
+
+    Map<String, Object> row = new HashMap<>();
+    row.put("A", "[1,2,3]");
+    ValidationResult result = validator.validateRow(row);
+
+    assertTrue(result.isValid());
+    Object normalized = row.get("A");
+    assertTrue(normalized instanceof List, "Expected List but got: " + normalized.getClass());
+    assertEquals(Arrays.asList(1, 2, 3), normalized);
+  }
+
+  /**
+   * Non-array JSON string sent to ARRAY is wrapped in a single-element List (matching
+   * validateAndParseArray behavior which wraps non-arrays into single-element arrays).
+   */
+  @Test
+  public void testValidateRowArrayNonArrayJsonStringWrappedInList() {
+    Map<String, ColumnSchema> schema = new HashMap<>();
+    schema.put("A", createColumnSchema("A", ColumnLogicalType.ARRAY, true, null, null, null));
+    RowValidator validator = new RowValidator(schema);
+
+    Map<String, Object> row = new HashMap<>();
+    row.put("A", "\"hello\""); // JSON string (not an array)
+    ValidationResult result = validator.validateRow(row);
+
+    assertTrue(result.isValid());
+    Object normalized = row.get("A");
+    assertTrue(normalized instanceof List, "Expected List but got: " + normalized.getClass());
+    assertEquals(Arrays.asList("hello"), normalized);
+  }
+
+  /** Native List passed to ARRAY is returned unchanged. */
+  @Test
+  public void testValidateRowArrayNativeListPassthrough() {
+    Map<String, ColumnSchema> schema = new HashMap<>();
+    schema.put("A", createColumnSchema("A", ColumnLogicalType.ARRAY, true, null, null, null));
+    RowValidator validator = new RowValidator(schema);
+
+    List<Integer> nativeList = Arrays.asList(10, 20, 30);
+    Map<String, Object> row = new HashMap<>();
+    row.put("A", nativeList);
+
+    ValidationResult result = validator.validateRow(row);
+    assertTrue(result.isValid());
+    assertSame(nativeList, row.get("A"), "Native List should not be replaced");
+  }
+
+  /** Invalid (non-JSON) string sent to ARRAY produces a type error. */
+  @Test
+  public void testValidateRowArrayInvalidJsonStringProducesTypeError() {
+    Map<String, ColumnSchema> schema = new HashMap<>();
+    schema.put("A", createColumnSchema("A", ColumnLogicalType.ARRAY, true, null, null, null));
+    RowValidator validator = new RowValidator(schema);
+
+    Map<String, Object> row = new HashMap<>();
+    row.put("A", "not_json");
+    ValidationResult result = validator.validateRow(row);
+
+    assertFalse(result.isValid());
+    assertTrue(result.hasTypeError());
+    assertEquals("A", result.getColumnName());
+  }
+
+  // ================ OBJECT validation Tests ================
+
+  /** Invalid (non-JSON) string sent to OBJECT produces a type error. */
+  @Test
+  public void testValidateRowObjectInvalidJsonStringProducesTypeError() {
+    Map<String, ColumnSchema> schema = new HashMap<>();
+    schema.put("O", createColumnSchema("O", ColumnLogicalType.OBJECT, true, null, null, null));
+    RowValidator validator = new RowValidator(schema);
+
+    Map<String, Object> row = new HashMap<>();
+    row.put("O", "not_json");
+    ValidationResult result = validator.validateRow(row);
+
+    assertFalse(result.isValid());
+    assertTrue(result.hasTypeError());
+    assertEquals("O", result.getColumnName());
+  }
+
+  /** Valid JSON array string sent to OBJECT is rejected (not an object). */
+  @Test
+  public void testValidateRowObjectArrayJsonStringProducesTypeError() {
+    Map<String, ColumnSchema> schema = new HashMap<>();
+    schema.put("O", createColumnSchema("O", ColumnLogicalType.OBJECT, true, null, null, null));
+    RowValidator validator = new RowValidator(schema);
+
+    Map<String, Object> row = new HashMap<>();
+    row.put("O", "[1,2,3]");
+    ValidationResult result = validator.validateRow(row);
+
+    assertFalse(result.isValid());
+    assertTrue(result.hasTypeError());
+    assertEquals("O", result.getColumnName());
+  }
+
+  /** Valid JSON object string sent to OBJECT is accepted. */
+  @Test
+  public void testValidateRowObjectValidJsonStringAccepted() {
+    Map<String, ColumnSchema> schema = new HashMap<>();
+    schema.put("O", createColumnSchema("O", ColumnLogicalType.OBJECT, true, null, null, null));
+    RowValidator validator = new RowValidator(schema);
+
+    Map<String, Object> row = new HashMap<>();
+    row.put("O", "{\"key\":\"value\"}");
+    ValidationResult result = validator.validateRow(row);
+
+    assertTrue(result.isValid());
+  }
+
   /** Invalid hex string for a BINARY column produces a type error. */
   @Test
   public void testValidateRowBinaryInvalidHexStringFails() {
@@ -936,6 +1362,95 @@ public class RowValidatorTest {
     assertFalse(result.isValid());
     assertTrue(result.hasTypeError());
     assertEquals("BIN_COL", result.getColumnName());
+  }
+
+  // ================ Timestamp normalization Tests ================
+
+  /**
+   * Integer epoch for TIMESTAMP_NTZ must be normalized to an ISO timestamp string. The SSv2 SDK
+   * passes raw integers to the Snowflake backend which interprets them using the channel's default
+   * timezone (America/Los_Angeles) instead of UTC. SSv1 SDK converts epochs to UTC client-side.
+   */
+  @Test
+  public void testValidateRowTimestampNtzIntegerEpochNormalized() {
+    Map<String, ColumnSchema> schema = new HashMap<>();
+    schema.put("TS", createTimestampColumnSchema("TS", ColumnLogicalType.TIMESTAMP_NTZ));
+    RowValidator validator = new RowValidator(schema);
+
+    // 1705312800 = 2024-01-15T10:00:00Z
+    Map<String, Object> row = new HashMap<>();
+    row.put("TS", 1705312800);
+    ValidationResult result = validator.validateRow(row);
+
+    assertTrue(result.isValid());
+    Object normalized = row.get("TS");
+    assertInstanceOf(String.class, normalized, "Integer epoch should be normalized to String");
+    assertEquals("2024-01-15T10:00", normalized);
+  }
+
+  /** Long epoch for TIMESTAMP_NTZ is also normalized (same as Integer). */
+  @Test
+  public void testValidateRowTimestampNtzLongEpochNormalized() {
+    Map<String, ColumnSchema> schema = new HashMap<>();
+    schema.put("TS", createTimestampColumnSchema("TS", ColumnLogicalType.TIMESTAMP_NTZ));
+    RowValidator validator = new RowValidator(schema);
+
+    Map<String, Object> row = new HashMap<>();
+    row.put("TS", 1705312800L);
+    ValidationResult result = validator.validateRow(row);
+
+    assertTrue(result.isValid());
+    Object normalized = row.get("TS");
+    assertInstanceOf(String.class, normalized, "Long epoch should be normalized to String");
+    assertEquals("2024-01-15T10:00", normalized);
+  }
+
+  /** String timestamp for TIMESTAMP_NTZ is validated but returned unchanged. */
+  @Test
+  public void testValidateRowTimestampNtzStringPassthrough() {
+    Map<String, ColumnSchema> schema = new HashMap<>();
+    schema.put("TS", createTimestampColumnSchema("TS", ColumnLogicalType.TIMESTAMP_NTZ));
+    RowValidator validator = new RowValidator(schema);
+
+    Map<String, Object> row = new HashMap<>();
+    row.put("TS", "2024-01-15T13:45:30");
+    ValidationResult result = validator.validateRow(row);
+
+    assertTrue(result.isValid());
+    assertEquals("2024-01-15T13:45:30", row.get("TS"));
+  }
+
+  /** Integer epoch for TIMESTAMP_LTZ is normalized to ISO string with UTC offset. */
+  @Test
+  public void testValidateRowTimestampLtzIntegerEpochNormalized() {
+    Map<String, ColumnSchema> schema = new HashMap<>();
+    schema.put("TS", createTimestampColumnSchema("TS", ColumnLogicalType.TIMESTAMP_LTZ));
+    RowValidator validator = new RowValidator(schema);
+
+    Map<String, Object> row = new HashMap<>();
+    row.put("TS", 1705312800);
+    ValidationResult result = validator.validateRow(row);
+
+    assertTrue(result.isValid());
+    Object normalized = row.get("TS");
+    assertInstanceOf(String.class, normalized, "Integer epoch should be normalized to String");
+    assertEquals("2024-01-15T10:00Z", normalized);
+  }
+
+  /** Invalid string for TIMESTAMP_NTZ produces a type error. */
+  @Test
+  public void testValidateRowTimestampNtzInvalidStringRejects() {
+    Map<String, ColumnSchema> schema = new HashMap<>();
+    schema.put("TS", createTimestampColumnSchema("TS", ColumnLogicalType.TIMESTAMP_NTZ));
+    RowValidator validator = new RowValidator(schema);
+
+    Map<String, Object> row = new HashMap<>();
+    row.put("TS", "not_a_timestamp");
+    ValidationResult result = validator.validateRow(row);
+
+    assertFalse(result.isValid());
+    assertTrue(result.hasTypeError());
+    assertEquals("TS", result.getColumnName());
   }
 
   // ================ Helper Methods ================
@@ -971,5 +1486,10 @@ public class RowValidatorTest {
 
     return new ColumnSchema(
         name, logicalType, physicalType, nullable, precision, scale, length, byteLength, null);
+  }
+
+  private ColumnSchema createTimestampColumnSchema(String name, ColumnLogicalType logicalType) {
+    return new ColumnSchema(
+        name, logicalType, ColumnPhysicalType.SB8, true, null, 9, null, null, null);
   }
 }

--- a/test/E2E_TEST_PLAN.md
+++ b/test/E2E_TEST_PLAN.md
@@ -397,68 +397,40 @@ FR5 (Default Pipes only) + FR7 (Default Pipe Improvements). Must be tested in bo
 
 ## 4. Data Type Compatibility
 
-This section addresses the critical question: **Does v4 compatibility mode handle every Snowflake data type the same way v3 does?**
+**Does v4 compatibility mode handle every Snowflake data type the same way v3 does?**
 
-### Background: How Type Validation Works
+V4 client-side validation (`RowValidator` + `DataValidationUtil`, code copied from SSv1 SDK) runs before the SSv2 SDK. Server-side mode bypasses client validation entirely. Divergences occur when SSv2 handles a value differently than SSv1 did, and client-side normalization doesn't compensate.
 
-V4's client-side validation (`RowValidator`) uses `DataValidationUtil` -- code **copied from the SSv1 Ingest SDK** into the KC v4 codebase. This copy can drift from the actual SDK. The validation chain is:
+Tests: `test_type_compatibility.py` (JSON, dual mode). Each test covers positive (valid values land correctly) and negative (invalid values routed to DLQ).
 
-1. **Kafka Connect converter** deserializes the message (JsonConverter, AvroConverter, etc.)
-2. **KC `KafkaRecordConverter`** transforms Kafka Connect types (Struct/Map) to `Map<String, Object>`
-3. **`RowValidator.validateRow()`** (when `validation.enabled=true`) checks each value against the target column's Snowflake type using `DataValidationUtil`
-4. **SSv2 SDK `channel.appendRow()`** performs its own validation (SSv2's validation layer)
+| Target Data Type | v3 | v4 Client | v4 Server | Notes |
+|---|:---:|:---:|:---:|---|
+| NUMBER | 🟢 | 🟢 | 🟢 | |
+| FLOAT | 🟢 | 🟢 | 🟢 | |
+| VARCHAR | 🟢 | 🟢 | 🟢 | |
+| BINARY (hex String input) | 🟢 | 🟢 | 🟡 | Server-side may interpret hex as base64, producing incorrect bytes |
+| BOOLEAN | 🟢 | 🟢 | 🟢 | |
+| BOOLEAN (Integer 0/1 input) | 🟢 | 🟢 | 🟡 | Server-side rejects Integer boolean values; rows not ingested |
+| DATE | 🟢 | 🟢 | 🟢 | |
+| TIME | 🟢 | 🟢 | 🟢 | |
+| TIMESTAMP_NTZ | 🟢 | 🟢 | 🟢 | |
+| TIMESTAMP_NTZ (Integer epoch) | 🟢 | 🟢 | 🟡 | Server-side shifts stored value by default timezone offset (~8h) |
+| TIMESTAMP_LTZ | 🟢 | 🟢 | 🟢 | |
+| TIMESTAMP_TZ | 🟢 | 🟢 | 🟢 | |
+| VARIANT | 🟢 | 🟢 | 🟢 | |
+| VARIANT (JSON String input) | 🟢 | 🟢 | 🟢 | |
+| VARIANT (bare String input) | 🟢 | 🟢 | 🟡 | Server-side accepts invalid JSON scalars; client-side correctly rejects to DLQ |
+| OBJECT | 🟢 | 🟢 | 🟢 | |
+| ARRAY | 🟢 | 🟢 | 🟢 | |
+| ARRAY (JSON String input) | 🟢 | 🟢 | 🟡 | Server-side wraps string as single-element array instead of parsing |
+| NULL | 🟢 | 🟢 | 🟢 | |
+| NULL (VARIANT column) | 🟢 | 🟡 | 🟡 | Stored as text `'null'` instead of SQL NULL |
+| Cross-type mismatch | 🟢 | 🟢 | 🟢 | |
+| GEOGRAPHY, GEOMETRY | 🟢 | 🟢 | 🟢 | Unsupported in Streaming; rejected in all modes |
+| VECTOR | 🟡 | 🟢 | 🟢 | New in v4. Not supported in v3. |
+| Structured OBJECT/ARRAY | 🟡 | 🟢 | 🟢 | New in v4. Not supported in v3. |
+| Collated VARCHAR | 🔴 | 🔴 | 🔴 | Not tested. Unit-level coverage only. |
 
-Parity risk: v3 relied on step 4 only (SSv1's built-in validation). V4 adds step 3 (copied SSv1 code) plus uses SSv2 in step 4. If the copied code drifts from SSv1, or SSv2 validates differently than SSv1, behavior diverges.
+### Avro-Specific Type Mapping
 
-### Existing Unit Test Coverage (KC Java Tests)
-
-- **`DataValidationUtilTest.java`**: Copied from SSv1 SDK. Covers DATE, TIME, all TIMESTAMP variants, BIGDECIMAL/FIXED, STRING, VARIANT, ARRAY, OBJECT, BINARY, REAL, BOOLEAN. Both positive and negative cases.
-- **`RowValidatorTest.java`**: Structural validation (extra columns, missing NOT NULL, null in NOT NULL). Type rejection for structured OBJECT/ARRAY and collated columns.
-- **`SnowflakeColumnTypeMapperTest.java`**: Kafka Connect type -> Snowflake DDL mapping.
-- **`ConverterTest.java`**: Kafka Connect record -> Map conversion. Decimal precision, Time/Date/Timestamp logical types, NaN/Infinity.
-
-### Per-Type E2E Coverage
-
-All new E2E type tests go into **`test_type_compatibility.py`** (JSON format, dual mode) and **`test_type_compatibility_avro.py`** (Avro SR format, dual but v3 blocked). Each test covers both **positive** (valid values land correctly) and **negative** (invalid values routed to DLQ) cases for that type.
-| Status | Snowflake Type | Test Functions | v3 | v4-compat | v4-ht | Notes |
-|:------:|----------------|----------------|:--:|:---------:|:-----:|-------|
-| 🟢 | NUMBER | `test_number` | Pass | Pass | Pass | Integers, zero, negative, max/min INT, invalid strings/objects. All modes identical. |
-| 🟢 | NUMBER(p,s) | `test_number_with_scale` | Pass | Pass | Pass | Decimals, negative, zero, max scale. Invalid text -> DLQ. All modes identical. |
-| 🟢 | FLOAT | `test_float` | Pass | Pass | Pass | pi, negative, zero, scientific notation. Invalid text/array -> DLQ. |
-| 🟢 | FLOAT (special) | `test_float_special` | Pass | Pass | Pass | NaN, +Infinity, -Infinity as string representations. All modes identical. |
-| 🟢 | VARCHAR | `test_varchar` | Pass | Pass | Pass | Normal strings, special chars, 1000-char string. All modes identical. |
-| 🟢 | VARCHAR(10) | `test_varchar_length_limit` | Pass | Pass | Pass | At-limit and over-limit strings. Over-limit -> DLQ in all modes. |
-| 🟡 | BINARY | `test_binary` | Pass | Pass | **Diverges** | **v4-compat**: fixed by PR #1412 (SNOW-3256183). `RowValidator` now converts hex strings to `byte[]` before passing to the Ingest SDK, matching SSv1 behavior. **v4-ht**: server-side validation passes the hex string directly to the SSv2 SDK. SSv2 treats it as base64 (when `ENABLE_SSV2_DEFAULT_BINARY_FORMAT_BASE64` is set), producing garbled bytes. Test is `xfail` for v4-ht and hard-asserts pass for v3 and v4-compat. Note: test will fail (not xfail) if the connector zip predates PR #1412. |
-| 🟢 | BOOLEAN | `test_boolean` | Pass | Pass | Pass | true/false literals, invalid objects/arrays -> DLQ. All modes identical. |
-| 🟡 | BOOLEAN (coercion) | `test_boolean_coercion` | Pass | **Diverges** | **Diverges** | SSv1 coerces `0`->false, `1`->true. v4 `RowValidator` rejects numeric values for BOOLEAN — only literal `true`/`false` and string tokens accepted. Rejected values silently dropped (not DLQ'd). |
-| 🟢 | DATE | `test_date` | Pass | Pass | Pass | ISO dates, epoch, future. Invalid string -> DLQ. All modes identical. |
-| 🟢 | TIME | `test_time` | Pass | Pass | Pass | Normal, midnight, end-of-day. Invalid string -> DLQ. All modes identical. |
-| 🟢 | TIMESTAMP_NTZ | `test_timestamp_ntz` | Pass | Pass | Pass | ISO timestamps. Invalid string -> DLQ. All modes identical. |
-| 🟡 | TIMESTAMP_NTZ (epoch) | `test_timestamp_ntz_epoch` | Pass | **Diverges** | **Diverges** | **v4-compat**: PR #1393 fixed the *rejection* (integers are no longer thrown out by `RowValidator`), but the stored value is shifted. `validateAndParseTimestamp` converts the `Integer/Long` to a string, then interprets it via `defaultTimezone = America/Los_Angeles` (hardcoded in `RowValidator` to match SSv1). `withOffsetSameLocal(UTC)` then preserves the *local* time, not UTC — e.g. epoch `1705312800` (= `2024-01-15 10:00:00 UTC`) is stored as `2024-01-15 02:00:00` (-8 h shift). SSv1 handles raw `Integer/Long` epochs directly without applying the default timezone, so v3 stores the correct UTC value. **v4-ht**: server-side applies the session timezone to unqualified integer epochs (same symptom, different cause). Test is `xfail` for both v4 modes. |
-| 🟢 | TIMESTAMP_LTZ | `test_timestamp_ltz` | Pass | Pass | Pass | TZ-aware timestamps, epoch. Invalid -> DLQ. All modes identical. |
-| 🟢 | TIMESTAMP_TZ | `test_timestamp_tz` | Pass | Pass | Pass | Timestamps with offset. Invalid -> DLQ. All modes identical. |
-| 🟢 | VARIANT | `test_variant` | Pass | Pass | Pass | Objects, arrays, nested, integers, floats, booleans, JSON strings. All modes identical. |
-| 🟡 | VARIANT (bare str) | `test_variant_bare_string` | Pass | Pass | **Diverges** | `"hello"` is not valid JSON. v3/v4-compat reject -> DLQ. v4-ht server-side accepts bare scalars and wraps as JSON string. |
-| 🟢 | OBJECT | `test_object` | Pass | Pass | Pass | Simple, nested, with arrays, from JSON string. All modes identical. |
-| 🟢 | ARRAY | `test_array` | Pass | Pass | Pass | Strings, numbers, objects. All modes identical. |
-| 🟡 | ARRAY (JSON str) | `test_array_json_string` | Pass | **Diverges** | **Diverges** | SSv1 parses JSON string `"[1,2,3]"` into native array `[1,2,3]`. SSv2 stores the string literal, producing single-element array `["[1,2,3]"]`. |
-| 🟢 | NULL (11 types) | `test_null[COL_*]` | Pass | Pass | Pass | NULL in NUMBER, FLOAT, VARCHAR, BOOLEAN, DATE, TIME, TS_NTZ, TS_LTZ, TS_TZ, OBJECT, ARRAY -- SQL NULL in all modes. |
-| 🟡 | NULL (VARIANT) | `test_null[COL_VARIANT]` | Pass | **Diverges** | **Diverges** | SSv1 stores SQL NULL. SSv2 serializes JSON null as the text literal `'null'` instead of SQL NULL. |
-| 🟡 | Cross-type mismatch | `test_cross_type_mismatch` | Pass | **Diverges** | **Diverges** | Multiple divergences: v4-compat is stricter (rejects object->VARCHAR via DLQ, silently drops numeric->BOOLEAN). v3 coerces both. v4-ht drops everything without DLQ (no client validation). |
-| 🟢 | GEOGRAPHY | `test_dt_geography` | Pass | Pass | Pass | Rejected in all modes (Snowpipe Streaming limitation). Correct error message confirmed. File: `compatibility/test_unsupported_types.py` |
-| 🟢 | GEOMETRY | `test_dt_geometry` | Pass | Pass | Pass | Rejected in all modes. Correct error message confirmed. File: `compatibility/test_unsupported_types.py` |
-| 🟢 | VECTOR | `test_dt_vector` | Error asserted | Pass | Pass | v3 rejects VECTOR (channel open error, asserted). v4 ingests VECTOR(FLOAT,3) correctly. File: `compatibility/test_unsupported_types.py` |
-| 🟡 | Structured OBJECT | `test_dt_structured_object` | **Diverges** | Pass | Pass | SSv1 rejects structured types at channel open. SSv2 accepts them — SDK supports typed OBJECT/ARRAY for non-Iceberg tables. New v4 capability, not a regression. File: `compatibility/test_unsupported_types.py` |
-| 🟡 | Structured ARRAY | `test_dt_structured_array` | **Diverges** | Pass | Pass | SSv1 rejects structured types at channel open. SSv2 accepts them — SDK supports typed OBJECT/ARRAY for non-Iceberg tables. New v4 capability, not a regression. File: `compatibility/test_unsupported_types.py` |
-| 🔴 | Collated VARCHAR | -- | -- | -- | -- | **P2.** Not yet tested. `RowValidatorTest.java` covers unit level. |
-
-### Avro-Specific Type Mapping (`test_type_compatibility_avro.py`)
-
-Avro has its own type system. These tests are dual but v3 is blocked by the classloader conflict. **File does not exist yet -- must be created.**
-
-| Status | Avro Types | SF Target Types | What to Test | Notes |
-|:------:|-----------|-----------------|-------------|-------|
-| 🟡 | int, long, float, double, bytes (decimal) | NUMBER, BIGINT, FLOAT, DOUBLE | Positive: each Avro numeric -> correct SF type. Negative: decimal overflow. v3 parity blocked by SR classloader. | SDK ref: `NumericTypesIT.java` |
-| 🟡 | date, time-millis, time-micros, timestamp-millis, timestamp-micros | DATE, TIME, TIMESTAMP_NTZ/LTZ | Positive: each Avro logical type -> correct SF type. Negative: out-of-range. v3 parity blocked by SR classloader. | SDK ref: `DateTimeIT.java` |
-| 🟡 | string, bytes, boolean, enum | VARCHAR, BINARY, BOOLEAN, VARCHAR | Positive: each primitive -> correct SF type. Negative: size overflow. v3 parity blocked by SR classloader. | SDK ref: `StringsIT.java`, `BinaryIT.java` |
-| 🟡 | record, array, map, union | VARIANT, ARRAY, OBJECT | Positive: complex Avro types -> SF semi-structured. Negative: size overflow. v3 parity blocked by SR classloader. | SDK ref: `SemiStructuredIT.java` |
+Not yet implemented. Avro has its own type system (logical types for dates, decimals, etc.). V3 parity testing is blocked by the SR classloader conflict. Planned file: `test_type_compatibility_avro.py`.

--- a/test/tests/compatibility/test_type_compatibility.py
+++ b/test/tests/compatibility/test_type_compatibility.py
@@ -151,9 +151,10 @@ CASES = [
     Case("bool_false", "COL_BOOLEAN", False, OK),
     Case("bool_bad_obj", "COL_BOOLEAN", {"key": "value"}, ERR),
     Case("bool_bad_arr", "COL_BOOLEAN", [1, 2, 3], ERR),
-    # Boolean coercion: numeric 0/1 and string tokens
-    # KNOWN DIVERGENCE: v4 rejects numeric 0/1 as boolean. String tokens
-    # ("true", "false", "yes", "no") work on all modes.
+    Case("bool_bad_str", "COL_BOOLEAN", "random_string", ERR),
+    # Boolean coercion: numeric 0/1 and string tokens.
+    # v4-compat fix: RowValidator normalizes any valid input to Boolean.
+    # v4-ht: RowValidator bypassed; Integer 0/1 reach SSv2 SDK directly and are dropped.
     Case(
         "bool_zero", "COL_BOOLEAN", 0, OK, expected_value=False, group="bool_coercion"
     ),
@@ -186,6 +187,22 @@ CASES = [
         "bool_str_no",
         "COL_BOOLEAN",
         "no",
+        OK,
+        expected_value=False,
+        group="bool_coercion",
+    ),
+    Case(
+        "bool_str_on",
+        "COL_BOOLEAN",
+        "on",
+        OK,
+        expected_value=True,
+        group="bool_coercion",
+    ),
+    Case(
+        "bool_str_off",
+        "COL_BOOLEAN",
+        "off",
         OK,
         expected_value=False,
         group="bool_coercion",
@@ -295,22 +312,71 @@ CASES = [
     # Bare string (not valid JSON) → DLQ on v3/v4-compat; v4-ht ingests it
     # as a string VARIANT value (server-side accepts non-JSON scalars).
     Case("var_str", "COL_VARIANT", "hello", ERR, group="variant_bare_str"),
-    # String containing valid JSON — probes SSv1/SSv2 parse divergence:
-    # SSv1 parses JSON-like strings into native objects, SSv2 may keep as string.
-    Case("var_json_str", "COL_VARIANT", '{"a":1}', OK),
+    # String containing valid JSON — probes SSv1/SSv2 parse divergence.
+    # v3/v4-compat: SSv1/RowValidator parses string into native object {"a":1}.
+    # v4-ht: SSv2 SDK stores the string as a JSON-quoted literal '"{\\"a\\":1}"'.
+    Case(
+        "var_json_str",
+        "COL_VARIANT",
+        '{"a":1}',
+        OK,
+        expected_value={"a": 1},
+        group="variant_json_str",
+    ),
+    # JSON scalar strings to VARIANT — exercises the String→native re-parse path
+    # for primitives (number, boolean, null).  All are valid JSON.
+    Case(
+        "var_json_num",
+        "COL_VARIANT",
+        "42",
+        OK,
+        expected_value=42,
+        group="variant_json_str",
+    ),
+    Case(
+        "var_json_bool",
+        "COL_VARIANT",
+        "true",
+        OK,
+        expected_value=True,
+        group="variant_json_str",
+    ),
+    Case(
+        "var_json_arr",
+        "COL_VARIANT",
+        "[1,2]",
+        OK,
+        expected_value=[1, 2],
+        group="variant_json_str",
+    ),
     # ---- OBJECT ----
     Case("obj_simple", "COL_OBJECT", {"key": "value"}, OK),
     Case("obj_nested", "COL_OBJECT", {"nested": {"a": 1, "b": 2}}, OK),
     Case("obj_with_arr", "COL_OBJECT", {"array_val": [1, 2, 3]}, OK),
     # JSON string that parses to an object
     Case("obj_str_json", "COL_OBJECT", '{"key":"value"}', OK),
+    # Invalid JSON string → OBJECT: rejected in all modes
+    Case("obj_bad_str", "COL_OBJECT", "not_json", ERR),
+    # Valid JSON but not an object (array) → OBJECT: rejected in all modes
+    Case("obj_str_arr", "COL_OBJECT", "[1,2,3]", ERR),
     # ---- ARRAY ----
     Case("arr_strings", "COL_ARRAY", ["a", "b", "c"], OK),
     Case("arr_numbers", "COL_ARRAY", [1, 2, 3], OK),
     Case("arr_objects", "COL_ARRAY", [{"key": "value"}, {"key": "value2"}], OK),
+    # Invalid JSON string → ARRAY: v3/v4-compat reject (DLQ); v4-ht wraps as ["not_json"].
+    Case("arr_bad_str", "COL_ARRAY", "not_json", ERR, group="array_json_str"),
     # JSON string sent to ARRAY: v3 (SSv1) parses it into [1,2,3],
     # v4 (SSv2) stores it as literal string element ["[1,2,3]"].
     Case("arr_str_json", "COL_ARRAY", "[1,2,3]", OK, group="array_json_str"),
+    # Non-array JSON string: validateAndParseArray wraps into single-element array.
+    Case(
+        "arr_str_scalar",
+        "COL_ARRAY",
+        "42",
+        OK,
+        expected_value=[42],
+        group="array_json_str",
+    ),
     # ---- NULL handling (one per supported type) ----
     # KNOWN DIVERGENCE for VARIANT: v4-compat stores JSON null as string 'null'
     # while v3 stores SQL NULL.
@@ -341,6 +407,17 @@ CASES = [
         expected_value='{"key":"value"}',
         group="xtype",
     ),
+    # List coerced to JSON string in VARCHAR — same as Map (xtype_obj_str)
+    Case(
+        "xtype_list_str",
+        "COL_VARCHAR",
+        [1, 2, 3],
+        OK,
+        expected_value="[1,2,3]",
+        group="xtype",
+    ),
+    # Map serialized to JSON exceeds VARCHAR(10) limit → rejected
+    Case("xtype_map_vc10", "COL_VARCHAR10", {"key": "value"}, ERR, group="xtype"),
     Case("xtype_arr_num", "COL_NUMBER", [1, 2, 3], ERR, group="xtype"),
 ]
 
@@ -353,6 +430,7 @@ _SPECIAL_GROUPS = {
     "xtype",
     "null",
     "variant_bare_str",
+    "variant_json_str",
     "array_json_str",
 }
 
@@ -499,8 +577,12 @@ def test_boolean(results):
 def test_boolean_coercion(results):
     """BOOLEAN coercion: numeric 0/1 and string tokens.
 
-    KNOWN DIVERGENCE: v4 RowValidator rejects numeric 0/1 as boolean.
-    v4-compat silently drops them (no DLQ). v4-ht DLQ's them.
+    v3 and v4-compat both coerce Integer 0->False, 1->True.
+    v4-compat fix: RowValidator now normalizes any valid input to Boolean before
+    passing to the SSv2 SDK (which only accepts Boolean, not Integer/String).
+
+    KNOWN DIVERGENCE for v4-ht: server-side validation bypasses RowValidator,
+    so Integer 0/1 reach the SSv2 SDK directly and are silently dropped.
     String tokens ("true"/"false"/"yes"/"no") work on all modes.
     """
     cases = cases_where(group="bool_coercion")
@@ -514,35 +596,29 @@ def test_boolean_coercion(results):
             else:
                 results.assert_error(c)
 
-    if results.mode == "v3":
-        # v3 reference: numeric 0/1 coerced to False/True
+    if results.mode in ("v3", "v4-compat"):
+        # Both v3 (SSv1 coercion) and v4-compat (RowValidator normalization) ingest 0/1 correctly.
         for c in cases:
             if c.name in numeric_cases:
                 results.assert_ingested(c)
         return
 
-    # KNOWN DIVERGENCE: v4 rejects numeric 0/1 for BOOLEAN.
+    # v4-ht: RowValidator is bypassed; SSv2 SDK silently drops Integer inputs for BOOLEAN.
     for c in cases:
         if c.name in numeric_cases:
-            if c.name in results.rows:
-                _log_divergence(
-                    results.mode, c.name, "v4 accepted numeric boolean (unexpected)"
-                )
-            else:
-                in_dlq = c.name in results.dlq_ids
-                _log_divergence(
-                    results.mode,
-                    c.name,
-                    f"v4 rejects numeric {c.value} as boolean; in_dlq={in_dlq}",
-                )
+            in_dlq = c.name in results.dlq_ids
+            _log_divergence(
+                results.mode,
+                c.name,
+                f"v4-ht drops numeric {c.value} for BOOLEAN (SSv2 SDK rejects Integer); in_dlq={in_dlq}",
+            )
 
-    # Assert v3 reference behavior — xfail if v4 diverges.
     try:
         for c in cases:
             if c.name in numeric_cases:
                 results.assert_ingested(c)
     except AssertionError as e:
-        pytest.xfail(f"v4 rejects numeric booleans (v3 coerces 0/1): {e}")
+        pytest.xfail(f"v4-ht drops numeric booleans (SSv2 SDK rejects Integer): {e}")
 
 
 # ---------------------------------------------------------------------------
@@ -568,16 +644,18 @@ def test_timestamp_ntz(results):
 def test_timestamp_ntz_epoch(results):
     """TIMESTAMP_NTZ with integer epoch.
 
-    v4-compat: Fixed in PR #1393 — now accepts Integer/Long epochs (same as v3).
-    KNOWN DIVERGENCE: v4-ht ingests epoch but interprets in session TZ instead
-    of UTC, producing a shifted timestamp.
+    v3: SSv1 SDK converts epoch to UTC client-side via parseInstantGuessScale.
+    v4-compat: RowValidator normalizes Integer epoch to ISO string (same as v3).
+    KNOWN DIVERGENCE: v4-ht bypasses RowValidator; SSv2 SDK passes raw Integer to
+    the Snowflake backend which interprets it using the channel's default timezone
+    (America/Los_Angeles) instead of UTC, producing a -8h shifted timestamp.
     """
     [case] = cases_where(group="ts_epoch")
-    if results.mode == "v3":
+    if results.mode in ("v3", "v4-compat"):
         results.assert_ingested(case)
         return
 
-    # Log detailed v4 divergence status.
+    # v4-ht: log and xfail on expected timezone shift.
     if case.name in results.rows:
         actual = results.rows[case.name].get(case.col)
         expected = (
@@ -591,23 +669,18 @@ def test_timestamp_ntz_epoch(results):
                 case.name,
                 f"epoch timestamp shifted: got {actual!r}, v3 expects {expected!r}",
             )
-        else:
-            _log_divergence(
-                results.mode, case.name, "ingested with correct value (same as v3)"
-            )
     else:
         in_dlq = case.name in results.dlq_ids
         _log_divergence(
             results.mode,
             case.name,
-            f"v4 rejects Long for TIMESTAMP_NTZ; in_dlq={in_dlq}",
+            f"v4-ht rejects Long for TIMESTAMP_NTZ; in_dlq={in_dlq}",
         )
 
-    # Assert v3 reference behavior — xfail if v4 diverges.
     try:
         results.assert_ingested(case)
     except AssertionError as e:
-        pytest.xfail(f"v4 diverges on integer epoch for TIMESTAMP_NTZ: {e}")
+        pytest.xfail(f"v4-ht: SSv2 backend uses channel TZ for integer epoch: {e}")
 
 
 def test_timestamp_ltz(results):
@@ -671,31 +744,106 @@ def test_variant_bare_string(results):
         results.assert_error(case)
 
 
-def test_array_json_string(results):
-    """JSON string sent to ARRAY: SSv1 parses, SSv2 stores as literal.
+def test_variant_json_string(results):
+    """JSON string sent to VARIANT: v3/v4-compat parse to native object, v4-ht stores as string.
 
-    KNOWN DIVERGENCE: v3 (SSv1) parses the JSON string '[1,2,3]' into a
-    proper array [1,2,3]. v4 (SSv2) stores it as a single-element array
-    containing the literal string: ["[1,2,3]"].
+    Covers JSON object strings ('{"a":1}'), scalar strings ('42', 'true'),
+    and JSON array strings ('[1,2]') sent as String values to a VARIANT column.
+
+    v3 and v4-compat: RowValidator normalizes the String to a native Java object
+    (Map, List, Integer, Boolean) so the SSv2 SDK stores it correctly.
+
+    KNOWN DIVERGENCE for v4-ht: server-side validation bypasses RowValidator; the SSv2 SDK
+    receives the raw String and stores it as a JSON-quoted string literal.
     """
-    [case] = cases_where(group="array_json_str")
-    if results.mode == "v3":
-        results.assert_ingested(case)
-    else:
-        # v4-compat/v4-ht: string stored as literal element
-        assert case.name in results.rows, (
-            f"[{case.name}] expected row in table on {results.mode}"
+    cases = cases_where(group="variant_json_str")
+    if results.mode in ("v3", "v4-compat"):
+        for c in cases:
+            results.assert_ingested(c)
+        return
+
+    # v4-ht: row is ingested but stored as a JSON-quoted string, not as a native object.
+    divergences = []
+    for c in cases:
+        assert c.name in results.rows, (
+            f"[{c.name}] expected row in table on {results.mode}"
         )
-        actual = results.rows[case.name].get(case.col)
-        parsed = json.loads(actual) if isinstance(actual, str) else actual
-        assert parsed == ["[1,2,3]"], (
-            f"[{case.name}] expected ['[1,2,3]'] on {results.mode}, got {parsed!r}"
+        try:
+            results.assert_ingested(c)
+        except AssertionError:
+            actual = results.rows[c.name].get(c.col)
+            _log_divergence(
+                results.mode,
+                c.name,
+                f"JSON string stored as quoted literal {actual!r} (v3 stores as {c.expected_value!r})",
+            )
+            divergences.append(c.name)
+
+    if divergences:
+        pytest.xfail(
+            f"v4-ht stores JSON strings as quoted literals in VARIANT: {divergences}"
         )
-        _log_divergence(
-            results.mode,
-            case.name,
-            "JSON string stored as literal array element (v3 parses into [1,2,3])",
-        )
+
+
+def test_array_json_string(results):
+    """String values sent to ARRAY: v3/v4-compat parse or reject, v4-ht wraps as literal element.
+
+    Covers:
+      - JSON array strings ('[1,2,3]') — v3/v4-compat parse to proper array
+      - Non-array JSON scalars ('42') — v3/v4-compat wrap as single-element array
+      - Invalid JSON strings ('not_json') — v3/v4-compat reject (DLQ)
+
+    v3 and v4-compat: RowValidator normalizes String to a List so the SSv2 SDK
+    stores it as a proper array.  Non-array scalars are wrapped into a
+    single-element array (e.g. '42' → [42]).  Invalid JSON is rejected.
+
+    KNOWN DIVERGENCE for v4-ht: server-side validation bypasses RowValidator; the SSv2 SDK
+    wraps ANY String as a single-element array, including invalid JSON and valid JSON alike.
+    """
+    cases = cases_where(group="array_json_str")
+    if results.mode in ("v3", "v4-compat"):
+        for c in cases:
+            if c.expect == "ingested":
+                results.assert_ingested(c)
+            else:
+                results.assert_error(c)
+        return
+
+    # v4-ht: SSv2 wraps all strings as single-element arrays (no rejection)
+    divergences = []
+    for c in cases:
+        if c.expect == "error":
+            # v3/v4-compat reject this, but v4-ht ingests it as ["<value>"]
+            if c.name in results.rows:
+                actual = results.rows[c.name].get(c.col)
+                parsed = json.loads(actual) if isinstance(actual, str) else actual
+                _log_divergence(
+                    results.mode,
+                    c.name,
+                    f"v4-ht ingested (v3 rejects): stored as {parsed!r}",
+                )
+                divergences.append(c.name)
+            else:
+                # Also rejected on v4-ht — no divergence
+                pass
+        else:
+            assert c.name in results.rows, (
+                f"[{c.name}] expected row in table on {results.mode}"
+            )
+            try:
+                results.assert_ingested(c)
+            except AssertionError:
+                actual = results.rows[c.name].get(c.col)
+                parsed = json.loads(actual) if isinstance(actual, str) else actual
+                _log_divergence(
+                    results.mode,
+                    c.name,
+                    f"JSON string stored as literal array element {parsed!r} (v3 stores {c.expected_value or c.value!r})",
+                )
+                divergences.append(c.name)
+
+    if divergences:
+        pytest.xfail(f"v4-ht array string handling diverges from v3: {divergences}")
 
 
 # ---------------------------------------------------------------------------
@@ -748,12 +896,7 @@ def test_null(results, col):
 
 
 def test_cross_type_mismatch(results):
-    """Values sent to incompatible column types — expected DLQ/drop.
-
-    KNOWN DIVERGENCES:
-    - v4-compat silently drops numeric→BOOLEAN (no DLQ, no table row)
-    - v4-compat DLQ's object→VARCHAR (v3/v4-ht coerce to JSON string)
-    """
+    """Values sent to incompatible column types — expected DLQ/drop."""
     if results.mode == "v3":
         _assert_all(results, cases_where(group="xtype"))
         return


### PR DESCRIPTION
## Background

In KC v3, `StreamingRecordMapper.getTextualValue()` serialized **every value to a String** before the SSv1 SDK saw it — Integer `42` became `"42"`, Boolean `true` became `"true"`, Map `{a:1}` became `"{\"a\":1}"`. The SSv1 SDK then re-parsed these strings using type-specific validators (`convertStringToBoolean`, `parseInstantGuessScale`, etc.).

In KC v4, commit `6be86dd2` (FLOW-7464) replaced `StreamingRecordMapper` with `KafkaRecordConverter`, which passes **native Java types** directly (Boolean stays `Boolean`, Integer stays `Integer`, Map stays `Map`). This was correct for SSv2-native mode (v4-ht) — SSv2 serializes the `Map<String, Object>` to NDJSON via Jackson, and pre-stringifying would cause double-encoding.

However, in v4-compat mode, `RowValidator` (vendored SSv1 `DataValidationUtil`) sits between `KafkaRecordConverter` and SSv2 SDK. It receives native types but SSv1's validators were designed to receive strings. This type convention mismatch caused all the divergences fixed here.

## Summary

Fixes data type handling divergences between KC v3 (SSv1 SDK) and v4-compat (RowValidator + SSv2 SDK):

- **BOOLEAN**: Normalize Integer 0/1 and String tokens to `Boolean` before the SSv2 SDK call. Pre-reject non-0/1 numeric values to match end-to-end KC v3 behavior (KC v3's record mapper converts integers to strings before SSv1, and SSv1's `convertStringToBoolean` only accepts "0"/"1"/"true"/"false"/"yes"/"no"/"on"/"off" — so "42" is rejected).
- **VARIANT (String input)**: Parse validated JSON to native Java object (Map/List/primitive) via `validateAndParseVariantAsObject` so the SSv2 SDK stores the parsed object, not a double-quoted JSON literal.
- **ARRAY (String input)**: Parse validated JSON array to native `List` via `validateAndParseArrayAsList` so the SSv2 SDK stores a proper array instead of a single-element wrapper.
- **VARCHAR (Map/Collection input)**: Serialize Map/Collection values to JSON strings before validation, replicating KC v3's record mapper serialization (`StreamingRecordMapper.getTextualValue → writeValueAsStringOrNanOrInfinity`). The SSv1 SDK itself rejects Map/Collection for VARCHAR — the serialization happens at the KC pipeline level.
- **TIMESTAMP (Integer/Long epoch)**: Normalize Integer/Long epoch values to ISO timestamp strings via `validateAndFormatTimestamp`. The SSv2 SDK passes raw integers to the Snowflake backend which interprets them using the channel's default timezone (America/Los_Angeles) instead of UTC. SSv1 SDK converted epochs to UTC client-side.


## Test plan

- [x] Unit tests: 104 cases pass (72 RowValidatorTest + 32 DataValidationUtilTest)
- [x] E2E tests: `test_type_compatibility.py` — 96 passed, 7 xfailed, 2 skipped across 3 modes (v3, v4-compat, v4-ht)
  - v4-compat `tsntz_int_epoch` now matches v3 (10:00:00 UTC) — was 02:00:00 before the fix
  - v4-ht still diverges on integer epochs (expected — no client-side validation)
- [x] Negative test cases cover: invalid JSON → OBJECT/ARRAY, bad strings → BOOLEAN, non-0/1 integers → BOOLEAN, cross-type Map/List → VARCHAR(10), invalid timestamps