### PR TITLE
Replace regex-based log formatting with StringBuilder

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -479,9 +479,21 @@ public class Utils {
   }
 
   public static String formatString(String format, Object... vars) {
-    for (int i = 0; i < vars.length; i++) {
-      format = format.replaceFirst("\\{}", Objects.toString(vars[i]).replaceAll("\\$", "\\\\\\$"));
+    if (vars.length == 0) {
+      return format;
     }
-    return format;
+    StringBuilder sb = new StringBuilder(format.length() + vars.length * 16);
+    int start = 0;
+    for (int i = 0; i < vars.length; i++) {
+      int idx = format.indexOf("{}", start);
+      if (idx < 0) {
+        break;
+      }
+      sb.append(format, start, idx);
+      sb.append(Objects.toString(vars[i]));
+      start = idx + 2;
+    }
+    sb.append(format, start, format.length());
+    return sb.toString();
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/UtilsTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/UtilsTest.java
@@ -163,6 +163,28 @@ public class UtilsTest {
   }
 
   @Test
+  public void testFormatStringEdgeCases() {
+    // Dollar signs in values (old regex code needed $ escaping)
+    assertEquals("price is $100", Utils.formatString("price is {}", "$100"));
+    assertEquals("a=$1 b=$2", Utils.formatString("a={} b={}", "$1", "$2"));
+
+    // More vars than placeholders — extra vars ignored
+    assertEquals("hello world", Utils.formatString("hello {}", "world", "extra", "ignored"));
+
+    // More placeholders than vars — remaining {} left as-is
+    assertEquals("hello world {}", Utils.formatString("hello {} {}", "world"));
+
+    // No placeholders at all
+    assertEquals("no placeholders", Utils.formatString("no placeholders", "unused"));
+
+    // Empty format
+    assertEquals("", Utils.formatString(""));
+
+    // Adjacent placeholders
+    assertEquals("ab", Utils.formatString("{}{}", "a", "b"));
+  }
+
+  @Test
   public void testSemanticVersionParsing() {
     // Test standard version parsing
     SemanticVersion version311 = new SemanticVersion("3.1.1");


### PR DESCRIPTION
## Summary
Replace regex-based `Utils.formatString()` with `indexOf` + `StringBuilder` to eliminate per-call `Pattern.compile` overhead.

**Root cause:** `formatString()` used `String.replaceFirst("\\{}")` per variable, which compiles a `Pattern` on every call. Additionally, each substituted value went through `replaceAll("\\$", "\\\\\\$")` to escape dollar signs (a regex backreference workaround). With `KCLogger` calling this on every log statement, this was the #1 allocation source in the connector.

**Fix:** Simple `indexOf("{}")` + `StringBuilder.append()` loop. No regex, no `$` escaping needed.

## Profiling results (before vs after)

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| formatString alloc samples | 26,699 (14.1%) | 345 (0.8%) | **-98.7%** |
| Regex alloc samples | 939 (0.5%) | 1 (0.0%) | **-99.9%** |
| Top formatString allocator | Pattern.compile | StringBuilder.init | No more regex |

## Test plan
- [x] All 20 existing `UtilsTest` tests pass (including format, null, multiline edge cases)
- [x] JFR profiling confirms formatString dropped from 14.1% to 0.8% of allocations
- [x] No `Pattern.compile` or `Matcher` in formatString stack traces

Jira: SNOW-3356560
