### PR TITLE
SNOW-3361266 fix race condition in channel recovery

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkService.java
@@ -37,8 +37,10 @@ public interface SnowflakeSinkService {
    * call pipe to insert a JSON record will not trigger time based flush
    *
    * @param record record content
+   * @return true if the record was processed successfully, false if recovery was triggered and the
+   *     caller should stop feeding records to this partition for the remainder of the batch
    */
-  void insert(final SinkRecord record);
+  boolean insert(final SinkRecord record);
 
   /**
    * retrieve offset of last loaded record for given pipe name

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -356,11 +356,11 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
 
     // If still in cooldown from a recent backpressure event, treat all partitions as
     // backpressured so we skip the entire batch and give the SDK time to drain.
-    Set<TopicPartition> backpressuredPartitions = new HashSet<>();
+    boolean skipAllPartitions = false;
     if (Instant.now().isBefore(backpressureUntil)) {
       LOGGER.debug(
           "Backpressure cooldown active until {}. Skipping entire batch.", backpressureUntil);
-      backpressuredPartitions.addAll(partitions);
+      skipAllPartitions = true;
     }
 
     Map<TopicPartition, Long> offsetsOfFirstSkippedRecord = new HashMap<>();
@@ -372,7 +372,10 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
       }
 
       TopicPartition tp = new TopicPartition(record.topic(), record.kafkaPartition());
-      if (initializingPartitions.contains(tp) || backpressuredPartitions.contains(tp)) {
+
+      if (skipAllPartitions || initializingPartitions.contains(tp)) {
+        // Make sure we store the first record in each partition that we skipped so we can correctly
+        // rewind the offset.
         offsetsOfFirstSkippedRecord.putIfAbsent(tp, record.kafkaOffset());
         continue;
       }
@@ -387,7 +390,7 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
             e.getMessage());
         taskMetrics.incBackpressureRewindCount();
         offsetsOfFirstSkippedRecord.putIfAbsent(tp, record.kafkaOffset());
-        backpressuredPartitions.add(tp);
+        skipAllPartitions = true;
         newBackpressure = true;
       }
     }

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -373,6 +373,11 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
 
       TopicPartition tp = new TopicPartition(record.topic(), record.kafkaPartition());
 
+      if (offsetsOfFirstSkippedRecord.containsKey(tp)) {
+        // We've already skipped a record in this partition, so should also skip the remaining
+        // records in this partition.
+        continue;
+      }
       if (skipAllPartitions || initializingPartitions.contains(tp)) {
         // Make sure we store the first record in each partition that we skipped so we can correctly
         // rewind the offset.
@@ -381,7 +386,9 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
       }
 
       try {
-        insert(record);
+        if (!insert(record)) {
+          offsetsOfFirstSkippedRecord.putIfAbsent(tp, record.kafkaOffset());
+        }
       } catch (BackpressureException e) {
         LOGGER.warn(
             "Backpressure on partition {}. Skipping remaining records for this partition."
@@ -411,7 +418,7 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
    * then each partition(Streaming channel) calls its respective appendRows API
    */
   @Override
-  public void insert(SinkRecord record) {
+  public boolean insert(SinkRecord record) {
     LOGGER.trace("Inserting record: {}", record);
 
     TopicPartition topicPartition = new TopicPartition(record.topic(), record.kafkaPartition());
@@ -434,7 +441,7 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
                         "Channel for " + topicPartition + " not found after startPartition"));
 
     boolean isFirstRowPerPartitionInBatch = channelsVisitedPerBatch.add(channel.getChannelName());
-    channel.insertRecord(record, isFirstRowPerPartitionInBatch);
+    return channel.insertRecord(record, isFirstRowPerPartitionInBatch);
   }
 
   private boolean shouldSkipNullValue(SinkRecord record) {

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/channel/TopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/channel/TopicPartitionChannel.java
@@ -22,8 +22,11 @@ public interface TopicPartitionChannel {
    * @param kafkaSinkRecord input record from Kafka
    * @param isFirstRowPerPartitionInBatch indicates whether the given record is the first record per
    *     partition in a batch
+   * @return true if the record was processed (or legitimately skipped as a duplicate), false if
+   *     recovery was triggered and the caller should stop feeding records to this partition for the
+   *     remainder of the batch
    */
-  void insertRecord(SinkRecord kafkaSinkRecord, boolean isFirstRowPerPartitionInBatch);
+  boolean insertRecord(SinkRecord kafkaSinkRecord, boolean isFirstRowPerPartitionInBatch);
 
   /**
    * Asynchronously closes a channel associated to this partition. Any {@link SFException} occurred

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannel.java
@@ -167,13 +167,14 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
   }
 
   @Override
-  public void insertRecord(SinkRecord kafkaSinkRecord, boolean isFirstRowPerPartitionInBatch) {
+  public boolean insertRecord(SinkRecord kafkaSinkRecord, boolean isFirstRowPerPartitionInBatch) {
     if (offsetTracker.shouldProcess(kafkaSinkRecord.kafkaOffset(), isFirstRowPerPartitionInBatch)) {
-      transformAndSend(kafkaSinkRecord);
+      return transformAndSend(kafkaSinkRecord);
     }
+    return true;
   }
 
-  private void transformAndSend(SinkRecord kafkaSinkRecord) {
+  private boolean transformAndSend(SinkRecord kafkaSinkRecord) {
     try {
       final long kafkaOffset = kafkaSinkRecord.kafkaOffset();
       final SnowflakeSinkRecord record =
@@ -203,7 +204,7 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
                 handleValidationError(validationResult, kafkaSinkRecord);
               }
               offsetTracker.recordProcessed(kafkaOffset);
-              return;
+              return true;
             }
           }
 
@@ -212,12 +213,13 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
             // logic already reset processedOffset + rewound Kafka. Do NOT call
             // recordProcessed() here — that would advance processedOffset past the
             // recovery point and cause replayed offsets to be skipped. See SNOW-3344243.
-            return;
+            return false;
           }
         }
       }
       // Always update processedOffset after processing, even for broken records
       offsetTracker.recordProcessed(kafkaOffset);
+      return true;
     } catch (BackpressureException ex) {
       snowflakeTelemetryChannelStatus.incBackpressureRetryCount();
       throw ex;
@@ -227,6 +229,7 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
           "Failed to insert row for channel:{}. Will be retried by Kafka. Exception: {}",
           this.channelName,
           ex);
+      return true;
     }
   }
 

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2Test.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2Test.java
@@ -434,6 +434,65 @@ class SnowflakeSinkServiceV2Test {
     verify(mockSinkTaskContext, never()).offset(any(TopicPartition.class), any(Long.class));
   }
 
+  // --- recovery skip logic ---
+
+  @Test
+  void insertSkipsRemainingRecordsForPartitionAfterRecovery() {
+    TopicPartition tp0 = new TopicPartition(TOPIC, 0);
+    TopicPartition tp1 = new TopicPartition(TOPIC, 1);
+
+    TopicPartitionChannel channel0 = mockChannel("ch_0", false);
+    TopicPartitionChannel channel1 = mockChannel("ch_1", false);
+
+    when(mockChannelManager.getChannel(tp0)).thenReturn(Optional.of(channel0));
+    when(mockChannelManager.getChannel(tp1)).thenReturn(Optional.of(channel1));
+
+    // channel0 signals recovery on its first record
+    when(channel0.insertRecord(any(), anyBoolean())).thenReturn(false);
+
+    List<SinkRecord> records =
+        Arrays.asList(
+            recordFor(TOPIC, 0, 100),
+            recordFor(TOPIC, 1, 200),
+            recordFor(TOPIC, 0, 101),
+            recordFor(TOPIC, 0, 102));
+    service.insert(records);
+
+    // channel0: only the first record was attempted; 101 and 102 were skipped
+    verify(channel0).insertRecord(records.get(0), true);
+    verify(channel0, never()).insertRecord(records.get(2), false);
+    verify(channel0, never()).insertRecord(records.get(3), false);
+
+    // channel1: processed normally
+    verify(channel1).insertRecord(records.get(1), true);
+
+    // Only the recovering partition is rewound, to the triggering record's offset
+    verify(mockSinkTaskContext).offset(tp0, 100L);
+    verify(mockSinkTaskContext, never()).offset(tp1, 200L);
+  }
+
+  @Test
+  void insertRewindsToFirstSkippedOffsetAfterRecoveryMidPartition() {
+    TopicPartition tp = new TopicPartition(TOPIC, 0);
+    TopicPartitionChannel channel = mockChannel("ch_0", false);
+    when(mockChannelManager.getChannel(tp)).thenReturn(Optional.of(channel));
+
+    // First record succeeds, second triggers recovery
+    when(channel.insertRecord(any(), anyBoolean())).thenReturn(true).thenReturn(false);
+
+    List<SinkRecord> records =
+        Arrays.asList(recordFor(TOPIC, 0, 100), recordFor(TOPIC, 0, 101), recordFor(TOPIC, 0, 102));
+    service.insert(records);
+
+    // First two records attempted, third skipped
+    verify(channel).insertRecord(records.get(0), true);
+    verify(channel).insertRecord(records.get(1), false);
+    verify(channel, never()).insertRecord(records.get(2), false);
+
+    // Rewind to the record that triggered recovery
+    verify(mockSinkTaskContext).offset(tp, 101L);
+  }
+
   // --- helpers ---
 
   private SnowflakeSinkServiceV2 buildService(
@@ -470,6 +529,7 @@ class SnowflakeSinkServiceV2Test {
     when(channel.getChannelName()).thenReturn(channelName);
     when(channel.isInitializing()).thenReturn(initializing);
     when(channel.isChannelClosed()).thenReturn(false);
+    when(channel.insertRecord(any(), anyBoolean())).thenReturn(true);
     return channel;
   }
 

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2Test.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2Test.java
@@ -282,7 +282,7 @@ class SnowflakeSinkServiceV2Test {
   // --- backpressure handling ---
 
   @Test
-  void insertRewindsOnlyBackpressuredPartition() {
+  void insertSkipsAllPartitionsAfterBackpressure() {
     TopicPartition tp0 = new TopicPartition(TOPIC, 0);
     TopicPartition tp1 = new TopicPartition(TOPIC, 1);
 
@@ -302,17 +302,17 @@ class SnowflakeSinkServiceV2Test {
     List<SinkRecord> records = Arrays.asList(recordFor(TOPIC, 0, 100), recordFor(TOPIC, 1, 200));
     service.insert(records);
 
-    // channel0 threw, but channel1 is still attempted (per-partition backpressure)
+    // channel0 threw; channel1 is skipped because backpressure stops all partitions
     verify(channel0).insertRecord(records.get(0), true);
-    verify(channel1).insertRecord(records.get(1), true);
+    verify(channel1, never()).insertRecord(any(), anyBoolean());
 
-    // Only the backpressured partition is rewound; channel1 succeeded
+    // Both partitions rewound
     verify(mockSinkTaskContext).offset(tp0, 100L);
-    verify(mockSinkTaskContext, never()).offset(tp1, 200L);
+    verify(mockSinkTaskContext).offset(tp1, 200L);
   }
 
   @Test
-  void insertSkipsRemainingRecordsForBackpressuredPartitionOnly() {
+  void insertSkipsRemainingRecordsForAllPartitionsAfterBackpressure() {
     TopicPartition tp0 = new TopicPartition(TOPIC, 0);
     TopicPartition tp1 = new TopicPartition(TOPIC, 1);
 
@@ -327,20 +327,19 @@ class SnowflakeSinkServiceV2Test {
         .when(channel1)
         .insertRecord(any(), anyBoolean());
 
-    // Interleaved: p0 records after p1's backpressure are still processed
+    // p0's first record succeeds, p1 throws, p0's second record is skipped
     List<SinkRecord> records =
         Arrays.asList(recordFor(TOPIC, 0, 100), recordFor(TOPIC, 1, 200), recordFor(TOPIC, 0, 101));
     service.insert(records);
 
-    // channel0 both records processed, channel1 threw on first
+    // channel0 first record processed, channel1 threw, channel0 second record skipped
     verify(channel0).insertRecord(records.get(0), true);
     verify(channel1).insertRecord(records.get(1), true);
-    verify(channel0).insertRecord(records.get(2), false);
+    verify(channel0, never()).insertRecord(records.get(2), false);
 
-    // Only p1 rewound; p0 fully processed
+    // p1 rewound to the backpressured record; p0 rewound to the first skipped record
     verify(mockSinkTaskContext).offset(tp1, 200L);
-    verify(mockSinkTaskContext, never()).offset(tp0, 100L);
-    verify(mockSinkTaskContext, never()).offset(tp0, 101L);
+    verify(mockSinkTaskContext).offset(tp0, 101L);
   }
 
   @Test


### PR DESCRIPTION
Issue originally identified in #1397.

## Problem

When a non-retryable `SFException` is thrown by `appendRow` mid-batch, `reopenChannel()` starts an async recovery on the IO executor. The task thread continues processing the next record in the same batch. This creates a race window where `shouldProcess()` and `resetAfterRecovery()` are not synchronised, causing `processedOffset` to advance past the recovery reset and subsequent re-delivered records to be silently dropped.

```mermaid
sequenceDiagram
    participant Task as Task Thread
    participant IO as IO Thread
    Note over Task: Batch: records 6, 7, 8
    Task->>Task: insertRecord(7) -> appendRow fails
    Task->>IO: reopenChannel() (async)
    Task->>Task: insertRecord(8) -> shouldProcess(8)=true (race!)
    IO->>IO: resetAfterRecovery(5) -> processedOffset=5
    Task->>Task: getChannel().join() blocks, then unblocks
    Task->>Task: appendRow(8) on new channel -> OK
    Task->>Task: recordProcessed(8) -> processedOffset=8 (OVERWRITES 5!)
    Note over Task: Re-delivered record 6: shouldProcess(6) -> 6 < 8+1 -> SKIP -> DATA LOSS
```

With the fix, after `insertRecord(7)` returns `false`, the task thread adds `tp -> 7` to `offsetsOfFirstSkippedRecord` and skips record 8 entirely. No `recordProcessed(8)` ever runs.

## Fix

Whenever a channel fails insertion and needs to be recovered, we propagate this information up to `SnowflakeSinkServiceV2`'s `insert` method so that all remaining records within this batch are skipped.

## Cross-batch safety

The same race could theoretically occur across batch boundaries: batch N triggers recovery, and batch N+1 arrives before recovery completes. However, this case is already handled by the existing `isInitializing()` check. `SnowpipeStreamingPartitionChannel.isInitializing()` returns `!channel.isDone()` — during recovery, `reopenChannel()` replaces the channel future with a new one that won't complete until the new channel is opened and `resetAfterRecovery` has run. The batch loop in `insert(Collection)` skips all initializing partitions and rewinds their offsets, so no `shouldProcess` / `recordProcessed` can run while recovery is in flight.

- If recovery is **still in flight** when the next batch starts: the partition is skipped (initializing), offsets are rewound, no race.
- If recovery has **already completed**: `resetAfterRecovery` has set `processedOffset` to the committed offset and rewound Kafka, so the batch receives correct records and `processedOffset` is authoritative.

## Additional change

The recovery logic in `insert` was getting complex so I also simplified the backpressure recovery to simply skip subsequent records across all partitions rather than just in the current one - this behavior matches the fact that we skip records in all partitions in *subsequent* batches.