### PR TITLE
use SinkTaskConfig directly where appropriate

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
@@ -66,7 +66,6 @@ public class SnowflakeSinkTask extends SinkTask {
   private KCLogger DYNAMIC_LOGGER;
 
   private volatile SnowflakeSinkService sink = null;
-  private Map<String, String> topic2table = null;
 
   // snowflake JDBC connection provides methods to interact with user's
   // snowflake
@@ -101,16 +100,6 @@ public class SnowflakeSinkTask extends SinkTask {
     DYNAMIC_LOGGER = new KCLogger(this.getClass().getName());
     this.sink = service;
     this.conn = connectionService;
-  }
-
-  @VisibleForTesting
-  // @codeCoverageIgnore
-  public SnowflakeSinkTask(
-      SnowflakeSinkService service,
-      SnowflakeConnectionService connectionService,
-      Map<String, String> topic2table) {
-    this(service, connectionService);
-    this.topic2table = topic2table;
   }
 
   private SnowflakeConnectionService getConnection() {
@@ -157,9 +146,6 @@ public class SnowflakeSinkTask extends SinkTask {
     // get task id and start time
     this.taskStartTime = System.currentTimeMillis();
     this.taskConfigId = config.getTaskId();
-
-    // generate topic to table map
-    this.topic2table = new HashMap<>(config.getTopicToTableMap());
 
     this.authorizationExceptionTracker.updateStateOnTaskStart(parsedConfig);
 

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTask.java
@@ -200,10 +200,7 @@ public class SnowflakeSinkTask extends SinkTask {
     // Initialize and start periodic telemetry reporter for channel status
     this.telemetryReporter =
         new PeriodicTelemetryReporter(
-            conn.getTelemetryClient(),
-            sink::getPartitionChannels,
-            connectorName,
-            this.taskConfigId);
+            conn.getTelemetryClient(), sink::getPartitionChannels, config);
     this.telemetryReporter.start();
 
     DYNAMIC_LOGGER.info(

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -59,24 +59,15 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
 
   private final SnowflakeConnectionService conn;
 
-  private final Map<String, String> topicToTableMap;
-
-  // Behavior to be set at the start of connector start. (For tombstone records)
-  private final ConnectorConfigTools.BehaviorOnNullValues behaviorOnNullValues;
   private final Optional<MetricsJmxReporter> metricsJmxReporter;
   private final String connectorName;
-  private final String taskId;
 
   private final SinkTaskConfig taskConfig;
   private final SinkTaskContext sinkTaskContext;
 
   // Set that keeps track of the channels that have been seen per input batch
   private final Set<String> channelsVisitedPerBatch = new HashSet<>();
-  // Whether to tolerate errors during ingestion (based on errors.tolerance config)
-  private final boolean tolerateErrors;
   private final BatchOffsetFetcher batchOffsetFetcher;
-  // Whether to enable table name sanitization
-  private final boolean enableSanitization;
 
   private final PartitionChannelManager channelManager;
   private final TaskMetrics taskMetrics;
@@ -134,13 +125,7 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
     this.sinkTaskContext = sinkTaskContext;
     this.metricsJmxReporter = metricsJmxReporter;
 
-    // Connector name and task ID already validated by SinkTaskConfig.from()
     this.connectorName = taskConfig.getConnectorName();
-    this.taskId = taskConfig.getTaskId();
-    this.topicToTableMap = taskConfig.getTopicToTableMap();
-    this.behaviorOnNullValues = taskConfig.getBehaviorOnNullValues();
-    this.tolerateErrors = taskConfig.isTolerateErrors();
-    this.enableSanitization = taskConfig.isEnableSanitization();
 
     ThreadPools.registerTask(this.connectorName, taskConfig);
 
@@ -155,9 +140,9 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
         "SnowflakeSinkServiceV2 initialized for connector: {}, task: {}, tolerateErrors: {},"
             + " enableSanitization: {}",
         this.connectorName,
-        this.taskId,
-        this.tolerateErrors,
-        this.enableSanitization);
+        taskConfig.getTaskId(),
+        taskConfig.isTolerateErrors(),
+        taskConfig.isEnableSanitization());
   }
 
   /**
@@ -196,7 +181,7 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
       // Check each target table for ERROR_LOGGING.
       // Note: makes up to 3 network calls per table (tableExist + isIcebergTable +
       // hasErrorLoggingEnabled). Acceptable at startup; only runs once per task constructor.
-      Set<String> uniqueTables = new HashSet<>(topicToTableMap.values());
+      Set<String> uniqueTables = new HashSet<>(taskConfig.getTopicToTableMap().values());
       for (String tableName : uniqueTables) {
         if (!conn.tableExist(tableName)) {
           // Table doesn't exist yet — will be auto-created with ERROR_LOGGING = TRUE
@@ -282,7 +267,8 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
         partitions.stream().map(TopicPartition::topic).collect(Collectors.toSet());
 
     for (String topic : uniqueTopics) {
-      final String tableName = getTableName(topic, this.topicToTableMap, this.enableSanitization);
+      final String tableName =
+          getTableName(topic, taskConfig.getTopicToTableMap(), taskConfig.isEnableSanitization());
       createTableIfNotExists(tableName);
 
       // Client-side validation only supports default pipes.
@@ -443,7 +429,7 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
   }
 
   private boolean shouldSkipNullValue(SinkRecord record) {
-    if (behaviorOnNullValues == ConnectorConfigTools.BehaviorOnNullValues.DEFAULT) {
+    if (taskConfig.getBehaviorOnNullValues() == ConnectorConfigTools.BehaviorOnNullValues.DEFAULT) {
       return false;
     }
     if (record.value() == null) {
@@ -518,13 +504,13 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
     LOGGER.info(
         "Stopping SnowflakeSinkServiceV2 for connector: {}, task: {}",
         this.connectorName,
-        this.taskId);
+        taskConfig.getTaskId());
 
     channelManager.waitForAllChannelsToCommitData();
 
     // Release all streaming clients used by this service.
     // Clients will only be closed if no other tasks are using them.
-    StreamingClientPools.closeTaskClients(connectorName, taskId);
+    StreamingClientPools.closeTaskClients(connectorName, taskConfig.getTaskId());
 
     // Release this task's claim on the shared thread pool.
     // The pool is shut down when the last task for this connector unregisters.

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -113,8 +113,6 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
                 recordErrorReporter,
                 sinkTaskContext,
                 metricsJmxReporter,
-                taskConfig.getConnectorName(),
-                taskConfig.getTaskId(),
                 taskMetrics,
                 conn),
         taskMetrics);

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/telemetry/PeriodicTelemetryReporter.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/telemetry/PeriodicTelemetryReporter.java
@@ -1,6 +1,7 @@
 package com.snowflake.kafka.connector.internal.streaming.telemetry;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.snowflake.kafka.connector.config.SinkTaskConfig;
 import com.snowflake.kafka.connector.internal.KCLogger;
 import com.snowflake.kafka.connector.internal.streaming.channel.TopicPartitionChannel;
 import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryService;
@@ -33,9 +34,13 @@ public final class PeriodicTelemetryReporter {
   public PeriodicTelemetryReporter(
       SnowflakeTelemetryService telemetryService,
       Supplier<Map<String, TopicPartitionChannel>> channelsSupplier,
-      String connectorName,
-      String taskId) {
-    this(telemetryService, channelsSupplier, connectorName, taskId, DEFAULT_REPORT_INTERVAL_MS);
+      SinkTaskConfig taskConfig) {
+    this(
+        telemetryService,
+        channelsSupplier,
+        taskConfig.getConnectorName(),
+        taskConfig.getTaskId(),
+        DEFAULT_REPORT_INTERVAL_MS);
   }
 
   @VisibleForTesting

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannel.java
@@ -12,6 +12,8 @@ import com.snowflake.ingest.streaming.OpenChannelResult;
 import com.snowflake.ingest.streaming.SFException;
 import com.snowflake.ingest.streaming.SnowflakeStreamingIngestChannel;
 import com.snowflake.ingest.streaming.SnowflakeStreamingIngestClient;
+import com.snowflake.kafka.connector.config.SinkTaskConfig;
+import com.snowflake.kafka.connector.config.SnowflakeValidation;
 import com.snowflake.kafka.connector.internal.DescribeTableRow;
 import com.snowflake.kafka.connector.internal.KCLogger;
 import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
@@ -33,7 +35,6 @@ import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryServic
 import com.snowflake.kafka.connector.internal.validation.ColumnSchema;
 import com.snowflake.kafka.connector.internal.validation.RowValidator;
 import com.snowflake.kafka.connector.internal.validation.ValidationResult;
-import com.snowflake.kafka.connector.records.SnowflakeMetadataConfig;
 import com.snowflake.kafka.connector.records.SnowflakeSinkRecord;
 import java.time.Duration;
 import java.util.Arrays;
@@ -79,9 +80,7 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
 
   private final SnowflakeTelemetryChannelStatus snowflakeTelemetryChannelStatus;
 
-  private final SnowflakeMetadataConfig metadataConfig;
-  private final boolean enableSchematization;
-  private final boolean enableColumnIdentifierNormalization;
+  private final SinkTaskConfig taskConfig;
 
   /**
    * Used to send telemetry to Snowflake. Currently, TelemetryClient created from a Snowflake
@@ -99,11 +98,9 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
   private final TaskMetrics taskMetrics;
 
   // SSv1 offset migration
-  private final Ssv1MigrationMode ssv1MigrationMode;
   private final Optional<String> ssv1ChannelName;
 
   // Client-side validation fields
-  private final boolean clientValidationEnabled;
   private final SnowflakeConnectionService conn;
   private final String tableName;
   private volatile RowValidator rowValidator;
@@ -120,33 +117,25 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
       SnowflakeTelemetryService telemetryService,
       SnowflakeTelemetryChannelStatus snowflakeTelemetryChannelStatus,
       PartitionOffsetTracker offsetTracker,
-      SnowflakeMetadataConfig metadataConfig,
-      boolean enableSchematization,
-      boolean enableColumnIdentifierNormalization,
+      SinkTaskConfig taskConfig,
       StreamingErrorHandler streamingErrorHandler,
       TaskMetrics taskMetrics,
-      boolean clientValidationEnabled,
       boolean shouldEvolveSchema,
       SnowflakeConnectionService conn,
-      Ssv1MigrationMode ssv1MigrationMode,
       Optional<String> ssv1ChannelName) {
     this.channelName = channelName;
     this.pipeName = pipeName;
     this.streamingClient = streamingClient;
     this.openChannelIoExecutor = openChannelIoExecutor;
-    this.metadataConfig = metadataConfig;
-    this.enableSchematization = enableSchematization;
-    this.enableColumnIdentifierNormalization = enableColumnIdentifierNormalization;
+    this.taskConfig = taskConfig;
     this.streamingErrorHandler = streamingErrorHandler;
     this.taskMetrics = taskMetrics;
     this.telemetryService = telemetryService;
     this.snowflakeTelemetryChannelStatus = snowflakeTelemetryChannelStatus;
     this.offsetTracker = offsetTracker;
-    this.clientValidationEnabled = clientValidationEnabled;
     this.shouldEvolveSchema = shouldEvolveSchema;
     this.conn = conn;
     this.tableName = tableName;
-    this.ssv1MigrationMode = ssv1MigrationMode;
     this.ssv1ChannelName = ssv1ChannelName;
 
     LOGGER.info(
@@ -164,7 +153,7 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
             },
             openChannelIoExecutor);
 
-    if (clientValidationEnabled) {
+    if (taskConfig.getValidation() == SnowflakeValidation.CLIENT_SIDE) {
       initializeValidation();
     } else {
       LOGGER.info("Client-side validation disabled for channel {}", channelName);
@@ -188,9 +177,9 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
       final SnowflakeSinkRecord record =
           SnowflakeSinkRecord.from(
               kafkaSinkRecord,
-              metadataConfig,
-              enableSchematization,
-              enableColumnIdentifierNormalization);
+              taskConfig.getMetadataConfig(),
+              taskConfig.isEnableSchematization(),
+              taskConfig.isEnableColumnIdentifierNormalization());
 
       if (record.isBroken()) {
         LOGGER.debug("Broken record offset:{}, topic:{}", kafkaOffset, kafkaSinkRecord.topic());
@@ -200,9 +189,11 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
       } else {
         // If we reach here, it means we should ingest a record (possibly empty for tombstones)
         final Map<String, Object> row =
-            record.getContentWithMetadata(metadataConfig.shouldIncludeAllMetadata());
+            record.getContentWithMetadata(
+                taskConfig.getMetadataConfig().shouldIncludeAllMetadata());
         if (!row.isEmpty()) {
-          if (clientValidationEnabled && rowValidator != null) {
+          if (taskConfig.getValidation() == SnowflakeValidation.CLIENT_SIDE
+              && rowValidator != null) {
             ValidationResult validationResult = rowValidator.validateRow(row);
 
             if (!validationResult.isValid()) {
@@ -410,7 +401,7 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
     // Only consult SSv1 when SSv2 has no committed offset yet (first-time migration).
     // Once SSv2 has its own offset, it is authoritative.
     if (ssv2Offset == NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE
-        && ssv1MigrationMode != Ssv1MigrationMode.SKIP) {
+        && taskConfig.getSsv1MigrationMode() != Ssv1MigrationMode.SKIP) {
       // migrateSsv1ChannelOffset calls SYSTEM$MIGRATE_SSV1_CHANNEL_OFFSET which:
       //   - returns ssv1ChannelFound=false if the SSv1 channel doesn't exist
       //   - returns ssv1ChannelFound=true, migratedOffset=null if found but no committed offset
@@ -422,7 +413,7 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
               () ->
                   new IllegalStateException(
                       "ssv1ChannelName must be present when migration mode is "
-                          + ssv1MigrationMode));
+                          + taskConfig.getSsv1MigrationMode()));
       Ssv1MigrationResponse response =
           conn.migrateSsv1ChannelOffset(tableName, ssv1Channel, channelName, pipeName);
       Long migrated = response.getMigratedOffset();
@@ -443,8 +434,9 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
       }
       telemetryService.reportSsv1Migration(
           new SnowflakeTelemetrySsv1Migration(
-              tableName, channelName, ssv1Channel, ssv1MigrationMode, response));
-      if (!response.isSsv1ChannelFound() && ssv1MigrationMode == Ssv1MigrationMode.STRICT) {
+              tableName, channelName, ssv1Channel, taskConfig.getSsv1MigrationMode(), response));
+      if (!response.isSsv1ChannelFound()
+          && taskConfig.getSsv1MigrationMode() == Ssv1MigrationMode.STRICT) {
         throw new ConnectException(
             "Snowpipe Streaming Classic channel "
                 + ssv1Channel
@@ -544,7 +536,7 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
           channelName,
           tableName,
           this.tableSchema.size(),
-          enableSchematization);
+          taskConfig.isEnableSchematization());
     } catch (Exception e) {
       LOGGER.warn(
           "Failed to initialize client-side validation for channel {}. "

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/service/PartitionChannelManager.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/service/PartitionChannelManager.java
@@ -154,7 +154,6 @@ public class PartitionChannelManager {
 
     final StreamingErrorHandler streamingErrorHandler =
         new StreamingErrorHandler(taskConfig, kafkaRecordErrorReporter, telemetryService);
-    final boolean enableSchematization = taskConfig.isEnableSchematization();
     final StreamingClientProperties streamingClientProperties =
         StreamingClientProperties.from(taskConfig);
     final SnowflakeStreamingIngestClient streamingClient =
@@ -165,9 +164,6 @@ public class PartitionChannelManager {
             taskConfig,
             streamingClientProperties,
             taskMetrics);
-    final boolean clientValidationEnabled =
-        taskConfig.getValidation() == SnowflakeValidation.CLIENT_SIDE;
-
     final PartitionOffsetTracker offsetTracker =
         new PartitionOffsetTracker(topicPartition, this.sinkTaskContext, channelName);
 
@@ -201,7 +197,7 @@ public class PartitionChannelManager {
       ssv1ChannelName =
           Optional.of(
               taskConfig.isSsv1MigrationIncludeConnectorName()
-                  ? connectorName + "_" + topic + "_" + partition
+                  ? taskConfig.getConnectorName() + "_" + topic + "_" + partition
                   : topic + "_" + partition);
     } else {
       ssv1ChannelName = Optional.empty();
@@ -216,15 +212,11 @@ public class PartitionChannelManager {
         this.telemetryService,
         telemetryChannelStatus,
         offsetTracker,
-        taskConfig.getMetadataConfig(),
-        enableSchematization,
-        taskConfig.isEnableColumnIdentifierNormalization(),
+        taskConfig,
         streamingErrorHandler,
         this.taskMetrics,
-        clientValidationEnabled,
         shouldEvolveSchema,
         this.conn,
-        ssv1MigrationMode,
         ssv1ChannelName);
   }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/service/PartitionChannelManager.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/service/PartitionChannelManager.java
@@ -47,9 +47,6 @@ public class PartitionChannelManager {
         TopicPartition topicPartition, String tableName, String channelName, String pipeName);
   }
 
-  private final String connectorName;
-  private final String taskId;
-
   private final SnowflakeTelemetryService telemetryService;
   private final KafkaRecordErrorReporter kafkaRecordErrorReporter;
   private final Optional<MetricsJmxReporter> metricsJmxReporter;
@@ -58,8 +55,6 @@ public class PartitionChannelManager {
   private final SinkTaskContext sinkTaskContext;
 
   private final SinkTaskConfig taskConfig;
-  private final Map<String, String> topicToTableMap;
-  private final boolean enableSanitization;
   private final SnowflakeConnectionService conn;
 
   private final PartitionChannelBuilder partitionChannelBuilder;
@@ -72,8 +67,6 @@ public class PartitionChannelManager {
       KafkaRecordErrorReporter kafkaRecordErrorReporter,
       SinkTaskContext sinkTaskContext,
       Optional<MetricsJmxReporter> metricsJmxReporter,
-      String connectorName,
-      String taskId,
       TaskMetrics taskMetrics,
       SnowflakeConnectionService conn) {
     this.telemetryService = telemetryService;
@@ -81,11 +74,7 @@ public class PartitionChannelManager {
     this.kafkaRecordErrorReporter = kafkaRecordErrorReporter;
     this.sinkTaskContext = sinkTaskContext;
     this.metricsJmxReporter = metricsJmxReporter;
-    this.connectorName = connectorName;
-    this.taskId = taskId;
     this.taskMetrics = taskMetrics;
-    this.topicToTableMap = taskConfig.getTopicToTableMap();
-    this.enableSanitization = taskConfig.isEnableSanitization();
     this.conn = conn;
     this.partitionChannelBuilder = this::buildChannel;
     this.partitionChannels = new ConcurrentHashMap<>();
@@ -93,19 +82,11 @@ public class PartitionChannelManager {
 
   @VisibleForTesting
   PartitionChannelManager(
-      String connectorName,
-      String taskId,
-      Map<String, String> topicToTableMap,
-      boolean enableSanitization,
-      PartitionChannelBuilder partitionChannelBuilder) {
-    this.connectorName = connectorName;
-    this.taskId = taskId;
-    this.topicToTableMap = topicToTableMap;
-    this.enableSanitization = enableSanitization;
+      SinkTaskConfig taskConfig, PartitionChannelBuilder partitionChannelBuilder) {
+    this.taskConfig = taskConfig;
     this.partitionChannelBuilder = partitionChannelBuilder;
     this.partitionChannels = new ConcurrentHashMap<>();
     this.telemetryService = null;
-    this.taskConfig = null;
     this.kafkaRecordErrorReporter = null;
     this.sinkTaskContext = null;
     this.metricsJmxReporter = Optional.empty();
@@ -122,12 +103,13 @@ public class PartitionChannelManager {
   }
 
   private String getChannelName(TopicPartition topicPartition) {
-    return makeChannelName(this.connectorName, topicPartition.topic(), topicPartition.partition());
+    return makeChannelName(
+        taskConfig.getConnectorName(), topicPartition.topic(), topicPartition.partition());
   }
 
   private String getTableName(TopicPartition topicPartition) {
     return Utils.getTableName(
-        topicPartition.topic(), this.topicToTableMap, this.enableSanitization);
+        topicPartition.topic(), taskConfig.getTopicToTableMap(), taskConfig.isEnableSanitization());
   }
 
   /**
@@ -142,8 +124,8 @@ public class PartitionChannelManager {
     LOGGER.info(
         "Starting {} partitions for connector: {}, task: {}",
         partitions.size(),
-        this.connectorName,
-        this.taskId);
+        taskConfig.getConnectorName(),
+        taskConfig.getTaskId());
 
     warmUpStreamingClients(tableToPipeMapping);
 
@@ -177,7 +159,12 @@ public class PartitionChannelManager {
         StreamingClientProperties.from(taskConfig);
     final SnowflakeStreamingIngestClient streamingClient =
         StreamingClientPools.getClient(
-            connectorName, taskId, pipeName, taskConfig, streamingClientProperties, taskMetrics);
+            taskConfig.getConnectorName(),
+            taskConfig.getTaskId(),
+            pipeName,
+            taskConfig,
+            streamingClientProperties,
+            taskMetrics);
     final boolean clientValidationEnabled =
         taskConfig.getValidation() == SnowflakeValidation.CLIENT_SIDE;
 
@@ -187,7 +174,7 @@ public class PartitionChannelManager {
     final SnowflakeTelemetryChannelStatus telemetryChannelStatus =
         new SnowflakeTelemetryChannelStatus(
             tableName,
-            this.connectorName,
+            taskConfig.getConnectorName(),
             channelName,
             System.currentTimeMillis(),
             this.metricsJmxReporter,
@@ -196,7 +183,7 @@ public class PartitionChannelManager {
             offsetTracker.consumerGroupOffsetRef());
 
     final ExecutorService openChannelIoExecutor =
-        ThreadPools.getOpenChannelIoExecutor(connectorName);
+        ThreadPools.getOpenChannelIoExecutor(taskConfig.getConnectorName());
 
     final boolean shouldEvolveSchema =
         (taskConfig.getValidation() == SnowflakeValidation.CLIENT_SIDE)
@@ -246,10 +233,10 @@ public class PartitionChannelManager {
    * parallel. Subsequent per-partition calls to {@link StreamingClientPools#getClient} in {@link
    * #buildChannel} will return the cached clients immediately.
    *
-   * <p>Skipped when using the test constructor (connectorConfig is null).
+   * <p>Skipped when using the test constructor (conn is null).
    */
   private void warmUpStreamingClients(Map<String, String> tableToPipeMapping) {
-    if (taskConfig == null) {
+    if (conn == null) {
       return;
     }
 
@@ -262,8 +249,8 @@ public class PartitionChannelManager {
             .map(
                 pipeName ->
                     StreamingClientPools.getClientAsync(
-                        connectorName,
-                        taskId,
+                        taskConfig.getConnectorName(),
+                        taskConfig.getTaskId(),
                         pipeName,
                         taskConfig,
                         streamingClientProperties,
@@ -301,8 +288,8 @@ public class PartitionChannelManager {
     LOGGER.info(
         "Closing all {} partition channels for connector: {}, task: {}",
         partitionChannels.size(),
-        this.connectorName,
-        this.taskId);
+        taskConfig.getConnectorName(),
+        taskConfig.getTaskId());
 
     CompletableFuture<?>[] futures =
         partitionChannels.values().stream()
@@ -314,8 +301,8 @@ public class PartitionChannelManager {
 
     LOGGER.info(
         "Completed closing all partition channels for connector: {}, task: {}",
-        this.connectorName,
-        this.taskId);
+        taskConfig.getConnectorName(),
+        taskConfig.getTaskId());
   }
 
   /**
@@ -334,8 +321,8 @@ public class PartitionChannelManager {
     LOGGER.info(
         "Closing {} partitions for connector: {}, task: {}",
         partitions.size(),
-        this.connectorName,
-        this.taskId);
+        taskConfig.getConnectorName(),
+        taskConfig.getTaskId());
 
     CompletableFuture<?>[] futures =
         partitions.stream()
@@ -365,7 +352,8 @@ public class PartitionChannelManager {
   /** Returns the channel for the given TopicPartition, or empty if not found. */
   public Optional<TopicPartitionChannel> getChannel(TopicPartition topicPartition) {
     String channelName =
-        makeChannelName(this.connectorName, topicPartition.topic(), topicPartition.partition());
+        makeChannelName(
+            taskConfig.getConnectorName(), topicPartition.topic(), topicPartition.partition());
     return getChannel(channelName);
   }
 

--- a/src/test/java/com/snowflake/kafka/connector/SnowflakeSinkTaskForStreamingIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/SnowflakeSinkTaskForStreamingIT.java
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams;
-import com.snowflake.kafka.connector.config.SinkTaskConfig;
 import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
 import com.snowflake.kafka.connector.internal.SnowflakeErrors;
 import com.snowflake.kafka.connector.internal.SnowflakeSinkService;
@@ -297,9 +296,7 @@ public class SnowflakeSinkTaskForStreamingIT {
     Map<String, String> config = new HashMap<>(connectorBaseConfig);
     config.putIfAbsent(KafkaConnectorConfigParams.NAME, "test-topic-to-table-regex");
     config.put(Utils.TASK_ID, "1");
-    Map<String, String> parsedConfig = SinkTaskConfig.from(config).getTopicToTableMap();
-
-    SnowflakeSinkTask sinkTask = new SnowflakeSinkTask(serviceSpy, connSpy, parsedConfig);
+    SnowflakeSinkTask sinkTask = new SnowflakeSinkTask(serviceSpy, connSpy);
 
     // test topics were mapped correctly
     sinkTask.open(testPartitions);

--- a/src/test/java/com/snowflake/kafka/connector/SnowflakeSinkTaskForStreamingIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/SnowflakeSinkTaskForStreamingIT.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams;
 import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
-import com.snowflake.kafka.connector.internal.SnowflakeErrors;
 import com.snowflake.kafka.connector.internal.SnowflakeSinkService;
 import com.snowflake.kafka.connector.internal.TestUtils;
 import com.snowflake.kafka.connector.internal.streaming.InMemorySinkTaskContext;
@@ -225,43 +224,6 @@ public class SnowflakeSinkTaskForStreamingIT {
     twoRegexExpected.put(dogTopicStr1, dogTable);
     twoRegexExpected.put(birdTopicStr1, birdTopicStr1);
     testTopicToTableRegexRunner(config, twoRegexConfig, twoRegexPartitionStrs, twoRegexExpected);
-
-    // test two regexes with catchall. catchall should overlap both regexes and fail the test
-    String twoRegexCatchAllConfig =
-        Utils.formatString(
-            "{}:{}, {}:{},{}:{}",
-            catchAllRegex,
-            catchallTable,
-            catTopicRegex,
-            catTable,
-            dogTopicRegex,
-            dogTable);
-    List<String> twoRegexCatchAllPartitionStrs =
-        Arrays.asList(catTopicStr1, catTopicStr2, bigCatTopicStr1, dogTopicStr1, birdTopicStr1);
-    Map<String, String> twoRegexCatchAllExpected = new HashMap<>();
-    assert TestUtils.assertError(
-        SnowflakeErrors.ERROR_0021,
-        () ->
-            testTopicToTableRegexRunner(
-                config,
-                twoRegexCatchAllConfig,
-                twoRegexCatchAllPartitionStrs,
-                twoRegexCatchAllExpected));
-
-    // test invalid overlapping regexes
-    String invalidTwoRegexConfig =
-        Utils.formatString("{}:{}, {}:{}", catTopicRegex, catTable, bigCatTopicRegex, bigCatTable);
-    List<String> invalidTwoRegexPartitionStrs =
-        Arrays.asList(catTopicStr1, catTopicStr2, dogTopicStr1, birdTopicStr1);
-    Map<String, String> invalidTwoRegexExpected = new HashMap<>();
-    assert TestUtils.assertError(
-        SnowflakeErrors.ERROR_0021,
-        () ->
-            testTopicToTableRegexRunner(
-                config,
-                invalidTwoRegexConfig,
-                invalidTwoRegexPartitionStrs,
-                invalidTwoRegexExpected));
 
     // test catchall regex
     String catchAllConfig = Utils.formatString("{}:{}", catchAllRegex, catchallTable);

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingErrorHandlerIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingErrorHandlerIT.java
@@ -15,9 +15,7 @@ import com.snowflake.kafka.connector.internal.metrics.TaskMetrics;
 import com.snowflake.kafka.connector.internal.streaming.telemetry.SnowflakeTelemetryChannelStatus;
 import com.snowflake.kafka.connector.internal.streaming.v2.SnowpipeStreamingPartitionChannel;
 import com.snowflake.kafka.connector.internal.streaming.v2.channel.PartitionOffsetTracker;
-import com.snowflake.kafka.connector.internal.streaming.v2.migration.Ssv1MigrationMode;
 import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryService;
-import com.snowflake.kafka.connector.records.SnowflakeMetadataConfig;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
@@ -296,8 +294,6 @@ class StreamingErrorHandlerIT {
             offsetTracker.processedOffsetRef(),
             offsetTracker.consumerGroupOffsetRef());
 
-    boolean enableSchematization = taskConfig.isEnableSchematization();
-
     return new SnowpipeStreamingPartitionChannel(
         "test_table",
         channelName,
@@ -307,15 +303,11 @@ class StreamingErrorHandlerIT {
         mockTelemetryService,
         telemetryChannelStatus,
         offsetTracker,
-        new SnowflakeMetadataConfig(),
-        enableSchematization,
-        true,
+        taskConfig,
         errorHandler,
         TaskMetrics.noop(),
         false,
-        false,
         null,
-        Ssv1MigrationMode.SKIP,
         Optional.empty());
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannelTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannelTest.java
@@ -21,6 +21,9 @@ import com.snowflake.ingest.streaming.SFException;
 import com.snowflake.ingest.streaming.SnowflakeStreamingIngestChannel;
 import com.snowflake.ingest.streaming.SnowflakeStreamingIngestClient;
 import com.snowflake.kafka.connector.builder.SinkRecordBuilder;
+import com.snowflake.kafka.connector.config.SinkTaskConfig;
+import com.snowflake.kafka.connector.config.SinkTaskConfigTestBuilder;
+import com.snowflake.kafka.connector.config.SnowflakeValidation;
 import com.snowflake.kafka.connector.internal.DescribeTableRow;
 import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
 import com.snowflake.kafka.connector.internal.metrics.TaskMetrics;
@@ -31,7 +34,6 @@ import com.snowflake.kafka.connector.internal.streaming.v2.channel.PartitionOffs
 import com.snowflake.kafka.connector.internal.streaming.v2.migration.Ssv1MigrationMode;
 import com.snowflake.kafka.connector.internal.streaming.v2.migration.Ssv1MigrationResponse;
 import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryService;
-import com.snowflake.kafka.connector.records.SnowflakeMetadataConfig;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
@@ -344,6 +346,15 @@ class SnowpipeStreamingPartitionChannelTest {
             offsetTracker.processedOffsetRef(),
             offsetTracker.consumerGroupOffsetRef());
 
+    SinkTaskConfig taskConfig =
+        SinkTaskConfigTestBuilder.builder()
+            .connectorName(CONNECTOR_NAME)
+            .taskId("0")
+            .enableSchematization(false)
+            .enableColumnIdentifierNormalization(true)
+            .validation(SnowflakeValidation.SERVER_SIDE)
+            .build();
+
     return new SnowpipeStreamingPartitionChannel(
         TABLE_NAME,
         channelName,
@@ -353,15 +364,11 @@ class SnowpipeStreamingPartitionChannelTest {
         mockTelemetryService,
         telemetryChannelStatus,
         offsetTracker,
-        new SnowflakeMetadataConfig(),
-        false,
-        true,
+        taskConfig,
         mockErrorHandler,
         TaskMetrics.noop(),
         false,
-        false,
         null,
-        Ssv1MigrationMode.SKIP,
         Optional.empty());
   }
 
@@ -420,6 +427,15 @@ class SnowpipeStreamingPartitionChannelTest {
             offsetTracker.processedOffsetRef(),
             offsetTracker.consumerGroupOffsetRef());
 
+    SinkTaskConfig taskConfig =
+        SinkTaskConfigTestBuilder.builder()
+            .connectorName(CONNECTOR_NAME)
+            .taskId("0")
+            .enableSchematization(enableSchematization)
+            .enableColumnIdentifierNormalization(true)
+            .validation(SnowflakeValidation.CLIENT_SIDE)
+            .build();
+
     return new SnowpipeStreamingPartitionChannel(
         TABLE_NAME,
         channelName,
@@ -429,15 +445,11 @@ class SnowpipeStreamingPartitionChannelTest {
         mockTelemetryService,
         telemetryChannelStatus,
         offsetTracker,
-        new SnowflakeMetadataConfig(),
-        enableSchematization,
-        true,
+        taskConfig,
         mockErrorHandler,
         TaskMetrics.noop(),
-        true,
         shouldEvolveSchema,
         mockConnService,
-        Ssv1MigrationMode.SKIP,
         Optional.empty());
   }
 
@@ -508,6 +520,15 @@ class SnowpipeStreamingPartitionChannelTest {
             offsetTracker.processedOffsetRef(),
             offsetTracker.consumerGroupOffsetRef());
 
+    SinkTaskConfig taskConfig =
+        SinkTaskConfigTestBuilder.builder()
+            .connectorName(CONNECTOR_NAME)
+            .taskId("0")
+            .enableSchematization(true)
+            .enableColumnIdentifierNormalization(true)
+            .validation(SnowflakeValidation.CLIENT_SIDE)
+            .build();
+
     SnowpipeStreamingPartitionChannel channel =
         new SnowpipeStreamingPartitionChannel(
             TABLE_NAME,
@@ -518,15 +539,11 @@ class SnowpipeStreamingPartitionChannelTest {
             mockTelemetryService,
             telemetryChannelStatus,
             offsetTracker,
-            new SnowflakeMetadataConfig(),
-            true,
-            true,
+            taskConfig,
             mockErrorHandler,
             TaskMetrics.noop(),
             true,
-            true,
             mockConnService,
-            Ssv1MigrationMode.SKIP,
             Optional.empty());
 
     SinkRecord record = buildValidRecord(0);
@@ -642,6 +659,16 @@ class SnowpipeStreamingPartitionChannelTest {
             offsetTracker.processedOffsetRef(),
             offsetTracker.consumerGroupOffsetRef());
 
+    SinkTaskConfig migrationTaskConfig =
+        SinkTaskConfigTestBuilder.builder()
+            .connectorName(CONNECTOR_NAME)
+            .taskId("0")
+            .enableSchematization(false)
+            .enableColumnIdentifierNormalization(true)
+            .validation(SnowflakeValidation.SERVER_SIDE)
+            .ssv1MigrationMode(migrationMode)
+            .build();
+
     return new SnowpipeStreamingPartitionChannel(
         TABLE_NAME,
         channelName,
@@ -651,15 +678,11 @@ class SnowpipeStreamingPartitionChannelTest {
         mockTelemetryService,
         telemetryChannelStatus,
         offsetTracker,
-        new SnowflakeMetadataConfig(),
-        false,
-        true,
+        migrationTaskConfig,
         mockErrorHandler,
         TaskMetrics.noop(),
         false,
-        false,
         mockConn,
-        migrationMode,
         migrationMode == Ssv1MigrationMode.SKIP
             ? Optional.empty()
             : Optional.of(SSV1_CHANNEL_NAME));

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/service/PartitionChannelManagerTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/service/PartitionChannelManagerTest.java
@@ -9,6 +9,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.snowflake.kafka.connector.config.SinkTaskConfig;
+import com.snowflake.kafka.connector.config.SinkTaskConfigTestBuilder;
 import com.snowflake.kafka.connector.internal.streaming.channel.TopicPartitionChannel;
 import java.util.Arrays;
 import java.util.Collections;
@@ -45,9 +47,7 @@ class PartitionChannelManagerTest {
           return channel;
         };
 
-    manager =
-        new PartitionChannelManager(
-            CONNECTOR_NAME, TASK_ID, Collections.emptyMap(), false, trackingBuilder);
+    manager = new PartitionChannelManager(testConfig(Collections.emptyMap()), trackingBuilder);
   }
 
   // --- makeChannelName ---
@@ -89,8 +89,7 @@ class PartitionChannelManagerTest {
         };
 
     PartitionChannelManager capturingManager =
-        new PartitionChannelManager(
-            CONNECTOR_NAME, TASK_ID, Collections.emptyMap(), false, capturingBuilder);
+        new PartitionChannelManager(testConfig(Collections.emptyMap()), capturingBuilder);
 
     TopicPartition tp = new TopicPartition(TOPIC, 7);
     Map<String, String> tableToPipe = new HashMap<>();
@@ -120,7 +119,7 @@ class PartitionChannelManagerTest {
         };
 
     PartitionChannelManager managerWithMapping =
-        new PartitionChannelManager(CONNECTOR_NAME, TASK_ID, topicToTable, false, capturingBuilder);
+        new PartitionChannelManager(testConfig(topicToTable), capturingBuilder);
 
     TopicPartition tp = new TopicPartition("raw_topic", 0);
     Map<String, String> tableToPipe = new HashMap<>();
@@ -274,5 +273,14 @@ class PartitionChannelManagerTest {
       tableToPipe.putIfAbsent(tableName, "pipe_" + tableName);
     }
     manager.startPartitions(Arrays.asList(partitions), tableToPipe);
+  }
+
+  private static SinkTaskConfig testConfig(Map<String, String> topicToTableMap) {
+    return SinkTaskConfigTestBuilder.builder()
+        .connectorName(CONNECTOR_NAME)
+        .taskId(TASK_ID)
+        .topicToTableMap(topicToTableMap)
+        .enableSanitization(false)
+        .build();
   }
 }


### PR DESCRIPTION
Remove redundant connectorName/taskId params from PartitionChannelManager production constructor

Pass SinkTaskConfig into SnowpipeStreamingPartitionChannel instead of individual config flags

Remove duplicate field extraction in SnowflakeSinkServiceV2; use taskConfig getters directly

Remove dead topic2table field and 3-arg test constructor from SnowflakeSinkTask

PeriodicTelemetryReporter accepts SinkTaskConfig instead of separate connectorName/taskId