### PR TITLE
Add ClientRecreationException and ClientRecreator interface

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/ClientRecreationException.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/ClientRecreationException.java
@@ -1,0 +1,80 @@
+package com.snowflake.kafka.connector.internal.streaming.v2;
+
+import com.google.common.base.Preconditions;
+import com.snowflake.ingest.streaming.SFException;
+import java.util.Set;
+
+/**
+ * Unchecked exception thrown when the Snowflake SDK signals that the streaming client is in an
+ * invalid state and must be recreated.
+ *
+ * <p>This exception wraps {@link SFException} instances with specific error codes indicating the
+ * client itself is no longer usable. Unlike {@link BackpressureException} (where the channel
+ * remains valid), this signals that the client and all its channels must be replaced.
+ *
+ * <p>Client-invalid error codes:
+ *
+ * <ul>
+ *   <li>{@code InvalidClientError} - client marked invalid after a fatal internal error or pipe
+ *       failover (409 Conflict)
+ *   <li>{@code SfApiPipeFailedOverError} - HTTP 410 on any API call triggers client invalidation
+ *   <li>{@code ClosedClientError} - client has been closed and cannot be reused (409 Conflict)
+ * </ul>
+ */
+public class ClientRecreationException extends RuntimeException {
+
+  private static final Set<String> CLIENT_INVALID_ERROR_CODE_NAMES =
+      Set.of(
+          // Client invalidated by SDK (pipe failover, auth refresh failure, etc.)
+          "InvalidClientError",
+          // HTTP 410 on open_channel, insert_rows, get_channel_status, or pipe refresh
+          "SfApiPipeFailedOverError",
+          // Client was closed
+          "ClosedClientError");
+
+  /**
+   * Constructs a new {@code ClientRecreationException} wrapping the given {@link SFException}.
+   *
+   * @param cause the SDK exception indicating the client is invalid
+   */
+  public ClientRecreationException(SFException cause) {
+    super(
+        "SDK client invalid: " + Preconditions.checkNotNull(cause, "cause").getErrorCodeName(),
+        cause);
+    Preconditions.checkArgument(
+        isClientInvalidError(cause),
+        "ClientRecreationException requires a client-invalid SFException, got: %s",
+        cause.getErrorCodeName());
+  }
+
+  /**
+   * Wraps the given throwable as a {@code ClientRecreationException} if it is a client-invalid
+   * {@link SFException}. Avoids the need for callers to cast to {@code SFException} manually.
+   *
+   * @param e the exception to wrap
+   * @return a new {@code ClientRecreationException} wrapping the cause
+   * @throws IllegalArgumentException if {@code e} is not a client-invalid {@link SFException}
+   */
+  public static ClientRecreationException wrap(Throwable e) {
+    Preconditions.checkArgument(
+        isClientInvalidError(e),
+        "Cannot wrap non-client-invalid exception: %s",
+        e.getClass().getName());
+    return new ClientRecreationException((SFException) e);
+  }
+
+  /**
+   * Checks if the given throwable represents a client-level invalidation error that requires client
+   * recreation.
+   *
+   * @param e the exception to check (may be null)
+   * @return {@code true} if {@code e} is an {@link SFException} with a client-invalid error code
+   *     name; {@code false} otherwise
+   */
+  public static boolean isClientInvalidError(Throwable e) {
+    if (!(e instanceof SFException)) {
+      return false;
+    }
+    return CLIENT_INVALID_ERROR_CODE_NAMES.contains(((SFException) e).getErrorCodeName());
+  }
+}

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/ClientRecreator.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/ClientRecreator.java
@@ -1,0 +1,23 @@
+package com.snowflake.kafka.connector.internal.streaming.v2;
+
+import com.snowflake.ingest.streaming.SnowflakeStreamingIngestClient;
+
+/**
+ * Strategy for replacing an invalid {@link SnowflakeStreamingIngestClient} with a new one.
+ *
+ * <p>Implementations are expected to use compare-and-swap semantics: if the client has already been
+ * replaced by another caller, the existing replacement should be returned without creating a second
+ * one.
+ */
+@FunctionalInterface
+public interface ClientRecreator {
+
+  /**
+   * Replaces the given invalid client with a new one.
+   *
+   * @param invalidClient the client instance that is no longer valid (identity-compared in the
+   *     pool)
+   * @return the new client, or the already-replaced client if another caller got there first
+   */
+  SnowflakeStreamingIngestClient recreate(SnowflakeStreamingIngestClient invalidClient);
+}

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/ClientRecreationExceptionTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/ClientRecreationExceptionTest.java
@@ -1,0 +1,101 @@
+package com.snowflake.kafka.connector.internal.streaming.v2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.snowflake.ingest.streaming.SFException;
+import org.junit.jupiter.api.Test;
+
+public class ClientRecreationExceptionTest {
+
+  @Test
+  void shouldWrapSFExceptionWithCorrectMessage() {
+    SFException cause = new SFException("InvalidClientError", "Client is invalid", 409, "Conflict");
+
+    ClientRecreationException exception = new ClientRecreationException(cause);
+
+    assertEquals("SDK client invalid: InvalidClientError", exception.getMessage());
+    assertSame(cause, exception.getCause());
+  }
+
+  @Test
+  void shouldRecognizeInvalidClientError() {
+    SFException sfException =
+        new SFException("InvalidClientError", "Client is invalid", 409, "Conflict");
+
+    assertTrue(ClientRecreationException.isClientInvalidError(sfException));
+  }
+
+  @Test
+  void shouldRecognizeSfApiPipeFailedOverError() {
+    SFException sfException =
+        new SFException("SfApiPipeFailedOverError", "HTTP 410 pipe failover", 400, "Bad Request");
+
+    assertTrue(ClientRecreationException.isClientInvalidError(sfException));
+  }
+
+  @Test
+  void shouldRecognizeClosedClientError() {
+    SFException sfException =
+        new SFException("ClosedClientError", "Client is closed", 409, "Conflict");
+
+    assertTrue(ClientRecreationException.isClientInvalidError(sfException));
+  }
+
+  @Test
+  void shouldNotRecognizeBackpressureErrors() {
+    assertFalse(
+        ClientRecreationException.isClientInvalidError(
+            new SFException("ReceiverSaturated", "message", 429, "stack")));
+    assertFalse(
+        ClientRecreationException.isClientInvalidError(
+            new SFException("MemoryThresholdExceeded", "message", 429, "stack")));
+  }
+
+  @Test
+  void shouldNotRecognizeChannelLevelErrors() {
+    assertFalse(
+        ClientRecreationException.isClientInvalidError(
+            new SFException("InvalidChannelError", "Channel invalid", 409, "Conflict")));
+    assertFalse(
+        ClientRecreationException.isClientInvalidError(
+            new SFException("ClosedChannelError", "Channel closed", 409, "Conflict")));
+  }
+
+  @Test
+  void shouldNotRecognizeOtherSFException() {
+    SFException sfException = new SFException("SomeOtherError", "message", 500, "stack");
+
+    assertFalse(ClientRecreationException.isClientInvalidError(sfException));
+  }
+
+  @Test
+  void shouldNotRecognizeNonSFException() {
+    IllegalArgumentException nonSFException = new IllegalArgumentException("not an SFException");
+
+    assertFalse(ClientRecreationException.isClientInvalidError(nonSFException));
+  }
+
+  @Test
+  void shouldNotRecognizeNull() {
+    assertFalse(ClientRecreationException.isClientInvalidError(null));
+  }
+
+  @Test
+  void shouldRejectConstructionWithNonClientInvalidSFException() {
+    SFException nonClientInvalid = new SFException("SomeOtherError", "message", 500, "stack");
+
+    assertThrows(
+        IllegalArgumentException.class, () -> new ClientRecreationException(nonClientInvalid));
+  }
+
+  @Test
+  void shouldRejectConstructionWithBackpressureSFException() {
+    SFException backpressure = new SFException("ReceiverSaturated", "message", 429, "stack");
+
+    assertThrows(IllegalArgumentException.class, () -> new ClientRecreationException(backpressure));
+  }
+}


### PR DESCRIPTION
## Summary
- `ClientRecreationException`: unchecked exception wrapping `SFException` for client-invalid error codes (`InvalidClientError`, `SfApiPipeFailedOverError`, `ClosedClientError`). Static `isClientInvalidError()` classifies without instantiation; static `wrap(Throwable)` safely casts and wraps.
- `ClientRecreator`: `@FunctionalInterface` for replacing an invalid SDK client via CAS semantics.
- 11 unit tests covering all error code detection, constructor validation, wrap helper, and negative cases.

No callers yet — these are consumed in subsequent PRs in this stack.

**JIRA**: SNOW-3360429

## Test plan
- [x] `ClientRecreationExceptionTest` — 11 tests all pass