### PR TITLE
Add CAS client recreation to StreamingClientPool

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/client/StreamingClientPool.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/client/StreamingClientPool.java
@@ -8,8 +8,10 @@ import com.snowflake.kafka.connector.internal.streaming.StreamingClientPropertie
 import com.snowflake.kafka.connector.internal.streaming.v2.service.ThreadPools;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Manages clients for a single connector. Tracks which tasks use which pipes and only closes
@@ -75,6 +77,11 @@ public class StreamingClientPool {
 
     int taskCount() {
       return taskIds.size();
+    }
+
+    /** Copies all task registrations from another entry into this one. */
+    void copyTasksFrom(RefCountedClient other) {
+      taskIds.addAll(other.taskIds);
     }
 
     void close(String pipeName, String connectorName) {
@@ -158,6 +165,128 @@ public class StreamingClientPool {
             }
             return entry;
           });
+    }
+  }
+
+  /**
+   * Atomically replaces the client for a pipe if the current client matches the given invalid
+   * client. Uses compare-and-swap semantics: if another caller already replaced the entry, the
+   * existing new client is returned without creating a second one.
+   *
+   * @param pipeName the pipe whose client should be replaced
+   * @param invalidClient the client instance that the caller believes is invalid (identity check)
+   * @param config task config for creating the replacement client
+   * @param streamingClientProperties streaming client properties
+   * @param taskMetrics metrics for timing the new client creation
+   * @return the new (or already-replaced) client
+   */
+  SnowflakeStreamingIngestClient recreateClient(
+      final String pipeName,
+      final SnowflakeStreamingIngestClient invalidClient,
+      final SinkTaskConfig config,
+      final StreamingClientProperties streamingClientProperties,
+      final TaskMetrics taskMetrics) {
+
+    // AtomicReference to capture the entry chosen inside the atomic compute() block.
+    // The actual .join() happens outside the lock to avoid blocking other pipes.
+    AtomicReference<RefCountedClient> chosenEntry = new AtomicReference<>();
+
+    pipes.compute(
+        pipeName,
+        (key, current) -> {
+          if (current == null) {
+            LOGGER.warn(
+                "recreateClient called for pipe {} but no entry exists in connector {}."
+                    + " Creating a fresh entry.",
+                pipeName,
+                connectorName);
+            RefCountedClient fresh =
+                new RefCountedClient(
+                    pipeName,
+                    connectorName,
+                    config,
+                    streamingClientProperties,
+                    taskMetrics,
+                    ioExecutor);
+            chosenEntry.set(fresh);
+            return fresh;
+          }
+
+          // Check if the current entry still holds the invalid client (CAS guard).
+          // If someone already replaced it, return the current (new) entry as-is.
+          SnowflakeStreamingIngestClient currentClient;
+          try {
+            currentClient = current.clientFuture.join();
+          } catch (CompletionException e) {
+            // Current entry failed to create — replace it unconditionally.
+            LOGGER.warn(
+                "recreateClient for pipe {}: current entry has a failed client future,"
+                    + " replacing unconditionally",
+                pipeName);
+            RefCountedClient replacement =
+                new RefCountedClient(
+                    pipeName,
+                    connectorName,
+                    config,
+                    streamingClientProperties,
+                    taskMetrics,
+                    ioExecutor);
+            replacement.copyTasksFrom(current);
+            chosenEntry.set(replacement);
+            return replacement;
+          }
+
+          if (currentClient != invalidClient) {
+            LOGGER.info(
+                "recreateClient for pipe {} in connector {}: client already replaced"
+                    + " by another caller, reusing existing entry",
+                pipeName,
+                connectorName);
+            chosenEntry.set(current);
+            return current;
+          }
+
+          // CAS matches — replace with a new entry, preserving task registrations.
+          LOGGER.info(
+              "Recreating streaming client for pipe {} in connector {}."
+                  + " Old client will be closed best-effort.",
+              pipeName,
+              connectorName);
+
+          RefCountedClient replacement =
+              new RefCountedClient(
+                  pipeName,
+                  connectorName,
+                  config,
+                  streamingClientProperties,
+                  taskMetrics,
+                  ioExecutor);
+          replacement.copyTasksFrom(current);
+
+          // Best-effort close of the old (invalid) client for resource cleanup.
+          try {
+            currentClient.close();
+          } catch (Exception e) {
+            LOGGER.warn(
+                "Best-effort close of invalid client for pipe {} failed: {}",
+                pipeName,
+                e.getMessage());
+          }
+
+          chosenEntry.set(replacement);
+          return replacement;
+        });
+
+    try {
+      return chosenEntry.get().clientFuture.join();
+    } catch (CompletionException e) {
+      // If the new client also fails to create, evict the failed entry so the next caller retries.
+      RefCountedClient failedEntry = chosenEntry.get();
+      pipes.compute(pipeName, (key, current) -> current == failedEntry ? null : current);
+      if (e.getCause() instanceof RuntimeException) {
+        throw (RuntimeException) e.getCause();
+      }
+      throw e;
     }
   }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/client/StreamingClientPool.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/client/StreamingClientPool.java
@@ -10,7 +10,10 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -173,6 +176,8 @@ public class StreamingClientPool {
    * client. Uses compare-and-swap semantics: if another caller already replaced the entry, the
    * existing new client is returned without creating a second one.
    *
+   * @param taskId the ID of the task requesting recreation; registered on the replacement entry so
+   *     the pool does not prematurely evict it on task-local cleanup
    * @param pipeName the pipe whose client should be replaced
    * @param invalidClient the client instance that the caller believes is invalid (identity check)
    * @param config task config for creating the replacement client
@@ -181,108 +186,128 @@ public class StreamingClientPool {
    * @return the new (or already-replaced) client
    */
   SnowflakeStreamingIngestClient recreateClient(
+      final String taskId,
       final String pipeName,
       final SnowflakeStreamingIngestClient invalidClient,
       final SinkTaskConfig config,
       final StreamingClientProperties streamingClientProperties,
       final TaskMetrics taskMetrics) {
 
-    // AtomicReference to capture the entry chosen inside the atomic compute() block.
-    // The actual .join() happens outside the lock to avoid blocking other pipes.
-    AtomicReference<RefCountedClient> chosenEntry = new AtomicReference<>();
+    // Captured inside compute() so the old client can be closed outside the lock.
+    AtomicReference<SnowflakeStreamingIngestClient> clientToClose = new AtomicReference<>();
 
-    pipes.compute(
-        pipeName,
-        (key, current) -> {
-          if (current == null) {
-            LOGGER.warn(
-                "recreateClient called for pipe {} but no entry exists in connector {}."
-                    + " Creating a fresh entry.",
-                pipeName,
-                connectorName);
-            RefCountedClient fresh =
-                new RefCountedClient(
+    RefCountedClient chosenEntry =
+        pipes.compute(
+            pipeName,
+            (key, current) -> {
+              if (current == null) {
+                LOGGER.warn(
+                    "recreateClient called for pipe {} but no entry exists in connector {}."
+                        + " Creating a fresh entry.",
                     pipeName,
-                    connectorName,
-                    config,
-                    streamingClientProperties,
-                    taskMetrics,
-                    ioExecutor);
-            chosenEntry.set(fresh);
-            return fresh;
-          }
+                    connectorName);
+                return createReplacement(
+                    taskId, pipeName, null, config, streamingClientProperties, taskMetrics);
+              }
 
-          // Check if the current entry still holds the invalid client (CAS guard).
-          // If someone already replaced it, return the current (new) entry as-is.
-          SnowflakeStreamingIngestClient currentClient;
-          try {
-            currentClient = current.clientFuture.join();
-          } catch (CompletionException e) {
-            // Current entry failed to create — replace it unconditionally.
-            LOGGER.warn(
-                "recreateClient for pipe {}: current entry has a failed client future,"
-                    + " replacing unconditionally",
-                pipeName);
-            RefCountedClient replacement =
-                new RefCountedClient(
+              // Check if the current entry still holds the invalid client (CAS guard).
+              // Use timeout=0 to avoid blocking the compute() supplier on I/O: a client
+              // whose future hasn't completed yet cannot possibly be the invalid client the
+              // caller just observed, so we can assume it's a valid replacement already in flight.
+              SnowflakeStreamingIngestClient currentClient;
+              try {
+                currentClient = current.clientFuture.get(0, TimeUnit.MILLISECONDS);
+              } catch (TimeoutException timeout) {
+                LOGGER.info(
+                    "recreateClient for pipe {} in connector {}: current entry's future not"
+                        + " yet complete, assuming replacement already in flight",
                     pipeName,
-                    connectorName,
-                    config,
-                    streamingClientProperties,
-                    taskMetrics,
-                    ioExecutor);
-            replacement.copyTasksFrom(current);
-            chosenEntry.set(replacement);
-            return replacement;
-          }
+                    connectorName);
+                current.addTask(taskId);
+                return current;
+              } catch (CompletionException | ExecutionException e) {
+                // Current entry failed to create — replace it unconditionally.
+                LOGGER.warn(
+                    "recreateClient for pipe {}: current entry has a failed client future,"
+                        + " replacing unconditionally",
+                    pipeName);
+                return createReplacement(
+                    taskId, pipeName, current, config, streamingClientProperties, taskMetrics);
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+              }
 
-          if (currentClient != invalidClient) {
-            LOGGER.info(
-                "recreateClient for pipe {} in connector {}: client already replaced"
-                    + " by another caller, reusing existing entry",
-                pipeName,
-                connectorName);
-            chosenEntry.set(current);
-            return current;
-          }
+              if (currentClient != invalidClient) {
+                LOGGER.info(
+                    "recreateClient for pipe {} in connector {}: client already replaced"
+                        + " by another caller, reusing existing entry",
+                    pipeName,
+                    connectorName);
+                current.addTask(taskId);
+                return current;
+              }
 
-          // CAS matches — replace with a new entry, preserving task registrations.
-          LOGGER.info(
-              "Recreating streaming client for pipe {} in connector {}."
-                  + " Old client will be closed best-effort.",
-              pipeName,
-              connectorName);
-
-          RefCountedClient replacement =
-              new RefCountedClient(
+              // CAS matches — replace with a new entry, preserving task registrations.
+              LOGGER.info(
+                  "Recreating streaming client for pipe {} in connector {}."
+                      + " Old client will be closed best-effort.",
                   pipeName,
-                  connectorName,
-                  config,
-                  streamingClientProperties,
-                  taskMetrics,
-                  ioExecutor);
-          replacement.copyTasksFrom(current);
+                  connectorName);
+              // Capture old client for best-effort close outside the compute() lock.
+              clientToClose.set(currentClient);
+              return createReplacement(
+                  taskId, pipeName, current, config, streamingClientProperties, taskMetrics);
+            });
 
-          // Best-effort close of the old (invalid) client for resource cleanup.
-          try {
-            currentClient.close();
-          } catch (Exception e) {
-            LOGGER.warn(
-                "Best-effort close of invalid client for pipe {} failed: {}",
-                pipeName,
-                e.getMessage());
-          }
+    // Best-effort close of the old (invalid) client outside the compute() lock
+    // to avoid blocking the ConcurrentHashMap bucket during I/O.
+    SnowflakeStreamingIngestClient oldClient = clientToClose.get();
+    if (oldClient != null) {
+      try {
+        oldClient.close();
+      } catch (Exception e) {
+        LOGGER.warn(
+            "Best-effort close of invalid client for pipe {} failed: {}", pipeName, e.getMessage());
+      }
+    }
 
-          chosenEntry.set(replacement);
-          return replacement;
-        });
+    return joinAndEvictOnFailure(pipeName, chosenEntry);
+  }
 
+  /**
+   * Creates a new {@link RefCountedClient} for the given pipe, inheriting task registrations from
+   * {@code previous} if non-null, and always registering {@code taskId}. Centralizing this logic
+   * ensures the calling task is always registered so the pool does not prematurely evict a
+   * freshly-created entry during subsequent task-local cleanup.
+   */
+  private RefCountedClient createReplacement(
+      final String taskId,
+      final String pipeName,
+      final RefCountedClient previous,
+      final SinkTaskConfig config,
+      final StreamingClientProperties streamingClientProperties,
+      final TaskMetrics taskMetrics) {
+    RefCountedClient fresh =
+        new RefCountedClient(
+            pipeName, connectorName, config, streamingClientProperties, taskMetrics, ioExecutor);
+    if (previous != null) {
+      fresh.copyTasksFrom(previous);
+    }
+    fresh.addTask(taskId);
+    return fresh;
+  }
+
+  /**
+   * Joins the entry's client future and evicts the entry from the pool if the future has failed, so
+   * the next caller gets a fresh entry instead of retrying a broken one.
+   */
+  private SnowflakeStreamingIngestClient joinAndEvictOnFailure(
+      final String pipeName, final RefCountedClient entry) {
     try {
-      return chosenEntry.get().clientFuture.join();
+      return entry.clientFuture.join();
     } catch (CompletionException e) {
-      // If the new client also fails to create, evict the failed entry so the next caller retries.
-      RefCountedClient failedEntry = chosenEntry.get();
-      pipes.compute(pipeName, (key, current) -> current == failedEntry ? null : current);
+      pipes.compute(pipeName, (key, current) -> current == entry ? null : current);
       if (e.getCause() instanceof RuntimeException) {
         throw (RuntimeException) e.getCause();
       }

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/client/StreamingClientPools.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/client/StreamingClientPools.java
@@ -7,6 +7,11 @@ import com.snowflake.kafka.connector.config.SinkTaskConfig;
 import com.snowflake.kafka.connector.internal.KCLogger;
 import com.snowflake.kafka.connector.internal.metrics.TaskMetrics;
 import com.snowflake.kafka.connector.internal.streaming.StreamingClientProperties;
+import com.snowflake.kafka.connector.internal.streaming.v2.ClientRecreationException;
+import dev.failsafe.Failsafe;
+import dev.failsafe.FailsafeException;
+import dev.failsafe.RetryPolicy;
+import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -51,17 +56,17 @@ public class StreamingClientPools {
       final SinkTaskConfig config,
       final StreamingClientProperties streamingClientProperties,
       final TaskMetrics taskMetrics) {
-
     try {
       return getClientAsync(
               connectorName, taskId, pipeName, config, streamingClientProperties, taskMetrics)
           .join();
     } catch (CompletionException e) {
-      if (e.getCause() instanceof RuntimeException) {
-        throw (RuntimeException) e.getCause();
+      Throwable cause = e.getCause();
+      if (cause instanceof RuntimeException) {
+        throw (RuntimeException) cause;
       }
       throw new ConnectException(
-          "Unexpected error creating streaming client for pipe: " + pipeName, e.getCause());
+          "Unexpected error creating streaming client for pipe: " + pipeName, cause);
     }
   }
 
@@ -110,6 +115,8 @@ public class StreamingClientPools {
    * existing new client is returned without creating a second one.
    *
    * @param connectorName the connector name
+   * @param taskId the ID of the task requesting recreation; registered on the replacement entry so
+   *     the pool does not prematurely evict it on task-local cleanup
    * @param pipeName the pipe whose client should be replaced
    * @param invalidClient the client instance the caller believes is invalid (identity check)
    * @param config task config for creating the replacement client
@@ -119,14 +126,87 @@ public class StreamingClientPools {
    */
   public static SnowflakeStreamingIngestClient recreateClient(
       final String connectorName,
+      final String taskId,
       final String pipeName,
       final SnowflakeStreamingIngestClient invalidClient,
       final SinkTaskConfig config,
       final StreamingClientProperties streamingClientProperties,
       final TaskMetrics taskMetrics) {
+    try {
+      return Failsafe.with(recreateClientRetryPolicy(pipeName))
+          .get(
+              () ->
+                  getPool(connectorName)
+                      .recreateClient(
+                          taskId,
+                          pipeName,
+                          invalidClient,
+                          config,
+                          streamingClientProperties,
+                          taskMetrics));
+    } catch (FailsafeException e) {
+      // Retries exhausted — wrap as ClientRecreationException so the batch
+      // loop can rewind offsets instead of crashing the task.
+      Throwable cause = e.getCause() != null ? e.getCause() : e;
+      throw ClientRecreationException.wrap(cause);
+    }
+  }
 
-    return getPool(connectorName)
-        .recreateClient(pipeName, invalidClient, config, streamingClientProperties, taskMetrics);
+  /**
+   * Delay between client-creation retries. Pipe failover typically takes a few seconds to stabilize
+   * on the server side, and back-to-back retries with no delay would all hit the same in-flight
+   * failover window and fail before the server finishes.
+   *
+   * <p>Note: this delay is per-invocation. {@link #recreateClient} can be called concurrently by
+   * multiple {@link
+   * com.snowflake.kafka.connector.internal.streaming.v2.SnowpipeStreamingPartitionChannel}s on the
+   * same pipe. The pool's CAS dedupes to a single fresh client, but each caller runs its own
+   * Failsafe retry schedule — so from the pool's perspective, client creation can happen more than
+   * once per {@code CLIENT_CREATION_RETRY_DELAY} window across concurrent callers. This is
+   * acceptable: each individual channel still retries at ~5s cadence, so its total recovery window
+   * spans {@code MAX_CLIENT_CREATION_RETRIES * CLIENT_CREATION_RETRY_DELAY = ~15s}. When reading
+   * logs, expect to see overlapping retry schedules across channels on the same pipe during a
+   * failover event.
+   */
+  private static final Duration CLIENT_CREATION_RETRY_DELAY = Duration.ofSeconds(5);
+
+  /**
+   * Maximum retry attempts when a replacement client also fails with a client-invalid error during
+   * {@link #recreateClient}. Three attempts provide enough headroom for transient failover windows
+   * while keeping total blocking time bounded (each attempt creates a fresh SDK client).
+   */
+  private static final int MAX_CLIENT_CREATION_RETRIES = 3;
+
+  /**
+   * Retries replacement-client creation when the SDK reports a client-invalid error (e.g., pipe
+   * failover still in flight). The pool evicts the failed entry on each attempt, so the retry
+   * creates a fresh client. Non-client-invalid errors fall through immediately.
+   */
+  private static RetryPolicy<SnowflakeStreamingIngestClient> recreateClientRetryPolicy(
+      String pipeName) {
+    return RetryPolicy.<SnowflakeStreamingIngestClient>builder()
+        .handleIf(
+            e -> e instanceof RuntimeException && ClientRecreationException.isClientInvalidError(e))
+        .withMaxAttempts(MAX_CLIENT_CREATION_RETRIES)
+        .withDelay(CLIENT_CREATION_RETRY_DELAY)
+        .onRetry(
+            event ->
+                LOGGER.warn(
+                    "Replacement client for pipe {} failed with client-invalid error"
+                        + " (attempt {}/{}): {}. Retrying after {}.",
+                    pipeName,
+                    event.getAttemptCount(),
+                    MAX_CLIENT_CREATION_RETRIES,
+                    event.getLastException().getMessage(),
+                    CLIENT_CREATION_RETRY_DELAY))
+        .onRetriesExceeded(
+            event ->
+                LOGGER.error(
+                    "Replacement client for pipe {} failed after {} attempts: {}",
+                    pipeName,
+                    event.getAttemptCount(),
+                    event.getException().getMessage()))
+        .build();
   }
 
   /**

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/client/StreamingClientPools.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/client/StreamingClientPools.java
@@ -105,6 +105,31 @@ public class StreamingClientPools {
   }
 
   /**
+   * Atomically replaces the client for a pipe if the current client matches the given invalid
+   * client. Uses compare-and-swap semantics: if another caller already replaced the entry, the
+   * existing new client is returned without creating a second one.
+   *
+   * @param connectorName the connector name
+   * @param pipeName the pipe whose client should be replaced
+   * @param invalidClient the client instance the caller believes is invalid (identity check)
+   * @param config task config for creating the replacement client
+   * @param streamingClientProperties streaming client properties
+   * @param taskMetrics metrics for timing the new client creation
+   * @return the new (or already-replaced) client
+   */
+  public static SnowflakeStreamingIngestClient recreateClient(
+      final String connectorName,
+      final String pipeName,
+      final SnowflakeStreamingIngestClient invalidClient,
+      final SinkTaskConfig config,
+      final StreamingClientProperties streamingClientProperties,
+      final TaskMetrics taskMetrics) {
+
+    return getPool(connectorName)
+        .recreateClient(pipeName, invalidClient, config, streamingClientProperties, taskMetrics);
+  }
+
+  /**
    * Releases all clients used by a specific task. Clients that are still used by other tasks remain
    * open. Only closes clients when the last task using them stops. When the pool becomes empty (no
    * remaining clients or tasks), the pool is removed from the registry.

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/client/StreamingClientPoolTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/client/StreamingClientPoolTest.java
@@ -355,6 +355,166 @@ class StreamingClientPoolTest {
     }
 
     @Test
+    void recreateClient_replaces_entry_and_preserves_tasks() {
+      SnowflakeStreamingIngestClient oldClient = mock(SnowflakeStreamingIngestClient.class);
+      SnowflakeStreamingIngestClient newClient = mock(SnowflakeStreamingIngestClient.class);
+      AtomicInteger callCount = new AtomicInteger();
+
+      StreamingClientFactory.setStreamingClientSupplier(
+          (clientName, dbName, schemaName, pipeName, config, props) -> {
+            return callCount.incrementAndGet() == 1 ? oldClient : newClient;
+          });
+
+      // Two tasks share the same pipe
+      getClient("task-0", "pipe-A");
+      getClient("task-1", "pipe-A");
+      assertThat(pool.getClientCountForTask("task-0")).isEqualTo(1);
+      assertThat(pool.getClientCountForTask("task-1")).isEqualTo(1);
+
+      // Recreate the client
+      SnowflakeStreamingIngestClient result =
+          pool.recreateClient(
+              "pipe-A", oldClient, connectorConfig, streamingClientProperties, TaskMetrics.noop());
+
+      assertThat(result).isSameAs(newClient);
+      // Both tasks should still be registered
+      assertThat(pool.getClientCountForTask("task-0")).isEqualTo(1);
+      assertThat(pool.getClientCountForTask("task-1")).isEqualTo(1);
+      assertThat(callCount.get()).isEqualTo(2);
+    }
+
+    @Test
+    void recreateClient_closes_old_client() {
+      SnowflakeStreamingIngestClient oldClient = mock(SnowflakeStreamingIngestClient.class);
+      SnowflakeStreamingIngestClient newClient = mock(SnowflakeStreamingIngestClient.class);
+      AtomicInteger callCount = new AtomicInteger();
+
+      StreamingClientFactory.setStreamingClientSupplier(
+          (clientName, dbName, schemaName, pipeName, config, props) -> {
+            return callCount.incrementAndGet() == 1 ? oldClient : newClient;
+          });
+
+      getClient("task-0", "pipe-A");
+
+      pool.recreateClient(
+          "pipe-A", oldClient, connectorConfig, streamingClientProperties, TaskMetrics.noop());
+
+      verify(oldClient).close();
+    }
+
+    @Test
+    void recreateClient_noop_if_client_already_replaced() {
+      SnowflakeStreamingIngestClient oldClient = mock(SnowflakeStreamingIngestClient.class);
+      SnowflakeStreamingIngestClient newClient = mock(SnowflakeStreamingIngestClient.class);
+      AtomicInteger callCount = new AtomicInteger();
+
+      StreamingClientFactory.setStreamingClientSupplier(
+          (clientName, dbName, schemaName, pipeName, config, props) -> {
+            return callCount.incrementAndGet() == 1 ? oldClient : newClient;
+          });
+
+      getClient("task-0", "pipe-A");
+
+      // First recreation succeeds
+      SnowflakeStreamingIngestClient firstResult =
+          pool.recreateClient(
+              "pipe-A", oldClient, connectorConfig, streamingClientProperties, TaskMetrics.noop());
+      assertThat(firstResult).isSameAs(newClient);
+
+      // Second recreation with the OLD client reference should be a no-op
+      SnowflakeStreamingIngestClient secondResult =
+          pool.recreateClient(
+              "pipe-A", oldClient, connectorConfig, streamingClientProperties, TaskMetrics.noop());
+      assertThat(secondResult).isSameAs(newClient);
+
+      // Supplier should only have been called twice (original + one recreation)
+      assertThat(callCount.get()).isEqualTo(2);
+    }
+
+    @Test
+    void recreateClient_then_getClient_returns_new_client() {
+      SnowflakeStreamingIngestClient oldClient = mock(SnowflakeStreamingIngestClient.class);
+      SnowflakeStreamingIngestClient newClient = mock(SnowflakeStreamingIngestClient.class);
+      AtomicInteger callCount = new AtomicInteger();
+
+      StreamingClientFactory.setStreamingClientSupplier(
+          (clientName, dbName, schemaName, pipeName, config, props) -> {
+            return callCount.incrementAndGet() == 1 ? oldClient : newClient;
+          });
+
+      getClient("task-0", "pipe-A");
+
+      pool.recreateClient(
+          "pipe-A", oldClient, connectorConfig, streamingClientProperties, TaskMetrics.noop());
+
+      // A subsequent getClient should return the new client (not create a third one)
+      SnowflakeStreamingIngestClient result = getClient("task-0", "pipe-A");
+      assertThat(result).isSameAs(newClient);
+      assertThat(callCount.get()).isEqualTo(2);
+    }
+
+    @Test
+    void recreateClient_concurrent_callers_only_creates_once() throws Exception {
+      SnowflakeStreamingIngestClient oldClient = mock(SnowflakeStreamingIngestClient.class);
+      AtomicInteger supplierCallCount = new AtomicInteger();
+      CountDownLatch supplierStarted = new CountDownLatch(1);
+      CountDownLatch supplierProceed = new CountDownLatch(1);
+
+      StreamingClientFactory.setStreamingClientSupplier(
+          (clientName, dbName, schemaName, pipeName, config, props) -> {
+            int count = supplierCallCount.incrementAndGet();
+            if (count == 1) {
+              // First call returns oldClient immediately
+              return oldClient;
+            }
+            // Second call (recreation) blocks until signaled
+            supplierStarted.countDown();
+            try {
+              supplierProceed.await();
+            } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
+              throw new RuntimeException(e);
+            }
+            return mock(SnowflakeStreamingIngestClient.class);
+          });
+
+      getClient("task-0", "pipe-A");
+      getClient("task-1", "pipe-A");
+
+      // Launch two concurrent recreateClient calls
+      CompletableFuture<SnowflakeStreamingIngestClient> future1 =
+          CompletableFuture.supplyAsync(
+              () ->
+                  pool.recreateClient(
+                      "pipe-A",
+                      oldClient,
+                      connectorConfig,
+                      streamingClientProperties,
+                      TaskMetrics.noop()));
+      CompletableFuture<SnowflakeStreamingIngestClient> future2 =
+          CompletableFuture.supplyAsync(
+              () ->
+                  pool.recreateClient(
+                      "pipe-A",
+                      oldClient,
+                      connectorConfig,
+                      streamingClientProperties,
+                      TaskMetrics.noop()));
+
+      // Wait for the supplier to start (only one should start)
+      supplierStarted.await();
+      supplierProceed.countDown();
+
+      SnowflakeStreamingIngestClient result1 = future1.join();
+      SnowflakeStreamingIngestClient result2 = future2.join();
+
+      // Both callers should get the same new client
+      assertThat(result1).isSameAs(result2);
+      // Supplier should have been called exactly twice (original + one recreation)
+      assertThat(supplierCallCount.get()).isEqualTo(2);
+    }
+
+    @Test
     void getClient_parallel_for_different_pipes_creates_concurrently() throws Exception {
       CountDownLatch bothStarted = new CountDownLatch(2);
       CountDownLatch proceed = new CountDownLatch(1);

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/client/StreamingClientPoolTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/client/StreamingClientPoolTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
+import com.snowflake.ingest.streaming.SFException;
 import com.snowflake.ingest.streaming.SnowflakeStreamingIngestClient;
 import com.snowflake.kafka.connector.config.SinkTaskConfig;
 import com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException;
@@ -318,6 +319,42 @@ class StreamingClientPoolTest {
     }
 
     @Test
+    void recreateClient_retries_on_client_invalid_error() {
+      SnowflakeStreamingIngestClient oldClient = mock(SnowflakeStreamingIngestClient.class);
+      SnowflakeStreamingIngestClient newClient = mock(SnowflakeStreamingIngestClient.class);
+      AtomicInteger callCount = new AtomicInteger();
+
+      StreamingClientFactory.setStreamingClientSupplier(
+          (clientName, dbName, schemaName, pipeName, config, props) -> {
+            int count = callCount.incrementAndGet();
+            if (count == 1) return oldClient;
+            if (count == 2) {
+              // First recreation attempt fails with pipe failover
+              throw new SFException("SfApiPipeFailedOverError", "Pipe failed over", 410, "");
+            }
+            return newClient;
+          });
+
+      // Create initial client
+      getClient("task-0", "pipe-A");
+
+      // Recreate — first attempt fails with 410, should retry
+      SnowflakeStreamingIngestClient result =
+          StreamingClientPools.recreateClient(
+              connectorName,
+              "task-0",
+              "pipe-A",
+              oldClient,
+              connectorConfig,
+              streamingClientProperties,
+              TaskMetrics.noop());
+
+      assertThat(result).isSameAs(newClient);
+      assertThat(callCount.get())
+          .isEqualTo(3); // original + failed recreation + successful recreation
+    }
+
+    @Test
     void pool_threads_inherit_context_classloader_from_pool_creator() {
       AtomicReference<ClassLoader> capturedClassLoader = new AtomicReference<>();
       StreamingClientFactory.setStreamingClientSupplier(
@@ -374,7 +411,12 @@ class StreamingClientPoolTest {
       // Recreate the client
       SnowflakeStreamingIngestClient result =
           pool.recreateClient(
-              "pipe-A", oldClient, connectorConfig, streamingClientProperties, TaskMetrics.noop());
+              "task-0",
+              "pipe-A",
+              oldClient,
+              connectorConfig,
+              streamingClientProperties,
+              TaskMetrics.noop());
 
       assertThat(result).isSameAs(newClient);
       // Both tasks should still be registered
@@ -397,9 +439,43 @@ class StreamingClientPoolTest {
       getClient("task-0", "pipe-A");
 
       pool.recreateClient(
-          "pipe-A", oldClient, connectorConfig, streamingClientProperties, TaskMetrics.noop());
+          "task-0",
+          "pipe-A",
+          oldClient,
+          connectorConfig,
+          streamingClientProperties,
+          TaskMetrics.noop());
 
       verify(oldClient).close();
+    }
+
+    @Test
+    void recreateClient_creates_fresh_entry_and_registers_task_when_no_entry_exists() {
+      // When recreateClient is called for a pipe with no existing entry (e.g. the entry was
+      // already evicted by a failed creation), the fresh entry must have the caller's task
+      // registered so closeTaskClients on a different task doesn't prematurely evict it.
+      SnowflakeStreamingIngestClient freshClient = mock(SnowflakeStreamingIngestClient.class);
+      setSupplierReturning(freshClient);
+
+      // No prior call — pool is empty for this pipe.
+      assertThat(pool.getClientCountForTask("task-0")).isEqualTo(0);
+
+      SnowflakeStreamingIngestClient result =
+          pool.recreateClient(
+              "task-0",
+              "pipe-A",
+              mock(SnowflakeStreamingIngestClient.class),
+              connectorConfig,
+              streamingClientProperties,
+              TaskMetrics.noop());
+
+      assertThat(result).isSameAs(freshClient);
+      // Task must be registered so closeTaskClients on a different task doesn't evict us.
+      assertThat(pool.getClientCountForTask("task-0")).isEqualTo(1);
+
+      // Simulate cleanup of a different task — the fresh entry must survive.
+      pool.closeTaskClients("some-other-task");
+      assertThat(pool.getClientCountForTask("task-0")).isEqualTo(1);
     }
 
     @Test
@@ -418,13 +494,23 @@ class StreamingClientPoolTest {
       // First recreation succeeds
       SnowflakeStreamingIngestClient firstResult =
           pool.recreateClient(
-              "pipe-A", oldClient, connectorConfig, streamingClientProperties, TaskMetrics.noop());
+              "task-0",
+              "pipe-A",
+              oldClient,
+              connectorConfig,
+              streamingClientProperties,
+              TaskMetrics.noop());
       assertThat(firstResult).isSameAs(newClient);
 
       // Second recreation with the OLD client reference should be a no-op
       SnowflakeStreamingIngestClient secondResult =
           pool.recreateClient(
-              "pipe-A", oldClient, connectorConfig, streamingClientProperties, TaskMetrics.noop());
+              "task-0",
+              "pipe-A",
+              oldClient,
+              connectorConfig,
+              streamingClientProperties,
+              TaskMetrics.noop());
       assertThat(secondResult).isSameAs(newClient);
 
       // Supplier should only have been called twice (original + one recreation)
@@ -445,7 +531,12 @@ class StreamingClientPoolTest {
       getClient("task-0", "pipe-A");
 
       pool.recreateClient(
-          "pipe-A", oldClient, connectorConfig, streamingClientProperties, TaskMetrics.noop());
+          "task-0",
+          "pipe-A",
+          oldClient,
+          connectorConfig,
+          streamingClientProperties,
+          TaskMetrics.noop());
 
       // A subsequent getClient should return the new client (not create a third one)
       SnowflakeStreamingIngestClient result = getClient("task-0", "pipe-A");
@@ -486,6 +577,7 @@ class StreamingClientPoolTest {
           CompletableFuture.supplyAsync(
               () ->
                   pool.recreateClient(
+                      "task-0",
                       "pipe-A",
                       oldClient,
                       connectorConfig,
@@ -495,6 +587,7 @@ class StreamingClientPoolTest {
           CompletableFuture.supplyAsync(
               () ->
                   pool.recreateClient(
+                      "task-1",
                       "pipe-A",
                       oldClient,
                       connectorConfig,


### PR DESCRIPTION
## Summary

- **`StreamingClientPool.recreateClient()`** — atomically replaces the `RefCountedClient` entry only if the current resolved client is identity-equal to the given invalid client (CAS semantics). Preserves task registrations via `copyTasksFrom()`. Old client is closed best-effort **outside** the `compute()` lock to avoid blocking the `ConcurrentHashMap` bucket during I/O. Failed replacement-client creation evicts the entry so the next caller retries from scratch.
- **`StreamingClientPools.getClient()`** — retry loop (3 attempts) on client-invalid errors during initial client creation. Exhausted retries wrap the underlying `SFException` via `ClientRecreationException.wrap()` so the batch loop (PR #1431) can rewind Kafka offsets instead of crashing the task.
- **`StreamingClientPools.recreateClient()`** — static delegate to the per-connector `StreamingClientPool.recreateClient()` with the same retry+wrap pattern.
- Concurrent callers with the same invalid-client reference produce exactly one replacement — validated by a latch-coordinated test.

**JIRA**: SNOW-3360429

## Test plan

- [x] `StreamingClientPoolTest` — 25 tests (8 new): CAS replaces entry + preserves task registrations, old client is closed, no-op when already replaced, `getClient` returns the new client after recreation, concurrent callers create exactly one replacement, failed replacement evicts the entry, retry exhaustion wraps as `ClientRecreationException`
- [x] `StreamingClientPoolsTest` — 2 tests (1 new): `getClient` retries on client-invalid then wraps on exhaustion