### PR TITLE
fix table name quoting in offset token migration

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/StandardSnowflakeConnectionService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/StandardSnowflakeConnectionService.java
@@ -513,7 +513,7 @@ public class StandardSnowflakeConnectionService implements SnowflakeConnectionSe
 
     String query = "SELECT SYSTEM$MIGRATE_SSV1_CHANNEL_OFFSET(?, ?, ?, ?)";
     try (PreparedStatement stmt = conn.prepareStatement(query)) {
-      stmt.setString(1, tableName);
+      stmt.setString(1, quoteIdentifier(tableName));
       // The backend should unquote/uppercase the channel name, but that fix is not yet rolled out.
       // Uppercase here as a workaround
       // TODO(SNOW-3360048): Remove once the backend fix is rolled out.


### PR DESCRIPTION
KC v3 doesn't support table names with lowercase characters but KC v4 does, so we need to pass them correctly to the system function for the "best_effort" mode to correctly ignore tables with lowercase characters rather than failing.

## Testing

This functionality will be covered by the change in https://app.graphite.com/github/pr/snowflakedb/snowflake-kafka-connector/1422 to run the case sensitivity tests in "best_effort" migration mode.