### PR TITLE
remove hardcoded role from e2e channel invalidation tests

### DIFF
--- a/test/tests/test_channel_invalidation.py
+++ b/test/tests/test_channel_invalidation.py
@@ -53,20 +53,16 @@ def invalidate_channel(driver, credentials, table_name, topic, partition=0):
 
     cur = driver.snowflake_conn.cursor()
     try:
-        cur.execute("USE ROLE SYSADMIN")
-        try:
-            result = cur.execute(
-                f"SELECT SYSTEM$STREAMING_CHANNEL_INVALIDATE('{pipe_fqn}', '{channel_name}')"
-            ).fetchone()[0]
-        except snowflake.connector.errors.ProgrammingError as e:
-            if e.errno == 2140 or "Unknown function" in str(e):
-                pytest.skip(
-                    f"SYSTEM$STREAMING_CHANNEL_INVALIDATE is not available on this "
-                    f"Snowflake account — skipping channel invalidation test ({e})"
-                )
-            raise
-    finally:
-        cur.execute(f"USE ROLE {credentials.role}")
+        result = cur.execute(
+            f"SELECT SYSTEM$STREAMING_CHANNEL_INVALIDATE('{pipe_fqn}', '{channel_name}')"
+        ).fetchone()[0]
+    except snowflake.connector.errors.ProgrammingError as e:
+        if e.errno == 2140 or "Unknown function" in str(e):
+            pytest.skip(
+                f"SYSTEM$STREAMING_CHANNEL_INVALIDATE is not available on this "
+                f"Snowflake account — skipping channel invalidation test ({e})"
+            )
+        raise
 
     logger.info(f"Invalidation result: {result}")
     assert "ERR_CHANNEL_MUST_BE_REOPENED" in result, f"Invalidation failed: {result}"


### PR DESCRIPTION
Remove the hardcoded `USE ROLE SYSADMIN` from the `invalidate_channel` helper in the e2e channel invalidation tests.

The default role from `profile.json` already has sufficient permissions for `SYSTEM$STREAMING_CHANNEL_INVALIDATE`, so the explicit role switch was unnecessary. This also simplifies the try/finally block.

Tested against QA3 — all 8 invalidation tests pass.
