### PR TITLE
bump kafka-clients, assertj-core, log4j-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,9 +53,9 @@
         <skipUnitTests>${skipTests}</skipUnitTests>
         <skipIntegrationTests>${skipTests}</skipIntegrationTests>
 
-        <kafka.version>3.9.1</kafka.version>
+        <kafka.version>3.9.2</kafka.version>
         <awaitility.version>4.2.2</awaitility.version>
-        <assertj-core.version>3.26.3</assertj-core.version>
+        <assertj-core.version>3.27.7</assertj-core.version>
         <confluent.version>7.9.2</confluent.version>
         <!--Compatible protobuf version https://github.com/confluentinc/common/blob/v7.7.0/pom.xml#L91 -->
         <protobuf.version>3.25.5</protobuf.version>
@@ -523,7 +523,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.17.1</version>
+            <version>2.25.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Summary
- Bump `kafka-clients` 3.9.1 → 3.9.2
- Bump `assertj-core` 3.26.3 → 3.27.7 (test-only)
- Bump `log4j-core` 2.17.1 → 2.25.4 (test-only)

Addresses SNOW-3417227.

## Test plan
- [x] `mvn clean compile` passes
- [x] Unit tests pass
- [ ] CI green