### PR TITLE
CODEOWNERS: remove @snowflakedb/streaming-connectors

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @snowflakedb/streaming-connectors @snowflakedb/streaming-ingest
+* @snowflakedb/streaming-ingest


### PR DESCRIPTION
Removing @snowflakedb/streaming-connectors from CODEOWNERS after the project's transition.