### PR TITLE
actually use StreamingClientProperties

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/Constants.java
+++ b/src/main/java/com/snowflake/kafka/connector/Constants.java
@@ -122,12 +122,4 @@ public final class Constants {
     public static final String HTTP_PROXY_USER = "http.proxyUser";
     public static final String HTTP_PROXY_PASSWORD = "http.proxyPassword";
   }
-
-  public static final class StreamingIngestClientConfigParams {
-
-    public static final String USER = "user";
-    public static final String ACCOUNT_URL = "url";
-    public static final String ROLE = "role";
-    public static final String PRIVATE_KEY = "private_key";
-  }
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProperties.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProperties.java
@@ -32,19 +32,21 @@ import java.util.Properties;
  * equality between clients in {@code StreamingClientProvider}.
  */
 public class StreamingClientProperties {
-  public static final String STREAMING_CLIENT_PREFIX_NAME = "KC_CLIENT_";
+  public static final String STREAMING_CLIENT_V2_PREFIX_NAME = "KC_CLIENT_V2_";
   public static final String DEFAULT_CLIENT_NAME = "DEFAULT_CLIENT";
 
   private static final KCLogger LOGGER = new KCLogger(StreamingClientProperties.class.getName());
   public final Properties clientProperties;
-  public final String clientName;
+  public final String clientNamePrefix;
   public final Map<String, Object> parameterOverrides;
 
   /** Constructor used by {@link #from(SinkTaskConfig)}. */
   private StreamingClientProperties(
-      Properties clientProperties, String clientName, Map<String, Object> parameterOverrides) {
+      Properties clientProperties,
+      String clientNamePrefix,
+      Map<String, Object> parameterOverrides) {
     this.clientProperties = clientProperties;
-    this.clientName = clientName;
+    this.clientNamePrefix = clientNamePrefix;
     this.parameterOverrides = parameterOverrides;
   }
 
@@ -65,8 +67,8 @@ public class StreamingClientProperties {
           StreamingIngestClientConfigParams.PRIVATE_KEY, config.getSnowflakePrivateKey());
     }
 
-    String clientName =
-        STREAMING_CLIENT_PREFIX_NAME
+    String clientNamePrefix =
+        STREAMING_CLIENT_V2_PREFIX_NAME
             + (config.getConnectorName() != null ? config.getConnectorName() : DEFAULT_CLIENT_NAME);
 
     Map<String, Object> parameterOverrides = new HashMap<>();
@@ -77,7 +79,7 @@ public class StreamingClientProperties {
       LOGGER.info("Streaming Client config overrides: {}", parameterOverrides);
     }
 
-    return new StreamingClientProperties(clientProperties, clientName, parameterOverrides);
+    return new StreamingClientProperties(clientProperties, clientNamePrefix, parameterOverrides);
   }
 
   /**

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProperties.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProperties.java
@@ -17,6 +17,7 @@
 
 package com.snowflake.kafka.connector.internal.streaming;
 
+import com.google.common.base.Strings;
 import com.snowflake.kafka.connector.Utils;
 import com.snowflake.kafka.connector.config.SinkTaskConfig;
 import com.snowflake.kafka.connector.internal.KCLogger;
@@ -56,7 +57,7 @@ public class StreamingClientProperties {
   /** Creates streaming client properties from parsed {@link SinkTaskConfig}. */
   public static StreamingClientProperties from(SinkTaskConfig config) {
     final Properties clientProperties = new Properties();
-    if (config.getSnowflakeUrl() != null) {
+    if (!Strings.isNullOrEmpty(config.getSnowflakeUrl())) {
       SnowflakeURL url = new SnowflakeURL(config.getSnowflakeUrl());
       final String privateKeyStr = config.getSnowflakePrivateKey();
       final String privateKeyPassphrase = config.getSnowflakePrivateKeyPassphrase();

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProperties.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProperties.java
@@ -17,10 +17,13 @@
 
 package com.snowflake.kafka.connector.internal.streaming;
 
-import com.snowflake.kafka.connector.Constants.StreamingIngestClientConfigParams;
 import com.snowflake.kafka.connector.Utils;
 import com.snowflake.kafka.connector.config.SinkTaskConfig;
 import com.snowflake.kafka.connector.internal.KCLogger;
+import com.snowflake.kafka.connector.internal.PrivateKeyTool;
+import com.snowflake.kafka.connector.internal.SnowflakeURL;
+import java.security.PrivateKey;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -52,19 +55,20 @@ public class StreamingClientProperties {
 
   /** Creates streaming client properties from parsed {@link SinkTaskConfig}. */
   public static StreamingClientProperties from(SinkTaskConfig config) {
-    Properties clientProperties = new Properties();
+    final Properties clientProperties = new Properties();
     if (config.getSnowflakeUrl() != null) {
-      clientProperties.put(StreamingIngestClientConfigParams.ACCOUNT_URL, config.getSnowflakeUrl());
-    }
-    if (config.getSnowflakeRole() != null) {
-      clientProperties.put(StreamingIngestClientConfigParams.ROLE, config.getSnowflakeRole());
-    }
-    if (config.getSnowflakeUser() != null) {
-      clientProperties.put(StreamingIngestClientConfigParams.USER, config.getSnowflakeUser());
-    }
-    if (config.getSnowflakePrivateKey() != null) {
-      clientProperties.put(
-          StreamingIngestClientConfigParams.PRIVATE_KEY, config.getSnowflakePrivateKey());
+      SnowflakeURL url = new SnowflakeURL(config.getSnowflakeUrl());
+      final String privateKeyStr = config.getSnowflakePrivateKey();
+      final String privateKeyPassphrase = config.getSnowflakePrivateKeyPassphrase();
+      final PrivateKey privateKey =
+          PrivateKeyTool.parsePrivateKey(privateKeyStr, privateKeyPassphrase);
+      final String privateKeyEncoded = Base64.getEncoder().encodeToString(privateKey.getEncoded());
+      clientProperties.put("private_key", privateKeyEncoded);
+
+      clientProperties.put("user", config.getSnowflakeUser());
+      clientProperties.put("role", config.getSnowflakeRole());
+      clientProperties.put("account", url.getAccount());
+      clientProperties.put("host", url.getUrlWithoutPort());
     }
 
     String clientNamePrefix =

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/client/StreamingClientFactory.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/client/StreamingClientFactory.java
@@ -35,7 +35,7 @@ public class StreamingClientFactory {
     String schemaName = config.getSnowflakeSchema();
 
     return ingestClientSupplier.get(
-        clientName, dbName, schemaName, pipeName, config, streamingClientProperties);
+        clientName, dbName, schemaName, pipeName, streamingClientProperties);
   }
 
   private static String clientName(final StreamingClientProperties streamingClientProperties) {
@@ -49,7 +49,6 @@ public class StreamingClientFactory {
         final String dbName,
         final String schemaName,
         final String pipeName,
-        final SinkTaskConfig config,
         final StreamingClientProperties streamingClientProperties) {
 
       // Quote the pipe name to handle lowercase / special characters in the name.

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/client/StreamingClientFactory.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/client/StreamingClientFactory.java
@@ -3,18 +3,11 @@ package com.snowflake.kafka.connector.internal.streaming.v2.client;
 import com.snowflake.ingest.streaming.SnowflakeStreamingIngestClient;
 import com.snowflake.ingest.streaming.SnowflakeStreamingIngestClientFactory;
 import com.snowflake.kafka.connector.config.SinkTaskConfig;
-import com.snowflake.kafka.connector.internal.PrivateKeyTool;
-import com.snowflake.kafka.connector.internal.SnowflakeURL;
 import com.snowflake.kafka.connector.internal.streaming.StreamingClientProperties;
-import java.security.PrivateKey;
-import java.util.Base64;
-import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /** Factory for creating Snowpipe Streaming clients. Shared by all connectors. */
 public class StreamingClientFactory {
-  private static final String STREAMING_CLIENT_V2_PREFIX_NAME = "KC_CLIENT_V2_";
-  private static final String DEFAULT_CLIENT_NAME = "DEFAULT_CLIENT";
 
   // Supplier reference is here so that we can swap it to mocked one in the tests
   private static volatile StreamingClientSupplier ingestClientSupplier =
@@ -49,26 +42,6 @@ public class StreamingClientFactory {
     return streamingClientProperties.clientNamePrefix + createdClientId.incrementAndGet();
   }
 
-  public static Properties getClientProperties(final SinkTaskConfig config) {
-    final Properties props = new Properties();
-    if (config.getSnowflakeUrl() == null) {
-      return props;
-    }
-    SnowflakeURL url = new SnowflakeURL(config.getSnowflakeUrl());
-    final String privateKeyStr = config.getSnowflakePrivateKey();
-    final String privateKeyPassphrase = config.getSnowflakePrivateKeyPassphrase();
-    final PrivateKey privateKey =
-        PrivateKeyTool.parsePrivateKey(privateKeyStr, privateKeyPassphrase);
-    final String privateKeyEncoded = Base64.getEncoder().encodeToString(privateKey.getEncoded());
-    props.put("private_key", privateKeyEncoded);
-
-    props.put("user", config.getSnowflakeUser());
-    props.put("role", config.getSnowflakeRole());
-    props.put("account", url.getAccount());
-    props.put("host", url.getUrlWithoutPort());
-    return props;
-  }
-
   static final class StreamingClientSupplierImpl implements StreamingClientSupplier {
     @Override
     public SnowflakeStreamingIngestClient get(
@@ -82,7 +55,7 @@ public class StreamingClientFactory {
       // Quote the pipe name to handle lowercase / special characters in the name.
       return SnowflakeStreamingIngestClientFactory.builder(
               clientName, dbName, schemaName, '"' + pipeName + '"')
-          .setProperties(getClientProperties(config))
+          .setProperties(streamingClientProperties.clientProperties)
           .setParameterOverrides(streamingClientProperties.parameterOverrides)
           .build();
     }

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/client/StreamingClientFactory.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/client/StreamingClientFactory.java
@@ -37,7 +37,7 @@ public class StreamingClientFactory {
       final SinkTaskConfig config,
       final StreamingClientProperties streamingClientProperties) {
 
-    String clientName = clientNameFromConfig(config);
+    String clientName = clientName(streamingClientProperties);
     String dbName = config.getSnowflakeDatabase();
     String schemaName = config.getSnowflakeSchema();
 
@@ -45,10 +45,8 @@ public class StreamingClientFactory {
         clientName, dbName, schemaName, pipeName, config, streamingClientProperties);
   }
 
-  private static String clientNameFromConfig(final SinkTaskConfig config) {
-    return STREAMING_CLIENT_V2_PREFIX_NAME
-        + (config.getConnectorName() != null ? config.getConnectorName() : DEFAULT_CLIENT_NAME)
-        + createdClientId.incrementAndGet();
+  private static String clientName(final StreamingClientProperties streamingClientProperties) {
+    return streamingClientProperties.clientNamePrefix + createdClientId.incrementAndGet();
   }
 
   public static Properties getClientProperties(final SinkTaskConfig config) {

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/client/StreamingClientSupplier.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/client/StreamingClientSupplier.java
@@ -1,7 +1,6 @@
 package com.snowflake.kafka.connector.internal.streaming.v2.client;
 
 import com.snowflake.ingest.streaming.SnowflakeStreamingIngestClient;
-import com.snowflake.kafka.connector.config.SinkTaskConfig;
 import com.snowflake.kafka.connector.internal.streaming.StreamingClientProperties;
 
 public interface StreamingClientSupplier {
@@ -10,6 +9,5 @@ public interface StreamingClientSupplier {
       String dbName,
       String schemaName,
       String pipeName,
-      SinkTaskConfig config,
       StreamingClientProperties streamingClientProperties);
 }

--- a/src/test/java/com/snowflake/kafka/connector/ConnectClusterBaseIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectClusterBaseIT.java
@@ -125,7 +125,7 @@ public abstract class ConnectClusterBaseIT {
     Utils.convertAppName(config);
     String sanitizedConnectorName = config.get(KafkaConnectorConfigParams.NAME);
     return fakeClientSupplier.getFakeIngestClients().stream()
-        .filter((client) -> client.getConnectorName().equals(sanitizedConnectorName))
+        .filter((client) -> client.getClientName().contains(sanitizedConnectorName))
         .findFirst()
         .orElseThrow();
   }

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/BatchOffsetFetcherTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/BatchOffsetFetcherTest.java
@@ -246,7 +246,6 @@ class BatchOffsetFetcherTest {
         String dbName,
         String schemaName,
         String pipeName,
-        SinkTaskConfig config,
         StreamingClientProperties streamingClientProperties) {
       SnowflakeStreamingIngestClient client = mock(SnowflakeStreamingIngestClient.class);
       when(client.getChannelStatus(any()))

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/ChannelStatusCheckIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/ChannelStatusCheckIT.java
@@ -270,7 +270,7 @@ class ChannelStatusCheckIT {
     Utils.convertAppName(config);
     String sanitizedConnectorName = config.get(KafkaConnectorConfigParams.NAME);
     return fakeClientSupplier.getFakeIngestClients().stream()
-        .filter((client) -> client.getConnectorName().equals(sanitizedConnectorName))
+        .filter((client) -> client.getClientName().contains(sanitizedConnectorName))
         .findFirst()
         .orElseThrow();
   }

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/FakeIngestClientSupplier.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/FakeIngestClientSupplier.java
@@ -1,7 +1,6 @@
 package com.snowflake.kafka.connector.internal.streaming;
 
 import com.snowflake.ingest.streaming.SnowflakeStreamingIngestClient;
-import com.snowflake.kafka.connector.config.SinkTaskConfig;
 import com.snowflake.kafka.connector.internal.streaming.v2.client.StreamingClientSupplier;
 import java.util.Collection;
 import java.util.concurrent.ConcurrentHashMap;
@@ -19,13 +18,12 @@ public class FakeIngestClientSupplier implements StreamingClientSupplier {
       final String dbName,
       final String schemaName,
       final String pipeName,
-      final SinkTaskConfig config,
       final StreamingClientProperties streamingClientProperties) {
     return pipeToIngestClientMap.computeIfAbsent(
         pipeName,
         (key) -> {
           final FakeSnowflakeStreamingIngestClient client =
-              new FakeSnowflakeStreamingIngestClient(pipeName, config.getConnectorName());
+              new FakeSnowflakeStreamingIngestClient(pipeName, clientName);
           client.setDefaultErrorCount(preExistingErrorCount);
           return client;
         });

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/FakeSnowflakeStreamingIngestClient.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/FakeSnowflakeStreamingIngestClient.java
@@ -15,7 +15,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class FakeSnowflakeStreamingIngestClient implements SnowflakeStreamingIngestClient {
 
   private final String pipeName;
-  private final String connectorName;
+  private final String clientName;
   private final Map<String, FakeSnowflakeStreamingIngestChannel> openedChannels =
       new ConcurrentHashMap<>();
   private final Map<String, String> channelNameToOffsetTokens = new ConcurrentHashMap<>();
@@ -25,9 +25,9 @@ public class FakeSnowflakeStreamingIngestClient implements SnowflakeStreamingIng
   private long defaultErrorCount = 0;
   private boolean closed = false;
 
-  public FakeSnowflakeStreamingIngestClient(final String pipeName, final String connectorName) {
+  public FakeSnowflakeStreamingIngestClient(final String pipeName, final String clientName) {
     this.pipeName = pipeName;
-    this.connectorName = connectorName;
+    this.clientName = clientName;
   }
 
   public void setDefaultErrorCount(final long errorCount) {
@@ -131,15 +131,11 @@ public class FakeSnowflakeStreamingIngestClient implements SnowflakeStreamingIng
 
   @Override
   public String getClientName() {
-    throw new UnsupportedOperationException();
+    return clientName;
   }
 
   public List<FakeSnowflakeStreamingIngestChannel> getOpenedChannels() {
     return new ArrayList<>(openedChannels.values());
-  }
-
-  public String getConnectorName() {
-    return connectorName;
   }
 
   public long countClosedChannels() {

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientPropertiesTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientPropertiesTest.java
@@ -18,16 +18,20 @@
 package com.snowflake.kafka.connector.internal.streaming;
 
 import static com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams.SNOWFLAKE_STREAMING_CLIENT_PROVIDER_OVERRIDE_MAP;
+import static com.snowflake.kafka.connector.internal.TestUtils.generatePrivateKey;
 import static com.snowflake.kafka.connector.internal.TestUtils.getConnectorConfigurationForStreaming;
 import static com.snowflake.kafka.connector.internal.streaming.StreamingClientProperties.STREAMING_CLIENT_V2_PREFIX_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams;
-import com.snowflake.kafka.connector.Constants.StreamingIngestClientConfigParams;
 import com.snowflake.kafka.connector.Utils;
 import com.snowflake.kafka.connector.config.SinkTaskConfig;
 import com.snowflake.kafka.connector.config.SnowflakeSinkConnectorConfigBuilder;
+import com.snowflake.kafka.connector.internal.PrivateKeyTool;
 import com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException;
+import com.snowflake.kafka.connector.internal.SnowflakeURL;
+import java.security.PrivateKey;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -41,32 +45,33 @@ public class StreamingClientPropertiesTest {
 
   @Test
   public void testGetValidProperties() {
-    // setup config with all loggable properties and parameter override
-    Map<String, String> connectorConfig = getConnectorConfigurationForStreaming(false);
+    String privateKeyPem = Base64.getEncoder().encodeToString(generatePrivateKey().getEncoded());
+    String testUrl = "https://testaccount.us-east-1.snowflakecomputing.com";
+
+    Map<String, String> connectorConfig = new HashMap<>();
     connectorConfig.put(KafkaConnectorConfigParams.NAME, "testName");
-    connectorConfig.put(KafkaConnectorConfigParams.SNOWFLAKE_URL_NAME, "testUrl");
+    connectorConfig.put(Utils.TASK_ID, "0");
+    connectorConfig.put(KafkaConnectorConfigParams.SNOWFLAKE_URL_NAME, testUrl);
     connectorConfig.put(KafkaConnectorConfigParams.SNOWFLAKE_ROLE_NAME, "testRole");
     connectorConfig.put(KafkaConnectorConfigParams.SNOWFLAKE_USER_NAME, "testUser");
+    connectorConfig.put(KafkaConnectorConfigParams.SNOWFLAKE_PRIVATE_KEY, privateKeyPem);
 
-    Properties expectedProps = new Properties();
-    expectedProps.put(StreamingIngestClientConfigParams.ACCOUNT_URL, "testUrl");
-    expectedProps.put(StreamingIngestClientConfigParams.ROLE, "testRole");
-    expectedProps.put(StreamingIngestClientConfigParams.USER, "testUser");
-    String privateKey = connectorConfig.get(KafkaConnectorConfigParams.SNOWFLAKE_PRIVATE_KEY);
-    if (privateKey != null) {
-      expectedProps.put(StreamingIngestClientConfigParams.PRIVATE_KEY, privateKey);
-    }
-    String expectedClientName = STREAMING_CLIENT_V2_PREFIX_NAME + "testName";
-    Map<String, Object> expectedParameterOverrides = new HashMap<>();
-
-    // test get properties
     SinkTaskConfig config = SinkTaskConfig.from(connectorConfig);
-    StreamingClientProperties resultProperties = StreamingClientProperties.from(config);
+    StreamingClientProperties result = StreamingClientProperties.from(config);
 
-    // verify
-    assert resultProperties.clientProperties.equals(expectedProps);
-    assert resultProperties.clientNamePrefix.equals(expectedClientName);
-    assert resultProperties.parameterOverrides.equals(expectedParameterOverrides);
+    // verify client properties
+    Properties clientProps = result.clientProperties;
+    assertThat(clientProps.getProperty("user")).isEqualTo("testUser");
+    assertThat(clientProps.getProperty("role")).isEqualTo("testRole");
+    assertThat(clientProps.getProperty("account")).isEqualTo("testaccount");
+    assertThat(clientProps.getProperty("host"))
+        .isEqualTo("testaccount.us-east-1.snowflakecomputing.com");
+    assertThat(clientProps.getProperty("private_key")).isEqualTo(privateKeyPem);
+    assertThat(clientProps).hasSize(5);
+
+    // verify client name prefix and empty parameter overrides
+    assertThat(result.clientNamePrefix).isEqualTo(STREAMING_CLIENT_V2_PREFIX_NAME + "testName");
+    assertThat(result.parameterOverrides).isEmpty();
   }
 
   @Test
@@ -76,6 +81,9 @@ public class StreamingClientPropertiesTest {
         SnowflakeSinkConnectorConfigBuilder.streamingConfig().build();
 
     connectorConfig.put(Utils.TASK_ID, "0");
+    connectorConfig.put(
+        KafkaConnectorConfigParams.SNOWFLAKE_PRIVATE_KEY,
+        Base64.getEncoder().encodeToString(generatePrivateKey().getEncoded()));
     connectorConfig.put(
         SNOWFLAKE_STREAMING_CLIENT_PROVIDER_OVERRIDE_MAP, "EXAMPLE_PARAM1:1,EXAMPLE_PARAM2:2");
 
@@ -99,6 +107,9 @@ public class StreamingClientPropertiesTest {
 
     connectorConfig.put(Utils.TASK_ID, "0");
     connectorConfig.put(
+        KafkaConnectorConfigParams.SNOWFLAKE_PRIVATE_KEY,
+        Base64.getEncoder().encodeToString(generatePrivateKey().getEncoded()));
+    connectorConfig.put(
         SNOWFLAKE_STREAMING_CLIENT_PROVIDER_OVERRIDE_MAP, "EXAMPLE_PARAM1:1,EXAMPLE_PARAM2:2");
 
     Map<String, Object> expectedParameterOverrides = new HashMap<>();
@@ -117,19 +128,25 @@ public class StreamingClientPropertiesTest {
   public void testValidPropertiesWithOverriddenStreamingPropertiesMap() {
     Map<String, String> connectorConfig = getConnectorConfigurationForStreaming(true);
     connectorConfig.put(KafkaConnectorConfigParams.NAME, "testName");
-    connectorConfig.put(KafkaConnectorConfigParams.SNOWFLAKE_URL_NAME, "testUrl");
+    String testUrl = "https://testaccount.us-east-1.snowflakecomputing.com";
+    connectorConfig.put(KafkaConnectorConfigParams.SNOWFLAKE_URL_NAME, testUrl);
     connectorConfig.put(KafkaConnectorConfigParams.SNOWFLAKE_ROLE_NAME, "testRole");
     connectorConfig.put(KafkaConnectorConfigParams.SNOWFLAKE_USER_NAME, "testUser");
     connectorConfig.put(
         SNOWFLAKE_STREAMING_CLIENT_PROVIDER_OVERRIDE_MAP, "EXAMPLE_PARAM2:10000000");
 
+    SnowflakeURL parsedUrl = new SnowflakeURL(testUrl);
     Properties expectedProps = new Properties();
-    expectedProps.put(StreamingIngestClientConfigParams.ACCOUNT_URL, "testUrl");
-    expectedProps.put(StreamingIngestClientConfigParams.ROLE, "testRole");
-    expectedProps.put(StreamingIngestClientConfigParams.USER, "testUser");
-    String privateKey = connectorConfig.get(KafkaConnectorConfigParams.SNOWFLAKE_PRIVATE_KEY);
-    if (privateKey != null) {
-      expectedProps.put(StreamingIngestClientConfigParams.PRIVATE_KEY, privateKey);
+    expectedProps.put("user", "testUser");
+    expectedProps.put("role", "testRole");
+    expectedProps.put("account", parsedUrl.getAccount());
+    expectedProps.put("host", parsedUrl.getUrlWithoutPort());
+    String privateKeyStr = connectorConfig.get(KafkaConnectorConfigParams.SNOWFLAKE_PRIVATE_KEY);
+    if (privateKeyStr != null) {
+      String passphrase =
+          connectorConfig.get(KafkaConnectorConfigParams.SNOWFLAKE_PRIVATE_KEY_PASSPHRASE);
+      PrivateKey privateKey = PrivateKeyTool.parsePrivateKey(privateKeyStr, passphrase);
+      expectedProps.put("private_key", Base64.getEncoder().encodeToString(privateKey.getEncoded()));
     }
     String expectedClientName = STREAMING_CLIENT_V2_PREFIX_NAME + "testName";
     Map<String, Object> expectedParameterOverrides = new HashMap<>();
@@ -149,7 +166,9 @@ public class StreamingClientPropertiesTest {
   public void testInvalidStreamingClientPropertiesMap() {
     Map<String, String> connectorConfig = getConnectorConfigurationForStreaming(true);
     connectorConfig.put(KafkaConnectorConfigParams.NAME, "testName");
-    connectorConfig.put(KafkaConnectorConfigParams.SNOWFLAKE_URL_NAME, "testUrl");
+    connectorConfig.put(
+        KafkaConnectorConfigParams.SNOWFLAKE_URL_NAME,
+        "https://testaccount.us-east-1.snowflakecomputing.com");
     connectorConfig.put(KafkaConnectorConfigParams.SNOWFLAKE_ROLE_NAME, "testRole");
     connectorConfig.put(KafkaConnectorConfigParams.SNOWFLAKE_USER_NAME, "testUser");
     connectorConfig.put(

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientPropertiesTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientPropertiesTest.java
@@ -19,7 +19,7 @@ package com.snowflake.kafka.connector.internal.streaming;
 
 import static com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams.SNOWFLAKE_STREAMING_CLIENT_PROVIDER_OVERRIDE_MAP;
 import static com.snowflake.kafka.connector.internal.TestUtils.getConnectorConfigurationForStreaming;
-import static com.snowflake.kafka.connector.internal.streaming.StreamingClientProperties.STREAMING_CLIENT_PREFIX_NAME;
+import static com.snowflake.kafka.connector.internal.streaming.StreamingClientProperties.STREAMING_CLIENT_V2_PREFIX_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams;
@@ -56,7 +56,7 @@ public class StreamingClientPropertiesTest {
     if (privateKey != null) {
       expectedProps.put(StreamingIngestClientConfigParams.PRIVATE_KEY, privateKey);
     }
-    String expectedClientName = STREAMING_CLIENT_PREFIX_NAME + "testName";
+    String expectedClientName = STREAMING_CLIENT_V2_PREFIX_NAME + "testName";
     Map<String, Object> expectedParameterOverrides = new HashMap<>();
 
     // test get properties
@@ -65,7 +65,7 @@ public class StreamingClientPropertiesTest {
 
     // verify
     assert resultProperties.clientProperties.equals(expectedProps);
-    assert resultProperties.clientName.equals(expectedClientName);
+    assert resultProperties.clientNamePrefix.equals(expectedClientName);
     assert resultProperties.parameterOverrides.equals(expectedParameterOverrides);
   }
 
@@ -131,7 +131,7 @@ public class StreamingClientPropertiesTest {
     if (privateKey != null) {
       expectedProps.put(StreamingIngestClientConfigParams.PRIVATE_KEY, privateKey);
     }
-    String expectedClientName = STREAMING_CLIENT_PREFIX_NAME + "testName";
+    String expectedClientName = STREAMING_CLIENT_V2_PREFIX_NAME + "testName";
     Map<String, Object> expectedParameterOverrides = new HashMap<>();
     expectedParameterOverrides.put(EXAMPLE_PARAM2, "10000000");
 
@@ -141,7 +141,7 @@ public class StreamingClientPropertiesTest {
 
     // verify
     assert resultProperties.clientProperties.equals(expectedProps);
-    assert resultProperties.clientName.equals(expectedClientName);
+    assert resultProperties.clientNamePrefix.equals(expectedClientName);
     assert resultProperties.parameterOverrides.equals(expectedParameterOverrides);
   }
 

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/StreamingClientManagerIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/StreamingClientManagerIT.java
@@ -1,23 +1,17 @@
 package com.snowflake.kafka.connector.internal.streaming.v2;
 
 import static com.snowflake.kafka.connector.Constants.DEFAULT_PIPE_NAME_SUFFIX;
-import static com.snowflake.kafka.connector.internal.TestUtils.generatePrivateKey;
 import static org.assertj.core.api.Assertions.*;
 
 import com.snowflake.ingest.streaming.SnowflakeStreamingIngestClient;
-import com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams;
 import com.snowflake.kafka.connector.config.SinkTaskConfig;
 import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
 import com.snowflake.kafka.connector.internal.TestUtils;
 import com.snowflake.kafka.connector.internal.metrics.TaskMetrics;
 import com.snowflake.kafka.connector.internal.streaming.StreamingClientProperties;
-import com.snowflake.kafka.connector.internal.streaming.v2.client.StreamingClientFactory;
 import com.snowflake.kafka.connector.internal.streaming.v2.client.StreamingClientPools;
 import com.snowflake.kafka.connector.internal.streaming.v2.service.ThreadPools;
-import java.util.Base64;
-import java.util.HashMap;
 import java.util.Map;
-import java.util.Properties;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -141,31 +135,6 @@ public class StreamingClientManagerIT {
   }
 
   @Test
-  void test_GetClientProperties_includes_all_needed_properties() {
-    // Given
-    String privateKey = generatePemPrivateKey();
-    Map<String, String> connectorConfig = new HashMap<>();
-    connectorConfig.put(KafkaConnectorConfigParams.NAME, "test_connector");
-    connectorConfig.put(com.snowflake.kafka.connector.Utils.TASK_ID, "0");
-    connectorConfig.put(
-        KafkaConnectorConfigParams.SNOWFLAKE_URL_NAME, "https://test.snowflakecomputing.com");
-    connectorConfig.put(KafkaConnectorConfigParams.SNOWFLAKE_PRIVATE_KEY, privateKey);
-    connectorConfig.put(KafkaConnectorConfigParams.SNOWFLAKE_USER_NAME, "test_user");
-    connectorConfig.put(KafkaConnectorConfigParams.SNOWFLAKE_ROLE_NAME, "TEST_ROLE");
-
-    // When
-    SinkTaskConfig taskConfig = SinkTaskConfig.from(connectorConfig);
-    Properties properties = StreamingClientFactory.getClientProperties(taskConfig);
-
-    // Then
-    assertThat(properties).isNotNull();
-    assertThat(properties.getProperty("role")).isEqualTo("TEST_ROLE");
-    assertThat(properties.getProperty("user")).isEqualTo("test_user");
-    assertThat(properties.getProperty("host")).isEqualTo("test.snowflakecomputing.com");
-    assertThat(properties.getProperty("private_key")).isEqualTo(privateKey);
-  }
-
-  @Test
   public void testProvider_ReuseAfterPartialClose_WorksCorrectly() {
     // task 1 uses 2 pipes, so it has 2 ingest clients
     SnowflakeStreamingIngestClient client1 = getClient(task1, pipe1);
@@ -197,10 +166,6 @@ public class StreamingClientManagerIT {
         sinkTaskConfig,
         streamingClientProperties,
         TaskMetrics.noop());
-  }
-
-  private String generatePemPrivateKey() {
-    return Base64.getEncoder().encodeToString(generatePrivateKey().getEncoded());
   }
 
   private void closeTaskClients(String task) {

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/client/StreamingClientPoolTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/client/StreamingClientPoolTest.java
@@ -188,7 +188,7 @@ class StreamingClientPoolTest {
     void getClient_reuses_client_for_same_pipe() {
       AtomicInteger callCount = new AtomicInteger();
       StreamingClientFactory.setStreamingClientSupplier(
-          (clientName, dbName, schemaName, pipeName, config, props) -> {
+          (clientName, dbName, schemaName, pipeName, props) -> {
             callCount.incrementAndGet();
             return mock(SnowflakeStreamingIngestClient.class);
           });
@@ -205,7 +205,7 @@ class StreamingClientPoolTest {
     void getClient_returns_different_clients_for_different_pipes() {
       AtomicInteger callCount = new AtomicInteger();
       StreamingClientFactory.setStreamingClientSupplier(
-          (clientName, dbName, schemaName, pipeName, config, props) -> {
+          (clientName, dbName, schemaName, pipeName, props) -> {
             callCount.incrementAndGet();
             return mock(SnowflakeStreamingIngestClient.class);
           });
@@ -262,7 +262,7 @@ class StreamingClientPoolTest {
     void closeTaskClients_then_getClient_creates_new_client() {
       AtomicInteger callCount = new AtomicInteger();
       StreamingClientFactory.setStreamingClientSupplier(
-          (clientName, dbName, schemaName, pipeName, config, props) -> {
+          (clientName, dbName, schemaName, pipeName, props) -> {
             callCount.incrementAndGet();
             return mock(SnowflakeStreamingIngestClient.class);
           });
@@ -300,7 +300,7 @@ class StreamingClientPoolTest {
       SnowflakeStreamingIngestClient mockClient = mock(SnowflakeStreamingIngestClient.class);
 
       StreamingClientFactory.setStreamingClientSupplier(
-          (clientName, dbName, schemaName, pipeName, config, props) -> {
+          (clientName, dbName, schemaName, pipeName, props) -> {
             if (callCount.incrementAndGet() == 1) {
               throw new SnowflakeKafkaConnectorException("transient", "TEST_ERROR");
             }
@@ -321,7 +321,7 @@ class StreamingClientPoolTest {
     void pool_threads_inherit_context_classloader_from_pool_creator() {
       AtomicReference<ClassLoader> capturedClassLoader = new AtomicReference<>();
       StreamingClientFactory.setStreamingClientSupplier(
-          (clientName, dbName, schemaName, pipeName, config, props) -> {
+          (clientName, dbName, schemaName, pipeName, props) -> {
             capturedClassLoader.set(Thread.currentThread().getContextClassLoader());
             return mock(SnowflakeStreamingIngestClient.class);
           });
@@ -360,7 +360,7 @@ class StreamingClientPoolTest {
       CountDownLatch proceed = new CountDownLatch(1);
 
       StreamingClientFactory.setStreamingClientSupplier(
-          (clientName, dbName, schemaName, pipeName, config, props) -> {
+          (clientName, dbName, schemaName, pipeName, props) -> {
             bothStarted.countDown();
             try {
               proceed.await();
@@ -391,12 +391,12 @@ class StreamingClientPoolTest {
 
   private void setSupplierReturning(SnowflakeStreamingIngestClient client) {
     StreamingClientFactory.setStreamingClientSupplier(
-        (clientName, dbName, schemaName, pipeName, config, props) -> client);
+        (clientName, dbName, schemaName, pipeName, props) -> client);
   }
 
   private void setSupplierThrowing(RuntimeException exception) {
     StreamingClientFactory.setStreamingClientSupplier(
-        (clientName, dbName, schemaName, pipeName, config, props) -> {
+        (clientName, dbName, schemaName, pipeName, props) -> {
           throw exception;
         });
   }
@@ -404,7 +404,7 @@ class StreamingClientPoolTest {
   @SuppressWarnings("unchecked")
   private void setSupplierThrowingChecked(Exception checkedException) {
     StreamingClientFactory.setStreamingClientSupplier(
-        (clientName, dbName, schemaName, pipeName, config, props) -> {
+        (clientName, dbName, schemaName, pipeName, props) -> {
           sneakyThrow(checkedException);
           return null; // unreachable
         });

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/client/StreamingClientPoolsTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/client/StreamingClientPoolsTest.java
@@ -39,7 +39,7 @@ class StreamingClientPoolsTest {
     SnowflakeKafkaConnectorException originalException =
         new SnowflakeKafkaConnectorException("creation failed", "TEST_ERROR");
     StreamingClientFactory.setStreamingClientSupplier(
-        (clientName, dbName, schemaName, pipeName, config, props) -> {
+        (clientName, dbName, schemaName, pipeName, props) -> {
           throw originalException;
         });
 


### PR DESCRIPTION
Turns out, neither `clientName` nor `clientProperties` from `StreamingClientProperties::from` were in use - its only utility was for `parameterOverrides`. We had two different ways of creating `Properties` out of the `SinkTaskConfig` and one was only relevant for tests.

This PR moves SSv2 SDK property creation from `StreamingClientFactory` into `StreamingClientProperties` - the old code in `StreamingClientProperties` is effectively thrown away.