### PR TITLE
add OAuth error codes, URL extensions, and token infrastructure

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeErrors.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeErrors.java
@@ -19,6 +19,7 @@ package com.snowflake.kafka.connector.internal;
 
 import com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams;
 import com.snowflake.kafka.connector.Utils;
+import com.snowflake.kafka.connector.config.AuthenticatorType;
 import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryService;
 
 public enum SnowflakeErrors {
@@ -88,6 +89,25 @@ public enum SnowflakeErrors {
       "0023",
       "Invalid proxy username or password",
       "Both username and password need to be provided if one of them is provided"),
+  ERROR_0026(
+      "0026",
+      "Missing OAuth client id in connector config",
+      "oauth_client_id must be provided with "
+          + KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_CLIENT_ID
+          + " parameter when using oauth as authenticator"),
+  ERROR_0027(
+      "0027",
+      "Missing OAuth client secret in connector config",
+      "oauth_client_secret must be provided with "
+          + KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_CLIENT_SECRET
+          + " parameter when using oauth as authenticator"),
+  ERROR_0029(
+      "0029",
+      "Invalid authenticator",
+      "Authenticator should be either "
+          + AuthenticatorType.OAUTH.toConfigValue()
+          + " or "
+          + AuthenticatorType.SNOWFLAKE_JWT.toConfigValue()),
   ERROR_0030(
       "0030",
       String.format(
@@ -100,6 +120,13 @@ public enum SnowflakeErrors {
       "0031",
       "Failed to combine JDBC properties",
       "One of snowflake.jdbc.map property overrides other jdbc property"),
+  ERROR_0033(
+      "0033",
+      "Invalid OAuth URL",
+      "OAuth URL format: '[http://|https://]<oauth_server>[:<port>][/<path>]'. Protocol defaults"
+          + " to 'https://'. Port defaults to 443 for https and 80 for http. Path may contain"
+          + " alphanumeric characters, dots, hyphens, and forward slashes (e.g.,"
+          + " 'login.example.com/oauth2/v2.0/token')."),
   ERROR_1001(
       "1001",
       "Failed to connect to Snowflake Server",
@@ -108,6 +135,8 @@ public enum SnowflakeErrors {
       "1003",
       "Snowflake connection is closed",
       "Either the current connection is closed or hasn't connect to snowflake" + " server"),
+  ERROR_1004(
+      "1004", "Fetching OAuth token failed", "Failed to get OAuth token from authorization server"),
   ERROR_1005(
       "1005",
       "Task failed due to authorization error",

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeURL.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeURL.java
@@ -89,10 +89,17 @@ public class SnowflakeURL implements URL {
     return account;
   }
 
+  @Override
   public boolean sslEnabled() {
     return ssl;
   }
 
+  @Override
+  public String path() {
+    return "";
+  }
+
+  @Override
   public String getScheme() {
     if (ssl) {
       return "https";

--- a/src/main/java/com/snowflake/kafka/connector/internal/URL.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/URL.java
@@ -4,4 +4,8 @@ public interface URL {
   String hostWithPort();
 
   String getScheme();
+
+  boolean sslEnabled();
+
+  String path();
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/oauth/OAuthAccessTokenFetcher.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/oauth/OAuthAccessTokenFetcher.java
@@ -1,0 +1,194 @@
+package com.snowflake.kafka.connector.internal.oauth;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.snowflake.kafka.connector.internal.KCLogger;
+import com.snowflake.kafka.connector.internal.SnowflakeErrors;
+import com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException;
+import com.snowflake.kafka.connector.internal.URL;
+import dev.failsafe.Failsafe;
+import dev.failsafe.RetryPolicy;
+import java.io.IOException;
+import java.net.ProxySelector;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.apache.kafka.common.config.types.Password;
+
+/**
+ * Fetches an OAuth access token from an OAuth token endpoint. Used only for JDBC connections; the
+ * streaming SDK handles its own OAuth token lifecycle.
+ *
+ * <p>Supports two grant types:
+ *
+ * <ul>
+ *   <li><b>refresh_token</b>: when a refresh token is provided
+ *   <li><b>client_credentials</b>: when no refresh token is provided
+ * </ul>
+ *
+ * @see <a
+ *     href="https://github.com/snowflakedb/snowflake/blob/4fdb96cd5849f266cda430c5d49a13c29e866af5/GlobalServices/src/main/java/com/snowflake/resources/ResourceConstants.java">ResourceConstants</a>
+ */
+public class OAuthAccessTokenFetcher {
+
+  private static final KCLogger LOGGER = new KCLogger(OAuthAccessTokenFetcher.class.getName());
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  private static final String TOKEN_REQUEST_ENDPOINT = "/oauth/token-request";
+  private static final String OAUTH_CONTENT_TYPE_HEADER = "application/x-www-form-urlencoded";
+  private static final String BASIC_AUTH_HEADER_PREFIX = "Basic ";
+  private static final String GRANT_TYPE_PARAM = "grant_type";
+  private static final String GRANT_TYPE_REFRESH_TOKEN = "refresh_token";
+  private static final String GRANT_TYPE_CLIENT_CREDENTIALS = "client_credentials";
+  private static final String REFRESH_TOKEN = "refresh_token";
+  private static final String ACCESS_TOKEN = "access_token";
+  private static final String REDIRECT_URI = "redirect_uri";
+  private static final String DEFAULT_REDIRECT_URI = "https://localhost.com/oauth";
+
+  private static final int HTTP_TOO_MANY_REQUESTS = 429;
+
+  private static final int MAX_RETRIES = 4;
+  private static final Duration INITIAL_DELAY = Duration.ofSeconds(1);
+  private static final Duration MAX_DELAY = Duration.ofSeconds(8);
+
+  /**
+   * Fetch an OAuth access token. Retries with exponential backoff on transient failures. Uses the
+   * JVM's default {@link ProxySelector} so that proxy settings from {@code Utils.enableJVMProxy}
+   * (including {@code jvm.nonProxy.hosts} bypass rules) are respected, matching KC v3 behavior.
+   *
+   * @param url OAuth server URL (scheme, host, port, path)
+   * @param clientId OAuth client ID
+   * @param clientSecret OAuth client secret
+   * @param refreshToken OAuth refresh token; empty selects client_credentials grant
+   * @return the access token string
+   * @throws SnowflakeKafkaConnectorException if the token fetch fails after all retries
+   */
+  public static String fetchAccessToken(
+      URL url, String clientId, Password clientSecret, Optional<Password> refreshToken) {
+    HttpClient httpClient = HttpClient.newBuilder().proxy(ProxySelector.getDefault()).build();
+    return fetchAccessToken(url, clientId, clientSecret, refreshToken, httpClient);
+  }
+
+  static String fetchAccessToken(
+      URL url,
+      String clientId,
+      Password clientSecret,
+      Optional<Password> refreshToken,
+      HttpClient httpClient) {
+    String basicAuth =
+        BASIC_AUTH_HEADER_PREFIX
+            + Base64.getEncoder()
+                .encodeToString(
+                    (clientId + ":" + clientSecret.value()).getBytes(StandardCharsets.UTF_8));
+
+    Map<String, String> formParams = new LinkedHashMap<>();
+    refreshToken
+        .map(Password::value)
+        .ifPresentOrElse(
+            value -> {
+              formParams.put(GRANT_TYPE_PARAM, GRANT_TYPE_REFRESH_TOKEN);
+              formParams.put(REFRESH_TOKEN, value);
+              formParams.put(REDIRECT_URI, DEFAULT_REDIRECT_URI);
+            },
+            () -> formParams.put(GRANT_TYPE_PARAM, GRANT_TYPE_CLIENT_CREDENTIALS));
+
+    String formBody =
+        formParams.entrySet().stream()
+            .map(
+                entry ->
+                    URLEncoder.encode(entry.getKey(), StandardCharsets.UTF_8)
+                        + "="
+                        + URLEncoder.encode(entry.getValue(), StandardCharsets.UTF_8))
+            .collect(Collectors.joining("&"));
+
+    URI tokenUri = buildTokenUri(url);
+
+    HttpRequest request =
+        HttpRequest.newBuilder()
+            .uri(tokenUri)
+            .header("Content-Type", OAUTH_CONTENT_TYPE_HEADER)
+            .header("Authorization", basicAuth)
+            .POST(HttpRequest.BodyPublishers.ofString(formBody))
+            .build();
+
+    RetryPolicy<String> retryPolicy =
+        RetryPolicy.<String>builder()
+            .handle(Exception.class)
+            // A SnowflakeKafkaConnectorException here is terminal (bad credentials, malformed
+            // request, or a response without an access_token) -- retrying cannot make it succeed,
+            // so only genuinely transient failures (IOException/timeout) are retried.
+            .abortOn(SnowflakeKafkaConnectorException.class)
+            .withBackoff(INITIAL_DELAY, MAX_DELAY)
+            .withMaxRetries(MAX_RETRIES)
+            .onRetry(
+                event ->
+                    LOGGER.warn(
+                        "OAuth token fetch retry attempt #{} due to: {}",
+                        event.getAttemptCount(),
+                        event.getLastException().getMessage()))
+            .build();
+
+    try {
+      return Failsafe.with(retryPolicy)
+          .get(
+              () -> {
+                HttpResponse<String> response =
+                    httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+                int statusCode = response.statusCode();
+                if (statusCode < 200 || statusCode >= 300) {
+                  String message = "HTTP " + statusCode + ": " + response.body();
+                  // 5xx and 429 are transient -- rethrow as IOException so the retry policy handles
+                  // them. Every other non-2xx status (e.g. 400/401/403) is a permanent auth/request
+                  // error that retrying cannot fix, so surface it as the terminal exception, which
+                  // the retry policy aborts on.
+                  if (statusCode >= 500 || statusCode == HTTP_TOO_MANY_REQUESTS) {
+                    throw new IOException(message);
+                  }
+                  throw SnowflakeErrors.ERROR_1004.getException(message);
+                }
+
+                JsonNode json = MAPPER.readTree(response.body());
+                JsonNode accessTokenNode = json.get(ACCESS_TOKEN);
+                if (accessTokenNode == null || accessTokenNode.isNull()) {
+                  throw SnowflakeErrors.ERROR_1004.getException(
+                      "Response does not contain access_token: " + response.body());
+                }
+                return accessTokenNode.asText();
+              });
+    } catch (SnowflakeKafkaConnectorException e) {
+      throw e;
+    } catch (Exception e) {
+      throw SnowflakeErrors.ERROR_1004.getException(e);
+    }
+  }
+
+  private static URI buildTokenUri(URL url) {
+    try {
+      String path = url.path();
+      if (path.isEmpty()) {
+        path = TOKEN_REQUEST_ENDPOINT;
+      }
+      return new URI(
+          url.getScheme(),
+          null,
+          url.hostWithPort().split(":")[0],
+          Integer.parseInt(url.hostWithPort().split(":")[1]),
+          path,
+          null,
+          null);
+    } catch (Exception e) {
+      throw SnowflakeErrors.ERROR_0033.getException(
+          "Failed to build OAuth token URI: " + e.getMessage());
+    }
+  }
+}

--- a/src/main/java/com/snowflake/kafka/connector/internal/oauth/OAuthURL.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/oauth/OAuthURL.java
@@ -1,0 +1,89 @@
+package com.snowflake.kafka.connector.internal.oauth;
+
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+
+import com.snowflake.kafka.connector.internal.KCLogger;
+import com.snowflake.kafka.connector.internal.SnowflakeErrors;
+import com.snowflake.kafka.connector.internal.URL;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.commons.lang3.StringUtils;
+
+public class OAuthURL implements URL {
+  private static final KCLogger LOGGER = new KCLogger(OAuthURL.class.getName());
+
+  private static final String OAUTH_SERVER_URL_REGEX_PATTERN =
+      "^(https?://)?((([\\w\\d-]+)(\\.[\\w\\d-]+)*)(:(\\d+))?)((/[\\w\\d\\.-]*)*)/?$";
+
+  private final String url;
+
+  private final boolean ssl;
+
+  private final int port;
+
+  private final String urlPath;
+
+  private OAuthURL(String url, boolean ssl, int port, String urlPath) {
+    this.url = url;
+    this.ssl = ssl;
+    this.port = port;
+    this.urlPath = urlPath;
+  }
+
+  public static OAuthURL from(final String urlStr) {
+    Pattern pattern = Pattern.compile(OAUTH_SERVER_URL_REGEX_PATTERN, Pattern.CASE_INSENSITIVE);
+
+    // Match against the original (case-preserving) input. Scheme and host are case-insensitive
+    // per RFC 3986 and are normalized to lowercase below, but the path is case-sensitive and must
+    // be preserved -- some OAuth token endpoints have mixed-case paths (e.g. '/oauth2/v2.0/Token').
+    Matcher matcher = pattern.matcher(urlStr.trim());
+
+    if (!matcher.find()) {
+      throw SnowflakeErrors.ERROR_0033.getException("input url: " + urlStr);
+    }
+
+    boolean ssl = !"http://".equalsIgnoreCase(matcher.group(1));
+
+    String url = matcher.group(3).toLowerCase(Locale.ROOT);
+
+    int port = 0;
+    if (matcher.group(7) != null) {
+      port = Integer.parseInt(matcher.group(7));
+    } else if (ssl) {
+      port = 443;
+    } else {
+      port = 80;
+    }
+
+    String path = StringUtils.defaultIfBlank(matcher.group(8), EMPTY);
+
+    LOGGER.debug("parsed OAuth URL: {}", urlStr);
+
+    return new OAuthURL(url, ssl, port, path);
+  }
+
+  @Override
+  public String hostWithPort() {
+    return String.format("%s:%s", this.url, this.port);
+  }
+
+  @Override
+  public String getScheme() {
+    if (ssl) {
+      return "https";
+    } else {
+      return "http";
+    }
+  }
+
+  @Override
+  public boolean sslEnabled() {
+    return ssl;
+  }
+
+  @Override
+  public String path() {
+    return urlPath;
+  }
+}

--- a/src/main/java/com/snowflake/kafka/connector/internal/telemetry/SnowflakeTelemetryService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/telemetry/SnowflakeTelemetryService.java
@@ -234,6 +234,8 @@ public class SnowflakeTelemetryService {
       Set.of(
           KafkaConnectorConfigParams.SNOWFLAKE_PRIVATE_KEY,
           KafkaConnectorConfigParams.SNOWFLAKE_PRIVATE_KEY_PASSPHRASE,
+          KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_CLIENT_SECRET,
+          KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_REFRESH_TOKEN,
           KafkaConnectorConfigParams.JVM_PROXY_USERNAME,
           KafkaConnectorConfigParams.JVM_PROXY_PASSWORD,
           KafkaConnectorConfigParams.HTTPS_PROXY_USER,

--- a/src/test/java/com/snowflake/kafka/connector/internal/oauth/OAuthAccessTokenFetcherTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/oauth/OAuthAccessTokenFetcherTest.java
@@ -1,0 +1,158 @@
+package com.snowflake.kafka.connector.internal.oauth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Optional;
+import org.apache.kafka.common.config.types.Password;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class OAuthAccessTokenFetcherTest {
+
+  private HttpClient httpClient;
+  private HttpResponse<String> httpResponse;
+  private OAuthURL url;
+
+  @SuppressWarnings("unchecked")
+  @BeforeEach
+  void setUp() throws Exception {
+    httpClient = mock(HttpClient.class);
+    httpResponse = mock(HttpResponse.class);
+    when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenReturn(httpResponse);
+    url = OAuthURL.from("https://oauth.example.com:443/oauth/token-request");
+  }
+
+  @Test
+  void fetchAccessToken_refreshTokenGrant_returnsToken() {
+    when(httpResponse.statusCode()).thenReturn(200);
+    when(httpResponse.body()).thenReturn("{\"access_token\": \"my-access-token\"}");
+
+    String token =
+        OAuthAccessTokenFetcher.fetchAccessToken(
+            url,
+            "client_id",
+            new Password("client_secret"),
+            Optional.of(new Password("my_refresh_token")),
+            httpClient);
+
+    assertThat(token).isEqualTo("my-access-token");
+  }
+
+  @Test
+  void fetchAccessToken_clientCredentialsGrant_returnsToken() {
+    when(httpResponse.statusCode()).thenReturn(200);
+    when(httpResponse.body()).thenReturn("{\"access_token\": \"cc-token\"}");
+
+    String token =
+        OAuthAccessTokenFetcher.fetchAccessToken(
+            url, "client_id", new Password("client_secret"), Optional.empty(), httpClient);
+
+    assertThat(token).isEqualTo("cc-token");
+  }
+
+  @Test
+  void fetchAccessToken_emptyRefreshToken_usesClientCredentials() {
+    when(httpResponse.statusCode()).thenReturn(200);
+    when(httpResponse.body()).thenReturn("{\"access_token\": \"cc-token\"}");
+
+    String token =
+        OAuthAccessTokenFetcher.fetchAccessToken(
+            url, "client_id", new Password("client_secret"), Optional.empty(), httpClient);
+
+    assertThat(token).isEqualTo("cc-token");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void fetchAccessToken_nonSuccessStatus_throwsError1004() throws Exception {
+    when(httpResponse.statusCode()).thenReturn(401);
+    when(httpResponse.body()).thenReturn("Unauthorized");
+
+    assertThatExceptionOfType(SnowflakeKafkaConnectorException.class)
+        .isThrownBy(
+            () ->
+                OAuthAccessTokenFetcher.fetchAccessToken(
+                    url,
+                    "client_id",
+                    new Password("client_secret"),
+                    Optional.of(new Password("token")),
+                    httpClient))
+        .matches(exception -> exception.getCode().equals("1004"));
+
+    // A 401 is a permanent auth error -- it must not be retried.
+    verify(httpClient, times(1)).send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+  }
+
+  @Test
+  void fetchAccessToken_missingAccessTokenInResponse_throwsError1004() {
+    when(httpResponse.statusCode()).thenReturn(200);
+    when(httpResponse.body()).thenReturn("{\"token_type\": \"bearer\"}");
+
+    assertThatExceptionOfType(SnowflakeKafkaConnectorException.class)
+        .isThrownBy(
+            () ->
+                OAuthAccessTokenFetcher.fetchAccessToken(
+                    url,
+                    "client_id",
+                    new Password("client_secret"),
+                    Optional.of(new Password("token")),
+                    httpClient))
+        .matches(exception -> exception.getCode().equals("1004"));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void fetchAccessToken_httpClientThrows_throwsError1004() throws Exception {
+    when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenThrow(new java.io.IOException("connection refused"));
+
+    assertThatExceptionOfType(SnowflakeKafkaConnectorException.class)
+        .isThrownBy(
+            () ->
+                OAuthAccessTokenFetcher.fetchAccessToken(
+                    url,
+                    "client_id",
+                    new Password("client_secret"),
+                    Optional.of(new Password("token")),
+                    httpClient))
+        .matches(exception -> exception.getCode().equals("1004"));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void fetchAccessToken_retriesOnFailureThenSucceeds() throws Exception {
+    HttpResponse<String> failResponse = mock(HttpResponse.class);
+    when(failResponse.statusCode()).thenReturn(503);
+    when(failResponse.body()).thenReturn("Service Unavailable");
+
+    HttpResponse<String> successResponse = mock(HttpResponse.class);
+    when(successResponse.statusCode()).thenReturn(200);
+    when(successResponse.body()).thenReturn("{\"access_token\": \"retry-token\"}");
+
+    when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+        .thenReturn(failResponse)
+        .thenReturn(successResponse);
+
+    String token =
+        OAuthAccessTokenFetcher.fetchAccessToken(
+            url,
+            "client_id",
+            new Password("client_secret"),
+            Optional.of(new Password("token")),
+            httpClient);
+
+    assertThat(token).isEqualTo("retry-token");
+    verify(httpClient, times(2)).send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+  }
+}

--- a/src/test/java/com/snowflake/kafka/connector/internal/oauth/OAuthURLTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/oauth/OAuthURLTest.java
@@ -1,0 +1,60 @@
+package com.snowflake.kafka.connector.internal.oauth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import com.google.common.collect.ImmutableList;
+import com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class OAuthURLTest {
+
+  static Stream<Arguments> correctUrls() {
+    return Stream.of(
+        Arguments.of(
+            "https://localhost:8085/push/token",
+            ImmutableList.of("https", "localhost:8085", "/push/token", true)),
+        Arguments.of("localhost:8085", ImmutableList.of("https", "localhost:8085", "", true)),
+        Arguments.of(
+            "http://localhost:8085", ImmutableList.of("http", "localhost:8085", "", false)),
+        Arguments.of("localhost", ImmutableList.of("https", "localhost:443", "", true)),
+        Arguments.of(
+            "https://login.test.com/xxxxxxx/oauth2/v2.0/token",
+            ImmutableList.of("https", "login.test.com:443", "/xxxxxxx/oauth2/v2.0/token", true)),
+        Arguments.of(
+            "https://example.com/my-api/v2.0/get-token",
+            ImmutableList.of("https", "example.com:443", "/my-api/v2.0/get-token", true)),
+        // Path is case-sensitive (RFC 3986) and must be preserved verbatim.
+        Arguments.of(
+            "https://login.test.com/oauth2/v2.0/Token",
+            ImmutableList.of("https", "login.test.com:443", "/oauth2/v2.0/Token", true)),
+        // Scheme and host are case-insensitive and normalized to lowercase; path case preserved.
+        Arguments.of(
+            "HTTPS://Login.Test.COM/oauth2/v2.0/Token",
+            ImmutableList.of("https", "login.test.com:443", "/oauth2/v2.0/Token", true)),
+        Arguments.of(
+            "HTTP://Login.Test.COM:8085/Push/Token",
+            ImmutableList.of("http", "login.test.com:8085", "/Push/Token", false)));
+  }
+
+  @ParameterizedTest(name = "url: {0}, parsed: {1}")
+  @MethodSource("correctUrls")
+  void shouldParseUrlCorrectly(String url, List<String> parts) {
+    assertThat(OAuthURL.from(url))
+        .extracting(
+            OAuthURL::getScheme, OAuthURL::hostWithPort, OAuthURL::path, OAuthURL::sslEnabled)
+        .doesNotContainNull()
+        .containsExactlyElementsOf(parts);
+  }
+
+  @Test
+  void shouldNotParseIncorrectUrls() {
+    assertThatExceptionOfType(SnowflakeKafkaConnectorException.class)
+        .isThrownBy(() -> OAuthURL.from("wrong url"));
+  }
+}

--- a/src/test/java/com/snowflake/kafka/connector/internal/telemetry/SnowflakeTelemetryServiceTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/telemetry/SnowflakeTelemetryServiceTest.java
@@ -56,6 +56,10 @@ public class SnowflakeTelemetryServiceTest {
     Map<String, String> connectorConfig = createConnectorConfig();
     connectorConfig.put(KEY_CONVERTER, KAFKA_STRING_CONVERTER);
     connectorConfig.put(KafkaConnectorConfigParams.VALUE_CONVERTER, KAFKA_CONFLUENT_AVRO_CONVERTER);
+    connectorConfig.put(
+        KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_CLIENT_SECRET, "test-client-secret");
+    connectorConfig.put(
+        KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_REFRESH_TOKEN, "test-refresh-token");
     SnowflakeTelemetryService snowflakeTelemetryService =
         createSnowflakeTelemetryService(connectorConfig);
 
@@ -94,6 +98,8 @@ public class SnowflakeTelemetryServiceTest {
     // Sensitive keys must NOT be present
     assertFalse(dataNode.has(KafkaConnectorConfigParams.SNOWFLAKE_PRIVATE_KEY));
     assertFalse(dataNode.has(KafkaConnectorConfigParams.SNOWFLAKE_PRIVATE_KEY_PASSPHRASE));
+    assertFalse(dataNode.has(KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_CLIENT_SECRET));
+    assertFalse(dataNode.has(KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_REFRESH_TOKEN));
   }
 
   @Test


### PR DESCRIPTION
## Summary

Adds OAuth error codes, the `URL` interface extensions (`sslEnabled()`, `path()`), and the token infrastructure needed by subsequent PRs in the OAuth stack.

- **Error codes**: ERROR_0026, ERROR_0027, ERROR_0029, ERROR_0033, ERROR_1004
- **`URL` interface**: added `sslEnabled()` and `path()` as abstract methods; `SnowflakeURL` implements both (with `@Override` on `sslEnabled()` and `getScheme()`)
- **`OAuthURL`**: URL parser for OAuth endpoints (non-Snowflake URLs with arbitrary paths). Scheme and host are normalized to lowercase (case-insensitive per RFC 3986), but the path is preserved verbatim so case-sensitive token endpoints (e.g. `/oauth2/v2.0/Token`) are not corrupted.
- **`OAuthAccessTokenFetcher`**: fetches OAuth access tokens via `refresh_token` or `client_credentials` grant — extracted from `Utils.getSnowflakeOAuthToken()` in KC v3. Retries with exponential backoff (via Failsafe `RetryPolicy`, matching v3's backoff schedule), but **only for genuinely transient failures**: `IOException`/timeout and HTTP 5xx/429 (rethrown as `IOException`) are retried, while terminal errors surfaced as `SnowflakeKafkaConnectorException` (bad client id/secret → 4xx, malformed request, or a 2xx response with no `access_token`) abort immediately instead of retrying. This diverges from v3, whose `backoffAndRetry` retried every failure — so a typo'd secret no longer hangs `validate()` for ~15s or repeatedly hits the IdP. Uses the JVM's default `ProxySelector`, so proxy settings from `Utils.enableJVMProxy` — including `jvm.nonProxy.hosts` bypass rules — are respected, matching KC v3 behavior.

OAuth constants (grant types, header values, etc.) are inlined as private fields in `OAuthAccessTokenFetcher` — they were only used by that class. All OAuth classes are grouped under `internal.oauth`.

## Cross-reference with KC v3 (`3.2.x`)

| v4 file | v3 equivalent | Notes |
|---------|---------------|-------|
| [`SnowflakeErrors.java`](https://github.com/snowflakedb/snowflake-kafka-connector/blob/skurella-oauth-infra/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeErrors.java) | [`SnowflakeErrors.java`](https://github.com/snowflakedb/snowflake-kafka-connector/blob/3.2.x/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeErrors.java) | ERROR_0026, 0027, 0029, 0033, 1004 — same codes as v3 |
| [`URL.java`](https://github.com/snowflakedb/snowflake-kafka-connector/blob/skurella-oauth-infra/src/main/java/com/snowflake/kafka/connector/internal/URL.java) | [`URL.java`](https://github.com/snowflakedb/snowflake-kafka-connector/blob/3.2.x/src/main/java/com/snowflake/kafka/connector/internal/URL.java) | v4 makes `sslEnabled()` and `path()` abstract (v3 had defaults) |
| [`SnowflakeURL.java`](https://github.com/snowflakedb/snowflake-kafka-connector/blob/skurella-oauth-infra/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeURL.java) | [`SnowflakeURL.java`](https://github.com/snowflakedb/snowflake-kafka-connector/blob/3.2.x/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeURL.java) | Added `path()` returning `""`, added `@Override` annotations |
| [`OAuthURL.java`](https://github.com/snowflakedb/snowflake-kafka-connector/blob/skurella-oauth-infra/src/main/java/com/snowflake/kafka/connector/internal/oauth/OAuthURL.java) | [`OAuthURL.java`](https://github.com/snowflakedb/snowflake-kafka-connector/blob/3.2.x/src/main/java/com/snowflake/kafka/connector/internal/OAuthURL.java) | Moved to `internal.oauth` package; fixes v3 bug where the whole URL was lowercased (now preserves path case) |
| [`OAuthAccessTokenFetcher.java`](https://github.com/snowflakedb/snowflake-kafka-connector/blob/skurella-oauth-infra/src/main/java/com/snowflake/kafka/connector/internal/oauth/OAuthAccessTokenFetcher.java) | [`Utils.getSnowflakeOAuthAccessToken()` / `Utils.getSnowflakeOAuthToken()`](https://github.com/snowflakedb/snowflake-kafka-connector/blob/3.2.x/src/main/java/com/snowflake/kafka/connector/Utils.java#L791-L862) | Extracted into dedicated class; adds `client_credentials` grant and Failsafe retry. Retry now aborts on terminal `SnowflakeKafkaConnectorException` (4xx/malformed/missing token) and only retries transient failures (IOException/timeout, 5xx/429) — v3 retried everything. Proxy handling unchanged from v3 (JVM default `ProxySelector`, honoring `jvm.nonProxy.hosts`) |
| *(inlined in `OAuthAccessTokenFetcher`)* | [`OAuthConstants.java`](https://github.com/snowflakedb/snowflake-kafka-connector/blob/3.2.x/src/main/java/com/snowflake/kafka/connector/internal/OAuthConstants.java) | Constants moved to private fields in the only consumer |

## Test plan

- [x] `OAuthURLTest` — parameterized URL parsing and invalid URL rejection, including mixed-case scheme/host normalization and case-sensitive path preservation
- [x] `OAuthAccessTokenFetcherTest` — unit tests covering `refresh_token` grant, `client_credentials` grant, empty refresh token fallback, HTTP error status, missing `access_token` in response, `HttpClient` exceptions, and retry-then-succeed (all using Mockito-mocked `HttpClient`)
- [x] `OAuthAccessTokenFetcherTest` — asserts a permanent 4xx (401) is not retried (`verify(httpClient, times(1))`), so terminal failures abort immediately