### PR TITLE
add OAuth support to JDBC connection properties

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeStreamingSinkConnector.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeStreamingSinkConnector.java
@@ -17,6 +17,7 @@
 package com.snowflake.kafka.connector;
 
 import com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams;
+import com.snowflake.kafka.connector.config.AuthenticatorType;
 import com.snowflake.kafka.connector.config.ConnectorConfigDefinition;
 import com.snowflake.kafka.connector.internal.KCLogger;
 import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
@@ -48,6 +49,10 @@ public class SnowflakeStreamingSinkConnector extends SinkConnector {
   // create logger without correlationId for now
   private static final KCLogger LOGGER =
       new KCLogger(SnowflakeStreamingSinkConnector.class.getName());
+
+  // Matches a Kafka Connect config-provider reference such as ${vault:...} or ${file:...}, whose
+  // value is resolved per-worker at task start and is therefore not available during validate().
+  private static final Pattern CONFIG_PROVIDER_PREFIX = Pattern.compile("[$][{][a-zA-Z]+:");
 
   private Map<String, String> config; // connector configuration, provided by
   // user through kafka connect framework
@@ -216,11 +221,16 @@ public class SnowflakeStreamingSinkConnector extends SinkConnector {
       Utils.updateConfigErrorMessage(result, invalidKey, invalidProxyParams.get(invalidKey));
     }
 
-    // If private key or private key passphrase is
-    // provided through a config provider, skip validation
-    if (isUsingConfigProviderForPrivateKey(connectorConfigs)) {
+    // Skip live connection validation only when a credential is supplied through a config provider
+    // (private key/passphrase or an OAuth credential); its placeholder cannot be resolved here.
+    if (isUsingConfigProviderForPrivateKey(connectorConfigs)
+        || isUsingConfigProviderForOAuth(connectorConfigs)) {
       return result;
     }
+
+    // Apply proxy settings before the test connection so the OAuth token fetch (which uses the JVM
+    // default ProxySelector) sees the same proxy/nonProxyHosts config as runtime does in start().
+    Utils.enableJVMProxy(connectorConfigs);
 
     // We don't validate name, since it is not included in the return value
     // so just put a test connector here
@@ -243,12 +253,16 @@ public class SnowflakeStreamingSinkConnector extends SinkConnector {
               ": Cannot connect to Snowflake");
           Utils.updateConfigErrorMessage(
               result,
-              KafkaConnectorConfigParams.SNOWFLAKE_PRIVATE_KEY,
-              ": Cannot connect to Snowflake");
-          Utils.updateConfigErrorMessage(
-              result,
               KafkaConnectorConfigParams.SNOWFLAKE_USER_NAME,
               ": Cannot connect to Snowflake");
+          // A 1001 for OAuth means the token fetch already succeeded (a fetch failure surfaces as
+          // 1004), so the private key -- which OAuth users do not configure -- is not the culprit.
+          if (!isUsingOAuth(connectorConfigs)) {
+            Utils.updateConfigErrorMessage(
+                result,
+                KafkaConnectorConfigParams.SNOWFLAKE_PRIVATE_KEY,
+                ": Cannot connect to Snowflake");
+          }
           break;
         case "0007":
           Utils.updateConfigErrorMessage(
@@ -271,6 +285,45 @@ public class SnowflakeStreamingSinkConnector extends SinkConnector {
               result,
               KafkaConnectorConfigParams.SNOWFLAKE_PRIVATE_KEY,
               " must be a valid PEM RSA private key");
+          break;
+        case "0026":
+          Utils.updateConfigErrorMessage(
+              result,
+              KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_CLIENT_ID,
+              " must be non-empty when using oauth authenticator");
+          break;
+        case "0027":
+          Utils.updateConfigErrorMessage(
+              result,
+              KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_CLIENT_SECRET,
+              " must be non-empty when using oauth authenticator");
+          break;
+        case "0029":
+          Utils.updateConfigErrorMessage(
+              result,
+              KafkaConnectorConfigParams.SNOWFLAKE_AUTHENTICATOR,
+              " is not a valid authenticator");
+          break;
+        case "0033":
+          Utils.updateConfigErrorMessage(
+              result,
+              KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_TOKEN_ENDPOINT,
+              " is not a valid OAuth token endpoint URL");
+          break;
+        case "1004":
+          {
+            // The token fetch can fail for a bad client id/secret, a wrong token endpoint, or a
+            // transient network/proxy issue - flag the whole OAuth credential set.
+            String tokenFetchError =
+                ": Could not fetch OAuth access token. Check the client ID, client secret, and"
+                    + " token endpoint.";
+            Utils.updateConfigErrorMessage(
+                result, KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_CLIENT_ID, tokenFetchError);
+            Utils.updateConfigErrorMessage(
+                result, KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_CLIENT_SECRET, tokenFetchError);
+            Utils.updateConfigErrorMessage(
+                result, KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_TOKEN_ENDPOINT, tokenFetchError);
+          }
           break;
         default:
           throw e; // Shouldn't reach here, so crash.
@@ -310,18 +363,38 @@ public class SnowflakeStreamingSinkConnector extends SinkConnector {
     return result;
   }
 
-  private static boolean isUsingConfigProviderForPrivateKey(Map<String, String> connectorConfigs) {
-    Pattern configProviderPrefix = Pattern.compile("[$][{][a-zA-Z]+:");
+  private static boolean isUsingOAuth(Map<String, String> connectorConfigs) {
+    try {
+      return AuthenticatorType.fromConfig(
+              connectorConfigs.getOrDefault(
+                  KafkaConnectorConfigParams.SNOWFLAKE_AUTHENTICATOR,
+                  AuthenticatorType.SNOWFLAKE_JWT.toConfigValue()))
+          == AuthenticatorType.OAUTH;
+    } catch (IllegalArgumentException e) {
+      return false;
+    }
+  }
 
-    return configProviderPrefix
-            .matcher(
-                connectorConfigs.getOrDefault(KafkaConnectorConfigParams.SNOWFLAKE_PRIVATE_KEY, ""))
-            .find()
-        || configProviderPrefix
-            .matcher(
-                connectorConfigs.getOrDefault(
-                    KafkaConnectorConfigParams.SNOWFLAKE_PRIVATE_KEY_PASSPHRASE, ""))
-            .find();
+  private static boolean isUsingConfigProviderForPrivateKey(Map<String, String> connectorConfigs) {
+    return isConfigProviderReference(
+            connectorConfigs.get(KafkaConnectorConfigParams.SNOWFLAKE_PRIVATE_KEY))
+        || isConfigProviderReference(
+            connectorConfigs.get(KafkaConnectorConfigParams.SNOWFLAKE_PRIVATE_KEY_PASSPHRASE));
+  }
+
+  private static boolean isUsingConfigProviderForOAuth(Map<String, String> connectorConfigs) {
+    return isConfigProviderReference(
+            connectorConfigs.get(KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_CLIENT_ID))
+        || isConfigProviderReference(
+            connectorConfigs.get(KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_CLIENT_SECRET))
+        || isConfigProviderReference(
+            connectorConfigs.get(KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_REFRESH_TOKEN))
+        || isConfigProviderReference(
+            connectorConfigs.get(KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_TOKEN_ENDPOINT));
+  }
+
+  private static boolean isConfigProviderReference(String value) {
+    return value != null && CONFIG_PROVIDER_PREFIX.matcher(value).find();
   }
 
   /**

--- a/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
@@ -3,13 +3,17 @@ package com.snowflake.kafka.connector.internal;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import com.snowflake.kafka.connector.Utils;
+import com.snowflake.kafka.connector.config.AuthenticatorType;
 import com.snowflake.kafka.connector.config.SinkTaskConfig;
+import com.snowflake.kafka.connector.internal.oauth.OAuthAccessTokenFetcher;
+import com.snowflake.kafka.connector.internal.oauth.OAuthURL;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.Properties;
+import org.apache.kafka.common.config.types.Password;
 
 public class InternalUtils {
   // authenticator type
@@ -88,13 +92,35 @@ public class InternalUtils {
     putIfNotBlank(properties, JDBC_USER, config.getSnowflakeUser());
     putIfNotBlank(properties, JdbcPropertyKeys.ROLE, config.getSnowflakeRole());
 
-    properties.put(JdbcPropertyKeys.AUTHENTICATOR, SNOWFLAKE_JWT);
-
-    properties.put(
-        JDBC_PRIVATE_KEY,
-        PrivateKeyTool.parsePrivateKey(
-            config.getSnowflakePrivateKey().orElseThrow(SnowflakeErrors.ERROR_0013::getException),
-            config.getSnowflakePrivateKeyPassphrase()));
+    switch (config.getAuthenticator()) {
+      case OAUTH:
+        properties.put(JdbcPropertyKeys.AUTHENTICATOR, AuthenticatorType.OAUTH.toConfigValue());
+        String oauthClientId =
+            config.getOauthClientId().orElseThrow(SnowflakeErrors.ERROR_0026::getException);
+        Password oauthClientSecret =
+            config.getOauthClientSecret().orElseThrow(SnowflakeErrors.ERROR_0027::getException);
+        URL oauthUrl =
+            config.getOauthTokenEndpoint().isPresent()
+                ? OAuthURL.from(config.getOauthTokenEndpoint().get())
+                : url;
+        properties.put(
+            JDBC_TOKEN,
+            OAuthAccessTokenFetcher.fetchAccessToken(
+                oauthUrl, oauthClientId, oauthClientSecret, config.getOauthRefreshToken()));
+        break;
+      case SNOWFLAKE_JWT:
+        properties.put(JdbcPropertyKeys.AUTHENTICATOR, SNOWFLAKE_JWT);
+        properties.put(
+            JDBC_PRIVATE_KEY,
+            PrivateKeyTool.parsePrivateKey(
+                config
+                    .getSnowflakePrivateKey()
+                    .orElseThrow(SnowflakeErrors.ERROR_0013::getException),
+                config.getSnowflakePrivateKeyPassphrase()));
+        break;
+      default:
+        throw new IllegalStateException("unhandled authenticator: " + config.getAuthenticator());
+    }
 
     properties.put(JDBC_SSL, url.sslEnabled() ? "on" : "off");
     // put values for optional parameters

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorIT.java
@@ -22,6 +22,7 @@ import static com.snowflake.kafka.connector.internal.TestUtils.TEST_CONNECTOR_NA
 import static com.snowflake.kafka.connector.internal.TestUtils.transformProfileFileToConnectorConfiguration;
 
 import com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams;
+import com.snowflake.kafka.connector.config.AuthenticatorType;
 import com.snowflake.kafka.connector.internal.SnowflakeDataSourceFactory;
 import java.util.*;
 import java.util.concurrent.ExecutorService;
@@ -252,6 +253,24 @@ public class ConnectorIT {
     Map<String, ConfigValue> validateMap = toValidateMap(config);
     assertPropHasError(
         validateMap, new String[] {SNOWFLAKE_PRIVATE_KEY, SNOWFLAKE_PRIVATE_KEY_PASSPHRASE});
+  }
+
+  @Test
+  public void testValidateErrorOAuthTokenEndpointConfig() {
+    Map<String, String> config = getCorrectConfig();
+    config.put(
+        KafkaConnectorConfigParams.SNOWFLAKE_AUTHENTICATOR,
+        AuthenticatorType.OAUTH.toConfigValue());
+    config.put(KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_CLIENT_ID, "client_id");
+    config.put(KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_CLIENT_SECRET, "client_secret");
+    // Malformed token endpoint makes OAuthURL.from throw ERROR_0033 before any network call.
+    config.put(KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_TOKEN_ENDPOINT, "@@@ not a url @@@");
+    config.remove(SNOWFLAKE_PRIVATE_KEY);
+    Map<String, ConfigValue> validateMap = toValidateMap(config);
+    assert !validateMap
+        .get(KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_TOKEN_ENDPOINT)
+        .errorMessages()
+        .isEmpty();
   }
 
   @Test

--- a/src/test/java/com/snowflake/kafka/connector/internal/InternalUtilsTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/InternalUtilsTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams;
+import com.snowflake.kafka.connector.config.AuthenticatorType;
 import com.snowflake.kafka.connector.config.SinkTaskConfig;
 import com.snowflake.kafka.connector.config.SinkTaskConfigTestBuilder;
 import com.snowflake.kafka.connector.mock.MockResultSetForSizeTest;
@@ -165,6 +166,56 @@ public class InternalUtilsTest {
     assert InternalUtils.resultSize(resultSet) == 0;
     resultSet = new MockResultSetForSizeTest(100);
     assert InternalUtils.resultSize(resultSet) == 100;
+  }
+
+  @Test
+  public void testMakeJdbcDriverProperties_oauthMissingClientId_throws() {
+    SinkTaskConfig config =
+        SinkTaskConfigTestBuilder.builder()
+            .connectorName("test")
+            .taskId("0")
+            .snowflakeDatabase("db")
+            .snowflakeSchema("schema")
+            .snowflakeUser("user")
+            .snowflakeUrl("https://account.snowflake.com")
+            .authenticator(AuthenticatorType.OAUTH)
+            .oauthClientSecret(new Password("secret"))
+            .build();
+
+    SnowflakeURL url = new SnowflakeURL("https://account.snowflake.com");
+    assert TestUtils.assertError(
+        SnowflakeErrors.ERROR_0026, () -> InternalUtils.makeJdbcDriverProperties(config, url));
+  }
+
+  @Test
+  public void testMakeJdbcDriverProperties_oauthMissingClientSecret_throws() {
+    SinkTaskConfig config =
+        SinkTaskConfigTestBuilder.builder()
+            .connectorName("test")
+            .taskId("0")
+            .snowflakeDatabase("db")
+            .snowflakeSchema("schema")
+            .snowflakeUser("user")
+            .snowflakeUrl("https://account.snowflake.com")
+            .authenticator(AuthenticatorType.OAUTH)
+            .oauthClientId("client_id")
+            .build();
+
+    SnowflakeURL url = new SnowflakeURL("https://account.snowflake.com");
+    assert TestUtils.assertError(
+        SnowflakeErrors.ERROR_0027, () -> InternalUtils.makeJdbcDriverProperties(config, url));
+  }
+
+  @Test
+  public void testMakeJdbcDriverProperties_invalidAuthenticator_throws() {
+    Map<String, String> rawConfig = new HashMap<>();
+    rawConfig.put(KafkaConnectorConfigParams.SNOWFLAKE_DATABASE_NAME, "db");
+    rawConfig.put(KafkaConnectorConfigParams.SNOWFLAKE_SCHEMA_NAME, "schema");
+    rawConfig.put(KafkaConnectorConfigParams.SNOWFLAKE_USER_NAME, "user");
+    rawConfig.put(KafkaConnectorConfigParams.SNOWFLAKE_URL_NAME, "https://account.snowflake.com");
+    rawConfig.put(KafkaConnectorConfigParams.SNOWFLAKE_AUTHENTICATOR, "invalid_auth");
+
+    assertThrows(IllegalArgumentException.class, () -> SinkTaskConfig.from(rawConfig, true));
   }
 
   @Test

--- a/src/test/java/com/snowflake/kafka/connector/internal/OAuthConnectionIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/OAuthConnectionIT.java
@@ -1,0 +1,50 @@
+package com.snowflake.kafka.connector.internal;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams;
+import com.snowflake.kafka.connector.config.AuthenticatorType;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration test for OAuth authentication. Reads OAuth credentials from {@code profile.json}
+ * (fields: {@code oauth_client_id}, {@code oauth_client_secret}, {@code oauth_refresh_token},
+ * {@code oauth_token_endpoint}). Skipped when the profile does not contain OAuth credentials.
+ */
+class OAuthConnectionIT {
+
+  @Test
+  void oauthConnection_shouldConnectAndQuerySnowflake() {
+    TestUtils.Profile profile = TestUtils.getProfile();
+
+    assumeTrue(
+        profile.oauthClientId != null
+            && profile.oauthClientSecret != null
+            && profile.oauthTokenEndpoint != null,
+        "OAuth credentials not present in profile.json, skipping");
+
+    Map<String, String> config = TestUtils.transformProfileFileToConnectorConfiguration(false);
+    config.put(
+        KafkaConnectorConfigParams.SNOWFLAKE_AUTHENTICATOR,
+        AuthenticatorType.OAUTH.toConfigValue());
+    config.put(KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_CLIENT_ID, profile.oauthClientId);
+    config.put(KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_CLIENT_SECRET, profile.oauthClientSecret);
+    config.put(
+        KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_TOKEN_ENDPOINT, profile.oauthTokenEndpoint);
+    if (profile.oauthRefreshToken != null) {
+      config.put(
+          KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_REFRESH_TOKEN, profile.oauthRefreshToken);
+    }
+    config.remove(KafkaConnectorConfigParams.SNOWFLAKE_PRIVATE_KEY);
+    config.remove(KafkaConnectorConfigParams.SNOWFLAKE_PRIVATE_KEY_PASSPHRASE);
+
+    SnowflakeConnectionService conn =
+        SnowflakeConnectionServiceFactory.builder().setProperties(config).build();
+    try {
+      conn.databaseExists(config.get(KafkaConnectorConfigParams.SNOWFLAKE_DATABASE_NAME));
+    } finally {
+      conn.close();
+    }
+  }
+}

--- a/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
@@ -140,7 +140,7 @@ public class TestUtils {
           + "}";
   public static final String JSON_WITHOUT_SCHEMA = "{\"userid\": \"User_1\"}";
 
-  private static Profile getProfile() {
+  public static Profile getProfile() {
     if (profile == null) {
       String path = System.getenv(SNOWFLAKE_CREDENTIAL_FILE_ENV);
       if (path == null || path.isEmpty()) {


### PR DESCRIPTION
## Summary

Adds OAuth support to JDBC connection properties. When the connector is configured with `snowflake.authenticator=oauth`, `makeJdbcDriverProperties` fetches an access token via `OAuthAccessTokenFetcher` and passes it to the JDBC driver instead of a private key.

- **`InternalUtils.makeJdbcDriverProperties`**: switches on `AuthenticatorType` from the parsed `SinkTaskConfig` — `SNOWFLAKE_JWT` uses key-pair auth (existing behavior), `OAUTH` validates client ID/secret, fetches an access token, and sets the JDBC `token` property. Includes `default` case throwing `IllegalStateException` for future-proofing.
- **`SnowflakeStreamingSinkConnector.validate()`**: maps the OAuth-specific error codes that a live token fetch can raise to per-field config errors instead of letting them escape as a generic worker error — `ERROR_0033` (invalid token endpoint URL) to `snowflake.oauth.token.endpoint`, and `ERROR_1004` (token fetch failed) to the client ID, client secret, and token endpoint fields.
- **`TestUtils.getProfile()`**: made public so tests can access `Profile` fields directly (e.g. OAuth credentials).
- **`OAuthConnectionIT`**: integration test that connects to Snowflake with OAuth credentials read from `profile.json` (skipped when OAuth fields are absent). Uses try/finally for connection cleanup.

## Config validation and live OAuth fetch

`SnowflakeStreamingSinkConnector.validate()` builds a real `SnowflakeConnectionService` to verify credentials, which now triggers a live OAuth token fetch. This is intentional — it's consistent with the existing behavior (JWT validation already makes a live JDBC connection here) and gives the customer immediate feedback if their OAuth credentials are misconfigured. KC v3 behaves the same way.

## Token refresh strategy

The access token is fetched once when JDBC properties are built — this matches KC v3 behavior exactly ([v3 `createProperties`](https://github.com/snowflakedb/snowflake-kafka-connector/blob/3.2.x/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java#L212-L216) also calls `getSnowflakeOAuthAccessToken()` once). A 6-hour soak test (`OAuthSoakIT`) with 1-hour token expiry showed no issues: JDBC DDL calls continued past expiry, and the streaming SDK handles token renewal transparently via its internal `OAuthManager`.

If the token does expire during a long-lived task, the auth failure triggers task restart via `SnowflakeSinkTaskAuthorizationExceptionTracker`, which re-fetches the token on restart.

Future work: [SNOW-3535094](https://snowflakecomputing.atlassian.net/browse/SNOW-3535094) tracks adding a headless `oauth_refresh_token` authenticator to the JDBC driver. If that lands, we can delegate token renewal to JDBC directly, but we found no evidence that complex manual refresh logic is necessary at this point.

## Cross-reference with KC v3 (`3.2.x`)

| v4 file | v3 equivalent | Notes |
|---------|---------------|-------|
| [`InternalUtils.makeJdbcDriverProperties`](https://github.com/snowflakedb/snowflake-kafka-connector/blob/skurella-oauth-jdbc/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java) | [`InternalUtils.createProperties`](https://github.com/snowflakedb/snowflake-kafka-connector/blob/3.2.x/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java#L131-L230) | v4 reads from `SinkTaskConfig` instead of raw map; uses `AuthenticatorType` enum instead of string comparison |
| [`OAuthConnectionIT`](https://github.com/snowflakedb/snowflake-kafka-connector/blob/skurella-oauth-jdbc/src/test/java/com/snowflake/kafka/connector/internal/OAuthConnectionIT.java) | [`ConnectionServiceIT.testOAuthAZ`](https://github.com/snowflakedb/snowflake-kafka-connector/blob/3.2.x/src/test/java/com/snowflake/kafka/connector/internal/ConnectionServiceIT.java) | v4 reads OAuth creds from `profile.json` fields; v3 used `TestUtils.getConfWithOAuth()` |

### Key differences from v3

- v3 `createProperties` iterates a raw `Map<String, String>` and compares authenticator strings; v4 uses the already-parsed `SinkTaskConfig` and switches on an enum
- v3 requires `refresh_token` (throws ERROR_0028 if absent); v4 allows omitting it to fall back to `client_credentials` grant
- v3 calls `Utils.getSnowflakeOAuthAccessToken()`; v4 calls `OAuthAccessTokenFetcher.fetchAccessToken()` (introduced in PR #1447)
- Invalid authenticator values are caught at `SinkTaskConfig` parse time by `AuthenticatorType.fromConfig()` rather than in `makeJdbcDriverProperties`

## Test plan

- [x] `InternalUtilsTest.testMakeJdbcDriverProperties_oauthMissingClientId_throws`
- [x] `InternalUtilsTest.testMakeJdbcDriverProperties_oauthMissingClientSecret_throws`
- [x] `InternalUtilsTest.testMakeJdbcDriverProperties_invalidAuthenticator_throws` — tests `AuthenticatorType.fromConfig()` rejects unknown authenticator values
- [x] `ConnectorIT.testValidateErrorOAuthTokenEndpointConfig` — a malformed `snowflake.oauth.token.endpoint` surfaces as a per-field config error (ERROR_0033 mapping)
- [x] `OAuthConnectionIT.oauthConnection_shouldConnectAndQuerySnowflake` — reads OAuth credentials from `profile.json`; verified locally against Snowflake

[SNOW-3535094]: https://snowflakecomputing.atlassian.net/browse/SNOW-3535094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ