### PR TITLE
remove misleading warning

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -164,19 +164,6 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
     boolean dlqConfigured = dlqTopic != null && !dlqTopic.trim().isEmpty();
     boolean tolerateAll = "all".equalsIgnoreCase(errorsTolerance);
 
-    // Check for legacy KC v3 config and warn if present (schematization enabled via task config)
-    if (taskConfig.isEnableSchematization()) {
-      LOGGER.warn(
-          "Config 'snowflake.enable.schematization' is not supported in KC v4. "
-              + "Schema evolution is now handled server-side via table property "
-              + "'ENABLE_SCHEMA_EVOLUTION'. For pre-created tables, run: "
-              + "ALTER TABLE ... SET ENABLE_SCHEMA_EVOLUTION = TRUE");
-    } else {
-      LOGGER.info(
-          "Schematization is disabled — the connector wraps payloads into"
-              + " RECORD_CONTENT/RECORD_METADATA.");
-    }
-
     if (taskConfig.getValidation() != SnowflakeValidation.CLIENT_SIDE) {
       // Check each target table for ERROR_LOGGING.
       // Note: makes up to 3 network calls per table (tableExist + isIcebergTable +

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2ValidationLoggingTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2ValidationLoggingTest.java
@@ -298,35 +298,6 @@ public class SnowflakeSinkServiceV2ValidationLoggingTest {
         "Should NOT emit the generic missing-ERROR_LOGGING warning for Iceberg tables");
   }
 
-  /**
-   * Test: Legacy KC v3 config warning
-   *
-   * <p>Warns if snowflake.enable.schematization is present (not supported in KC v4)
-   */
-  @Test
-  public void testLegacySchematizationConfigWarning() {
-    SinkTaskConfig config =
-        SinkTaskConfigTestBuilder.builder()
-            .connectorName("test-connector")
-            .taskId("0")
-            .enableSchematization(true)
-            .build();
-
-    SnowflakeSinkServiceV2 service = createServiceWithConfig(config);
-    assertNotNull(service);
-
-    // Verify WARN log about legacy config
-    assertTrue(
-        testAppender.containsMessage(Level.WARN, "snowflake.enable.schematization"),
-        "Should mention legacy config name");
-    assertTrue(
-        testAppender.containsMessage(Level.WARN, "not supported in KC v4"),
-        "Should explain config is not supported");
-    assertTrue(
-        testAppender.containsMessage(Level.WARN, "ENABLE_SCHEMA_EVOLUTION"),
-        "Should mention server-side schema evolution");
-  }
-
   /** Helper to create SnowflakeSinkServiceV2 with minimal mocked dependencies. */
   private SnowflakeSinkServiceV2 createServiceWithConfig(SinkTaskConfig config) {
     return createServiceWithConfig(config, mockConn -> {});


### PR DESCRIPTION
We do handle schematization, both client-side and server-side. It's also a different setting to schema evolution.