### PR TITLE
improve password parsing

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/DefaultConnectorConfigValidator.java
+++ b/src/main/java/com/snowflake/kafka/connector/DefaultConnectorConfigValidator.java
@@ -161,7 +161,7 @@ public class DefaultConnectorConfigValidator implements ConnectorConfigValidator
   private void validateOAuthConfig(
       Map<String, String> config, Map<String, String> invalidConfigParams) {
     String clientId = config.getOrDefault(KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_CLIENT_ID, "");
-    if (clientId.isEmpty()) {
+    if (clientId.isBlank()) {
       invalidConfigParams.put(
           KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_CLIENT_ID,
           Utils.formatString(
@@ -171,7 +171,7 @@ public class DefaultConnectorConfigValidator implements ConnectorConfigValidator
 
     String clientSecret =
         config.getOrDefault(KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_CLIENT_SECRET, "");
-    if (clientSecret.isEmpty()) {
+    if (clientSecret.isBlank()) {
       invalidConfigParams.put(
           KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_CLIENT_SECRET,
           Utils.formatString(

--- a/src/main/java/com/snowflake/kafka/connector/config/SinkTaskConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/config/SinkTaskConfig.java
@@ -69,25 +69,19 @@ public abstract class SinkTaskConfig {
   @Nullable
   public abstract String getSnowflakeRole();
 
-  @Nullable
-  public abstract Password getSnowflakePrivateKey();
+  public abstract Optional<Password> getSnowflakePrivateKey();
 
-  @Nullable
-  public abstract Password getSnowflakePrivateKeyPassphrase();
+  public abstract Optional<Password> getSnowflakePrivateKeyPassphrase();
 
   public abstract AuthenticatorType getAuthenticator();
 
-  @Nullable
-  public abstract String getOauthClientId();
+  public abstract Optional<String> getOauthClientId();
 
-  @Nullable
-  public abstract Password getOauthClientSecret();
+  public abstract Optional<Password> getOauthClientSecret();
 
-  @Nullable
-  public abstract Password getOauthRefreshToken();
+  public abstract Optional<Password> getOauthRefreshToken();
 
-  @Nullable
-  public abstract String getOauthTokenEndpoint();
+  public abstract Optional<String> getOauthTokenEndpoint();
 
   @Nullable
   public abstract String getSnowflakeDatabase();
@@ -294,23 +288,26 @@ public abstract class SinkTaskConfig {
     String snowflakeUrl = config.get(KafkaConnectorConfigParams.SNOWFLAKE_URL_NAME);
     String snowflakeUser = config.get(KafkaConnectorConfigParams.SNOWFLAKE_USER_NAME);
     String snowflakeRole = config.get(KafkaConnectorConfigParams.SNOWFLAKE_ROLE_NAME);
-    Password snowflakePrivateKey =
-        passwordOrNull(config.get(KafkaConnectorConfigParams.SNOWFLAKE_PRIVATE_KEY));
-    Password snowflakePrivateKeyPassphrase =
-        passwordOrNull(config.get(KafkaConnectorConfigParams.SNOWFLAKE_PRIVATE_KEY_PASSPHRASE));
     String snowflakeDatabase = config.get(KafkaConnectorConfigParams.SNOWFLAKE_DATABASE_NAME);
     String snowflakeSchema = config.get(KafkaConnectorConfigParams.SNOWFLAKE_SCHEMA_NAME);
 
     AuthenticatorType authenticator =
         AuthenticatorType.fromConfig(
             config.get(KafkaConnectorConfigParams.SNOWFLAKE_AUTHENTICATOR));
-    String oauthClientId = config.get(KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_CLIENT_ID);
-    Password oauthClientSecret =
-        passwordOrNull(config.get(KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_CLIENT_SECRET));
-    Password oauthRefreshToken =
-        passwordOrNull(config.get(KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_REFRESH_TOKEN));
-    String oauthTokenEndpoint =
-        config.get(KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_TOKEN_ENDPOINT);
+
+    Optional<Password> snowflakePrivateKey =
+        optionalPassword(config.get(KafkaConnectorConfigParams.SNOWFLAKE_PRIVATE_KEY));
+    Optional<Password> snowflakePrivateKeyPassphrase =
+        optionalPassword(config.get(KafkaConnectorConfigParams.SNOWFLAKE_PRIVATE_KEY_PASSPHRASE));
+
+    Optional<String> oauthClientId =
+        optionalString(config.get(KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_CLIENT_ID));
+    Optional<Password> oauthClientSecret =
+        optionalPassword(config.get(KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_CLIENT_SECRET));
+    Optional<Password> oauthRefreshToken =
+        optionalPassword(config.get(KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_REFRESH_TOKEN));
+    Optional<String> oauthTokenEndpoint =
+        optionalString(config.get(KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_TOKEN_ENDPOINT));
 
     String proxyHost = config.get(KafkaConnectorConfigParams.JVM_PROXY_HOST);
     String proxyPort = config.get(KafkaConnectorConfigParams.JVM_PROXY_PORT);
@@ -327,8 +324,8 @@ public abstract class SinkTaskConfig {
             .orElse(
                 KafkaConnectorConfigParams.SNOWFLAKE_FEATURE_ASSERT_PARTITION_ASSIGNMENT_DEFAULT);
 
-    return builder()
-        .connectorName(connectorName)
+    Builder b = builder();
+    b.connectorName(connectorName)
         .taskId(taskId)
         .topicToTableMap(topicToTableMap)
         .behaviorOnNullValues(behaviorOnNullValues)
@@ -347,13 +344,7 @@ public abstract class SinkTaskConfig {
         .snowflakeUrl(snowflakeUrl)
         .snowflakeUser(snowflakeUser)
         .snowflakeRole(snowflakeRole)
-        .snowflakePrivateKey(snowflakePrivateKey)
-        .snowflakePrivateKeyPassphrase(snowflakePrivateKeyPassphrase)
         .authenticator(authenticator)
-        .oauthClientId(oauthClientId)
-        .oauthClientSecret(oauthClientSecret)
-        .oauthRefreshToken(oauthRefreshToken)
-        .oauthTokenEndpoint(oauthTokenEndpoint)
         .snowflakeDatabase(snowflakeDatabase)
         .snowflakeSchema(snowflakeSchema)
         .proxyHost(proxyHost)
@@ -366,10 +357,23 @@ public abstract class SinkTaskConfig {
         .ssv1MigrationIncludeConnectorName(ssv1MigrationIncludeConnectorName)
         .assertPartitionAssignmentEnabled(assertPartitionAssignmentEnabled)
         .precommitClientRecoveryEnabled(precommitClientRecoveryEnabled);
+
+    snowflakePrivateKey.ifPresent(b::snowflakePrivateKey);
+    snowflakePrivateKeyPassphrase.ifPresent(b::snowflakePrivateKeyPassphrase);
+
+    oauthClientId.ifPresent(b::oauthClientId);
+    oauthClientSecret.ifPresent(b::oauthClientSecret);
+    oauthRefreshToken.ifPresent(b::oauthRefreshToken);
+    oauthTokenEndpoint.ifPresent(b::oauthTokenEndpoint);
+    return b;
   }
 
-  private static Password passwordOrNull(String value) {
-    return value == null ? null : new Password(value);
+  private static Optional<String> optionalString(String value) {
+    return Optional.ofNullable(value).filter(v -> !v.isBlank());
+  }
+
+  private static Optional<Password> optionalPassword(String value) {
+    return optionalString(value).map(Password::new);
   }
 
   /** Creates a new builder. Used by {@link #from(Map)} and by tests. */

--- a/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
@@ -9,9 +9,7 @@ import java.sql.SQLException;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
-import java.util.Optional;
 import java.util.Properties;
-import org.apache.kafka.common.config.types.Password;
 
 public class InternalUtils {
   // authenticator type
@@ -92,17 +90,11 @@ public class InternalUtils {
 
     properties.put(JdbcPropertyKeys.AUTHENTICATOR, SNOWFLAKE_JWT);
 
-    String privateKey =
-        Optional.ofNullable(config.getSnowflakePrivateKey()).map(Password::value).orElse(null);
-    if (isBlank(privateKey)) {
-      throw SnowflakeErrors.ERROR_0013.getException();
-    }
-    String privateKeyPassphrase =
-        Optional.ofNullable(config.getSnowflakePrivateKeyPassphrase())
-            .map(Password::value)
-            .orElse(null);
     properties.put(
-        JDBC_PRIVATE_KEY, PrivateKeyTool.parsePrivateKey(privateKey, privateKeyPassphrase));
+        JDBC_PRIVATE_KEY,
+        PrivateKeyTool.parsePrivateKey(
+            config.getSnowflakePrivateKey().orElseThrow(SnowflakeErrors.ERROR_0013::getException),
+            config.getSnowflakePrivateKeyPassphrase()));
 
     properties.put(JDBC_SSL, url.sslEnabled() ? "on" : "off");
     // put values for optional parameters

--- a/src/main/java/com/snowflake/kafka/connector/internal/PrivateKeyTool.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/PrivateKeyTool.java
@@ -1,13 +1,13 @@
 package com.snowflake.kafka.connector.internal;
 
-import static org.apache.commons.lang3.StringUtils.isBlank;
-
 import java.io.StringReader;
 import java.security.KeyFactory;
 import java.security.PrivateKey;
 import java.security.Security;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.Base64;
+import java.util.Optional;
+import org.apache.kafka.common.config.types.Password;
 import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
 import org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider;
 import org.bouncycastle.openssl.PEMParser;
@@ -20,12 +20,11 @@ public final class PrivateKeyTool {
 
   private static final KCLogger LOGGER = new KCLogger(PrivateKeyTool.class.getName());
 
-  public static PrivateKey parsePrivateKey(String privateKeyStr, String privateKeyPassword) {
-    if (isBlank(privateKeyPassword)) {
-      return parseNonEncryptedPrivateKey(privateKeyStr);
-    } else {
-      return parseEncryptedPrivateKey(privateKeyStr, privateKeyPassword);
-    }
+  public static PrivateKey parsePrivateKey(
+      Password privateKey, Optional<Password> privateKeyPassphrase) {
+    return privateKeyPassphrase
+        .map(passphrase -> parseEncryptedPrivateKey(privateKey.value(), passphrase.value()))
+        .orElseGet(() -> parseNonEncryptedPrivateKey(privateKey.value()));
   }
 
   private static PrivateKey parseNonEncryptedPrivateKey(String key) {

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProperties.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProperties.java
@@ -22,15 +22,14 @@ import com.snowflake.kafka.connector.Utils;
 import com.snowflake.kafka.connector.config.SinkTaskConfig;
 import com.snowflake.kafka.connector.internal.KCLogger;
 import com.snowflake.kafka.connector.internal.PrivateKeyTool;
+import com.snowflake.kafka.connector.internal.SnowflakeErrors;
 import com.snowflake.kafka.connector.internal.SnowflakeURL;
 import java.security.PrivateKey;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Properties;
-import org.apache.kafka.common.config.types.Password;
 
 /**
  * Object to convert and store properties for {@code
@@ -67,14 +66,10 @@ public class StreamingClientProperties {
     final Properties clientProperties = new Properties();
     if (!Strings.isNullOrEmpty(config.getSnowflakeUrl())) {
       SnowflakeURL url = new SnowflakeURL(config.getSnowflakeUrl());
-      final String privateKeyStr =
-          Optional.ofNullable(config.getSnowflakePrivateKey()).map(Password::value).orElse(null);
-      final String privateKeyPassphrase =
-          Optional.ofNullable(config.getSnowflakePrivateKeyPassphrase())
-              .map(Password::value)
-              .orElse(null);
       final PrivateKey privateKey =
-          PrivateKeyTool.parsePrivateKey(privateKeyStr, privateKeyPassphrase);
+          PrivateKeyTool.parsePrivateKey(
+              config.getSnowflakePrivateKey().orElseThrow(SnowflakeErrors.ERROR_0013::getException),
+              config.getSnowflakePrivateKeyPassphrase());
       final String privateKeyEncoded = Base64.getEncoder().encodeToString(privateKey.getEncoded());
       clientProperties.put("private_key", privateKeyEncoded);
 

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigValidatorLogsTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigValidatorLogsTest.java
@@ -13,6 +13,8 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.security.PrivateKey;
 import java.util.Map;
+import java.util.Optional;
+import org.apache.kafka.common.config.types.Password;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -35,7 +37,7 @@ public class ConnectorConfigValidatorLogsTest {
     connectorConfigValidator.validateConfig(testConf);
 
     // then
-    PrivateKeyTool.parsePrivateKey(testKey, testPasswd);
+    PrivateKeyTool.parsePrivateKey(new Password(testKey), Optional.of(new Password(testPasswd)));
     Assertions.assertFalse(logFileContains(testPasswd));
   }
 

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigValidatorTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigValidatorTest.java
@@ -757,6 +757,34 @@ public class ConnectorConfigValidatorTest {
   }
 
   @Test
+  public void testOAuthBlankClientId() {
+    Map<String, String> config =
+        SnowflakeSinkConnectorConfigBuilder.streamingConfig()
+            .withAuthenticator(AuthenticatorType.OAUTH.toConfigValue())
+            .withOauthClientId("   ")
+            .withOauthClientSecret("client_secret")
+            .withoutPrivateKey()
+            .build();
+    assertThatThrownBy(() -> connectorConfigValidator.validateConfig(config))
+        .isInstanceOf(SnowflakeKafkaConnectorException.class)
+        .hasMessageContaining(KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_CLIENT_ID);
+  }
+
+  @Test
+  public void testOAuthBlankClientSecret() {
+    Map<String, String> config =
+        SnowflakeSinkConnectorConfigBuilder.streamingConfig()
+            .withAuthenticator(AuthenticatorType.OAUTH.toConfigValue())
+            .withOauthClientId("client_id")
+            .withOauthClientSecret("   ")
+            .withoutPrivateKey()
+            .build();
+    assertThatThrownBy(() -> connectorConfigValidator.validateConfig(config))
+        .isInstanceOf(SnowflakeKafkaConnectorException.class)
+        .hasMessageContaining(KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_CLIENT_SECRET);
+  }
+
+  @Test
   public void testOAuthDoesNotRequirePrivateKey() {
     Map<String, String> config =
         SnowflakeSinkConnectorConfigBuilder.streamingConfig()

--- a/src/test/java/com/snowflake/kafka/connector/config/SinkTaskConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/config/SinkTaskConfigTest.java
@@ -8,6 +8,7 @@ import com.snowflake.kafka.connector.Utils;
 import com.snowflake.kafka.connector.internal.streaming.v2.migration.Ssv1MigrationMode;
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.kafka.common.config.types.Password;
 import org.junit.jupiter.api.Test;
 
 public class SinkTaskConfigTest {
@@ -181,10 +182,12 @@ public class SinkTaskConfigTest {
     SinkTaskConfig config = SinkTaskConfig.from(raw);
 
     assertEquals(AuthenticatorType.OAUTH, config.getAuthenticator());
-    assertEquals("my_client_id", config.getOauthClientId());
-    assertEquals("my_client_secret", config.getOauthClientSecret().value());
-    assertEquals("my_refresh_token", config.getOauthRefreshToken().value());
-    assertEquals("https://oauth.example.com/token", config.getOauthTokenEndpoint());
+    assertEquals("my_client_id", config.getOauthClientId().orElse(null));
+    assertEquals(
+        "my_client_secret", config.getOauthClientSecret().map(Password::value).orElse(null));
+    assertEquals(
+        "my_refresh_token", config.getOauthRefreshToken().map(Password::value).orElse(null));
+    assertEquals("https://oauth.example.com/token", config.getOauthTokenEndpoint().orElse(null));
   }
 
   @Test
@@ -195,16 +198,19 @@ public class SinkTaskConfigTest {
 
     SinkTaskConfig config = SinkTaskConfig.from(raw);
 
-    assertEquals("my_private_key", config.getSnowflakePrivateKey().value());
-    assertEquals("my_passphrase", config.getSnowflakePrivateKeyPassphrase().value());
+    assertEquals(
+        "my_private_key", config.getSnowflakePrivateKey().map(Password::value).orElse(null));
+    assertEquals(
+        "my_passphrase",
+        config.getSnowflakePrivateKeyPassphrase().map(Password::value).orElse(null));
   }
 
   @Test
-  public void from_missingPrivateKey_returnsNull() {
+  public void from_missingPrivateKey_returnsEmpty() {
     SinkTaskConfig config = SinkTaskConfig.from(minimalConfig());
 
-    assertNull(config.getSnowflakePrivateKey());
-    assertNull(config.getSnowflakePrivateKeyPassphrase());
+    assertTrue(config.getSnowflakePrivateKey().isEmpty());
+    assertTrue(config.getSnowflakePrivateKeyPassphrase().isEmpty());
   }
 
   @Test
@@ -222,8 +228,8 @@ public class SinkTaskConfigTest {
 
     SinkTaskConfig config = SinkTaskConfig.from(raw);
     assertEquals(AuthenticatorType.OAUTH, config.getAuthenticator());
-    assertNull(config.getOauthRefreshToken());
-    assertNull(config.getOauthTokenEndpoint());
+    assertTrue(config.getOauthRefreshToken().isEmpty());
+    assertTrue(config.getOauthTokenEndpoint().isEmpty());
   }
 
   @Test

--- a/src/test/java/com/snowflake/kafka/connector/config/SinkTaskConfigTestBuilder.java
+++ b/src/test/java/com/snowflake/kafka/connector/config/SinkTaskConfigTestBuilder.java
@@ -47,8 +47,6 @@ public final class SinkTaskConfigTestBuilder {
         .snowflakeUrl("")
         .snowflakeUser("")
         .snowflakeRole("")
-        .snowflakePrivateKey(null)
-        .snowflakePrivateKeyPassphrase(null)
         .authenticator(AuthenticatorType.SNOWFLAKE_JWT)
         .snowflakeDatabase("")
         .snowflakeSchema("")

--- a/src/test/java/com/snowflake/kafka/connector/internal/InternalUtilsTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/InternalUtilsTest.java
@@ -14,6 +14,7 @@ import java.sql.SQLException;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import org.apache.kafka.common.config.types.Password;
 import org.junit.jupiter.api.Test;
@@ -22,26 +23,30 @@ public class InternalUtilsTest {
   @Test
   public void testPrivateKey() {
     assert TestUtils.assertError(
-        SnowflakeErrors.ERROR_0002, () -> PrivateKeyTool.parsePrivateKey("adfsfsaff", null));
+        SnowflakeErrors.ERROR_0002,
+        () -> PrivateKeyTool.parsePrivateKey(new Password("adfsfsaff"), Optional.empty()));
 
     Map<String, String> connectorConfiguration =
         TestUtils.transformProfileFileToConnectorConfiguration(true);
-    String privateKey =
-        connectorConfiguration.get(KafkaConnectorConfigParams.SNOWFLAKE_PRIVATE_KEY);
-    String pass =
-        connectorConfiguration.get(KafkaConnectorConfigParams.SNOWFLAKE_PRIVATE_KEY_PASSPHRASE);
+    Password privateKey =
+        new Password(connectorConfiguration.get(KafkaConnectorConfigParams.SNOWFLAKE_PRIVATE_KEY));
+    Optional<Password> pass =
+        Optional.ofNullable(
+                connectorConfiguration.get(
+                    KafkaConnectorConfigParams.SNOWFLAKE_PRIVATE_KEY_PASSPHRASE))
+            .map(Password::new);
     // no exception
     PrivateKeyTool.parsePrivateKey(privateKey, pass);
     StringBuilder builder = new StringBuilder();
     builder.append("-----BEGIN RSA PRIVATE KEY-----\n");
-    for (int i = 0; i < privateKey.length(); i++) {
-      builder.append(privateKey.charAt(i));
+    for (int i = 0; i < privateKey.value().length(); i++) {
+      builder.append(privateKey.value().charAt(i));
       if ((i + 1) % 64 == 0) {
         builder.append("\n");
       }
     }
     builder.append("\n-----END RSA PRIVATE KEY-----");
-    String originalKey = builder.toString();
+    Password originalKey = new Password(builder.toString());
     // no exception
     PrivateKeyTool.parsePrivateKey(originalKey, pass);
   }

--- a/src/test/java/com/snowflake/kafka/connector/internal/SnowflakeDataSourceFactory.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/SnowflakeDataSourceFactory.java
@@ -3,6 +3,7 @@ package com.snowflake.kafka.connector.internal;
 import com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams;
 import java.security.PrivateKey;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import javax.sql.DataSource;
 import net.snowflake.client.api.driver.SnowflakeDriver;
@@ -12,6 +13,7 @@ import org.apache.commons.dbcp2.PoolableConnection;
 import org.apache.commons.dbcp2.PoolableConnectionFactory;
 import org.apache.commons.dbcp2.PoolingDataSource;
 import org.apache.commons.pool2.impl.GenericObjectPool;
+import org.apache.kafka.common.config.types.Password;
 
 /** Factory class for creating DataSource instances using Apache Commons DBCP2 for testing. */
 public final class SnowflakeDataSourceFactory {
@@ -58,7 +60,9 @@ public final class SnowflakeDataSourceFactory {
 
         // JWT key pair auth - set private key
         final PrivateKey privateKey =
-            PrivateKeyTool.parsePrivateKey(privateKeyStr, privateKeyPassphrase);
+            PrivateKeyTool.parsePrivateKey(
+                new Password(privateKeyStr),
+                Optional.ofNullable(privateKeyPassphrase).map(Password::new));
         connectionProperties.put("privateKey", privateKey);
 
         // Create connection factory with Snowflake driver

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientPropertiesTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientPropertiesTest.java
@@ -34,7 +34,9 @@ import java.security.PrivateKey;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
+import org.apache.kafka.common.config.types.Password;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
 
@@ -146,9 +148,12 @@ public class StreamingClientPropertiesTest {
     expectedProps.put("application", "SnowflakeKafkaConnector/" + Utils.VERSION);
     String privateKeyStr = connectorConfig.get(KafkaConnectorConfigParams.SNOWFLAKE_PRIVATE_KEY);
     if (privateKeyStr != null) {
-      String passphrase =
-          connectorConfig.get(KafkaConnectorConfigParams.SNOWFLAKE_PRIVATE_KEY_PASSPHRASE);
-      PrivateKey privateKey = PrivateKeyTool.parsePrivateKey(privateKeyStr, passphrase);
+      Optional<Password> passphrase =
+          Optional.ofNullable(
+                  connectorConfig.get(KafkaConnectorConfigParams.SNOWFLAKE_PRIVATE_KEY_PASSPHRASE))
+              .map(Password::new);
+      PrivateKey privateKey =
+          PrivateKeyTool.parsePrivateKey(new Password(privateKeyStr), passphrase);
       expectedProps.put("private_key", Base64.getEncoder().encodeToString(privateKey.getEncoded()));
     }
     String expectedClientName = STREAMING_CLIENT_V2_PREFIX_NAME + "testName";


### PR DESCRIPTION
## Summary

Reworks how authentication config is modeled in `SinkTaskConfig`. Previously sensitive fields were typed as `Password` but had to tiptoe around nullability; now all auth-related config is `Optional`, which removes null-handling at call sites and reads more cleanly. The cleanup is modest here but has a larger payoff in the OAuth PR stack that builds on top of it.

## Changes

- **`SinkTaskConfig` accessors** now return `Optional`:
  - `getSnowflakePrivateKey()` / `getSnowflakePrivateKeyPassphrase()` → `Optional<Password>`
  - `getOauthClientId()` / `getOauthTokenEndpoint()` → `Optional<String>`
  - `getOauthClientSecret()` / `getOauthRefreshToken()` → `Optional<Password>`
- **`optionalString` / `optionalPassword` helpers**: parse raw config values into `Optional`, treating `null` or blank (whitespace-only) strings as absent via `isBlank()`. Builder setters take the raw `Password`/`String`; `from()` sets them conditionally with `ifPresent(...)` so AutoValue defaults unset optionals to `Optional.empty()`.
- **`PrivateKeyTool.parsePrivateKey`**: signature changed to `(Password privateKey, Optional<Password> privateKeyPassphrase)`.
- **`InternalUtils` / `StreamingClientProperties`**: updated to the new optional accessors; JWT paths use `orElseThrow` to fail fast when a private key is required but missing.
- **`DefaultConnectorConfigValidator.validateOAuthConfig`**: now rejects blank (whitespace-only) OAuth client ID / secret using `isBlank()`, consistent with the parse-time `isBlank()` semantics — previously a whitespace-only value passed validation but was dropped at parse time, surfacing later as ERROR_0026/0027 at connection setup.

## Test plan

- [x] `SinkTaskConfigTest` — updated for `Optional` accessors; blank/whitespace handling
- [x] `ConnectorConfigValidatorTest` — added `testOAuthBlankClientId` / `testOAuthBlankClientSecret`
- [x] `InternalUtilsTest`, `StreamingClientPropertiesTest` — updated `parsePrivateKey` callers to `Password` + `Optional<Password>`