### PR TITLE
Fix recovery seek-overwrite race in batch loop

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkService.java
@@ -2,6 +2,7 @@ package com.snowflake.kafka.connector.internal;
 
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.annotations.VisibleForTesting;
+import com.snowflake.kafka.connector.internal.streaming.channel.InsertResult;
 import com.snowflake.kafka.connector.internal.streaming.channel.TopicPartitionChannel;
 import java.util.Collection;
 import java.util.Map;
@@ -36,11 +37,11 @@ public interface SnowflakeSinkService {
   /**
    * call pipe to insert a JSON record will not trigger time based flush
    *
-   * @param record record content
-   * @return true if the record was processed successfully, false if recovery was triggered and the
-   *     caller should stop feeding records to this partition for the remainder of the batch
+   * @return the outcome — see {@link
+   *     com.snowflake.kafka.connector.internal.streaming.channel.InsertResult}. The batch loop uses
+   *     this to decide whether to rewind Kafka and whether to enter backpressure cooldown.
    */
-  boolean insert(final SinkRecord record);
+  InsertResult insert(final SinkRecord record);
 
   /**
    * retrieve offset of last loaded record for given pipe name

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -17,8 +17,8 @@ import com.snowflake.kafka.connector.internal.SnowflakeErrors;
 import com.snowflake.kafka.connector.internal.SnowflakeSinkService;
 import com.snowflake.kafka.connector.internal.metrics.MetricsJmxReporter;
 import com.snowflake.kafka.connector.internal.metrics.TaskMetrics;
+import com.snowflake.kafka.connector.internal.streaming.channel.InsertResult;
 import com.snowflake.kafka.connector.internal.streaming.channel.TopicPartitionChannel;
-import com.snowflake.kafka.connector.internal.streaming.v2.BackpressureException;
 import com.snowflake.kafka.connector.internal.streaming.v2.client.StreamingClientPools;
 import com.snowflake.kafka.connector.internal.streaming.v2.service.BatchOffsetFetcher;
 import com.snowflake.kafka.connector.internal.streaming.v2.service.PartitionChannelManager;
@@ -338,57 +338,47 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
           initializingPartitions);
     }
 
-    // If still in cooldown from a recent backpressure event, treat all partitions as
-    // backpressured so we skip the entire batch and give the SDK time to drain.
-    boolean skipAllPartitions = false;
-    if (Instant.now().isBefore(backpressureUntil)) {
-      LOGGER.debug(
-          "Backpressure cooldown active until {}. Skipping entire batch.", backpressureUntil);
-      skipAllPartitions = true;
-    }
-
     Map<TopicPartition, Long> offsetsOfFirstSkippedRecord = new HashMap<>();
-    boolean newBackpressure = false;
     for (SinkRecord record : records) {
-      // check if it needs to handle null value records
       if (shouldSkipNullValue(record)) {
         continue;
       }
-
       TopicPartition tp = new TopicPartition(record.topic(), record.kafkaPartition());
 
+      InsertResult result;
       if (offsetsOfFirstSkippedRecord.containsKey(tp)) {
-        // We've already skipped a record in this partition, so should also skip the remaining
-        // records in this partition.
-        continue;
-      }
-      if (skipAllPartitions || initializingPartitions.contains(tp)) {
-        // Make sure we store the first record in each partition that we skipped so we can correctly
-        // rewind the offset.
-        offsetsOfFirstSkippedRecord.putIfAbsent(tp, record.kafkaOffset());
-        continue;
+        result = InsertResult.PREVIOUSLY_SKIPPED_IN_BATCH;
+      } else if (Instant.now().isBefore(backpressureUntil)) {
+        result = InsertResult.IN_BACKPRESSURE_COOLDOWN;
+      } else if (initializingPartitions.contains(tp)) {
+        result = InsertResult.CHANNEL_INITIALIZING;
+      } else {
+        result = insert(record);
       }
 
-      try {
-        if (!insert(record)) {
+      switch (result) {
+        case PROCESSED:
+        case RECOVERY_IN_FLIGHT:
+          // PROCESSED: nothing to rewind. RECOVERY_IN_FLIGHT: the channel's resetAfterRecovery
+          // owns the authoritative seek; our rewind would clobber it.
+          break;
+
+        case PREVIOUSLY_SKIPPED_IN_BATCH:
+          // Already in the rewind map from an earlier record in this partition.
+          break;
+
+        case CHANNEL_INITIALIZING:
+        case IN_BACKPRESSURE_COOLDOWN:
           offsetsOfFirstSkippedRecord.putIfAbsent(tp, record.kafkaOffset());
-        }
-      } catch (BackpressureException e) {
-        LOGGER.warn(
-            "Backpressure on partition {}. Skipping remaining records for this partition."
-                + " Exception: {}",
-            tp,
-            e.getMessage());
-        taskMetrics.incBackpressureRewindCount();
-        offsetsOfFirstSkippedRecord.putIfAbsent(tp, record.kafkaOffset());
-        skipAllPartitions = true;
-        newBackpressure = true;
-      }
-    }
+          break;
 
-    if (newBackpressure) {
-      backpressureUntil = Instant.now().plus(BACKPRESSURE_COOLDOWN);
-      LOGGER.info("Backpressure cooldown set until {}", backpressureUntil);
+        case BACKPRESSURE_TRIGGERED:
+          LOGGER.warn("Backpressure on partition {}. Starting cooldown.", tp);
+          taskMetrics.incBackpressureRewindCount();
+          offsetsOfFirstSkippedRecord.putIfAbsent(tp, record.kafkaOffset());
+          backpressureUntil = Instant.now().plus(BACKPRESSURE_COOLDOWN);
+          break;
+      }
     }
 
     if (!offsetsOfFirstSkippedRecord.isEmpty()) {
@@ -398,21 +388,26 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
   }
 
   /**
-   * Inserts individual records into buffer. It fetches the TopicPartitionChannel from the map and
-   * then each partition(Streaming channel) calls its respective appendRows API
+   * Inserts a single record. Fetches the channel (creating one on first contact) and delegates to
+   * {@link TopicPartitionChannel#insertRecord}.
+   *
+   * <p>We never rebuild an already-registered partition from scratch here. Rebuilding would
+   * construct a fresh {@link
+   * com.snowflake.kafka.connector.internal.streaming.v2.channel.PartitionOffsetTracker} and wipe
+   * the recovery state (pending seek, processedOffset). Recovery for an existing channel goes
+   * through the appendRow fallback path ({@code reopenChannel} / {@code
+   * recreateClientAndReopenChannel}), which preserves the tracker. The manager removes entries only
+   * on explicit {@link #close}/{@link #closeAll}, so {@code isEmpty()} cleanly distinguishes "first
+   * time we see this partition" from "recovery needed".
    */
   @Override
-  public boolean insert(SinkRecord record) {
+  public InsertResult insert(SinkRecord record) {
     LOGGER.trace("Inserting record: {}", record);
 
     TopicPartition topicPartition = new TopicPartition(record.topic(), record.kafkaPartition());
 
-    // Initialize a new topic partition if it's not in the cache or if the channel is closed.
-    if (channelManager
-        .getChannel(topicPartition)
-        .map(TopicPartitionChannel::isChannelClosed)
-        .orElse(true)) {
-      LOGGER.warn("Streaming channel doesn't exist or is closed for {}", topicPartition);
+    if (channelManager.getChannel(topicPartition).isEmpty()) {
+      LOGGER.warn("Streaming channel missing for {}, creating", topicPartition);
       startPartition(topicPartition);
     }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/channel/InsertResult.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/channel/InsertResult.java
@@ -1,0 +1,39 @@
+package com.snowflake.kafka.connector.internal.streaming.channel;
+
+/**
+ * Outcome of attempting to insert one record into a {@link TopicPartitionChannel}, or — when
+ * returned by the batch loop's pre-check — the reason the record was not even attempted.
+ *
+ * <p>Each value names a distinct reason so the batch loop can decide whether to rewind Kafka (add
+ * to the skipped-offsets map) and whether to trigger backpressure cooldown, without having to
+ * reason about two-writer races between {@code sinkTaskContext.offset} callers.
+ */
+public enum InsertResult {
+  /** appendRow succeeded and the record is in the SDK buffer. */
+  PROCESSED,
+
+  /**
+   * Tracker has a Kafka seek in flight (either from this call's fallback, or from an earlier
+   * batch's recovery that hasn't landed yet). The tracker owns the rewind; do NOT add to the skip
+   * map — doing so would overwrite the authoritative seek.
+   */
+  RECOVERY_IN_FLIGHT,
+
+  /** Channel has not finished opening. Rewind so Kafka redelivers once it's ready. */
+  CHANNEL_INITIALIZING,
+
+  /** Prior batch triggered backpressure; we're still in cooldown. Rewind to try later. */
+  IN_BACKPRESSURE_COOLDOWN,
+
+  /**
+   * Earlier record in this batch was added to the rewind map for this partition (because of {@link
+   * #CHANNEL_INITIALIZING}, {@link #IN_BACKPRESSURE_COOLDOWN}, or {@link #BACKPRESSURE_TRIGGERED});
+   * skip the rest. Does NOT apply to {@link #RECOVERY_IN_FLIGHT} — that partition is never added to
+   * the rewind map in the first place, so each record is independently classified as
+   * RECOVERY_IN_FLIGHT by the in-channel check.
+   */
+  PREVIOUSLY_SKIPPED_IN_BATCH,
+
+  /** appendRow returned a retryable backpressure error. Rewind + start cooldown. */
+  BACKPRESSURE_TRIGGERED
+}

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/channel/TopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/channel/TopicPartitionChannel.java
@@ -11,7 +11,7 @@ public interface TopicPartitionChannel {
   long NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE = -1L;
 
   /**
-   * Inserts the record into buffer
+   * Inserts the record into the SDK buffer.
    *
    * <p>Step 1: Initializes this channel by fetching the offsetToken from Snowflake for the first
    * time this channel/partition has received offset after start/restart.
@@ -19,14 +19,10 @@ public interface TopicPartitionChannel {
    * <p>Step 2: Decides whether given offset from Kafka needs to be processed and whether it
    * qualifies for being added into buffer.
    *
-   * @param kafkaSinkRecord input record from Kafka
-   * @param isFirstRowPerPartitionInBatch indicates whether the given record is the first record per
-   *     partition in a batch
-   * @return true if the record was processed (or legitimately skipped as a duplicate), false if
-   *     recovery was triggered and the caller should stop feeding records to this partition for the
-   *     remainder of the batch
+   * @return the outcome — see {@link InsertResult}. The batch loop uses this to decide whether to
+   *     rewind Kafka and whether to enter backpressure cooldown.
    */
-  boolean insertRecord(SinkRecord kafkaSinkRecord, boolean isFirstRowPerPartitionInBatch);
+  InsertResult insertRecord(SinkRecord kafkaSinkRecord, boolean isFirstRowPerPartitionInBatch);
 
   /**
    * Asynchronously closes a channel associated to this partition. Any {@link SFException} occurred

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/AppendRowWithFallbackPolicy.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/AppendRowWithFallbackPolicy.java
@@ -33,23 +33,16 @@ class AppendRowWithFallbackPolicy {
    * @param channelName the channel name for logging purposes
    */
   private static void withDelay(CheckedRunnable action, String channelName) throws Throwable {
+    long delayMs = FALLBACK_DELAY.toMillis() + (long) (Math.random() * JITTER_DURATION.toMillis());
+    LOGGER.info("Delaying channel recovery by {}ms for channel: {}", delayMs, channelName);
     try {
-      long delayMs =
-          FALLBACK_DELAY.toMillis() + (long) (Math.random() * JITTER_DURATION.toMillis());
-
-      LOGGER.info("Delaying channel recovery by {}ms for channel: {}", delayMs, channelName);
       Thread.sleep(delayMs);
-
-      LOGGER.info("Executing channel recovery for channel: {}", channelName);
-      action.run();
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-    } catch (SFException e) {
-      // Re-throw SFException unchanged so Fallback can handle it properly
-      throw e;
-    } catch (Exception e) {
-      throw new RuntimeException(e);
+      return;
     }
+    LOGGER.info("Executing channel recovery for channel: {}", channelName);
+    action.run();
   }
 
   /**

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannel.java
@@ -24,6 +24,7 @@ import com.snowflake.kafka.connector.internal.schemaevolution.SnowflakeSchemaEvo
 import com.snowflake.kafka.connector.internal.schemaevolution.ValidationResultMapper;
 import com.snowflake.kafka.connector.internal.streaming.StreamingErrorHandler;
 import com.snowflake.kafka.connector.internal.streaming.TopicPartitionChannelInsertionException;
+import com.snowflake.kafka.connector.internal.streaming.channel.InsertResult;
 import com.snowflake.kafka.connector.internal.streaming.channel.TopicPartitionChannel;
 import com.snowflake.kafka.connector.internal.streaming.telemetry.SnowflakeTelemetryChannelCreation;
 import com.snowflake.kafka.connector.internal.streaming.telemetry.SnowflakeTelemetryChannelStatus;
@@ -164,14 +165,17 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
   }
 
   @Override
-  public boolean insertRecord(SinkRecord kafkaSinkRecord, boolean isFirstRowPerPartitionInBatch) {
+  public InsertResult insertRecord(
+      SinkRecord kafkaSinkRecord, boolean isFirstRowPerPartitionInBatch) {
     if (offsetTracker.shouldProcess(kafkaSinkRecord.kafkaOffset(), isFirstRowPerPartitionInBatch)) {
       return transformAndSend(kafkaSinkRecord);
     }
-    return true;
+    // shouldProcess returned false — the record is either a duplicate (already processed) or
+    // skipped because needToSkipCurrentBatch is set after a mid-batch recovery. Nothing to do.
+    return InsertResult.PROCESSED;
   }
 
-  private boolean transformAndSend(SinkRecord kafkaSinkRecord) {
+  private InsertResult transformAndSend(SinkRecord kafkaSinkRecord) {
     try {
       final long kafkaOffset = kafkaSinkRecord.kafkaOffset();
       final SnowflakeSinkRecord record =
@@ -203,32 +207,34 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
                 handleValidationError(validationResult, kafkaSinkRecord);
               }
               offsetTracker.recordProcessed(kafkaOffset);
-              return true;
+              return InsertResult.PROCESSED;
             }
           }
 
           if (!insertRowWithFallback(row, kafkaOffset)) {
-            // Fallback fired: the record was NOT inserted, and the fallback's recovery
-            // logic already reset processedOffset + rewound Kafka. Do NOT call
-            // recordProcessed() here — that would advance processedOffset past the
-            // recovery point and cause replayed offsets to be skipped. See SNOW-3344243.
-            return false;
+            // Fallback fired: the record was NOT inserted. The fallback's resetAfterRecovery
+            // already issued the authoritative Kafka seek to (committed + 1). Do NOT call
+            // recordProcessed() here — that would advance processedOffset past the recovery
+            // point and cause replayed offsets to be skipped. See SNOW-3344243. The batch
+            // loop receives RECOVERY_IN_FLIGHT and skips its own end-of-batch rewind for
+            // this partition, so the authoritative seek survives.
+            return InsertResult.RECOVERY_IN_FLIGHT;
           }
         }
       }
       // Always update processedOffset after processing, even for broken records
       offsetTracker.recordProcessed(kafkaOffset);
-      return true;
+      return InsertResult.PROCESSED;
     } catch (BackpressureException ex) {
       snowflakeTelemetryChannelStatus.incBackpressureRetryCount();
-      throw ex;
+      return InsertResult.BACKPRESSURE_TRIGGERED;
     } catch (TopicPartitionChannelInsertionException ex) {
       // Suppressing the exception because other channels might still continue to ingest
       LOGGER.warn(
           "Failed to insert row for channel:{}. Will be retried by Kafka. Exception: {}",
           this.channelName,
           ex);
-      return true;
+      return InsertResult.PROCESSED;
     }
   }
 
@@ -283,13 +289,19 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
         (Throwable ex) -> {
           consecutiveRecoveryCount++;
           if (consecutiveRecoveryCount > MAX_CONSECUTIVE_RECOVERIES) {
+            // Recovery is stuck. Throw ConnectException (NOT
+            // TopicPartitionChannelInsertionException — transformAndSend's catch swallows that
+            // and commits the offset without calling recordProcessed, silently losing the
+            // record). ConnectException fails the Kafka Connect task so offsets are not
+            // committed; the task retries recovery on restart.
             LOGGER.error(
                 "Channel {} exceeded max consecutive recoveries ({}), giving up",
                 this.channelName,
                 MAX_CONSECUTIVE_RECOVERIES);
-            throw new TopicPartitionChannelInsertionException(
+            throw new ConnectException(
                 String.format(
-                    "Channel %s failed after %d consecutive recovery attempts",
+                    "Channel %s could not be recovered after %d consecutive attempts."
+                        + " Check Snowflake service health.",
                     this.channelName, MAX_CONSECUTIVE_RECOVERIES),
                 ex);
           }

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2Test.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2Test.java
@@ -5,13 +5,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.Mockito.doThrow;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.snowflake.ingest.streaming.SFException;
 import com.snowflake.kafka.connector.builder.SinkRecordBuilder;
 import com.snowflake.kafka.connector.config.SinkTaskConfig;
 import com.snowflake.kafka.connector.config.SinkTaskConfigTestBuilder;
@@ -19,8 +19,8 @@ import com.snowflake.kafka.connector.config.SnowflakeValidation;
 import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
 import com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException;
 import com.snowflake.kafka.connector.internal.metrics.TaskMetrics;
+import com.snowflake.kafka.connector.internal.streaming.channel.InsertResult;
 import com.snowflake.kafka.connector.internal.streaming.channel.TopicPartitionChannel;
-import com.snowflake.kafka.connector.internal.streaming.v2.BackpressureException;
 import com.snowflake.kafka.connector.internal.streaming.v2.service.BatchOffsetFetcher;
 import com.snowflake.kafka.connector.internal.streaming.v2.service.PartitionChannelManager;
 import com.snowflake.kafka.connector.internal.streaming.v2.service.ThreadPools;
@@ -292,12 +292,9 @@ class SnowflakeSinkServiceV2Test {
     when(mockChannelManager.getChannel(tp0)).thenReturn(Optional.of(channel0));
     when(mockChannelManager.getChannel(tp1)).thenReturn(Optional.of(channel1));
 
-    // channel0 throws BackpressureException
-    doThrow(
-            new BackpressureException(
-                new SFException("MemoryThresholdExceeded", "backpressure", 0, "")))
-        .when(channel0)
-        .insertRecord(any(), anyBoolean());
+    // channel0 returns BACKPRESSURE_TRIGGERED
+    when(channel0.insertRecord(any(), anyBoolean()))
+        .thenReturn(InsertResult.BACKPRESSURE_TRIGGERED);
 
     List<SinkRecord> records = Arrays.asList(recordFor(TOPIC, 0, 100), recordFor(TOPIC, 1, 200));
     service.insert(records);
@@ -322,10 +319,9 @@ class SnowflakeSinkServiceV2Test {
     when(mockChannelManager.getChannel(tp0)).thenReturn(Optional.of(channel0));
     when(mockChannelManager.getChannel(tp1)).thenReturn(Optional.of(channel1));
 
-    // channel1 throws BackpressureException
-    doThrow(new BackpressureException(new SFException("ReceiverSaturated", "backpressure", 0, "")))
-        .when(channel1)
-        .insertRecord(any(), anyBoolean());
+    // channel1 returns BACKPRESSURE_TRIGGERED
+    when(channel1.insertRecord(any(), anyBoolean()))
+        .thenReturn(InsertResult.BACKPRESSURE_TRIGGERED);
 
     // p0's first record succeeds, p1 throws, p0's second record is skipped
     List<SinkRecord> records =
@@ -353,12 +349,9 @@ class SnowflakeSinkServiceV2Test {
     when(mockChannelManager.getChannel(tpInit)).thenReturn(Optional.of(initChannel));
     when(mockChannelManager.getChannel(tpReady)).thenReturn(Optional.of(readyChannel));
 
-    // Ready channel hits backpressure
-    doThrow(
-            new BackpressureException(
-                new SFException("MemoryThresholdExceeded", "backpressure", 0, "")))
-        .when(readyChannel)
-        .insertRecord(any(), anyBoolean());
+    // Ready channel returns BACKPRESSURE_TRIGGERED
+    when(readyChannel.insertRecord(any(), anyBoolean()))
+        .thenReturn(InsertResult.BACKPRESSURE_TRIGGERED);
 
     List<SinkRecord> records = Arrays.asList(recordFor(TOPIC, 0, 100), recordFor(TOPIC, 1, 200));
     service.insert(records);
@@ -378,11 +371,8 @@ class SnowflakeSinkServiceV2Test {
     TopicPartitionChannel channel0 = mockChannel("ch_0", false);
     when(mockChannelManager.getChannel(tp0)).thenReturn(Optional.of(channel0));
 
-    doThrow(
-            new BackpressureException(
-                new SFException("MemoryThresholdExceeded", "backpressure", 0, "")))
-        .when(channel0)
-        .insertRecord(any(), anyBoolean());
+    when(channel0.insertRecord(any(), anyBoolean()))
+        .thenReturn(InsertResult.BACKPRESSURE_TRIGGERED);
 
     service.insert(Collections.singletonList(recordFor(TOPIC, 0, 100)));
 
@@ -437,7 +427,7 @@ class SnowflakeSinkServiceV2Test {
   // --- recovery skip logic ---
 
   @Test
-  void insertSkipsRemainingRecordsForPartitionAfterRecovery() {
+  void insertDoesNotRewindWhenChannelReportsRecoveryInFlight() {
     TopicPartition tp0 = new TopicPartition(TOPIC, 0);
     TopicPartition tp1 = new TopicPartition(TOPIC, 1);
 
@@ -447,8 +437,9 @@ class SnowflakeSinkServiceV2Test {
     when(mockChannelManager.getChannel(tp0)).thenReturn(Optional.of(channel0));
     when(mockChannelManager.getChannel(tp1)).thenReturn(Optional.of(channel1));
 
-    // channel0 signals recovery on its first record
-    when(channel0.insertRecord(any(), anyBoolean())).thenReturn(false);
+    // channel0 returns RECOVERY_IN_FLIGHT — its fallback already issued the authoritative
+    // seek via resetAfterRecovery.
+    when(channel0.insertRecord(any(), anyBoolean())).thenReturn(InsertResult.RECOVERY_IN_FLIGHT);
 
     List<SinkRecord> records =
         Arrays.asList(
@@ -458,39 +449,17 @@ class SnowflakeSinkServiceV2Test {
             recordFor(TOPIC, 0, 102));
     service.insert(records);
 
-    // channel0: only the first record was attempted; 101 and 102 were skipped
+    // channel0: first record attempted (it's the one that triggers recovery); 101 and 102
+    // are skipped via PREVIOUSLY_SKIPPED_IN_BATCH.
     verify(channel0).insertRecord(records.get(0), true);
-    verify(channel0, never()).insertRecord(records.get(2), false);
-    verify(channel0, never()).insertRecord(records.get(3), false);
 
     // channel1: processed normally
     verify(channel1).insertRecord(records.get(1), true);
 
-    // Only the recovering partition is rewound, to the triggering record's offset
-    verify(mockSinkTaskContext).offset(tp0, 100L);
-    verify(mockSinkTaskContext, never()).offset(tp1, 200L);
-  }
-
-  @Test
-  void insertRewindsToFirstSkippedOffsetAfterRecoveryMidPartition() {
-    TopicPartition tp = new TopicPartition(TOPIC, 0);
-    TopicPartitionChannel channel = mockChannel("ch_0", false);
-    when(mockChannelManager.getChannel(tp)).thenReturn(Optional.of(channel));
-
-    // First record succeeds, second triggers recovery
-    when(channel.insertRecord(any(), anyBoolean())).thenReturn(true).thenReturn(false);
-
-    List<SinkRecord> records =
-        Arrays.asList(recordFor(TOPIC, 0, 100), recordFor(TOPIC, 0, 101), recordFor(TOPIC, 0, 102));
-    service.insert(records);
-
-    // First two records attempted, third skipped
-    verify(channel).insertRecord(records.get(0), true);
-    verify(channel).insertRecord(records.get(1), false);
-    verify(channel, never()).insertRecord(records.get(2), false);
-
-    // Rewind to the record that triggered recovery
-    verify(mockSinkTaskContext).offset(tp, 101L);
+    // No batch-loop rewind — the channel's tracker already issued its own seek via
+    // resetAfterRecovery. Issuing one from here would clobber it and lose records.
+    verify(mockSinkTaskContext, never()).offset(eq(tp0), anyLong());
+    verify(mockSinkTaskContext, never()).offset(eq(tp1), anyLong());
   }
 
   // --- helpers ---
@@ -525,11 +494,17 @@ class SnowflakeSinkServiceV2Test {
   }
 
   private static TopicPartitionChannel mockChannel(String channelName, boolean initializing) {
+    return mockChannel(channelName, initializing, "default-pipe");
+  }
+
+  private static TopicPartitionChannel mockChannel(
+      String channelName, boolean initializing, String pipeName) {
     TopicPartitionChannel channel = mock(TopicPartitionChannel.class);
     when(channel.getChannelName()).thenReturn(channelName);
+    when(channel.getPipeName()).thenReturn(pipeName);
     when(channel.isInitializing()).thenReturn(initializing);
     when(channel.isChannelClosed()).thenReturn(false);
-    when(channel.insertRecord(any(), anyBoolean())).thenReturn(true);
+    when(channel.insertRecord(any(), anyBoolean())).thenReturn(InsertResult.PROCESSED);
     return channel;
   }
 

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannelTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannelTest.java
@@ -29,6 +29,7 @@ import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
 import com.snowflake.kafka.connector.internal.metrics.TaskMetrics;
 import com.snowflake.kafka.connector.internal.streaming.InMemorySinkTaskContext;
 import com.snowflake.kafka.connector.internal.streaming.StreamingErrorHandler;
+import com.snowflake.kafka.connector.internal.streaming.channel.InsertResult;
 import com.snowflake.kafka.connector.internal.streaming.telemetry.SnowflakeTelemetryChannelStatus;
 import com.snowflake.kafka.connector.internal.streaming.v2.channel.PartitionOffsetTracker;
 import com.snowflake.kafka.connector.internal.streaming.v2.migration.Ssv1MigrationMode;
@@ -212,7 +213,7 @@ class SnowpipeStreamingPartitionChannelTest {
   }
 
   @Test
-  void insertRecordThrowsBackpressureExceptionOnRetryableError() {
+  void insertRecordReturnsBackpressureOnRetryableError() {
     SnowpipeStreamingPartitionChannel partitionChannel = createPartitionChannel();
     partitionChannel.getChannel();
     assertEquals(1, trackingClientSupplier.getTotalChannelsCreated());
@@ -220,17 +221,11 @@ class SnowpipeStreamingPartitionChannelTest {
     // appendRow will throw MemoryThresholdExceeded (retryable error)
     trackingClientSupplier.setRetryableAppendRowFailures(1);
 
-    // BackpressureException should propagate up (not caught in this layer)
-    // Task 4 will handle it at the batch-level insert() loop
-    BackpressureException exception =
-        assertThrows(
-            BackpressureException.class,
-            () -> partitionChannel.insertRecord(buildValidRecord(0), true));
+    // Returns BACKPRESSURE_TRIGGERED so the batch loop enters cooldown.
+    InsertResult result = partitionChannel.insertRecord(buildValidRecord(0), true);
+    assertEquals(InsertResult.BACKPRESSURE_TRIGGERED, result);
 
-    assertEquals("SDK backpressure: MemoryThresholdExceeded", exception.getMessage());
-
-    // No channel reopening should have happened - the exception signals backpressure, not channel
-    // invalidation
+    // No channel reopening — backpressure signals throttling, not channel invalidation.
     assertEquals(0, trackingClientSupplier.getCloseCallCount());
     assertEquals(1, trackingClientSupplier.getTotalChannelsCreated());
   }


### PR DESCRIPTION
## Summary

Fixes a silent data-loss race in `SnowflakeSinkServiceV2.insert(Collection)` where channel recovery's Kafka seek gets overwritten by the batch loop's end-of-batch rewind. Reproducible on master with `test_invalidation_offset_consistency` once `SYSTEM\$STREAMING_CHANNEL_INVALIDATE` is deployed (Seb's recent finding).

## The race

1. `appendRow` throws `InvalidChannelError` → fallback fires `reopenChannel` → tracker's `resetAfterRecovery(committed)` issues `sinkTaskContext.offset(tp, committed+1)` (**seek #1**).
2. `insertRowWithFallback` returns false → `transformAndSend` returns false → batch loop adds `tp -> failingOffset` to `offsetsOfFirstSkippedRecord`.
3. End of `put()` → `offsetsOfFirstSkippedRecord.forEach(sinkTaskContext::offset)` → `sinkTaskContext.offset(tp, failingOffset)` (**seek #2**).
4. Last writer wins; consumer seeks to `failingOffset`, skipping records `committed+1..failingOffset-1`.

## Fix

- **`InsertResult` enum** replaces `boolean` from `insert`/`insertRecord`. New `RECOVERY_IN_FLIGHT` value tells the batch loop "tracker already issued the authoritative seek; do NOT add this partition to the rewind map."
- **Batch loop** is a single switch on `InsertResult`. `RECOVERY_IN_FLIGHT` and `PROCESSED` land in the no-rewind branch.
- **`insert(record)` rebuild gate** simplified to `existing.isEmpty()`. Master's `isChannelClosed` check would rebuild the partition when `this.channel` completed exceptionally, wiping `PartitionOffsetTracker` recovery state.
- **Max-recoveries exhaustion** throws `ConnectException` (not `TopicPartitionChannelInsertionException`, which `transformAndSend` swallows → silent loss).
- **`BackpressureException`** now caught inside `transformAndSend` and returned as `BACKPRESSURE_TRIGGERED` — flow control out of exception handling.
- **`withDelay`** restructured: native exception propagation instead of re-wrapping in `RuntimeException`.

## Test plan

- [x] Unit tests pass (`SnowflakeSinkServiceV2Test`, `SnowpipeStreamingPartitionChannelTest`).
- [x] Reproduces against `test_invalidation_offset_consistency` once `SYSTEM\$STREAMING_CHANNEL_INVALIDATE` is enabled on the account.
- Stacked above: #1430 (client recreation) + #1432 (mitmproxy E2E).