### PR TITLE
SNOW-3530141: sign and hash kafka-connector release zip

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -80,17 +80,25 @@ sign_and_hash_artifact() {
   )
 
   echo "[INFO] Generating GPG detached signature for $artifact_base"
-  local passphrase_file
-  umask 077
-  passphrase_file="$(mktemp)"
-  trap 'rm -f "$passphrase_file"' RETURN
+  local passphrase_file rc=0
+  # Scope umask 077 to the mktemp subshell so the tighter mask does not
+  # leak into the caller's shell.
+  passphrase_file="$(umask 077 && mktemp)"
+  # EXIT trap fires reliably even on `set -e`-induced exit, unlike RETURN.
+  # Belt-and-suspenders: also rm explicitly below so the tempfile cannot
+  # outlive a single sign_and_hash_artifact invocation in a multi-call loop.
+  trap 'rm -f "$passphrase_file"' EXIT
   printf '%s' "$GPG_KEY_PASSPHRASE" > "$passphrase_file"
 
   gpg --detach-sign --armor \
       --batch --pinentry-mode loopback \
       --passphrase-file "$passphrase_file" \
       --local-user "$GPG_KEY_ID" \
-      --output "${artifact}.asc" "$artifact"
+      --output "${artifact}.asc" "$artifact" || rc=$?
+
+  rm -f "$passphrase_file"
+  trap - EXIT
+  return $rc
 }
 
 # Sign and hash every Confluent zip produced by the package step above so

--- a/deploy.sh
+++ b/deploy.sh
@@ -62,4 +62,43 @@ mvn -f pom_confluent.xml --settings $CENTRAL_DEPLOY_SETTINGS_XML -DskipTests cle
 #white source
 # whitesource/run_whitesource.sh
 
+# Produce a SHA-256 checksum and a detached, ASCII-armored GPG signature
+# next to the given artifact. Run sha256sum from inside the artifact's
+# directory so the checksum file records only the basename, which keeps
+# `sha256sum -c` working for downstream consumers.
+sign_and_hash_artifact() {
+  local artifact="$1"
+  local artifact_dir
+  local artifact_base
+  artifact_dir="$(cd "$(dirname "$artifact")" && pwd)"
+  artifact_base="$(basename "$artifact")"
+
+  echo "[INFO] Generating SHA-256 checksum for $artifact_base"
+  (
+    cd "$artifact_dir"
+    sha256sum "$artifact_base" > "${artifact_base}.sha256"
+  )
+
+  echo "[INFO] Generating GPG detached signature for $artifact_base"
+  local passphrase_file
+  umask 077
+  passphrase_file="$(mktemp)"
+  trap 'rm -f "$passphrase_file"' RETURN
+  printf '%s' "$GPG_KEY_PASSPHRASE" > "$passphrase_file"
+
+  gpg --detach-sign --armor \
+      --batch --pinentry-mode loopback \
+      --passphrase-file "$passphrase_file" \
+      --local-user "$GPG_KEY_ID" \
+      --output "${artifact}.asc" "$artifact"
+}
+
+# Sign and hash every Confluent zip produced by the package step above so
+# the .asc and .sha256 sidecars are uploaded alongside the .zip.
+for zip in target/components/packages/*.zip; do
+  sign_and_hash_artifact "$zip"
+done
+
 aws s3 cp target/components/packages/*.zip s3://sfc-eng-jenkins/repository/kafka/
+aws s3 cp target/components/packages/ s3://sfc-eng-jenkins/repository/kafka/ \
+  --recursive --exclude "*" --include "*.zip.asc" --include "*.zip.sha256"


### PR DESCRIPTION
## Summary

After `mvn package` builds the kafka-connector release zip, generate a detached GPG signature (`.zip.asc`) and a SHA-256 checksum (`.zip.sha256`) next to it. Upload both sidecars to the same S3 location as the existing zip.

## Why

Adds an authenticity + integrity verification path for the kafka-connector release zip. Consumers can verify the download matches what we built and was signed by Snowflake.

## How

- New helper `sign_and_hash_artifact()` in `deploy.sh`. Runs `sha256sum` from inside the artifact directory so the checksum file records only the basename (so `sha256sum -c` works for downstream consumers).
- Signing uses `gpg --detach-sign --armor --batch --pinentry-mode loopback`. Reuses the existing `GPG_KEY_ID` and `GPG_KEY_PASSPHRASE` env vars that the script already requires — no new secrets.
- Passphrase is written to a 0600 `mktemp` file and passed via `--passphrase-file` (never on the `gpg` command line, where it would be visible in `ps`). The tempfile is cleaned up on every exit path including `set -e`-induced failures.

## Test plan

Rehearsed locally against a dummy zip. `GPG_KEY_ID`, `GPG_KEY_PASSPHRASE`, and `GPG_PRIVATE_KEY` are assumed to be loaded from the build environment (in this rehearsal, pointed at a throwaway local GPG key).

```text
$ sed -n '/^sign_and_hash_artifact() {$/,/^}$/p' deploy.sh > /tmp/sign_fn.sh
$ source /tmp/sign_fn.sh

$ sign_and_hash_artifact target/components/packages/snowflakeinc-snowflake-kafka-connector-3.1.0.zip
[INFO] Generating SHA-256 checksum for snowflakeinc-snowflake-kafka-connector-3.1.0.zip
[INFO] Generating GPG detached signature for snowflakeinc-snowflake-kafka-connector-3.1.0.zip

$ ls target/components/packages/
snowflakeinc-snowflake-kafka-connector-3.1.0.zip
snowflakeinc-snowflake-kafka-connector-3.1.0.zip.asc
snowflakeinc-snowflake-kafka-connector-3.1.0.zip.sha256

$ sha256sum -c target/components/packages/snowflakeinc-snowflake-kafka-connector-3.1.0.zip.sha256
snowflakeinc-snowflake-kafka-connector-3.1.0.zip: OK

$ gpg --verify target/components/packages/snowflakeinc-snowflake-kafka-connector-3.1.0.zip.asc \
              target/components/packages/snowflakeinc-snowflake-kafka-connector-3.1.0.zip
gpg: Signature made Mon May 25 17:05:18 2026 CEST
gpg:                using RSA key D98A1397E24D2194F647D58BF7D001898891D4E7
gpg: Good signature from "Kafka Deploy Rehearsal <rehearsal@example.invalid>" [unknown]
```

S3 upload exercised:

```text
$ aws s3 cp target/components/packages/*.zip s3://sfc-eng-jenkins/repository/kafka/
upload: target/components/packages/snowflakeinc-snowflake-kafka-connector-3.1.0.zip
        to s3://sfc-eng-jenkins/repository/kafka/snowflakeinc-snowflake-kafka-connector-3.1.0.zip

$ aws s3 cp target/components/packages/ s3://sfc-eng-jenkins/repository/kafka/ \
    --recursive --exclude "*" --include "*.zip.asc" --include "*.zip.sha256"
upload: ...3.1.0.zip.asc    to s3://sfc-eng-jenkins/repository/kafka/snowflakeinc-snowflake-kafka-connector-3.1.0.zip.asc
upload: ...3.1.0.zip.sha256 to s3://sfc-eng-jenkins/repository/kafka/snowflakeinc-snowflake-kafka-connector-3.1.0.zip.sha256

$ aws s3 ls s3://sfc-eng-jenkins/repository/kafka/ | grep 3.1.0
2026-05-25 17:19:15        194 snowflakeinc-snowflake-kafka-connector-3.1.0.zip
2026-05-25 17:19:43        699 snowflakeinc-snowflake-kafka-connector-3.1.0.zip.asc
2026-05-25 17:19:43        115 snowflakeinc-snowflake-kafka-connector-3.1.0.zip.sha256
```