### PR TITLE
pause initializing and recovering partitions

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -65,8 +65,6 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
   private final SinkTaskConfig taskConfig;
   private final SinkTaskContext sinkTaskContext;
 
-  // Set that keeps track of the channels that have been seen per input batch
-  private final Set<String> channelsVisitedPerBatch = new HashSet<>();
   private final BatchOffsetFetcher batchOffsetFetcher;
 
   private final PartitionChannelManager channelManager;
@@ -302,18 +300,6 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
     }
   }
 
-  private Set<TopicPartition> currentlyInitializing(Collection<TopicPartition> partitions) {
-    return partitions.stream()
-        .filter(
-            tp -> {
-              return channelManager
-                  .getChannel(tp)
-                  .map(TopicPartitionChannel::isInitializing)
-                  .orElse(false);
-            })
-        .collect(Collectors.toSet());
-  }
-
   /**
    * @param records records coming from Kafka. Please note, they are not just from single topic and
    *     partition. It depends on the kafka connect worker node which can consume from multiple
@@ -321,67 +307,73 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
    */
   @Override
   public void insert(final Collection<SinkRecord> records) {
-    channelsVisitedPerBatch.clear();
+    // Resume partitions whose channels have finished initialization or recovery on the IO thread.
+    // This issues the Kafka seek and resume on the task thread, which is the only thread allowed
+    // to call SinkTaskContext methods.
+    channelManager.resumeReadyPartitions();
 
-    // Skip partitions for which the partition-channel bridge is currently being initialized.
-    Set<TopicPartition> partitions =
-        records.stream()
-            .map(record -> new TopicPartition(record.topic(), record.kafkaPartition()))
-            .collect(Collectors.toSet());
+    // Partitions to skip for the remainder of this batch. This is a batch-local set — it does NOT
+    // trigger a Kafka rewind, because paused partitions already have an authoritative seek set by
+    // the onChannelReady callback via resumeReadyPartitions().
+    Set<TopicPartition> partitionsToSkipInBatch = new HashSet<>();
 
-    Set<TopicPartition> initializingPartitions = currentlyInitializing(partitions);
-    if (!initializingPartitions.isEmpty()) {
-      LOGGER.debug(
-          "Skipping put for {}/{} partitions that are currently being initialized: {}",
-          initializingPartitions.size(),
-          partitions.size(),
-          initializingPartitions);
-    }
+    // Backpressure handling: rewind offsets are tracked separately because backpressured partitions
+    // are not paused — they need an explicit rewind to re-deliver the skipped records.
+    Map<TopicPartition, Long> backpressureRewindOffsets = new HashMap<>();
+    boolean newBackpressure = false;
 
     // If still in cooldown from a recent backpressure event, treat all partitions as
     // backpressured so we skip the entire batch and give the SDK time to drain.
-    boolean skipAllPartitions = false;
+    boolean skipAllForBackpressure = false;
     if (Instant.now().isBefore(backpressureUntil)) {
       LOGGER.debug(
           "Backpressure cooldown active until {}. Skipping entire batch.", backpressureUntil);
-      skipAllPartitions = true;
+      skipAllForBackpressure = true;
     }
 
-    Map<TopicPartition, Long> offsetsOfFirstSkippedRecord = new HashMap<>();
-    boolean newBackpressure = false;
     for (SinkRecord record : records) {
-      // check if it needs to handle null value records
       if (shouldSkipNullValue(record)) {
         continue;
       }
 
       TopicPartition tp = new TopicPartition(record.topic(), record.kafkaPartition());
 
-      if (offsetsOfFirstSkippedRecord.containsKey(tp)) {
-        // We've already skipped a record in this partition, so should also skip the remaining
-        // records in this partition.
+      if (partitionsToSkipInBatch.contains(tp)) {
         continue;
       }
-      if (skipAllPartitions || initializingPartitions.contains(tp)) {
-        // Make sure we store the first record in each partition that we skipped so we can correctly
-        // rewind the offset.
-        offsetsOfFirstSkippedRecord.putIfAbsent(tp, record.kafkaOffset());
+
+      // Paused partitions (initializing or recovering) — skip without rewind. The onChannelReady
+      // callback will set the authoritative seek when the channel is ready.
+      if (channelManager.isPaused(tp)) {
+        partitionsToSkipInBatch.add(tp);
+        continue;
+      }
+
+      // Backpressure cooldown — skip with rewind so records are re-delivered after cooldown.
+      if (skipAllForBackpressure) {
+        backpressureRewindOffsets.putIfAbsent(tp, record.kafkaOffset());
+        partitionsToSkipInBatch.add(tp);
         continue;
       }
 
       try {
         if (!insert(record)) {
-          offsetsOfFirstSkippedRecord.putIfAbsent(tp, record.kafkaOffset());
+          // Recovery triggered — the channel is being reopened. Pause the partition so the
+          // consumer stops delivering remaining records in this batch. The onChannelReady callback
+          // populates partitionsReadyToResume, and the next resumeReadyPartitions() call will
+          // seek + resume on the task thread.
+          channelManager.pausePartition(tp);
+          partitionsToSkipInBatch.add(tp);
         }
       } catch (BackpressureException e) {
         LOGGER.warn(
-            "Backpressure on partition {}. Skipping remaining records for this partition."
-                + " Exception: {}",
+            "Backpressure on partition {}. Skipping remaining records. Exception: {}",
             tp,
             e.getMessage());
         taskMetrics.incBackpressureRewindCount();
-        offsetsOfFirstSkippedRecord.putIfAbsent(tp, record.kafkaOffset());
-        skipAllPartitions = true;
+        backpressureRewindOffsets.putIfAbsent(tp, record.kafkaOffset());
+        partitionsToSkipInBatch.add(tp);
+        skipAllForBackpressure = true;
         newBackpressure = true;
       }
     }
@@ -391,15 +383,15 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
       LOGGER.info("Backpressure cooldown set until {}", backpressureUntil);
     }
 
-    if (!offsetsOfFirstSkippedRecord.isEmpty()) {
-      LOGGER.info("Rewinding offsets for skipped partitions: {}", offsetsOfFirstSkippedRecord);
-      offsetsOfFirstSkippedRecord.forEach(sinkTaskContext::offset);
+    if (!backpressureRewindOffsets.isEmpty()) {
+      LOGGER.info("Rewinding offsets for backpressured partitions: {}", backpressureRewindOffsets);
+      backpressureRewindOffsets.forEach(sinkTaskContext::offset);
     }
   }
 
   /**
-   * Inserts individual records into buffer. It fetches the TopicPartitionChannel from the map and
-   * then each partition(Streaming channel) calls its respective appendRows API
+   * Inserts a single record. Fetches the channel (creating one on first contact) and delegates to
+   * {@link TopicPartitionChannel#insertRecord}.
    */
   @Override
   public boolean insert(SinkRecord record) {
@@ -407,13 +399,13 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
 
     TopicPartition topicPartition = new TopicPartition(record.topic(), record.kafkaPartition());
 
-    // Initialize a new topic partition if it's not in the cache or if the channel is closed.
-    if (channelManager
-        .getChannel(topicPartition)
-        .map(TopicPartitionChannel::isChannelClosed)
-        .orElse(true)) {
-      LOGGER.warn("Streaming channel doesn't exist or is closed for {}", topicPartition);
+    // Initialize a new topic partition if it's not in the channel manager.
+    if (channelManager.getChannel(topicPartition).isEmpty()) {
+      LOGGER.warn("Streaming channel missing for {}, creating", topicPartition);
       startPartition(topicPartition);
+      // startPartition pauses the partition and the async init will resume it via onChannelReady.
+      // Signal to the caller that this record was not processed.
+      return false;
     }
 
     TopicPartitionChannel channel =
@@ -424,8 +416,7 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
                     new IllegalStateException(
                         "Channel for " + topicPartition + " not found after startPartition"));
 
-    boolean isFirstRowPerPartitionInBatch = channelsVisitedPerBatch.add(channel.getChannelName());
-    return channel.insertRecord(record, isFirstRowPerPartitionInBatch);
+    return channel.insertRecord(record);
   }
 
   private boolean shouldSkipNullValue(SinkRecord record) {
@@ -453,20 +444,19 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
   public Map<TopicPartition, Long> getCommittedOffsets(
       final Collection<TopicPartition> partitions) {
 
-    // Skip partitions for which the partition-channel bridge is currently being initialized.
-    Set<TopicPartition> initializingPartitions = currentlyInitializing(partitions);
-    if (!initializingPartitions.isEmpty()) {
+    // Skip paused partitions (initializing, recovering) — they don't have stable offsets yet.
+    Set<TopicPartition> currentlyPaused =
+        partitions.stream().filter(channelManager::isPaused).collect(Collectors.toSet());
+    if (!currentlyPaused.isEmpty()) {
       LOGGER.info(
-          "Skipping preCommit for {}/{} partitions that are currently being initialized: {}",
-          initializingPartitions.size(),
+          "Skipping preCommit for {}/{} paused partitions: {}",
+          currentlyPaused.size(),
           partitions.size(),
-          initializingPartitions);
+          currentlyPaused);
     }
 
     Set<TopicPartition> partitionsToFetchOffsetsFor =
-        partitions.stream()
-            .filter(tp -> !initializingPartitions.contains(tp))
-            .collect(Collectors.toSet());
+        partitions.stream().filter(tp -> !currentlyPaused.contains(tp)).collect(Collectors.toSet());
 
     return batchOffsetFetcher.getCommittedOffsets(
         partitionsToFetchOffsetsFor, channelManager::getChannel);

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -444,6 +444,9 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
   public Map<TopicPartition, Long> getCommittedOffsets(
       final Collection<TopicPartition> partitions) {
 
+    // Resume any partitions that have completed initialization or recovery since the last call.
+    channelManager.resumeReadyPartitions();
+
     // Skip paused partitions (initializing, recovering) — they don't have stable offsets yet.
     Set<TopicPartition> currentlyPaused =
         partitions.stream().filter(channelManager::isPaused).collect(Collectors.toSet());
@@ -526,10 +529,11 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
     return metricsJmxReporter.map(MetricsJmxReporter::getMetricRegistry);
   }
 
-  /** Blocks until all partition channels have finished initialization. */
+  /** Blocks until all partition channels have finished initialization, then resumes them. */
   @Override
   public void awaitInitialization() {
     channelManager.awaitAllPartitions();
+    channelManager.resumeReadyPartitions();
   }
 
   @VisibleForTesting

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/channel/TopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/channel/TopicPartitionChannel.java
@@ -11,22 +11,17 @@ public interface TopicPartitionChannel {
   long NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE = -1L;
 
   /**
-   * Inserts the record into buffer
+   * Inserts the record into buffer.
    *
-   * <p>Step 1: Initializes this channel by fetching the offsetToken from Snowflake for the first
-   * time this channel/partition has received offset after start/restart.
-   *
-   * <p>Step 2: Decides whether given offset from Kafka needs to be processed and whether it
-   * qualifies for being added into buffer.
+   * <p>Decides whether the given offset from Kafka needs to be processed and whether it qualifies
+   * for being added into the streaming channel.
    *
    * @param kafkaSinkRecord input record from Kafka
-   * @param isFirstRowPerPartitionInBatch indicates whether the given record is the first record per
-   *     partition in a batch
    * @return true if the record was processed (or legitimately skipped as a duplicate), false if
    *     recovery was triggered and the caller should stop feeding records to this partition for the
    *     remainder of the batch
    */
-  boolean insertRecord(SinkRecord kafkaSinkRecord, boolean isFirstRowPerPartitionInBatch);
+  boolean insertRecord(SinkRecord kafkaSinkRecord);
 
   /**
    * Asynchronously closes a channel associated to this partition. Any {@link SFException} occurred

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannel.java
@@ -47,6 +47,7 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.sink.SinkRecord;
@@ -107,6 +108,13 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
   private volatile Map<String, ColumnSchema> tableSchema;
   private final boolean shouldEvolveSchema;
 
+  /**
+   * Called on the IO thread when channel initialization or recovery completes. The consumer is
+   * responsible for issuing the Kafka seek and resume on the task thread. The argument is the Kafka
+   * offset to seek to (or {@link #NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE} if no seek is needed).
+   */
+  private final Consumer<Long> onChannelReady;
+
   public SnowpipeStreamingPartitionChannel(
       String tableName,
       String channelName,
@@ -121,7 +129,8 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
       TaskMetrics taskMetrics,
       boolean shouldEvolveSchema,
       SnowflakeConnectionService conn,
-      Optional<String> ssv1ChannelName) {
+      Optional<String> ssv1ChannelName,
+      Consumer<Long> onChannelReady) {
     this.channelName = channelName;
     this.pipeName = pipeName;
     this.streamingClient = streamingClient;
@@ -136,6 +145,7 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
     this.conn = conn;
     this.tableName = tableName;
     this.ssv1ChannelName = ssv1ChannelName;
+    this.onChannelReady = onChannelReady;
 
     LOGGER.info(
         "Initializing SnowpipeStreamingPartitionChannel channel: {}, pipe: {}",
@@ -144,13 +154,26 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
 
     this.channel =
         CompletableFuture.supplyAsync(
-            () -> {
-              OpenChannelResult openChannelResult = openChannelForTable(channelName);
-              long offsetRecoveredFromSnowflake = parseOrMigrateOffsetToken(openChannelResult);
-              offsetTracker.initializeFromSnowflake(offsetRecoveredFromSnowflake);
-              return openChannelResult.getChannel();
-            },
-            openChannelIoExecutor);
+                () -> {
+                  OpenChannelResult openChannelResult = openChannelForTable(channelName);
+                  long offsetRecoveredFromSnowflake = parseOrMigrateOffsetToken(openChannelResult);
+                  long resumeOffset =
+                      offsetTracker.initializeFromSnowflake(offsetRecoveredFromSnowflake);
+                  onChannelReady.accept(resumeOffset);
+                  return openChannelResult.getChannel();
+                },
+                openChannelIoExecutor)
+            .whenComplete(
+                (channel, failure) -> {
+                  if (failure != null) {
+                    LOGGER.error(
+                        "Channel {} initialization failed, unpausing partition so the circuit"
+                            + " breaker can fire: {}",
+                        channelName,
+                        failure.getMessage());
+                    onChannelReady.accept(NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE);
+                  }
+                });
 
     if (taskConfig.getValidation() == SnowflakeValidation.CLIENT_SIDE) {
       initializeValidation();
@@ -163,8 +186,8 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
   }
 
   @Override
-  public boolean insertRecord(SinkRecord kafkaSinkRecord, boolean isFirstRowPerPartitionInBatch) {
-    if (offsetTracker.shouldProcess(kafkaSinkRecord.kafkaOffset(), isFirstRowPerPartitionInBatch)) {
+  public boolean insertRecord(SinkRecord kafkaSinkRecord) {
+    if (offsetTracker.shouldProcess(kafkaSinkRecord.kafkaOffset())) {
       return transformAndSend(kafkaSinkRecord);
     }
     return true;
@@ -389,7 +412,9 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
                         offsetTracker.consumerGroupOffsetRef().get());
                   }
 
-                  offsetTracker.resetAfterRecovery(offsetRecoveredFromSnowflake);
+                  long resumeOffset =
+                      offsetTracker.resetAfterRecovery(offsetRecoveredFromSnowflake);
+                  onChannelReady.accept(resumeOffset);
 
                   LOGGER.info(
                       "{} Channel {} recovery complete, offsetRecoveredFromSnowflake={}",
@@ -398,6 +423,18 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
                       offsetRecoveredFromSnowflake);
 
                   return openChannelResult.getChannel();
+                })
+            .whenComplete(
+                (channel, failure) -> {
+                  if (failure != null) {
+                    LOGGER.error(
+                        "{} Channel {} recovery failed, unpausing partition so the circuit"
+                            + " breaker can fire: {}",
+                        reason,
+                        this.channelName,
+                        failure.getMessage());
+                    onChannelReady.accept(NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE);
+                  }
                 });
   }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/channel/PartitionOffsetTracker.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/channel/PartitionOffsetTracker.java
@@ -4,13 +4,11 @@ import static com.snowflake.kafka.connector.internal.streaming.channel.TopicPart
 
 import com.snowflake.kafka.connector.internal.KCLogger;
 import java.util.concurrent.atomic.AtomicLong;
-import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.connect.sink.SinkTaskContext;
 
 /**
  * Tracks all offset state for a single partition channel. This is a passive state holder -- it
- * makes no network calls. Offsets are updated during channel init/recovery, record processing in
- * `put`, and when processing channel statuses in `preCommit`.
+ * makes no network calls and no Kafka consumer calls. Offsets are updated during channel
+ * init/recovery, record processing in `put`, and when processing channel statuses in `preCommit`.
  *
  * <h3>Threading model</h3>
  *
@@ -22,15 +20,19 @@ import org.apache.kafka.connect.sink.SinkTaskContext;
  * set-if-greater logic uses a CAS loop for atomicity. The three AtomicLong fields use atomic types
  * for two reasons: (1) their refs are exposed for telemetry reads from other threads, and (2)
  * {@code currentConsumerGroupOffset} is written by both the task thread and {@link
- * #setLatestConsumerGroupOffset}. The remaining fields ({@code lastAppendRowsOffset}, {@code
- * needToSkipCurrentBatch}) are only accessed from the task thread and need no synchronization.
+ * #setLatestConsumerGroupOffset}.
+ *
+ * <h3>Kafka consumer interaction</h3>
+ *
+ * This class does NOT call {@code SinkTaskContext.offset()} or any other Kafka consumer API.
+ * Callers (via the {@code onChannelReady} callback in {@link
+ * com.snowflake.kafka.connector.internal.streaming.v2.SnowpipeStreamingPartitionChannel}) are
+ * responsible for issuing the Kafka seek and resume on the task thread.
  */
 public class PartitionOffsetTracker {
 
   private static final KCLogger LOGGER = new KCLogger(PartitionOffsetTracker.class.getName());
 
-  private final TopicPartition topicPartition;
-  private final SinkTaskContext sinkTaskContext;
   private final String channelName;
 
   // Offset persisted in Snowflake, determined from the insertRows API / fetchOffsetToken calls.
@@ -50,19 +52,18 @@ public class PartitionOffsetTracker {
   // Last offset passed to appendRow -- used by flush to know when all data is committed.
   private long lastAppendRowsOffset = NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE;
 
-  // When true, leftover rows in the current batch are skipped because the channel was
-  // invalidated and offsets were reset in Kafka.
-  private boolean needToSkipCurrentBatch = false;
-
-  public PartitionOffsetTracker(
-      TopicPartition topicPartition, SinkTaskContext sinkTaskContext, String channelName) {
-    this.topicPartition = topicPartition;
-    this.sinkTaskContext = sinkTaskContext;
+  public PartitionOffsetTracker(String channelName) {
     this.channelName = channelName;
   }
 
-  /** Sets both persisted and processed offsets, and resets the Kafka consumer position. */
-  public void initializeFromSnowflake(long committedOffset) {
+  /**
+   * Sets both persisted and processed offsets from the initial channel open.
+   *
+   * @return the Kafka offset to seek to (committedOffset + 1), or {@link
+   *     #NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE} if there is no committed offset and the caller
+   *     should rely on Kafka's consumer group offset
+   */
+  public long initializeFromSnowflake(long committedOffset) {
     LOGGER.info(
         "Initializing offsetPersistedInSnowflake=[{}], channel=[{}]", committedOffset, channelName);
     this.offsetPersistedInSnowflake.set(committedOffset);
@@ -70,33 +71,27 @@ public class PartitionOffsetTracker {
     LOGGER.info("Initializing processedOffset=[{}], channel=[{}]", committedOffset, channelName);
     this.processedOffset.set(committedOffset);
 
-    resetKafkaOffset(committedOffset);
+    if (committedOffset != NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE) {
+      return committedOffset + 1L;
+    } else {
+      LOGGER.info(
+          "TopicPartitionChannel:{}, offset token is NULL, will rely on Kafka to send us the"
+              + " correct offset instead",
+          channelName);
+      return NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE;
+    }
   }
 
   /**
-   * Determines whether the given kafka offset should be processed, and manages batch-skip state.
+   * Determines whether the given kafka offset should be processed.
    *
-   * @return true if the record should be ingested, false if it should be skipped
+   * @return true if the record should be ingested, false if it should be skipped (duplicate)
    */
-  public boolean shouldProcess(long kafkaOffset, boolean isFirstRowInBatch) {
+  public boolean shouldProcess(long kafkaOffset) {
     if (currentConsumerGroupOffset.compareAndSet(
         NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE, kafkaOffset)) {
       LOGGER.trace(
           "Setting currentConsumerGroupOffset=[{}], channel=[{}]", kafkaOffset, channelName);
-    }
-
-    if (isFirstRowInBatch) {
-      needToSkipCurrentBatch = false;
-    }
-
-    if (needToSkipCurrentBatch) {
-      LOGGER.info(
-          "Ignore inserting offset:{} for channel:{} because we recently reset offset in"
-              + " Kafka. currentProcessedOffset:{}",
-          kafkaOffset,
-          channelName,
-          processedOffset.get());
-      return false;
     }
 
     long currentProcessedOffset = this.processedOffset.get();
@@ -127,8 +122,7 @@ public class PartitionOffsetTracker {
   }
 
   /**
-   * Resets offset state after a channel recovery (reopen). Resets the Kafka consumer position and
-   * marks the current batch for skipping so leftover rows are discarded.
+   * Resets offset state after a channel recovery (reopen).
    *
    * <p>If we don't get a valid offset token (because of a table recreation or channel inactivity),
    * we will rely on Kafka to send us the correct offset.
@@ -137,19 +131,15 @@ public class PartitionOffsetTracker {
    * offsets starting from the next unprocessed record, avoiding data loss.
    *
    * @param offsetRecoveredFromSnowflake the offset recovered from Snowflake after reopening
+   * @return the Kafka offset to seek to, or {@link #NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE} if
+   *     there is nothing to seek to
    */
-  public void resetAfterRecovery(long offsetRecoveredFromSnowflake) {
+  public long resetAfterRecovery(long offsetRecoveredFromSnowflake) {
     long consumerGroupOffset = currentConsumerGroupOffset.get();
     final long offsetToResetInKafka =
         offsetRecoveredFromSnowflake == NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE
             ? consumerGroupOffset
             : offsetRecoveredFromSnowflake + 1L;
-
-    if (offsetToResetInKafka == NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE) {
-      return;
-    }
-
-    sinkTaskContext.offset(topicPartition, offsetToResetInKafka);
 
     this.offsetPersistedInSnowflake.set(offsetRecoveredFromSnowflake);
     LOGGER.info(
@@ -158,7 +148,7 @@ public class PartitionOffsetTracker {
         channelName);
     this.processedOffset.set(offsetRecoveredFromSnowflake);
 
-    needToSkipCurrentBatch = true;
+    return offsetToResetInKafka;
   }
 
   public void setLatestConsumerGroupOffset(long consumerOffset) {
@@ -207,16 +197,5 @@ public class PartitionOffsetTracker {
 
   public AtomicLong consumerGroupOffsetRef() {
     return currentConsumerGroupOffset;
-  }
-
-  private void resetKafkaOffset(long committedOffset) {
-    if (committedOffset != NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE) {
-      sinkTaskContext.offset(topicPartition, committedOffset + 1L);
-    } else {
-      LOGGER.info(
-          "TopicPartitionChannel:{}, offset token is NULL, will rely on Kafka to send us the"
-              + " correct offset instead",
-          channelName);
-    }
   }
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/service/PartitionChannelManager.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/service/PartitionChannelManager.java
@@ -20,8 +20,10 @@ import com.snowflake.kafka.connector.internal.streaming.v2.client.StreamingClien
 import com.snowflake.kafka.connector.internal.streaming.v2.migration.Ssv1MigrationMode;
 import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryService;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
@@ -61,6 +63,23 @@ public class PartitionChannelManager {
   private final Map<String, TopicPartitionChannel> partitionChannels;
   private final Map<String, Boolean> shouldEvolveSchemaCache = new ConcurrentHashMap<>();
 
+  /**
+   * Partitions that have completed channel initialization or recovery on the IO thread and are
+   * ready to be resumed on the task thread. Keyed by TopicPartition, value is the Kafka offset to
+   * seek to (or {@link TopicPartitionChannel#NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE} if no seek is
+   * needed). Written by the IO thread (via the {@code onChannelReady} callback passed to each
+   * channel), drained by the task thread via {@link #resumeReadyPartitions()}.
+   */
+  private final ConcurrentHashMap<TopicPartition, Long> partitionsReadyToResume =
+      new ConcurrentHashMap<>();
+
+  /**
+   * Partitions currently paused via {@code sinkTaskContext.pause()}. Includes partitions that are
+   * initializing or recovering. Tracked explicitly because {@code SinkTaskContext} does not expose
+   * its paused set in the public API.
+   */
+  @VisibleForTesting final Set<TopicPartition> pausedPartitions = ConcurrentHashMap.newKeySet();
+
   public PartitionChannelManager(
       SnowflakeTelemetryService telemetryService,
       SinkTaskConfig taskConfig,
@@ -82,13 +101,15 @@ public class PartitionChannelManager {
 
   @VisibleForTesting
   PartitionChannelManager(
-      SinkTaskConfig taskConfig, PartitionChannelBuilder partitionChannelBuilder) {
+      SinkTaskConfig taskConfig,
+      SinkTaskContext sinkTaskContext,
+      PartitionChannelBuilder partitionChannelBuilder) {
     this.taskConfig = taskConfig;
+    this.sinkTaskContext = sinkTaskContext;
     this.partitionChannelBuilder = partitionChannelBuilder;
     this.partitionChannels = new ConcurrentHashMap<>();
     this.telemetryService = null;
     this.kafkaRecordErrorReporter = null;
-    this.sinkTaskContext = null;
     this.metricsJmxReporter = Optional.empty();
     this.taskMetrics = null;
     this.conn = null;
@@ -127,6 +148,14 @@ public class PartitionChannelManager {
         taskConfig.getConnectorName(),
         taskConfig.getTaskId());
 
+    // Pause all partitions before starting channels. The async channel initialization will
+    // signal readiness via partitionsReadyToResume, and the task thread will seek + resume
+    // in the next resumeReadyPartitions() call.
+    for (TopicPartition tp : partitions) {
+      sinkTaskContext.pause(tp);
+      pausedPartitions.add(tp);
+    }
+
     warmUpStreamingClients(tableToPipeMapping);
 
     for (TopicPartition topicPartition : partitions) {
@@ -164,8 +193,7 @@ public class PartitionChannelManager {
             taskConfig,
             streamingClientProperties,
             taskMetrics);
-    final PartitionOffsetTracker offsetTracker =
-        new PartitionOffsetTracker(topicPartition, this.sinkTaskContext, channelName);
+    final PartitionOffsetTracker offsetTracker = new PartitionOffsetTracker(channelName);
 
     final SnowflakeTelemetryChannelStatus telemetryChannelStatus =
         new SnowflakeTelemetryChannelStatus(
@@ -217,7 +245,8 @@ public class PartitionChannelManager {
         this.taskMetrics,
         shouldEvolveSchema,
         this.conn,
-        ssv1ChannelName);
+        ssv1ChannelName,
+        offset -> partitionsReadyToResume.put(topicPartition, offset));
   }
 
   /**
@@ -316,6 +345,12 @@ public class PartitionChannelManager {
         taskConfig.getConnectorName(),
         taskConfig.getTaskId());
 
+    partitions.forEach(
+        tp -> {
+          partitionsReadyToResume.remove(tp);
+          pausedPartitions.remove(tp);
+        });
+
     CompletableFuture<?>[] futures =
         partitions.stream()
             .map(this::getChannel)
@@ -334,6 +369,56 @@ public class PartitionChannelManager {
         partitions.size(),
         partitionChannels.size(),
         partitionChannels.keySet().toString());
+  }
+
+  /**
+   * Drains all partitions that have completed initialization or recovery on the IO thread, issuing
+   * the Kafka seek and resume for each. Must be called on the task thread (the same thread that
+   * calls {@code SinkTaskContext} methods).
+   */
+  public void resumeReadyPartitions() {
+    if (partitionsReadyToResume.isEmpty()) {
+      return;
+    }
+    Map<TopicPartition, Long> drained = new HashMap<>();
+    partitionsReadyToResume
+        .keySet()
+        .forEach(
+            tp -> {
+              Long offset = partitionsReadyToResume.remove(tp);
+              if (offset != null) {
+                drained.put(tp, offset);
+              }
+            });
+
+    for (Map.Entry<TopicPartition, Long> entry : drained.entrySet()) {
+      TopicPartition topicPartition = entry.getKey();
+      long resumeOffset = entry.getValue();
+
+      if (resumeOffset != TopicPartitionChannel.NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE) {
+        LOGGER.info("Seeking {} to offset {} before resuming", topicPartition, resumeOffset);
+        sinkTaskContext.offset(topicPartition, resumeOffset);
+      }
+
+      sinkTaskContext.resume(topicPartition);
+      pausedPartitions.remove(topicPartition);
+
+      LOGGER.info("Resumed partition {}", topicPartition);
+    }
+  }
+
+  /**
+   * Pauses a partition via the Kafka Connect {@code SinkTaskContext}. The consumer will stop
+   * delivering records for this partition until it is resumed. Must be called on the task thread.
+   */
+  public void pausePartition(TopicPartition topicPartition) {
+    sinkTaskContext.pause(topicPartition);
+    pausedPartitions.add(topicPartition);
+  }
+
+  /** Returns {@code true} if the given partition is currently paused. */
+  public boolean isPaused(TopicPartition topicPartition) {
+    return pausedPartitions.contains(topicPartition);
   }
 
   /** Returns the channel for the given name, or empty if not found. */

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2Test.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2Test.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -82,26 +81,28 @@ class SnowflakeSinkServiceV2Test {
   @Test
   void insertSkipsRecordsForInitializingPartitions() {
     TopicPartition tp = new TopicPartition(TOPIC, 0);
-    TopicPartitionChannel channel = mockChannel("ch_0", true);
+    TopicPartitionChannel channel = mockChannel("ch_0");
     when(mockChannelManager.getChannel(tp)).thenReturn(Optional.of(channel));
+    when(mockChannelManager.isPaused(tp)).thenReturn(true);
 
     SinkRecord record = recordFor(TOPIC, 0, 10);
     service.insert(Collections.singletonList(record));
 
-    verify(channel, never()).insertRecord(any(), anyBoolean());
-    verify(mockSinkTaskContext).offset(tp, 10);
+    verify(channel, never()).insertRecord(any());
+    // Paused partitions don't rewind — the onChannelReady callback sets the authoritative seek
+    verify(mockSinkTaskContext, never()).offset(any(TopicPartition.class), any(Long.class));
   }
 
   @Test
   void insertProcessesRecordsForReadyPartitions() {
     TopicPartition tp = new TopicPartition(TOPIC, 0);
-    TopicPartitionChannel channel = mockChannel("ch_0", false);
+    TopicPartitionChannel channel = mockChannel("ch_0");
     when(mockChannelManager.getChannel(tp)).thenReturn(Optional.of(channel));
 
     SinkRecord record = recordFor(TOPIC, 0, 5);
     service.insert(Collections.singletonList(record));
 
-    verify(channel).insertRecord(record, true);
+    verify(channel).insertRecord(record);
     verify(mockSinkTaskContext, never()).offset(any(TopicPartition.class), any(Long.class));
   }
 
@@ -110,36 +111,38 @@ class SnowflakeSinkServiceV2Test {
     TopicPartition tpInit = new TopicPartition(TOPIC, 0);
     TopicPartition tpReady = new TopicPartition(TOPIC, 1);
 
-    TopicPartitionChannel initChannel = mockChannel("ch_0", true);
-    TopicPartitionChannel readyChannel = mockChannel("ch_1", false);
+    TopicPartitionChannel initChannel = mockChannel("ch_0");
+    TopicPartitionChannel readyChannel = mockChannel("ch_1");
 
     when(mockChannelManager.getChannel(tpInit)).thenReturn(Optional.of(initChannel));
     when(mockChannelManager.getChannel(tpReady)).thenReturn(Optional.of(readyChannel));
+    when(mockChannelManager.isPaused(tpInit)).thenReturn(true);
 
     List<SinkRecord> records = Arrays.asList(recordFor(TOPIC, 0, 100), recordFor(TOPIC, 1, 200));
 
     service.insert(records);
 
-    verify(initChannel, never()).insertRecord(any(), anyBoolean());
-    verify(readyChannel).insertRecord(records.get(1), true);
-    verify(mockSinkTaskContext).offset(tpInit, 100);
-    verify(mockSinkTaskContext, never()).offset(tpReady, 200);
+    verify(initChannel, never()).insertRecord(any());
+    verify(readyChannel).insertRecord(records.get(1));
+    // Paused partitions don't rewind
+    verify(mockSinkTaskContext, never()).offset(any(TopicPartition.class), any(Long.class));
   }
 
   @Test
   void insertResetsToFirstSkippedOffset() {
     TopicPartition tp = new TopicPartition(TOPIC, 0);
-    TopicPartitionChannel channel = mockChannel("ch_0", true);
+    TopicPartitionChannel channel = mockChannel("ch_0");
     when(mockChannelManager.getChannel(tp)).thenReturn(Optional.of(channel));
+    when(mockChannelManager.isPaused(tp)).thenReturn(true);
 
     List<SinkRecord> records =
         Arrays.asList(recordFor(TOPIC, 0, 5), recordFor(TOPIC, 0, 6), recordFor(TOPIC, 0, 7));
 
     service.insert(records);
 
-    verify(mockSinkTaskContext).offset(tp, 5);
-    verify(mockSinkTaskContext, never()).offset(tp, 6);
-    verify(mockSinkTaskContext, never()).offset(tp, 7);
+    verify(channel, never()).insertRecord(any());
+    // Paused partitions don't rewind
+    verify(mockSinkTaskContext, never()).offset(any(TopicPartition.class), any(Long.class));
   }
 
   // --- getCommittedOffsets() skip logic ---
@@ -150,11 +153,12 @@ class SnowflakeSinkServiceV2Test {
     TopicPartition tpInit = new TopicPartition(TOPIC, 0);
     TopicPartition tpReady = new TopicPartition(TOPIC, 1);
 
-    TopicPartitionChannel initChannel = mockChannel("ch_0", true);
-    TopicPartitionChannel readyChannel = mockChannel("ch_1", false);
+    TopicPartitionChannel initChannel = mockChannel("ch_0");
+    TopicPartitionChannel readyChannel = mockChannel("ch_1");
 
     when(mockChannelManager.getChannel(tpInit)).thenReturn(Optional.of(initChannel));
     when(mockChannelManager.getChannel(tpReady)).thenReturn(Optional.of(readyChannel));
+    when(mockChannelManager.isPaused(tpInit)).thenReturn(true);
 
     Map<TopicPartition, Long> expectedOffsets = new HashMap<>();
     expectedOffsets.put(tpReady, 42L);
@@ -179,10 +183,12 @@ class SnowflakeSinkServiceV2Test {
     TopicPartition tp0 = new TopicPartition(TOPIC, 0);
     TopicPartition tp1 = new TopicPartition(TOPIC, 1);
 
-    TopicPartitionChannel ch0 = mockChannel("ch_0", true);
-    TopicPartitionChannel ch1 = mockChannel("ch_1", true);
+    TopicPartitionChannel ch0 = mockChannel("ch_0");
+    TopicPartitionChannel ch1 = mockChannel("ch_1");
     when(mockChannelManager.getChannel(tp0)).thenReturn(Optional.of(ch0));
     when(mockChannelManager.getChannel(tp1)).thenReturn(Optional.of(ch1));
+    when(mockChannelManager.isPaused(tp0)).thenReturn(true);
+    when(mockChannelManager.isPaused(tp1)).thenReturn(true);
 
     when(mockBatchOffsetFetcher.getCommittedOffsets(any(), any(Function.class)))
         .thenReturn(Collections.emptyMap());
@@ -202,23 +208,23 @@ class SnowflakeSinkServiceV2Test {
   @Test
   void insertProcessesRecordsAfterChannelTransitionsFromInitializingToReady() {
     TopicPartition tp = new TopicPartition(TOPIC, 0);
-    TopicPartitionChannel channel = mockChannel("ch_0", true);
+    TopicPartitionChannel channel = mockChannel("ch_0");
     when(mockChannelManager.getChannel(tp)).thenReturn(Optional.of(channel));
+    when(mockChannelManager.isPaused(tp)).thenReturn(true);
 
     SinkRecord record1 = recordFor(TOPIC, 0, 10);
     service.insert(Collections.singletonList(record1));
 
-    verify(channel, never()).insertRecord(any(), anyBoolean());
-    verify(mockSinkTaskContext).offset(tp, 10);
+    verify(channel, never()).insertRecord(any());
 
-    // Channel finishes initializing — Kafka re-delivers from the rewound offset
-    when(channel.isInitializing()).thenReturn(false);
+    // Simulate resume — partition is no longer paused (onChannelReady has been called)
+    when(mockChannelManager.isPaused(tp)).thenReturn(false);
 
     SinkRecord record2 = recordFor(TOPIC, 0, 11);
     service.insert(List.of(record1, record2));
 
-    verify(channel).insertRecord(record1, true);
-    verify(channel).insertRecord(record2, false);
+    verify(channel).insertRecord(record1);
+    verify(channel).insertRecord(record2);
   }
 
   // --- startPartitions() pipe resolution (FR5) ---
@@ -286,8 +292,8 @@ class SnowflakeSinkServiceV2Test {
     TopicPartition tp0 = new TopicPartition(TOPIC, 0);
     TopicPartition tp1 = new TopicPartition(TOPIC, 1);
 
-    TopicPartitionChannel channel0 = mockChannel("ch_0", false);
-    TopicPartitionChannel channel1 = mockChannel("ch_1", false);
+    TopicPartitionChannel channel0 = mockChannel("ch_0");
+    TopicPartitionChannel channel1 = mockChannel("ch_1");
 
     when(mockChannelManager.getChannel(tp0)).thenReturn(Optional.of(channel0));
     when(mockChannelManager.getChannel(tp1)).thenReturn(Optional.of(channel1));
@@ -297,14 +303,14 @@ class SnowflakeSinkServiceV2Test {
             new BackpressureException(
                 new SFException("MemoryThresholdExceeded", "backpressure", 0, "")))
         .when(channel0)
-        .insertRecord(any(), anyBoolean());
+        .insertRecord(any());
 
     List<SinkRecord> records = Arrays.asList(recordFor(TOPIC, 0, 100), recordFor(TOPIC, 1, 200));
     service.insert(records);
 
     // channel0 threw; channel1 is skipped because backpressure stops all partitions
-    verify(channel0).insertRecord(records.get(0), true);
-    verify(channel1, never()).insertRecord(any(), anyBoolean());
+    verify(channel0).insertRecord(records.get(0));
+    verify(channel1, never()).insertRecord(any());
 
     // Both partitions rewound
     verify(mockSinkTaskContext).offset(tp0, 100L);
@@ -316,8 +322,8 @@ class SnowflakeSinkServiceV2Test {
     TopicPartition tp0 = new TopicPartition(TOPIC, 0);
     TopicPartition tp1 = new TopicPartition(TOPIC, 1);
 
-    TopicPartitionChannel channel0 = mockChannel("ch_0", false);
-    TopicPartitionChannel channel1 = mockChannel("ch_1", false);
+    TopicPartitionChannel channel0 = mockChannel("ch_0");
+    TopicPartitionChannel channel1 = mockChannel("ch_1");
 
     when(mockChannelManager.getChannel(tp0)).thenReturn(Optional.of(channel0));
     when(mockChannelManager.getChannel(tp1)).thenReturn(Optional.of(channel1));
@@ -325,7 +331,7 @@ class SnowflakeSinkServiceV2Test {
     // channel1 throws BackpressureException
     doThrow(new BackpressureException(new SFException("ReceiverSaturated", "backpressure", 0, "")))
         .when(channel1)
-        .insertRecord(any(), anyBoolean());
+        .insertRecord(any());
 
     // p0's first record succeeds, p1 throws, p0's second record is skipped
     List<SinkRecord> records =
@@ -333,9 +339,9 @@ class SnowflakeSinkServiceV2Test {
     service.insert(records);
 
     // channel0 first record processed, channel1 threw, channel0 second record skipped
-    verify(channel0).insertRecord(records.get(0), true);
-    verify(channel1).insertRecord(records.get(1), true);
-    verify(channel0, never()).insertRecord(records.get(2), false);
+    verify(channel0).insertRecord(records.get(0));
+    verify(channel1).insertRecord(records.get(1));
+    verify(channel0, never()).insertRecord(records.get(2));
 
     // p1 rewound to the backpressured record; p0 rewound to the first skipped record
     verify(mockSinkTaskContext).offset(tp1, 200L);
@@ -347,42 +353,43 @@ class SnowflakeSinkServiceV2Test {
     TopicPartition tpInit = new TopicPartition(TOPIC, 0);
     TopicPartition tpReady = new TopicPartition(TOPIC, 1);
 
-    TopicPartitionChannel initChannel = mockChannel("ch_0", true);
-    TopicPartitionChannel readyChannel = mockChannel("ch_1", false);
+    TopicPartitionChannel initChannel = mockChannel("ch_0");
+    TopicPartitionChannel readyChannel = mockChannel("ch_1");
 
     when(mockChannelManager.getChannel(tpInit)).thenReturn(Optional.of(initChannel));
     when(mockChannelManager.getChannel(tpReady)).thenReturn(Optional.of(readyChannel));
+    when(mockChannelManager.isPaused(tpInit)).thenReturn(true);
 
     // Ready channel hits backpressure
     doThrow(
             new BackpressureException(
                 new SFException("MemoryThresholdExceeded", "backpressure", 0, "")))
         .when(readyChannel)
-        .insertRecord(any(), anyBoolean());
+        .insertRecord(any());
 
     List<SinkRecord> records = Arrays.asList(recordFor(TOPIC, 0, 100), recordFor(TOPIC, 1, 200));
     service.insert(records);
 
-    // initChannel skipped (initializing), readyChannel attempted and threw
-    verify(initChannel, never()).insertRecord(any(), anyBoolean());
-    verify(readyChannel).insertRecord(records.get(1), true);
+    // initChannel skipped (paused), readyChannel attempted and threw
+    verify(initChannel, never()).insertRecord(any());
+    verify(readyChannel).insertRecord(records.get(1));
 
-    // Both partitions rewound via offsetsOfFirstSkippedRecord
-    verify(mockSinkTaskContext).offset(tpInit, 100L);
+    // Only backpressured partition is rewound; paused partition is already paused
+    verify(mockSinkTaskContext, never()).offset(tpInit, 100L);
     verify(mockSinkTaskContext).offset(tpReady, 200L);
   }
 
   @Test
   void insertSetsCooldownAfterBackpressure() {
     TopicPartition tp0 = new TopicPartition(TOPIC, 0);
-    TopicPartitionChannel channel0 = mockChannel("ch_0", false);
+    TopicPartitionChannel channel0 = mockChannel("ch_0");
     when(mockChannelManager.getChannel(tp0)).thenReturn(Optional.of(channel0));
 
     doThrow(
             new BackpressureException(
                 new SFException("MemoryThresholdExceeded", "backpressure", 0, "")))
         .when(channel0)
-        .insertRecord(any(), anyBoolean());
+        .insertRecord(any());
 
     service.insert(Collections.singletonList(recordFor(TOPIC, 0, 100)));
 
@@ -397,8 +404,8 @@ class SnowflakeSinkServiceV2Test {
     TopicPartition tp0 = new TopicPartition(TOPIC, 0);
     TopicPartition tp1 = new TopicPartition(TOPIC, 1);
 
-    TopicPartitionChannel channel0 = mockChannel("ch_0", false);
-    TopicPartitionChannel channel1 = mockChannel("ch_1", false);
+    TopicPartitionChannel channel0 = mockChannel("ch_0");
+    TopicPartitionChannel channel1 = mockChannel("ch_1");
 
     when(mockChannelManager.getChannel(tp0)).thenReturn(Optional.of(channel0));
     when(mockChannelManager.getChannel(tp1)).thenReturn(Optional.of(channel1));
@@ -410,8 +417,8 @@ class SnowflakeSinkServiceV2Test {
     service.insert(records);
 
     // No inserts attempted during cooldown
-    verify(channel0, never()).insertRecord(any(), anyBoolean());
-    verify(channel1, never()).insertRecord(any(), anyBoolean());
+    verify(channel0, never()).insertRecord(any());
+    verify(channel1, never()).insertRecord(any());
 
     // All partitions rewound
     verify(mockSinkTaskContext).offset(tp0, 100L);
@@ -421,7 +428,7 @@ class SnowflakeSinkServiceV2Test {
   @Test
   void insertResumesNormallyAfterCooldownExpires() {
     TopicPartition tp0 = new TopicPartition(TOPIC, 0);
-    TopicPartitionChannel channel0 = mockChannel("ch_0", false);
+    TopicPartitionChannel channel0 = mockChannel("ch_0");
     when(mockChannelManager.getChannel(tp0)).thenReturn(Optional.of(channel0));
 
     // Set cooldown to the past (expired)
@@ -430,7 +437,7 @@ class SnowflakeSinkServiceV2Test {
     service.insert(Collections.singletonList(recordFor(TOPIC, 0, 100)));
 
     // Normal processing resumes
-    verify(channel0).insertRecord(any(), anyBoolean());
+    verify(channel0).insertRecord(any());
     verify(mockSinkTaskContext, never()).offset(any(TopicPartition.class), any(Long.class));
   }
 
@@ -441,14 +448,14 @@ class SnowflakeSinkServiceV2Test {
     TopicPartition tp0 = new TopicPartition(TOPIC, 0);
     TopicPartition tp1 = new TopicPartition(TOPIC, 1);
 
-    TopicPartitionChannel channel0 = mockChannel("ch_0", false);
-    TopicPartitionChannel channel1 = mockChannel("ch_1", false);
+    TopicPartitionChannel channel0 = mockChannel("ch_0");
+    TopicPartitionChannel channel1 = mockChannel("ch_1");
 
     when(mockChannelManager.getChannel(tp0)).thenReturn(Optional.of(channel0));
     when(mockChannelManager.getChannel(tp1)).thenReturn(Optional.of(channel1));
 
     // channel0 signals recovery on its first record
-    when(channel0.insertRecord(any(), anyBoolean())).thenReturn(false);
+    when(channel0.insertRecord(any())).thenReturn(false);
 
     List<SinkRecord> records =
         Arrays.asList(
@@ -459,38 +466,40 @@ class SnowflakeSinkServiceV2Test {
     service.insert(records);
 
     // channel0: only the first record was attempted; 101 and 102 were skipped
-    verify(channel0).insertRecord(records.get(0), true);
-    verify(channel0, never()).insertRecord(records.get(2), false);
-    verify(channel0, never()).insertRecord(records.get(3), false);
+    verify(channel0).insertRecord(records.get(0));
+    verify(channel0, never()).insertRecord(records.get(2));
+    verify(channel0, never()).insertRecord(records.get(3));
 
     // channel1: processed normally
-    verify(channel1).insertRecord(records.get(1), true);
+    verify(channel1).insertRecord(records.get(1));
 
-    // Only the recovering partition is rewound, to the triggering record's offset
-    verify(mockSinkTaskContext).offset(tp0, 100L);
+    // Recovery pauses the partition instead of rewinding
+    verify(mockChannelManager).pausePartition(tp0);
+    verify(mockSinkTaskContext, never()).offset(tp0, 100L);
     verify(mockSinkTaskContext, never()).offset(tp1, 200L);
   }
 
   @Test
   void insertRewindsToFirstSkippedOffsetAfterRecoveryMidPartition() {
     TopicPartition tp = new TopicPartition(TOPIC, 0);
-    TopicPartitionChannel channel = mockChannel("ch_0", false);
+    TopicPartitionChannel channel = mockChannel("ch_0");
     when(mockChannelManager.getChannel(tp)).thenReturn(Optional.of(channel));
 
     // First record succeeds, second triggers recovery
-    when(channel.insertRecord(any(), anyBoolean())).thenReturn(true).thenReturn(false);
+    when(channel.insertRecord(any())).thenReturn(true).thenReturn(false);
 
     List<SinkRecord> records =
         Arrays.asList(recordFor(TOPIC, 0, 100), recordFor(TOPIC, 0, 101), recordFor(TOPIC, 0, 102));
     service.insert(records);
 
     // First two records attempted, third skipped
-    verify(channel).insertRecord(records.get(0), true);
-    verify(channel).insertRecord(records.get(1), false);
-    verify(channel, never()).insertRecord(records.get(2), false);
+    verify(channel).insertRecord(records.get(0));
+    verify(channel).insertRecord(records.get(1));
+    verify(channel, never()).insertRecord(records.get(2));
 
-    // Rewind to the record that triggered recovery
-    verify(mockSinkTaskContext).offset(tp, 101L);
+    // Recovery pauses the partition instead of rewinding
+    verify(mockChannelManager).pausePartition(tp);
+    verify(mockSinkTaskContext, never()).offset(tp, 101L);
   }
 
   // --- helpers ---
@@ -524,12 +533,10 @@ class SnowflakeSinkServiceV2Test {
         TaskMetrics.noop());
   }
 
-  private static TopicPartitionChannel mockChannel(String channelName, boolean initializing) {
+  private static TopicPartitionChannel mockChannel(String channelName) {
     TopicPartitionChannel channel = mock(TopicPartitionChannel.class);
     when(channel.getChannelName()).thenReturn(channelName);
-    when(channel.isInitializing()).thenReturn(initializing);
-    when(channel.isChannelClosed()).thenReturn(false);
-    when(channel.insertRecord(any(), anyBoolean())).thenReturn(true);
+    when(channel.insertRecord(any())).thenReturn(true);
     return channel;
   }
 

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingErrorHandlerIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingErrorHandlerIT.java
@@ -24,7 +24,6 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.errors.DataException;
@@ -50,7 +49,6 @@ class StreamingErrorHandlerIT {
   private String pipeName;
 
   private SnowflakeTelemetryService mockTelemetryService;
-  private InMemorySinkTaskContext sinkTaskContext;
   private ExecutorService openChannelIoExecutor;
 
   @BeforeEach
@@ -61,8 +59,6 @@ class StreamingErrorHandlerIT {
 
     mockTelemetryService = mock(SnowflakeTelemetryService.class);
 
-    sinkTaskContext =
-        new InMemorySinkTaskContext(Collections.singleton(new TopicPartition(TOPIC, PARTITION)));
     openChannelIoExecutor = Executors.newSingleThreadExecutor();
   }
 
@@ -82,7 +78,7 @@ class StreamingErrorHandlerIT {
     SinkRecord brokenSinkRecord = buildBrokenValueRecord(0);
 
     DataException thrown =
-        assertThrows(DataException.class, () -> channel.insertRecord(brokenSinkRecord, true));
+        assertThrows(DataException.class, () -> channel.insertRecord(brokenSinkRecord));
 
     // The cause should be the original SnowflakeKafkaConnectorException from convertToMap
     assertNotNull(thrown.getCause(), "DataException should wrap the original conversion exception");
@@ -102,7 +98,7 @@ class StreamingErrorHandlerIT {
     SinkRecord brokenSinkRecord = buildBrokenKeyRecord(0);
 
     DataException thrown =
-        assertThrows(DataException.class, () -> channel.insertRecord(brokenSinkRecord, true));
+        assertThrows(DataException.class, () -> channel.insertRecord(brokenSinkRecord));
 
     assertNotNull(thrown.getCause(), "DataException should wrap the original conversion exception");
     assertEquals(0, errorReporter.getReportedRecords().size());
@@ -121,7 +117,7 @@ class StreamingErrorHandlerIT {
     SinkRecord brokenSinkRecord = buildBrokenValueRecord(0);
 
     DataException thrown =
-        assertThrows(DataException.class, () -> channel.insertRecord(brokenSinkRecord, true));
+        assertThrows(DataException.class, () -> channel.insertRecord(brokenSinkRecord));
 
     assertNotNull(thrown.getCause(), "DataException should wrap the original conversion exception");
 
@@ -152,7 +148,7 @@ class StreamingErrorHandlerIT {
     SinkRecord brokenSinkRecord = buildBrokenValueRecord(0);
 
     // Should NOT throw
-    channel.insertRecord(brokenSinkRecord, true);
+    channel.insertRecord(brokenSinkRecord);
 
     assertEquals(1, errorReporter.getReportedRecords().size());
 
@@ -184,7 +180,7 @@ class StreamingErrorHandlerIT {
     SnowpipeStreamingPartitionChannel channel = createChannel(config, errorReporter);
     SinkRecord brokenSinkRecord = buildBrokenKeyRecord(0);
 
-    channel.insertRecord(brokenSinkRecord, true);
+    channel.insertRecord(brokenSinkRecord);
 
     assertEquals(1, errorReporter.getReportedRecords().size());
     InMemoryKafkaRecordErrorReporter.ReportedRecord reported =
@@ -208,10 +204,10 @@ class StreamingErrorHandlerIT {
 
     SnowpipeStreamingPartitionChannel channel = createChannel(config, errorReporter);
 
-    channel.insertRecord(buildBrokenValueRecord(0), true);
-    channel.insertRecord(buildValidRecord(1), false);
-    channel.insertRecord(buildBrokenValueRecord(2), false);
-    channel.insertRecord(buildBrokenValueRecord(3), false);
+    channel.insertRecord(buildBrokenValueRecord(0));
+    channel.insertRecord(buildValidRecord(1));
+    channel.insertRecord(buildBrokenValueRecord(2));
+    channel.insertRecord(buildBrokenValueRecord(3));
 
     assertEquals(3, errorReporter.getReportedRecords().size());
   }
@@ -229,7 +225,7 @@ class StreamingErrorHandlerIT {
     SinkRecord brokenSinkRecord = buildBrokenValueRecord(0);
 
     // Should NOT throw - record is silently dropped with a warning log
-    channel.insertRecord(brokenSinkRecord, true);
+    channel.insertRecord(brokenSinkRecord);
 
     assertEquals(0, errorReporter.getReportedRecords().size());
   }
@@ -280,9 +276,7 @@ class StreamingErrorHandlerIT {
     StreamingErrorHandler errorHandler =
         new StreamingErrorHandler(taskConfig, errorReporter, mockTelemetryService);
 
-    final TopicPartition topicPartition = new TopicPartition(TOPIC, PARTITION);
-    final PartitionOffsetTracker offsetTracker =
-        new PartitionOffsetTracker(topicPartition, sinkTaskContext, channelName);
+    final PartitionOffsetTracker offsetTracker = new PartitionOffsetTracker(channelName);
     final SnowflakeTelemetryChannelStatus telemetryChannelStatus =
         new SnowflakeTelemetryChannelStatus(
             "test_table",
@@ -308,6 +302,7 @@ class StreamingErrorHandlerIT {
         TaskMetrics.noop(),
         false,
         null,
-        Optional.empty());
+        Optional.empty(),
+        offset -> {});
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannelTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannelTest.java
@@ -69,6 +69,7 @@ class SnowpipeStreamingPartitionChannelTest {
   private static final String TOPIC_NAME = "test_topic";
   private static final int PARTITION = 0;
   private static final String SSV1_CHANNEL_NAME = TOPIC_NAME + "_" + PARTITION;
+  private static final TopicPartition TOPIC_PARTITION = new TopicPartition(TOPIC_NAME, PARTITION);
 
   private String channelName;
   private String pipeName;
@@ -130,7 +131,7 @@ class SnowpipeStreamingPartitionChannelTest {
     // When: appendRow throws SFException once, triggering the fallback that reopens the channel.
     // After recovery the fallback completes normally — no exception propagates.
     trackingClientSupplier.setNonRetryableAppendRowFailures(1);
-    partitionChannel.insertRecord(buildValidRecord(0), true);
+    partitionChannel.insertRecord(buildValidRecord(0));
 
     // reopenChannel closes the old channel before opening a new one
     assertEquals(closeCountBeforeRecovery + 1, trackingClientSupplier.getCloseCallCount());
@@ -182,7 +183,7 @@ class SnowpipeStreamingPartitionChannelTest {
     // First insertRecord triggers recovery via the Failsafe fallback. reopenChannel handles
     // the failed init future gracefully (skips close, opens a new channel). After successful
     // recovery the record is inserted on the new channel — no exception propagates.
-    partitionChannel.insertRecord(buildValidRecord(0), true);
+    partitionChannel.insertRecord(buildValidRecord(0));
 
     assertEquals(
         1,
@@ -199,7 +200,7 @@ class SnowpipeStreamingPartitionChannelTest {
 
     // Trigger reopenChannel via appendRow SFException (throw once, then succeed on new channel)
     trackingClientSupplier.setNonRetryableAppendRowFailures(1);
-    partitionChannel.insertRecord(buildValidRecord(0), true);
+    partitionChannel.insertRecord(buildValidRecord(0));
 
     // reopenChannel should have closed the old channel BEFORE opening the new one
     assertEquals(
@@ -225,8 +226,7 @@ class SnowpipeStreamingPartitionChannelTest {
     // Task 4 will handle it at the batch-level insert() loop
     BackpressureException exception =
         assertThrows(
-            BackpressureException.class,
-            () -> partitionChannel.insertRecord(buildValidRecord(0), true));
+            BackpressureException.class, () -> partitionChannel.insertRecord(buildValidRecord(0)));
 
     assertEquals("SDK backpressure: MemoryThresholdExceeded", exception.getMessage());
 
@@ -247,8 +247,7 @@ class SnowpipeStreamingPartitionChannelTest {
 
     IllegalStateException thrown =
         assertThrows(
-            IllegalStateException.class,
-            () -> partitionChannel.insertRecord(buildValidRecord(0), true));
+            IllegalStateException.class, () -> partitionChannel.insertRecord(buildValidRecord(0)));
 
     assertSame(cause, thrown);
     // No recovery should have been attempted
@@ -292,20 +291,20 @@ class SnowpipeStreamingPartitionChannelTest {
     assertEquals(1, trackingClientSupplier.getTotalChannelsCreated());
 
     // Insert first record successfully
-    partitionChannel.insertRecord(buildValidRecord(0), true);
+    partitionChannel.insertRecord(buildValidRecord(0));
 
     // Simulate channel invalidation: appendRow throws once (non-retryable SFException),
     // then succeeds on the reopened channel.
     trackingClientSupplier.setNonRetryableAppendRowFailures(1);
-    partitionChannel.insertRecord(buildValidRecord(1), false);
+    partitionChannel.insertRecord(buildValidRecord(1));
 
     // The channel should have been reopened (old closed, new opened)
     assertEquals(1, trackingClientSupplier.getCloseCallCount());
     assertEquals(2, trackingClientSupplier.getTotalChannelsCreated());
 
     // Subsequent records should continue to be ingested on the new channel
-    partitionChannel.insertRecord(buildValidRecord(2), false);
-    partitionChannel.insertRecord(buildValidRecord(3), false);
+    partitionChannel.insertRecord(buildValidRecord(2));
+    partitionChannel.insertRecord(buildValidRecord(3));
 
     // No additional channel reopenings
     assertEquals(1, trackingClientSupplier.getCloseCallCount());
@@ -325,9 +324,6 @@ class SnowpipeStreamingPartitionChannelTest {
     // Every appendRow throws — channel is permanently invalid
     trackingClientSupplier.setThrowOnAppendRow(true);
 
-    // Each record is sent as the first in a new batch (isFirstRowInBatch=true) because
-    // recovery sets needToSkipCurrentBatch=true, which would cause subsequent records
-    // in the same batch to be skipped before reaching appendRow.
     // The first 5 records trigger recovery attempts (channel reopening).
     // The 6th record exceeds MAX_CONSECUTIVE_RECOVERIES and throws ConnectException.
     ConnectException thrown =
@@ -335,7 +331,7 @@ class SnowpipeStreamingPartitionChannelTest {
             ConnectException.class,
             () -> {
               for (int i = 0; i < 20; i++) {
-                partitionChannel.insertRecord(buildValidRecord(i), true);
+                partitionChannel.insertRecord(buildValidRecord(i));
               }
             });
 
@@ -360,9 +356,7 @@ class SnowpipeStreamingPartitionChannelTest {
   }
 
   private SnowpipeStreamingPartitionChannel createPartitionChannel() {
-    final TopicPartition topicPartition = new TopicPartition(TOPIC_NAME, PARTITION);
-    final PartitionOffsetTracker offsetTracker =
-        new PartitionOffsetTracker(topicPartition, sinkTaskContext, channelName);
+    final PartitionOffsetTracker offsetTracker = new PartitionOffsetTracker(channelName);
     final SnowflakeTelemetryChannelStatus telemetryChannelStatus =
         new SnowflakeTelemetryChannelStatus(
             TABLE_NAME,
@@ -397,7 +391,8 @@ class SnowpipeStreamingPartitionChannelTest {
         TaskMetrics.noop(),
         false,
         null,
-        Optional.empty());
+        Optional.empty(),
+        offset -> {});
   }
 
   @Test
@@ -441,9 +436,7 @@ class SnowpipeStreamingPartitionChannelTest {
     mockConnService = mock(SnowflakeConnectionService.class);
     when(mockConnService.describeTable(TABLE_NAME)).thenReturn(Optional.of(describeResult));
 
-    final TopicPartition topicPartition = new TopicPartition(TOPIC_NAME, PARTITION);
-    final PartitionOffsetTracker offsetTracker =
-        new PartitionOffsetTracker(topicPartition, sinkTaskContext, channelName);
+    final PartitionOffsetTracker offsetTracker = new PartitionOffsetTracker(channelName);
     final SnowflakeTelemetryChannelStatus telemetryChannelStatus =
         new SnowflakeTelemetryChannelStatus(
             TABLE_NAME,
@@ -478,7 +471,8 @@ class SnowpipeStreamingPartitionChannelTest {
         TaskMetrics.noop(),
         shouldEvolveSchema,
         mockConnService,
-        Optional.empty());
+        Optional.empty(),
+        offset -> {});
   }
 
   private static final List<DescribeTableRow> STANDARD_TABLE_SCHEMA =
@@ -493,7 +487,7 @@ class SnowpipeStreamingPartitionChannelTest {
         createValidationEnabledChannel(STANDARD_TABLE_SCHEMA, false, true);
     SinkRecord record = buildValidRecord(0);
 
-    channel.insertRecord(record, true);
+    channel.insertRecord(record);
 
     verify(mockErrorHandler, never()).handleError(any(Exception.class), any(SinkRecord.class));
     assertEquals(1, trackingClientSupplier.getTotalChannelsCreated());
@@ -508,7 +502,7 @@ class SnowpipeStreamingPartitionChannelTest {
     SnowpipeStreamingPartitionChannel channel = createValidationEnabledChannel(schema, true, true);
 
     SinkRecord record = buildValidRecord(0);
-    channel.insertRecord(record, true);
+    channel.insertRecord(record);
 
     // Schema evolution attempted, but refreshed schema still missing RECORD_CONTENT -> error
     verify(mockErrorHandler).handleError(any(Exception.class), eq(record));
@@ -522,7 +516,7 @@ class SnowpipeStreamingPartitionChannelTest {
     SnowpipeStreamingPartitionChannel channel = createValidationEnabledChannel(schema, true, false);
 
     SinkRecord record = buildValidRecord(0);
-    channel.insertRecord(record, true);
+    channel.insertRecord(record);
 
     verify(mockErrorHandler).handleError(any(Exception.class), eq(record));
     verify(mockConnService, never()).appendColumnsToTable(any(), any());
@@ -534,9 +528,7 @@ class SnowpipeStreamingPartitionChannelTest {
     mockConnService = mock(SnowflakeConnectionService.class);
     when(mockConnService.describeTable(TABLE_NAME)).thenReturn(Optional.empty());
 
-    final TopicPartition topicPartition = new TopicPartition(TOPIC_NAME, PARTITION);
-    final PartitionOffsetTracker offsetTracker =
-        new PartitionOffsetTracker(topicPartition, sinkTaskContext, channelName);
+    final PartitionOffsetTracker offsetTracker = new PartitionOffsetTracker(channelName);
     final SnowflakeTelemetryChannelStatus telemetryChannelStatus =
         new SnowflakeTelemetryChannelStatus(
             TABLE_NAME,
@@ -572,10 +564,11 @@ class SnowpipeStreamingPartitionChannelTest {
             TaskMetrics.noop(),
             true,
             mockConnService,
-            Optional.empty());
+            Optional.empty(),
+            offset -> {});
 
     SinkRecord record = buildValidRecord(0);
-    channel.insertRecord(record, true);
+    channel.insertRecord(record);
 
     verify(mockErrorHandler, never()).handleError(any(Exception.class), any(SinkRecord.class));
   }
@@ -595,7 +588,7 @@ class SnowpipeStreamingPartitionChannelTest {
 
     // Record doesn't have REQUIRED_COL — should trigger structural error
     SinkRecord record = buildValidRecord(0);
-    channel.insertRecord(record, true);
+    channel.insertRecord(record);
 
     verify(mockErrorHandler).handleError(any(Exception.class), eq(record));
   }
@@ -618,7 +611,7 @@ class SnowpipeStreamingPartitionChannelTest {
             .withOffset(0)
             .build();
 
-    channel.insertRecord(record, true);
+    channel.insertRecord(record);
 
     verify(mockConnService)
         .appendColumnsToTable(
@@ -646,7 +639,7 @@ class SnowpipeStreamingPartitionChannelTest {
     SnowpipeStreamingPartitionChannel channel = createValidationEnabledChannel(schema, false, true);
     SinkRecord record = buildValidRecord(0);
 
-    channel.insertRecord(record, true);
+    channel.insertRecord(record);
 
     // Identity column is missing from the row but should not trigger an error
     verify(mockErrorHandler, never()).handleError(any(Exception.class), any(SinkRecord.class));
@@ -664,7 +657,7 @@ class SnowpipeStreamingPartitionChannelTest {
     SnowpipeStreamingPartitionChannel channel = createValidationEnabledChannel(schema, false, true);
     SinkRecord record = buildValidRecord(0);
 
-    channel.insertRecord(record, true);
+    channel.insertRecord(record);
 
     verify(mockErrorHandler, never()).handleError(any(Exception.class), any(SinkRecord.class));
   }
@@ -673,9 +666,7 @@ class SnowpipeStreamingPartitionChannelTest {
 
   private SnowpipeStreamingPartitionChannel createPartitionChannelWithMigration(
       Ssv1MigrationMode migrationMode, SnowflakeConnectionService mockConn) {
-    final TopicPartition topicPartition = new TopicPartition(TOPIC_NAME, PARTITION);
-    final PartitionOffsetTracker offsetTracker =
-        new PartitionOffsetTracker(topicPartition, sinkTaskContext, channelName);
+    final PartitionOffsetTracker offsetTracker = new PartitionOffsetTracker(channelName);
     final SnowflakeTelemetryChannelStatus telemetryChannelStatus =
         new SnowflakeTelemetryChannelStatus(
             TABLE_NAME,
@@ -711,9 +702,12 @@ class SnowpipeStreamingPartitionChannelTest {
         TaskMetrics.noop(),
         false,
         mockConn,
-        migrationMode == Ssv1MigrationMode.SKIP
-            ? Optional.empty()
-            : Optional.of(SSV1_CHANNEL_NAME));
+        migrationMode == Ssv1MigrationMode.SKIP ? Optional.empty() : Optional.of(SSV1_CHANNEL_NAME),
+        offset -> {
+          if (offset >= 0) {
+            sinkTaskContext.offset(TOPIC_PARTITION, offset);
+          }
+        });
   }
 
   @Test
@@ -913,7 +907,7 @@ class SnowpipeStreamingPartitionChannelTest {
     // Trigger reopenChannel via insertRecord: getChannel() re-throws the SFException from the
     // failed init future, which AppendRowWithFallbackPolicy catches and invokes reopenChannel.
     // reopenChannel's .exceptionally() handler handles the failed init, then opens a new channel.
-    channel.insertRecord(buildValidRecord(0), true);
+    channel.insertRecord(buildValidRecord(0));
 
     // Wait for the async reopen to complete
     channel.getChannel();

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/service/PartitionChannelManagerTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/service/PartitionChannelManagerTest.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.sink.SinkTaskContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -47,7 +48,9 @@ class PartitionChannelManagerTest {
           return channel;
         };
 
-    manager = new PartitionChannelManager(testConfig(Collections.emptyMap()), trackingBuilder);
+    manager =
+        new PartitionChannelManager(
+            testConfig(Collections.emptyMap()), mock(SinkTaskContext.class), trackingBuilder);
   }
 
   // --- makeChannelName ---
@@ -89,7 +92,8 @@ class PartitionChannelManagerTest {
         };
 
     PartitionChannelManager capturingManager =
-        new PartitionChannelManager(testConfig(Collections.emptyMap()), capturingBuilder);
+        new PartitionChannelManager(
+            testConfig(Collections.emptyMap()), mock(SinkTaskContext.class), capturingBuilder);
 
     TopicPartition tp = new TopicPartition(TOPIC, 7);
     Map<String, String> tableToPipe = new HashMap<>();
@@ -119,7 +123,8 @@ class PartitionChannelManagerTest {
         };
 
     PartitionChannelManager managerWithMapping =
-        new PartitionChannelManager(testConfig(topicToTable), capturingBuilder);
+        new PartitionChannelManager(
+            testConfig(topicToTable), mock(SinkTaskContext.class), capturingBuilder);
 
     TopicPartition tp = new TopicPartition("raw_topic", 0);
     Map<String, String> tableToPipe = new HashMap<>();

--- a/src/test/java/com/snowflake/kafka/connector/streaming/iceberg/IcebergIngestionIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/streaming/iceberg/IcebergIngestionIT.java
@@ -65,6 +65,8 @@ public abstract class IcebergIngestionIT extends BaseIcebergIT {
             .withErrorReporter(kafkaRecordErrorReporter)
             .withSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(topicPartition)))
             .build();
+    service.startPartition(topicPartition);
+    service.awaitInitialization();
   }
 
   @AfterEach


### PR DESCRIPTION
## Summary

Use Kafka Connect's `SinkTaskContext.pause()` and `resume()` APIs to handle partitions whose channels are initializing or recovering, replacing the previous skip/rewind mechanism.

**Problem**: When a channel is initializing (async `openChannel`) or recovering (async `reopenChannel`), records arriving for that partition had to be skipped and then rewound via `SinkTaskContext.offset()`. This required tracking `needToSkipCurrentBatch`, `offsetsOfFirstSkippedRecord`, and `isFirstRowPerPartitionInBatch` — complex state spread across `PartitionOffsetTracker`, `SnowflakeSinkServiceV2`, and `TopicPartitionChannel`. The rewind also raced with the async recovery's own seek, and `SinkTaskContext.offset()` was called from the IO thread (via `CompletableFuture` chains), violating thread-safety expectations.

**Solution**:
- **Pause** partitions at the Kafka consumer level during channel init and recovery. No records are delivered, so there's nothing to skip or rewind.
- **Resume** on the task thread when the channel signals readiness via a callback, with an authoritative seek to the correct offset.
- All `SinkTaskContext` interactions (pause/resume/offset) are centralized in `PartitionChannelManager` and called exclusively on the task thread.

### Changes by file

- **`PartitionOffsetTracker`**: Removed `SinkTaskContext` dependency, `needToSkipCurrentBatch`, and `resetKafkaOffset()`. `initializeFromSnowflake()` and `resetAfterRecovery()` now return the resume offset. `shouldProcess()` no longer takes `isFirstRowInBatch`.
- **`TopicPartitionChannel`**: Removed `isFirstRowPerPartitionInBatch` from `insertRecord()` signature.
- **`SnowpipeStreamingPartitionChannel`**: Removed `TopicPartition` field. Constructor and `reopenChannel()` accept a `Consumer<Long>` callback that fires with the resume offset when the channel is ready.
- **`PartitionChannelManager`**: Now owns `SinkTaskContext`, `pausedPartitions`, and `partitionsReadyToResume`. Exposes `pausePartition()`, `isPaused()`, and `resumeReadyPartitions()` (drains ready partitions, issues seek + resume). `startPartitions()` pauses all partitions before creating channels. `close()` cleans up paused state.
- **`SnowflakeSinkServiceV2`**: Delegates all pause/resume/isPaused logic to `PartitionChannelManager`. Retains `SinkTaskContext` only for backpressure offset rewinds.

## Test plan

- [x] `SnowflakeSinkServiceV2Test` — updated to mock `channelManager.isPaused()` and verify `channelManager.pausePartition()`
- [x] `SnowpipeStreamingPartitionChannelTest` — updated constructor calls (`Consumer<Long>` callback, no `TopicPartition`)
- [x] `StreamingErrorHandlerIT` — updated constructor calls
- [x] All unit tests pass (`mvn test`)
- [x] `test_invalidation_offset_consistency` E2E — skipped (same as master; `SYSTEM$STREAMING_CHANNEL_INVALIDATE` not available on test account)