### PR TITLE
Lock-based channel recovery + fix SNOW-3574225

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeSinkService.java
@@ -2,6 +2,7 @@ package com.snowflake.kafka.connector.internal;
 
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.annotations.VisibleForTesting;
+import com.snowflake.kafka.connector.internal.streaming.channel.InsertResult;
 import com.snowflake.kafka.connector.internal.streaming.channel.TopicPartitionChannel;
 import java.util.Collection;
 import java.util.Map;
@@ -37,10 +38,11 @@ public interface SnowflakeSinkService {
    * call pipe to insert a JSON record will not trigger time based flush
    *
    * @param record record content
-   * @return true if the record was processed successfully, false if recovery was triggered and the
-   *     caller should stop feeding records to this partition for the remainder of the batch
+   * @return {@link InsertResult#PROCESSED} on success or duplicate-skip; {@link
+   *     InsertResult#RECOVERY_COMPLETED} when recovery was triggered and the caller should stop
+   *     feeding records to this partition for the remainder of the batch
    */
-  boolean insert(final SinkRecord record);
+  InsertResult insert(final SinkRecord record);
 
   /**
    * retrieve offset of last loaded record for given pipe name

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -17,6 +17,7 @@ import com.snowflake.kafka.connector.internal.SnowflakeErrors;
 import com.snowflake.kafka.connector.internal.SnowflakeSinkService;
 import com.snowflake.kafka.connector.internal.metrics.MetricsJmxReporter;
 import com.snowflake.kafka.connector.internal.metrics.TaskMetrics;
+import com.snowflake.kafka.connector.internal.streaming.channel.InsertResult;
 import com.snowflake.kafka.connector.internal.streaming.channel.TopicPartitionChannel;
 import com.snowflake.kafka.connector.internal.streaming.v2.BackpressureException;
 import com.snowflake.kafka.connector.internal.streaming.v2.client.StreamingClientPools;
@@ -65,8 +66,6 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
   private final SinkTaskConfig taskConfig;
   private final SinkTaskContext sinkTaskContext;
 
-  // Set that keeps track of the channels that have been seen per input batch
-  private final Set<String> channelsVisitedPerBatch = new HashSet<>();
   private final BatchOffsetFetcher batchOffsetFetcher;
 
   private final PartitionChannelManager channelManager;
@@ -320,9 +319,7 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
    *     Topic and multiple Partitions
    */
   @Override
-  public void insert(final Collection<SinkRecord> records) {
-    channelsVisitedPerBatch.clear();
-
+  public synchronized void insert(final Collection<SinkRecord> records) {
     // Skip partitions for which the partition-channel bridge is currently being initialized.
     Set<TopicPartition> partitions =
         records.stream()
@@ -370,8 +367,15 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
       }
 
       try {
-        if (!insert(record)) {
-          offsetsOfFirstSkippedRecord.putIfAbsent(tp, record.kafkaOffset());
+        if (insert(record) == InsertResult.RECOVERY_COMPLETED) {
+          // Recovery seeked Kafka to the committed offset for this partition. Exit the
+          // batch loop without rewinding — recovery's seek is the authoritative position
+          // (SNOW-3574225). Other partitions' records will be redelivered on the next put().
+          LOGGER.info(
+              "Recovery fired for partition {} at offset {}; aborting batch without rewind.",
+              tp,
+              record.kafkaOffset());
+          return;
         }
       } catch (BackpressureException e) {
         LOGGER.warn(
@@ -402,7 +406,7 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
    * then each partition(Streaming channel) calls its respective appendRows API
    */
   @Override
-  public boolean insert(SinkRecord record) {
+  public InsertResult insert(SinkRecord record) {
     LOGGER.trace("Inserting record: {}", record);
 
     TopicPartition topicPartition = new TopicPartition(record.topic(), record.kafkaPartition());
@@ -424,8 +428,7 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
                     new IllegalStateException(
                         "Channel for " + topicPartition + " not found after startPartition"));
 
-    boolean isFirstRowPerPartitionInBatch = channelsVisitedPerBatch.add(channel.getChannelName());
-    return channel.insertRecord(record, isFirstRowPerPartitionInBatch);
+    return channel.insertRecord(record);
   }
 
   private boolean shouldSkipNullValue(SinkRecord record) {

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/channel/InsertResult.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/channel/InsertResult.java
@@ -1,0 +1,14 @@
+package com.snowflake.kafka.connector.internal.streaming.channel;
+
+/** Outcome of {@link TopicPartitionChannel#insertRecord}. */
+public enum InsertResult {
+  /** Record was ingested or legitimately skipped (duplicate, broken-but-tolerated). */
+  PROCESSED,
+
+  /**
+   * Recovery was triggered for this channel: the channel was (or will be) reopened and Kafka was
+   * (or will be) seeked to the recovery point. The batch loop must abort the rest of this batch
+   * without rewinding any partition — recovery's seek is the authoritative position.
+   */
+  RECOVERY_COMPLETED;
+}

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/channel/TopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/channel/TopicPartitionChannel.java
@@ -11,22 +11,14 @@ public interface TopicPartitionChannel {
   long NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE = -1L;
 
   /**
-   * Inserts the record into buffer
-   *
-   * <p>Step 1: Initializes this channel by fetching the offsetToken from Snowflake for the first
-   * time this channel/partition has received offset after start/restart.
-   *
-   * <p>Step 2: Decides whether given offset from Kafka needs to be processed and whether it
-   * qualifies for being added into buffer.
+   * Inserts the record into the channel.
    *
    * @param kafkaSinkRecord input record from Kafka
-   * @param isFirstRowPerPartitionInBatch indicates whether the given record is the first record per
-   *     partition in a batch
-   * @return true if the record was processed (or legitimately skipped as a duplicate), false if
-   *     recovery was triggered and the caller should stop feeding records to this partition for the
-   *     remainder of the batch
+   * @return {@link InsertResult#PROCESSED} on success or duplicate-skip; {@link
+   *     InsertResult#RECOVERY_COMPLETED} when recovery was (or will be) triggered for this channel
+   *     and the caller should stop feeding it records for the remainder of the batch.
    */
-  boolean insertRecord(SinkRecord kafkaSinkRecord, boolean isFirstRowPerPartitionInBatch);
+  InsertResult insertRecord(SinkRecord kafkaSinkRecord);
 
   /**
    * Asynchronously closes a channel associated to this partition. Any {@link SFException} occurred

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannel.java
@@ -23,6 +23,7 @@ import com.snowflake.kafka.connector.internal.schemaevolution.SchemaEvolutionTar
 import com.snowflake.kafka.connector.internal.schemaevolution.SnowflakeSchemaEvolutionService;
 import com.snowflake.kafka.connector.internal.schemaevolution.ValidationResultMapper;
 import com.snowflake.kafka.connector.internal.streaming.StreamingErrorHandler;
+import com.snowflake.kafka.connector.internal.streaming.channel.InsertResult;
 import com.snowflake.kafka.connector.internal.streaming.channel.TopicPartitionChannel;
 import com.snowflake.kafka.connector.internal.streaming.telemetry.SnowflakeTelemetryChannelCreation;
 import com.snowflake.kafka.connector.internal.streaming.telemetry.SnowflakeTelemetryChannelStatus;
@@ -163,14 +164,14 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
   }
 
   @Override
-  public boolean insertRecord(SinkRecord kafkaSinkRecord, boolean isFirstRowPerPartitionInBatch) {
-    if (offsetTracker.shouldProcess(kafkaSinkRecord.kafkaOffset(), isFirstRowPerPartitionInBatch)) {
+  public InsertResult insertRecord(SinkRecord kafkaSinkRecord) {
+    if (offsetTracker.shouldProcess(kafkaSinkRecord.kafkaOffset())) {
       return transformAndSend(kafkaSinkRecord);
     }
-    return true;
+    return InsertResult.PROCESSED;
   }
 
-  private boolean transformAndSend(SinkRecord kafkaSinkRecord) {
+  private InsertResult transformAndSend(SinkRecord kafkaSinkRecord) {
     try {
       final long kafkaOffset = kafkaSinkRecord.kafkaOffset();
       final SnowflakeSinkRecord record =
@@ -197,12 +198,16 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
 
             if (!validationResult.isValid()) {
               if (validationResult.hasStructuralError()) {
-                handleStructuralError(validationResult, kafkaSinkRecord, record, row);
+                InsertResult structuralResult =
+                    handleStructuralError(validationResult, kafkaSinkRecord, record, row);
+                if (structuralResult == InsertResult.RECOVERY_COMPLETED) {
+                  return InsertResult.RECOVERY_COMPLETED;
+                }
               } else {
                 handleValidationError(validationResult, kafkaSinkRecord);
               }
               offsetTracker.recordProcessed(kafkaOffset);
-              return true;
+              return InsertResult.PROCESSED;
             }
           }
 
@@ -211,13 +216,13 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
             // logic already reset processedOffset + rewound Kafka. Do NOT call
             // recordProcessed() here — that would advance processedOffset past the
             // recovery point and cause replayed offsets to be skipped. See SNOW-3344243.
-            return false;
+            return InsertResult.RECOVERY_COMPLETED;
           }
         }
       }
       // Always update processedOffset after processing, even for broken records
       offsetTracker.recordProcessed(kafkaOffset);
-      return true;
+      return InsertResult.PROCESSED;
     } catch (BackpressureException ex) {
       snowflakeTelemetryChannelStatus.incBackpressureRetryCount();
       throw ex;
@@ -343,62 +348,52 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
    * (offsetReturnedFromSnowflake + 1).
    *
    * @param reason Reason for the channel recovery. Used for logging.
-   * @return offset which was last present in Snowflake
    */
-  private void reopenChannel(final String reason) {
+  private synchronized void reopenChannel(final String reason) {
     LOGGER.warn("{} Channel {} recovery initiated", reason, this.channelName);
 
     if (this.snowflakeTelemetryChannelStatus != null) {
       this.snowflakeTelemetryChannelStatus.incRecoveryCount();
     }
 
-    this.channel =
-        this.channel
-            // Close old channel before reopening a new one. We don't want to wait for the channel
-            // to flush since it will be reopened right away and the in-progress data will be lost.
-            .thenAccept(
-                oldChannel -> {
-                  if (!oldChannel.isClosed()) {
-                    LOGGER.info(
-                        "{} Channel {} is not closed before reopening", reason, this.channelName);
-                    closeChannelWithoutFlushing(oldChannel);
-                  }
-                })
-            // If the previous init failed, there is no old channel to close.
-            .exceptionally(
-                initFailure -> {
-                  LOGGER.warn(
-                      "{} Channel {} had a failed initialization, skipping close: {}",
-                      reason,
-                      this.channelName,
-                      initFailure.getMessage());
-                  return null;
-                })
-            .thenApply(
-                ignored -> {
-                  OpenChannelResult openChannelResult = openChannelForTable(channelName);
-                  final long offsetRecoveredFromSnowflake =
-                      parseOrMigrateOffsetToken(openChannelResult);
+    // Close old channel before reopening a new one. We don't want to wait for the channel
+    // to flush since it will be reopened right away and the in-progress data will be lost.
+    SnowflakeStreamingIngestChannel oldChannel = null;
+    try {
+      oldChannel = this.channel.getNow(null);
+    } catch (CompletionException initFailure) {
+      // If the previous init failed, there is no old channel to close.
+      LOGGER.warn(
+          "{} Channel {} had a failed initialization, skipping close: {}",
+          reason,
+          this.channelName,
+          initFailure.getMessage());
+    }
+    if (oldChannel != null && !oldChannel.isClosed()) {
+      LOGGER.info("{} Channel {} is not closed before reopening", reason, this.channelName);
+      closeChannelWithoutFlushing(oldChannel);
+    }
 
-                  if (offsetRecoveredFromSnowflake == NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE) {
-                    LOGGER.info(
-                        "{} Channel {} has no offset token. Will use consumer group offset,"
-                            + " currently {}",
-                        reason,
-                        this.channelName,
-                        offsetTracker.consumerGroupOffsetRef().get());
-                  }
+    OpenChannelResult openChannelResult = openChannelForTable(channelName);
+    final long offsetRecoveredFromSnowflake = parseOrMigrateOffsetToken(openChannelResult);
 
-                  offsetTracker.resetAfterRecovery(offsetRecoveredFromSnowflake);
+    if (offsetRecoveredFromSnowflake == NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE) {
+      LOGGER.info(
+          "{} Channel {} has no offset token. Will use consumer group offset, currently {}",
+          reason,
+          this.channelName,
+          offsetTracker.consumerGroupOffsetRef().get());
+    }
 
-                  LOGGER.info(
-                      "{} Channel {} recovery complete, offsetRecoveredFromSnowflake={}",
-                      reason,
-                      this.channelName,
-                      offsetRecoveredFromSnowflake);
+    offsetTracker.resetAfterRecovery(offsetRecoveredFromSnowflake);
 
-                  return openChannelResult.getChannel();
-                });
+    this.channel = CompletableFuture.completedFuture(openChannelResult.getChannel());
+
+    LOGGER.info(
+        "{} Channel {} recovery complete, offsetRecoveredFromSnowflake={}",
+        reason,
+        this.channelName,
+        offsetRecoveredFromSnowflake);
   }
 
   /**
@@ -591,7 +586,7 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
     snowflakeTelemetryChannelStatus.incErrorToleratedCount();
   }
 
-  private void handleStructuralError(
+  private InsertResult handleStructuralError(
       ValidationResult result,
       SinkRecord originalRecordForReporting,
       SnowflakeSinkRecord snowflakeRecord,
@@ -621,7 +616,7 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
       LOGGER.info("Routing to DLQ for channel {}: {}", channelName, errorMsg);
       streamingErrorHandler.handleError(new DataException(errorMsg), originalRecordForReporting);
       snowflakeTelemetryChannelStatus.incErrorToleratedCount();
-      return;
+      return InsertResult.PROCESSED;
     }
 
     try {
@@ -636,8 +631,12 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
       if (rowValidator != null) {
         retryResult = rowValidator.validateRow(row);
         if (retryResult.isValid()) {
-          insertRowWithFallback(row, originalRecordForReporting.kafkaOffset());
-          return;
+          // Propagate recovery signal: if insertRowWithFallback returns false, the channel was
+          // reopened and Kafka was seeked. The caller (transformAndSend) must abort the batch.
+          if (!insertRowWithFallback(row, originalRecordForReporting.kafkaOffset())) {
+            return InsertResult.RECOVERY_COMPLETED;
+          }
+          return InsertResult.PROCESSED;
         }
       }
 
@@ -650,6 +649,7 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
               retryResult.getExtraColNames(), retryResult.getMissingNotNullColNames());
       streamingErrorHandler.handleError(new DataException(errorMsg), originalRecordForReporting);
       snowflakeTelemetryChannelStatus.incErrorToleratedCount();
+      return InsertResult.PROCESSED;
     } catch (SnowflakeKafkaConnectorException e) {
       LOGGER.error("Schema evolution failed for table {}", tableName, e);
       throw e;
@@ -708,17 +708,19 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
     return channel
         .thenAccept(
             c -> {
-              try {
-                if (!c.isClosed()) {
-                  closeChannelWithoutFlushing(c);
+              synchronized (this) {
+                try {
+                  if (!c.isClosed()) {
+                    closeChannelWithoutFlushing(c);
+                  }
+                  LOGGER.info("Successfully closed streaming channel {}", this.channelName);
+                } catch (RuntimeException e) {
+                  tryRecoverFromCloseChannelError(e);
+                } finally {
+                  this.telemetryService.reportKafkaPartitionUsage(
+                      this.snowflakeTelemetryChannelStatus, true);
+                  this.snowflakeTelemetryChannelStatus.tryUnregisterChannelJMXMetrics();
                 }
-                LOGGER.info("Successfully closed streaming channel {}", this.channelName);
-              } catch (RuntimeException e) {
-                tryRecoverFromCloseChannelError(e);
-              } finally {
-                this.telemetryService.reportKafkaPartitionUsage(
-                    this.snowflakeTelemetryChannelStatus, true);
-                this.snowflakeTelemetryChannelStatus.tryUnregisterChannelJMXMetrics();
               }
             })
         .exceptionally(

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/channel/PartitionOffsetTracker.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/channel/PartitionOffsetTracker.java
@@ -22,8 +22,8 @@ import org.apache.kafka.connect.sink.SinkTaskContext;
  * set-if-greater logic uses a CAS loop for atomicity. The three AtomicLong fields use atomic types
  * for two reasons: (1) their refs are exposed for telemetry reads from other threads, and (2)
  * {@code currentConsumerGroupOffset} is written by both the task thread and {@link
- * #setLatestConsumerGroupOffset}. The remaining fields ({@code lastAppendRowsOffset}, {@code
- * needToSkipCurrentBatch}) are only accessed from the task thread and need no synchronization.
+ * #setLatestConsumerGroupOffset}. The remaining field ({@code lastAppendRowsOffset}) is only
+ * accessed from the task thread and needs no synchronization.
  */
 public class PartitionOffsetTracker {
 
@@ -50,10 +50,6 @@ public class PartitionOffsetTracker {
   // Last offset passed to appendRow -- used by flush to know when all data is committed.
   private long lastAppendRowsOffset = NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE;
 
-  // When true, leftover rows in the current batch are skipped because the channel was
-  // invalidated and offsets were reset in Kafka.
-  private boolean needToSkipCurrentBatch = false;
-
   public PartitionOffsetTracker(
       TopicPartition topicPartition, SinkTaskContext sinkTaskContext, String channelName) {
     this.topicPartition = topicPartition;
@@ -74,29 +70,15 @@ public class PartitionOffsetTracker {
   }
 
   /**
-   * Determines whether the given kafka offset should be processed, and manages batch-skip state.
+   * Determines whether the given kafka offset should be processed.
    *
    * @return true if the record should be ingested, false if it should be skipped
    */
-  public boolean shouldProcess(long kafkaOffset, boolean isFirstRowInBatch) {
+  public boolean shouldProcess(long kafkaOffset) {
     if (currentConsumerGroupOffset.compareAndSet(
         NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE, kafkaOffset)) {
       LOGGER.trace(
           "Setting currentConsumerGroupOffset=[{}], channel=[{}]", kafkaOffset, channelName);
-    }
-
-    if (isFirstRowInBatch) {
-      needToSkipCurrentBatch = false;
-    }
-
-    if (needToSkipCurrentBatch) {
-      LOGGER.info(
-          "Ignore inserting offset:{} for channel:{} because we recently reset offset in"
-              + " Kafka. currentProcessedOffset:{}",
-          kafkaOffset,
-          channelName,
-          processedOffset.get());
-      return false;
     }
 
     long currentProcessedOffset = this.processedOffset.get();
@@ -127,8 +109,10 @@ public class PartitionOffsetTracker {
   }
 
   /**
-   * Resets offset state after a channel recovery (reopen). Resets the Kafka consumer position and
-   * marks the current batch for skipping so leftover rows are discarded.
+   * Resets offset state after a channel recovery (reopen). Seeks the Kafka consumer to the
+   * Snowflake-committed offset + 1 so the next put() starts from the right place. Leftover records
+   * in the current batch are discarded by the batch loop's RECOVERY_COMPLETED branch (see
+   * SnowflakeSinkServiceV2.insert).
    *
    * <p>If we don't get a valid offset token (because of a table recreation or channel inactivity),
    * we will rely on Kafka to send us the correct offset.
@@ -157,8 +141,6 @@ public class PartitionOffsetTracker {
         offsetRecoveredFromSnowflake,
         channelName);
     this.processedOffset.set(offsetRecoveredFromSnowflake);
-
-    needToSkipCurrentBatch = true;
   }
 
   public void setLatestConsumerGroupOffset(long consumerOffset) {

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2Test.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2Test.java
@@ -4,10 +4,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -19,12 +21,14 @@ import com.snowflake.kafka.connector.config.SnowflakeValidation;
 import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
 import com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException;
 import com.snowflake.kafka.connector.internal.metrics.TaskMetrics;
+import com.snowflake.kafka.connector.internal.streaming.channel.InsertResult;
 import com.snowflake.kafka.connector.internal.streaming.channel.TopicPartitionChannel;
 import com.snowflake.kafka.connector.internal.streaming.v2.BackpressureException;
 import com.snowflake.kafka.connector.internal.streaming.v2.service.BatchOffsetFetcher;
 import com.snowflake.kafka.connector.internal.streaming.v2.service.PartitionChannelManager;
 import com.snowflake.kafka.connector.internal.streaming.v2.service.ThreadPools;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -88,7 +92,7 @@ class SnowflakeSinkServiceV2Test {
     SinkRecord record = recordFor(TOPIC, 0, 10);
     service.insert(Collections.singletonList(record));
 
-    verify(channel, never()).insertRecord(any(), anyBoolean());
+    verify(channel, never()).insertRecord(any());
     verify(mockSinkTaskContext).offset(tp, 10);
   }
 
@@ -101,7 +105,7 @@ class SnowflakeSinkServiceV2Test {
     SinkRecord record = recordFor(TOPIC, 0, 5);
     service.insert(Collections.singletonList(record));
 
-    verify(channel).insertRecord(record, true);
+    verify(channel).insertRecord(record);
     verify(mockSinkTaskContext, never()).offset(any(TopicPartition.class), any(Long.class));
   }
 
@@ -120,8 +124,8 @@ class SnowflakeSinkServiceV2Test {
 
     service.insert(records);
 
-    verify(initChannel, never()).insertRecord(any(), anyBoolean());
-    verify(readyChannel).insertRecord(records.get(1), true);
+    verify(initChannel, never()).insertRecord(any());
+    verify(readyChannel).insertRecord(records.get(1));
     verify(mockSinkTaskContext).offset(tpInit, 100);
     verify(mockSinkTaskContext, never()).offset(tpReady, 200);
   }
@@ -208,7 +212,7 @@ class SnowflakeSinkServiceV2Test {
     SinkRecord record1 = recordFor(TOPIC, 0, 10);
     service.insert(Collections.singletonList(record1));
 
-    verify(channel, never()).insertRecord(any(), anyBoolean());
+    verify(channel, never()).insertRecord(any());
     verify(mockSinkTaskContext).offset(tp, 10);
 
     // Channel finishes initializing — Kafka re-delivers from the rewound offset
@@ -217,8 +221,8 @@ class SnowflakeSinkServiceV2Test {
     SinkRecord record2 = recordFor(TOPIC, 0, 11);
     service.insert(List.of(record1, record2));
 
-    verify(channel).insertRecord(record1, true);
-    verify(channel).insertRecord(record2, false);
+    verify(channel).insertRecord(record1);
+    verify(channel).insertRecord(record2);
   }
 
   // --- startPartitions() pipe resolution (FR5) ---
@@ -297,14 +301,14 @@ class SnowflakeSinkServiceV2Test {
             new BackpressureException(
                 new SFException("MemoryThresholdExceeded", "backpressure", 0, "")))
         .when(channel0)
-        .insertRecord(any(), anyBoolean());
+        .insertRecord(any());
 
     List<SinkRecord> records = Arrays.asList(recordFor(TOPIC, 0, 100), recordFor(TOPIC, 1, 200));
     service.insert(records);
 
     // channel0 threw; channel1 is skipped because backpressure stops all partitions
-    verify(channel0).insertRecord(records.get(0), true);
-    verify(channel1, never()).insertRecord(any(), anyBoolean());
+    verify(channel0).insertRecord(records.get(0));
+    verify(channel1, never()).insertRecord(any());
 
     // Both partitions rewound
     verify(mockSinkTaskContext).offset(tp0, 100L);
@@ -325,7 +329,7 @@ class SnowflakeSinkServiceV2Test {
     // channel1 throws BackpressureException
     doThrow(new BackpressureException(new SFException("ReceiverSaturated", "backpressure", 0, "")))
         .when(channel1)
-        .insertRecord(any(), anyBoolean());
+        .insertRecord(any());
 
     // p0's first record succeeds, p1 throws, p0's second record is skipped
     List<SinkRecord> records =
@@ -333,9 +337,9 @@ class SnowflakeSinkServiceV2Test {
     service.insert(records);
 
     // channel0 first record processed, channel1 threw, channel0 second record skipped
-    verify(channel0).insertRecord(records.get(0), true);
-    verify(channel1).insertRecord(records.get(1), true);
-    verify(channel0, never()).insertRecord(records.get(2), false);
+    verify(channel0).insertRecord(records.get(0));
+    verify(channel1).insertRecord(records.get(1));
+    verify(channel0, never()).insertRecord(records.get(2));
 
     // p1 rewound to the backpressured record; p0 rewound to the first skipped record
     verify(mockSinkTaskContext).offset(tp1, 200L);
@@ -358,14 +362,14 @@ class SnowflakeSinkServiceV2Test {
             new BackpressureException(
                 new SFException("MemoryThresholdExceeded", "backpressure", 0, "")))
         .when(readyChannel)
-        .insertRecord(any(), anyBoolean());
+        .insertRecord(any());
 
     List<SinkRecord> records = Arrays.asList(recordFor(TOPIC, 0, 100), recordFor(TOPIC, 1, 200));
     service.insert(records);
 
     // initChannel skipped (initializing), readyChannel attempted and threw
-    verify(initChannel, never()).insertRecord(any(), anyBoolean());
-    verify(readyChannel).insertRecord(records.get(1), true);
+    verify(initChannel, never()).insertRecord(any());
+    verify(readyChannel).insertRecord(records.get(1));
 
     // Both partitions rewound via offsetsOfFirstSkippedRecord
     verify(mockSinkTaskContext).offset(tpInit, 100L);
@@ -382,7 +386,7 @@ class SnowflakeSinkServiceV2Test {
             new BackpressureException(
                 new SFException("MemoryThresholdExceeded", "backpressure", 0, "")))
         .when(channel0)
-        .insertRecord(any(), anyBoolean());
+        .insertRecord(any());
 
     service.insert(Collections.singletonList(recordFor(TOPIC, 0, 100)));
 
@@ -410,8 +414,8 @@ class SnowflakeSinkServiceV2Test {
     service.insert(records);
 
     // No inserts attempted during cooldown
-    verify(channel0, never()).insertRecord(any(), anyBoolean());
-    verify(channel1, never()).insertRecord(any(), anyBoolean());
+    verify(channel0, never()).insertRecord(any());
+    verify(channel1, never()).insertRecord(any());
 
     // All partitions rewound
     verify(mockSinkTaskContext).offset(tp0, 100L);
@@ -430,14 +434,14 @@ class SnowflakeSinkServiceV2Test {
     service.insert(Collections.singletonList(recordFor(TOPIC, 0, 100)));
 
     // Normal processing resumes
-    verify(channel0).insertRecord(any(), anyBoolean());
+    verify(channel0).insertRecord(any());
     verify(mockSinkTaskContext, never()).offset(any(TopicPartition.class), any(Long.class));
   }
 
   // --- recovery skip logic ---
 
   @Test
-  void insertSkipsRemainingRecordsForPartitionAfterRecovery() {
+  void insertAbortsBatchOnRecovery() {
     TopicPartition tp0 = new TopicPartition(TOPIC, 0);
     TopicPartition tp1 = new TopicPartition(TOPIC, 1);
 
@@ -448,7 +452,7 @@ class SnowflakeSinkServiceV2Test {
     when(mockChannelManager.getChannel(tp1)).thenReturn(Optional.of(channel1));
 
     // channel0 signals recovery on its first record
-    when(channel0.insertRecord(any(), anyBoolean())).thenReturn(false);
+    when(channel0.insertRecord(any())).thenReturn(InsertResult.RECOVERY_COMPLETED);
 
     List<SinkRecord> records =
         Arrays.asList(
@@ -458,39 +462,84 @@ class SnowflakeSinkServiceV2Test {
             recordFor(TOPIC, 0, 102));
     service.insert(records);
 
-    // channel0: only the first record was attempted; 101 and 102 were skipped
-    verify(channel0).insertRecord(records.get(0), true);
-    verify(channel0, never()).insertRecord(records.get(2), false);
-    verify(channel0, never()).insertRecord(records.get(3), false);
+    // channel0: only the first record was attempted; 101 and 102 were skipped because the batch
+    // loop returned immediately on RECOVERY_COMPLETED (SNOW-3574225).
+    verify(channel0).insertRecord(records.get(0));
+    verify(channel0, never()).insertRecord(records.get(2));
+    verify(channel0, never()).insertRecord(records.get(3));
 
-    // channel1: processed normally
-    verify(channel1).insertRecord(records.get(1), true);
+    // channel1: never reached — batch aborted before its record at index 1
+    verify(channel1, never()).insertRecord(any());
 
-    // Only the recovering partition is rewound, to the triggering record's offset
-    verify(mockSinkTaskContext).offset(tp0, 100L);
-    verify(mockSinkTaskContext, never()).offset(tp1, 200L);
+    // The batch loop must NOT seek either partition. Recovery's own seek (inside the channel) is
+    // the authoritative position; the batch loop seeking would clobber it (SNOW-3574225).
+    verify(mockSinkTaskContext, never()).offset(eq(tp0), anyLong());
+    verify(mockSinkTaskContext, never()).offset(eq(tp1), anyLong());
   }
 
   @Test
-  void insertRewindsToFirstSkippedOffsetAfterRecoveryMidPartition() {
+  void insertAbortsBatchOnRecoveryMidPartition() {
     TopicPartition tp = new TopicPartition(TOPIC, 0);
     TopicPartitionChannel channel = mockChannel("ch_0", false);
     when(mockChannelManager.getChannel(tp)).thenReturn(Optional.of(channel));
 
     // First record succeeds, second triggers recovery
-    when(channel.insertRecord(any(), anyBoolean())).thenReturn(true).thenReturn(false);
+    when(channel.insertRecord(any()))
+        .thenReturn(InsertResult.PROCESSED)
+        .thenReturn(InsertResult.RECOVERY_COMPLETED);
 
     List<SinkRecord> records =
         Arrays.asList(recordFor(TOPIC, 0, 100), recordFor(TOPIC, 0, 101), recordFor(TOPIC, 0, 102));
     service.insert(records);
 
-    // First two records attempted, third skipped
-    verify(channel).insertRecord(records.get(0), true);
-    verify(channel).insertRecord(records.get(1), false);
-    verify(channel, never()).insertRecord(records.get(2), false);
+    // First two records attempted, third skipped because batch loop returned on RECOVERY_COMPLETED
+    verify(channel).insertRecord(records.get(0));
+    verify(channel).insertRecord(records.get(1));
+    verify(channel, never()).insertRecord(records.get(2));
 
-    // Rewind to the record that triggered recovery
-    verify(mockSinkTaskContext).offset(tp, 101L);
+    // The batch loop must NOT seek — recovery's own seek (inside the channel) is authoritative
+    // (SNOW-3574225).
+    verify(mockSinkTaskContext, never()).offset(eq(tp), anyLong());
+  }
+
+  @Test
+  void insertCollection_recoveryAbortsBatchWithoutClobberingRecoverySeek() {
+    TopicPartition p0 = new TopicPartition(TOPIC, 0);
+    TopicPartition p1 = new TopicPartition(TOPIC, 1);
+
+    TopicPartitionChannel channelP0 = mockChannel("ch_0", false);
+    TopicPartitionChannel channelP1 = mockChannel("ch_1", false);
+
+    // Simulate the real channel: when recovery fires, it seeks Kafka to the Snowflake-committed
+    // offset (50) before returning RECOVERY_COMPLETED. The batch loop must NOT then clobber this
+    // seek with the batch-loop's own offsetsOfFirstSkippedRecord rewind.
+    when(channelP0.insertRecord(any()))
+        .thenAnswer(
+            inv -> {
+              mockSinkTaskContext.offset(p0, 50L); // recovery's seek to the committed offset
+              return InsertResult.RECOVERY_COMPLETED;
+            });
+
+    when(mockChannelManager.getChannel(p0)).thenReturn(Optional.of(channelP0));
+    when(mockChannelManager.getChannel(p1)).thenReturn(Optional.of(channelP1));
+
+    // Build a batch: 10 records on each partition.
+    List<SinkRecord> batch = new ArrayList<>();
+    for (long off = 100; off < 110; off++) batch.add(recordFor(TOPIC, 0, off));
+    for (long off = 200; off < 210; off++) batch.add(recordFor(TOPIC, 1, off));
+
+    service.insert(batch);
+
+    // Recovery's seek must be the only seek that fired for p0. The pre-fix bug clobbered it
+    // with sinkTaskContext.offset(p0, 100) at end-of-batch.
+    verify(mockSinkTaskContext, times(1)).offset(eq(p0), anyLong());
+    verify(mockSinkTaskContext).offset(p0, 50L);
+
+    // P1 must not be seeked at all — the batch aborted as soon as P0 returned RECOVERY_COMPLETED.
+    verify(mockSinkTaskContext, never()).offset(eq(p1), anyLong());
+
+    // P1's records were never even attempted.
+    verify(channelP1, never()).insertRecord(any());
   }
 
   // --- helpers ---
@@ -529,7 +578,7 @@ class SnowflakeSinkServiceV2Test {
     when(channel.getChannelName()).thenReturn(channelName);
     when(channel.isInitializing()).thenReturn(initializing);
     when(channel.isChannelClosed()).thenReturn(false);
-    when(channel.insertRecord(any(), anyBoolean())).thenReturn(true);
+    when(channel.insertRecord(any())).thenReturn(InsertResult.PROCESSED);
     return channel;
   }
 

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingErrorHandlerIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingErrorHandlerIT.java
@@ -82,7 +82,7 @@ class StreamingErrorHandlerIT {
     SinkRecord brokenSinkRecord = buildBrokenValueRecord(0);
 
     DataException thrown =
-        assertThrows(DataException.class, () -> channel.insertRecord(brokenSinkRecord, true));
+        assertThrows(DataException.class, () -> channel.insertRecord(brokenSinkRecord));
 
     // The cause should be the original SnowflakeKafkaConnectorException from convertToMap
     assertNotNull(thrown.getCause(), "DataException should wrap the original conversion exception");
@@ -102,7 +102,7 @@ class StreamingErrorHandlerIT {
     SinkRecord brokenSinkRecord = buildBrokenKeyRecord(0);
 
     DataException thrown =
-        assertThrows(DataException.class, () -> channel.insertRecord(brokenSinkRecord, true));
+        assertThrows(DataException.class, () -> channel.insertRecord(brokenSinkRecord));
 
     assertNotNull(thrown.getCause(), "DataException should wrap the original conversion exception");
     assertEquals(0, errorReporter.getReportedRecords().size());
@@ -121,7 +121,7 @@ class StreamingErrorHandlerIT {
     SinkRecord brokenSinkRecord = buildBrokenValueRecord(0);
 
     DataException thrown =
-        assertThrows(DataException.class, () -> channel.insertRecord(brokenSinkRecord, true));
+        assertThrows(DataException.class, () -> channel.insertRecord(brokenSinkRecord));
 
     assertNotNull(thrown.getCause(), "DataException should wrap the original conversion exception");
 
@@ -152,7 +152,7 @@ class StreamingErrorHandlerIT {
     SinkRecord brokenSinkRecord = buildBrokenValueRecord(0);
 
     // Should NOT throw
-    channel.insertRecord(brokenSinkRecord, true);
+    channel.insertRecord(brokenSinkRecord);
 
     assertEquals(1, errorReporter.getReportedRecords().size());
 
@@ -184,7 +184,7 @@ class StreamingErrorHandlerIT {
     SnowpipeStreamingPartitionChannel channel = createChannel(config, errorReporter);
     SinkRecord brokenSinkRecord = buildBrokenKeyRecord(0);
 
-    channel.insertRecord(brokenSinkRecord, true);
+    channel.insertRecord(brokenSinkRecord);
 
     assertEquals(1, errorReporter.getReportedRecords().size());
     InMemoryKafkaRecordErrorReporter.ReportedRecord reported =
@@ -208,10 +208,10 @@ class StreamingErrorHandlerIT {
 
     SnowpipeStreamingPartitionChannel channel = createChannel(config, errorReporter);
 
-    channel.insertRecord(buildBrokenValueRecord(0), true);
-    channel.insertRecord(buildValidRecord(1), false);
-    channel.insertRecord(buildBrokenValueRecord(2), false);
-    channel.insertRecord(buildBrokenValueRecord(3), false);
+    channel.insertRecord(buildBrokenValueRecord(0));
+    channel.insertRecord(buildValidRecord(1));
+    channel.insertRecord(buildBrokenValueRecord(2));
+    channel.insertRecord(buildBrokenValueRecord(3));
 
     assertEquals(3, errorReporter.getReportedRecords().size());
   }
@@ -229,7 +229,7 @@ class StreamingErrorHandlerIT {
     SinkRecord brokenSinkRecord = buildBrokenValueRecord(0);
 
     // Should NOT throw - record is silently dropped with a warning log
-    channel.insertRecord(brokenSinkRecord, true);
+    channel.insertRecord(brokenSinkRecord);
 
     assertEquals(0, errorReporter.getReportedRecords().size());
   }

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannelTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannelTest.java
@@ -3,6 +3,7 @@ package com.snowflake.kafka.connector.internal.streaming.v2;
 import static com.snowflake.kafka.connector.internal.streaming.channel.TopicPartitionChannel.NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -38,6 +39,7 @@ import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryServic
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -130,7 +132,7 @@ class SnowpipeStreamingPartitionChannelTest {
     // When: appendRow throws SFException once, triggering the fallback that reopens the channel.
     // After recovery the fallback completes normally — no exception propagates.
     trackingClientSupplier.setNonRetryableAppendRowFailures(1);
-    partitionChannel.insertRecord(buildValidRecord(0), true);
+    partitionChannel.insertRecord(buildValidRecord(0));
 
     // reopenChannel closes the old channel before opening a new one
     assertEquals(closeCountBeforeRecovery + 1, trackingClientSupplier.getCloseCallCount());
@@ -182,7 +184,7 @@ class SnowpipeStreamingPartitionChannelTest {
     // First insertRecord triggers recovery via the Failsafe fallback. reopenChannel handles
     // the failed init future gracefully (skips close, opens a new channel). After successful
     // recovery the record is inserted on the new channel — no exception propagates.
-    partitionChannel.insertRecord(buildValidRecord(0), true);
+    partitionChannel.insertRecord(buildValidRecord(0));
 
     assertEquals(
         1,
@@ -199,7 +201,7 @@ class SnowpipeStreamingPartitionChannelTest {
 
     // Trigger reopenChannel via appendRow SFException (throw once, then succeed on new channel)
     trackingClientSupplier.setNonRetryableAppendRowFailures(1);
-    partitionChannel.insertRecord(buildValidRecord(0), true);
+    partitionChannel.insertRecord(buildValidRecord(0));
 
     // reopenChannel should have closed the old channel BEFORE opening the new one
     assertEquals(
@@ -210,6 +212,35 @@ class SnowpipeStreamingPartitionChannelTest {
         2,
         trackingClientSupplier.getTotalChannelsCreated(),
         "A new channel should have been opened during reopenChannel");
+  }
+
+  @Test
+  void reopenChannel_runsOnPutThread_notOnIoExecutor() throws Exception {
+    SnowpipeStreamingPartitionChannel partitionChannel = createPartitionChannel();
+    partitionChannel.getChannel(); // Wait for async first-open to finish.
+    assertEquals(1, trackingClientSupplier.getTotalChannelsCreated());
+
+    Thread initialOpenThread = trackingClientSupplier.getOpenChannelThreads().get(0);
+    assertNotEquals(
+        Thread.currentThread(),
+        initialOpenThread,
+        "Sanity: initial open should run on openChannelIoExecutor, not the test thread");
+
+    // Trigger recovery: appendRow throws once, reopen runs, then appendRow on the new channel
+    // succeeds.
+    trackingClientSupplier.setNonRetryableAppendRowFailures(1);
+    partitionChannel.insertRecord(buildValidRecord(0));
+
+    assertEquals(2, trackingClientSupplier.getTotalChannelsCreated());
+
+    // The recovery openChannel must have run on the test thread (the "put thread"), not on
+    // openChannelIoExecutor. Pre-§B code dispatched it via CompletableFuture.thenApply on the
+    // executor — so this assertion fails against today's master.
+    Thread recoveryOpenThread = trackingClientSupplier.getOpenChannelThreads().get(1);
+    assertEquals(
+        Thread.currentThread(),
+        recoveryOpenThread,
+        "Recovery's openChannel must run on the put thread (synchronous reopen)");
   }
 
   @Test
@@ -225,8 +256,7 @@ class SnowpipeStreamingPartitionChannelTest {
     // Task 4 will handle it at the batch-level insert() loop
     BackpressureException exception =
         assertThrows(
-            BackpressureException.class,
-            () -> partitionChannel.insertRecord(buildValidRecord(0), true));
+            BackpressureException.class, () -> partitionChannel.insertRecord(buildValidRecord(0)));
 
     assertEquals("SDK backpressure: MemoryThresholdExceeded", exception.getMessage());
 
@@ -247,8 +277,7 @@ class SnowpipeStreamingPartitionChannelTest {
 
     IllegalStateException thrown =
         assertThrows(
-            IllegalStateException.class,
-            () -> partitionChannel.insertRecord(buildValidRecord(0), true));
+            IllegalStateException.class, () -> partitionChannel.insertRecord(buildValidRecord(0)));
 
     assertSame(cause, thrown);
     // No recovery should have been attempted
@@ -292,20 +321,20 @@ class SnowpipeStreamingPartitionChannelTest {
     assertEquals(1, trackingClientSupplier.getTotalChannelsCreated());
 
     // Insert first record successfully
-    partitionChannel.insertRecord(buildValidRecord(0), true);
+    partitionChannel.insertRecord(buildValidRecord(0));
 
     // Simulate channel invalidation: appendRow throws once (non-retryable SFException),
     // then succeeds on the reopened channel.
     trackingClientSupplier.setNonRetryableAppendRowFailures(1);
-    partitionChannel.insertRecord(buildValidRecord(1), false);
+    partitionChannel.insertRecord(buildValidRecord(1));
 
     // The channel should have been reopened (old closed, new opened)
     assertEquals(1, trackingClientSupplier.getCloseCallCount());
     assertEquals(2, trackingClientSupplier.getTotalChannelsCreated());
 
     // Subsequent records should continue to be ingested on the new channel
-    partitionChannel.insertRecord(buildValidRecord(2), false);
-    partitionChannel.insertRecord(buildValidRecord(3), false);
+    partitionChannel.insertRecord(buildValidRecord(2));
+    partitionChannel.insertRecord(buildValidRecord(3));
 
     // No additional channel reopenings
     assertEquals(1, trackingClientSupplier.getCloseCallCount());
@@ -325,9 +354,6 @@ class SnowpipeStreamingPartitionChannelTest {
     // Every appendRow throws — channel is permanently invalid
     trackingClientSupplier.setThrowOnAppendRow(true);
 
-    // Each record is sent as the first in a new batch (isFirstRowInBatch=true) because
-    // recovery sets needToSkipCurrentBatch=true, which would cause subsequent records
-    // in the same batch to be skipped before reaching appendRow.
     // The first 5 records trigger recovery attempts (channel reopening).
     // The 6th record exceeds MAX_CONSECUTIVE_RECOVERIES and throws ConnectException.
     ConnectException thrown =
@@ -335,7 +361,7 @@ class SnowpipeStreamingPartitionChannelTest {
             ConnectException.class,
             () -> {
               for (int i = 0; i < 20; i++) {
-                partitionChannel.insertRecord(buildValidRecord(i), true);
+                partitionChannel.insertRecord(buildValidRecord(i));
               }
             });
 
@@ -493,7 +519,7 @@ class SnowpipeStreamingPartitionChannelTest {
         createValidationEnabledChannel(STANDARD_TABLE_SCHEMA, false, true);
     SinkRecord record = buildValidRecord(0);
 
-    channel.insertRecord(record, true);
+    channel.insertRecord(record);
 
     verify(mockErrorHandler, never()).handleError(any(Exception.class), any(SinkRecord.class));
     assertEquals(1, trackingClientSupplier.getTotalChannelsCreated());
@@ -508,7 +534,7 @@ class SnowpipeStreamingPartitionChannelTest {
     SnowpipeStreamingPartitionChannel channel = createValidationEnabledChannel(schema, true, true);
 
     SinkRecord record = buildValidRecord(0);
-    channel.insertRecord(record, true);
+    channel.insertRecord(record);
 
     // Schema evolution attempted, but refreshed schema still missing RECORD_CONTENT -> error
     verify(mockErrorHandler).handleError(any(Exception.class), eq(record));
@@ -522,7 +548,7 @@ class SnowpipeStreamingPartitionChannelTest {
     SnowpipeStreamingPartitionChannel channel = createValidationEnabledChannel(schema, true, false);
 
     SinkRecord record = buildValidRecord(0);
-    channel.insertRecord(record, true);
+    channel.insertRecord(record);
 
     verify(mockErrorHandler).handleError(any(Exception.class), eq(record));
     verify(mockConnService, never()).appendColumnsToTable(any(), any());
@@ -575,7 +601,7 @@ class SnowpipeStreamingPartitionChannelTest {
             Optional.empty());
 
     SinkRecord record = buildValidRecord(0);
-    channel.insertRecord(record, true);
+    channel.insertRecord(record);
 
     verify(mockErrorHandler, never()).handleError(any(Exception.class), any(SinkRecord.class));
   }
@@ -595,7 +621,7 @@ class SnowpipeStreamingPartitionChannelTest {
 
     // Record doesn't have REQUIRED_COL — should trigger structural error
     SinkRecord record = buildValidRecord(0);
-    channel.insertRecord(record, true);
+    channel.insertRecord(record);
 
     verify(mockErrorHandler).handleError(any(Exception.class), eq(record));
   }
@@ -618,7 +644,7 @@ class SnowpipeStreamingPartitionChannelTest {
             .withOffset(0)
             .build();
 
-    channel.insertRecord(record, true);
+    channel.insertRecord(record);
 
     verify(mockConnService)
         .appendColumnsToTable(
@@ -646,7 +672,7 @@ class SnowpipeStreamingPartitionChannelTest {
     SnowpipeStreamingPartitionChannel channel = createValidationEnabledChannel(schema, false, true);
     SinkRecord record = buildValidRecord(0);
 
-    channel.insertRecord(record, true);
+    channel.insertRecord(record);
 
     // Identity column is missing from the row but should not trigger an error
     verify(mockErrorHandler, never()).handleError(any(Exception.class), any(SinkRecord.class));
@@ -664,7 +690,7 @@ class SnowpipeStreamingPartitionChannelTest {
     SnowpipeStreamingPartitionChannel channel = createValidationEnabledChannel(schema, false, true);
     SinkRecord record = buildValidRecord(0);
 
-    channel.insertRecord(record, true);
+    channel.insertRecord(record);
 
     verify(mockErrorHandler, never()).handleError(any(Exception.class), any(SinkRecord.class));
   }
@@ -913,7 +939,7 @@ class SnowpipeStreamingPartitionChannelTest {
     // Trigger reopenChannel via insertRecord: getChannel() re-throws the SFException from the
     // failed init future, which AppendRowWithFallbackPolicy catches and invokes reopenChannel.
     // reopenChannel's .exceptionally() handler handles the failed init, then opens a new channel.
-    channel.insertRecord(buildValidRecord(0), true);
+    channel.insertRecord(buildValidRecord(0));
 
     // Wait for the async reopen to complete
     channel.getChannel();
@@ -937,6 +963,7 @@ class SnowpipeStreamingPartitionChannelTest {
     private final AtomicInteger nonRetryableAppendRowFailures = new AtomicInteger(0);
     private volatile RuntimeException appendRowRuntimeException;
     private volatile CountDownLatch blockOnOpenChannel;
+    private final List<Thread> openChannelThreads = Collections.synchronizedList(new ArrayList<>());
 
     int getCloseCallCount() {
       return closeCallCount.get();
@@ -944,6 +971,10 @@ class SnowpipeStreamingPartitionChannelTest {
 
     int getTotalChannelsCreated() {
       return totalChannelsCreated.get();
+    }
+
+    List<Thread> getOpenChannelThreads() {
+      return new ArrayList<>(openChannelThreads);
     }
 
     void setThrowOnOffsetToken(boolean throwOnOffsetToken) {
@@ -999,6 +1030,7 @@ class SnowpipeStreamingPartitionChannelTest {
 
     @Override
     public OpenChannelResult openChannel(final String channelName, final String offsetToken) {
+      supplier.openChannelThreads.add(Thread.currentThread());
       if (supplier.throwOnOpenChannel) {
         throw new SFException("OpenChannelFailed", "Test simulated openChannel failure", 0, "");
       }


### PR DESCRIPTION
## Summary

Three coupled changes that together replace the async `CompletableFuture`-based channel recovery
with a synchronous lock-serialized model and fix the SNOW-3574225 data-loss race:

1. **`InsertResult` enum.** `TopicPartitionChannel.insertRecord` and `SnowflakeSinkService.insert(SinkRecord)`
   return `InsertResult.{PROCESSED, RECOVERY_COMPLETED}` instead of `boolean`.

2. **Task-wide lock + per-channel lock + synchronous reopen.** `SnowflakeSinkServiceV2.insert(Collection)`
   becomes `synchronized`. `SnowpipeStreamingPartitionChannel.reopenChannel` and the close callback in
   `closeChannelAsync` synchronize on the channel instance. The CF chain
   (`thenAccept().exceptionally().thenApply()`) inside `reopenChannel` is replaced with sequential calls
   on the put thread.

3. **SNOW-3574225 fix.** Batch loop exits early on `RECOVERY_COMPLETED` without populating
   `offsetsOfFirstSkippedRecord`. Recovery's `sinkTaskContext.offset()` seek is the only seek that fires.
   Also propagates `RECOVERY_COMPLETED` through `handleStructuralError`'s recursive `insertRowWithFallback`
   call (previously discarded). `needToSkipCurrentBatch` is deleted — synchronous reopen completes before
   the next record is processed, making the flag dead.

These three are bundled because none stands alone: the lock has no payoff without the bug fix, the bug
fix doesn't work without the lock, the enum is meaningless without the batch-loop branch.

## SNOW-3574225 anchor

Pre-fix sequence (causes data loss):
1. Records 100-209 buffered. Snowflake-committed offset = 99. Channel invalidated.
2. `appendRow` at offset 210 throws → recovery seeks Kafka to 100.
3. `insert(record-210)` returns `false` → batch loop adds `(p0, 210)` to rewind map.
4. End of `put()`: `sinkTaskContext.offset(p0, 210)` overwrites step 2's `offset(p0, 100)`.
5. Records 100-209 permanently lost.

Post-fix: step 3 returns `RECOVERY_COMPLETED`; batch loop returns from `insert(Collection)` immediately.
`sinkTaskContext.offset(p0, 100)` is the only seek that fires.

## Performance

Lock acquire/release ~50 ns on aarch64 HotSpot 17. `put()` is 10-100 ms typical. Lock overhead
< 0.001%. Synchronous reopen adds ~1-5 s to the failing put cycle (open-channel network round-trip),
but Connect immediately retries `put()`, so this is recovery latency not steady-state cost.

## Test plan

- [x] New `reopenChannel_runsOnPutThread_notOnIoExecutor` verifies sync reopen.
- [x] New `insertCollection_recoveryAbortsBatchWithoutClobberingRecoverySeek` verifies the
      SNOW-3574225 seek ordering directly.
- [x] Existing partition-channel and sink-service unit tests pass with enum returns.
- [ ] E2E (#1432) verifies the full pipe-failover recovery flow against this stack with PR3 (client
      recreation) on top.

## Stack

- This PR (PR1)
- PR2: drop count-based circuit breaker (orthogonal — independently revertable)
- PR3: client recreation for HTTP 410 / `InvalidClientError`
