### PR TITLE
drop count-based recovery circuit breaker; rely on Connect max.poll.interval.ms

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannel.java
@@ -66,16 +66,6 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
   // are cumulative and don't reset when a channel is reopened.
   private long initialErrorCount = 0;
 
-  /** Max consecutive channel recoveries before giving up and letting the task fail. */
-  private static final int MAX_CONSECUTIVE_RECOVERIES = 5;
-
-  /**
-   * Consecutive recovery counter. Incremented each time the fallback reopens the channel, reset to
-   * zero on every successful appendRow. If this reaches {@link #MAX_CONSECUTIVE_RECOVERIES} the
-   * fallback re-throws to let the KC framework kill the task.
-   */
-  private int consecutiveRecoveryCount = 0;
-
   private final String channelName;
 
   private final SnowflakeTelemetryChannelStatus snowflakeTelemetryChannelStatus;
@@ -273,7 +263,6 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
       LOGGER.trace("Inserting transformed record: {}, offset: {}", row, offset);
       getChannel().appendRow(row, Long.toString(offset));
       offsetTracker.recordAppended(offset);
-      consecutiveRecoveryCount = 0;
       return true;
     } catch (SFException e) {
       LOGGER.warn(
@@ -283,48 +272,10 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
         throw new BackpressureException(e);
       }
 
-      handleNonRetryableAppendRowFailure(e);
+      reopenChannel("APPEND_ROW_FALLBACK");
+      snowflakeTelemetryChannelStatus.incAppendRowFallbackCount();
       return false;
     }
-  }
-
-  /**
-   * Handles a non-retryable {@link SFException} from appendRow by reopening the channel after a
-   * short delay with jitter. Throws {@link ConnectException} if the circuit breaker ({@link
-   * #MAX_CONSECUTIVE_RECOVERIES}) has been exceeded, which causes Kafka Connect to kill and restart
-   * the task.
-   */
-  private void handleNonRetryableAppendRowFailure(SFException cause) {
-    consecutiveRecoveryCount++;
-    if (consecutiveRecoveryCount > MAX_CONSECUTIVE_RECOVERIES) {
-      LOGGER.error(
-          "Channel {} exceeded max consecutive recoveries ({}), giving up",
-          this.channelName,
-          MAX_CONSECUTIVE_RECOVERIES);
-      throw new ConnectException(
-          String.format(
-              "Channel %s failed after %d consecutive recovery attempts",
-              this.channelName, MAX_CONSECUTIVE_RECOVERIES),
-          cause);
-    }
-
-    final long recoveryDelayMs = 500;
-    final long recoveryJitterMaxMs = 200;
-    long delayMs = recoveryDelayMs + (long) (Math.random() * recoveryJitterMaxMs);
-    LOGGER.info("Delaying channel recovery by {}ms for channel: {}", delayMs, this.channelName);
-    try {
-      Thread.sleep(delayMs);
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-    }
-
-    LOGGER.warn(
-        "Channel {} recovery attempt {}/{}",
-        this.channelName,
-        consecutiveRecoveryCount,
-        MAX_CONSECUTIVE_RECOVERIES);
-    reopenChannel("APPEND_ROW_FALLBACK");
-    snowflakeTelemetryChannelStatus.incAppendRowFallbackCount();
   }
 
   private static void closeChannelWithoutFlushing(SnowflakeStreamingIngestChannel channel) {

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannelTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannelTest.java
@@ -342,35 +342,25 @@ class SnowpipeStreamingPartitionChannelTest {
   }
 
   @Test
-  void channelInvalidation_failsTaskAfterMaxConsecutiveRecoveries() {
-    // If the channel is permanently broken (every appendRow fails), the circuit breaker
-    // should trip after MAX_CONSECUTIVE_RECOVERIES (5) and throw ConnectException to
-    // kill the task — rather than silently dropping records forever.
+  void channelInvalidation_continuouslyReopens_relyingOnConnectTimeoutForFailFast() {
+    // After dropping the count-based circuit breaker, recovery loops indefinitely on a
+    // permanently-invalid channel within a single test run. Bounded-time failure for real
+    // permanent failures is provided by Kafka Connect's max.poll.interval.ms timeout
+    // (default 5 minutes), which is outside the scope of a unit test. Here we just verify
+    // the loop keeps reopening — no breaker fires after 5 attempts.
 
     SnowpipeStreamingPartitionChannel partitionChannel = createPartitionChannel();
     partitionChannel.getChannel();
     assertEquals(1, trackingClientSupplier.getTotalChannelsCreated());
 
-    // Every appendRow throws — channel is permanently invalid
     trackingClientSupplier.setThrowOnAppendRow(true);
 
-    // The first 5 records trigger recovery attempts (channel reopening).
-    // The 6th record exceeds MAX_CONSECUTIVE_RECOVERIES and throws ConnectException.
-    ConnectException thrown =
-        assertThrows(
-            ConnectException.class,
-            () -> {
-              for (int i = 0; i < 20; i++) {
-                partitionChannel.insertRecord(buildValidRecord(i));
-              }
-            });
+    for (int i = 0; i < 10; i++) {
+      partitionChannel.insertRecord(buildValidRecord(i));
+    }
 
-    assertTrue(
-        thrown.getMessage().contains("failed after 5 consecutive recovery attempts"),
-        "Expected circuit breaker message, got: " + thrown.getMessage());
-
-    // 1 initial + 5 recoveries = 6 channels created before the circuit breaker tripped
-    assertEquals(6, trackingClientSupplier.getTotalChannelsCreated());
+    // 1 initial open + 10 reopens. No ConnectException — that's the point of this PR.
+    assertEquals(11, trackingClientSupplier.getTotalChannelsCreated());
   }
 
   private SinkRecord buildValidRecord(long offset) {


### PR DESCRIPTION
## Summary

Deletes:
- `consecutiveRecoveryCount` field
- `MAX_CONSECUTIVE_RECOVERIES = 5` constant
- `Thread.sleep(500ms ± 200ms)` between recovery attempts
- `handleNonRetryableAppendRowFailure` method (the `ConnectException` thrower)

Inlines the reopen + telemetry increment back into `insertRowWithFallback`.

## Why drop the breaker

The breaker was added to prevent a permanent failure from looping forever. With PR1's
lock-held synchronous reopen, the put thread is bounded by Connect's `max.poll.interval.ms`
(default 5 min): if recovery keeps failing, `put()` keeps blocking on `openChannel`, Connect
declares the task stuck, kills it, and a fresh task instance picks up.

Trade-off: `max.poll.interval.ms` (5 min) is slower than the count-based breaker (5 attempts
× ~5 s = 25 s today). For genuinely permanent failures this is more dead time. For transient
failures (the common case — pipe failover takes 1-3 min), the breaker would have prevented
recovery from succeeding; dropping it makes recovery more lenient. The net is more correct
and simpler.

## Test plan

- [x] Existing recovery + invalidation unit tests pass.
- [ ] `channelInvalidation_failsTaskAfterMaxConsecutiveRecoveries` deleted (no longer
      meaningful at unit-test level). Loop-bounding now requires an integration / Connect-level
      test. Out of scope for this PR.
- [ ] E2E test (#1432) verifies recovery succeeds end-to-end without the breaker.
