### PR TITLE
Add client recreation for SDK pipe failover (HTTP 410)

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/telemetry/SnowflakeTelemetryChannelStatus.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/telemetry/SnowflakeTelemetryChannelStatus.java
@@ -58,6 +58,10 @@ public class SnowflakeTelemetryChannelStatus extends SnowflakeTelemetryBasicInfo
   // channel recovery counter (always tracked; also registered as JMX gauge if enabled)
   private final AtomicLong recoveryCount = new AtomicLong(0);
 
+  // client recreation counter — incremented when reopenChannel swaps the streaming client
+  // due to a client-invalid SDK error (HTTP 410 / pipe failover).
+  private final AtomicLong clientRecreationCount = new AtomicLong(0);
+
   // Aggregated count of client-side validation failures for this channel.
   // Reported in channel status telemetry on close, avoiding per-record telemetry overhead.
   private final AtomicLong validationFailureCount = new AtomicLong(0);
@@ -147,6 +151,7 @@ public class SnowflakeTelemetryChannelStatus extends SnowflakeTelemetryBasicInfo
     msg.put(TelemetryConstants.VALIDATION_FAILURE_COUNT, this.validationFailureCount.get());
     msg.put(TelemetryConstants.ERROR_TOLERATED_COUNT, this.errorToleratedCount.get());
     msg.put(TelemetryConstants.CHANNEL_RECOVERY_COUNT, this.recoveryCount.get());
+    msg.put(TelemetryConstants.CLIENT_RECREATION_COUNT, this.clientRecreationCount.get());
     msg.put(TelemetryConstants.VALIDATION_DISABLED, this.validationDisabled);
     msg.put(TelemetryConstants.ROWS_INSERTED_COUNT, this.rowsInsertedCount);
     msg.put(TelemetryConstants.ROWS_PARSED_COUNT, this.rowsParsedCount);
@@ -228,6 +233,16 @@ public class SnowflakeTelemetryChannelStatus extends SnowflakeTelemetryBasicInfo
   /** Increments the channel recovery counter. Thread-safe. */
   public void incRecoveryCount() {
     this.recoveryCount.incrementAndGet();
+  }
+
+  /** Increments the client recreation counter. Thread-safe. */
+  public void incClientRecreationCount() {
+    this.clientRecreationCount.incrementAndGet();
+  }
+
+  @VisibleForTesting
+  public long getClientRecreationCount() {
+    return this.clientRecreationCount.get();
   }
 
   /** Increments the validation failure counter. Thread-safe. */

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/ClientRecreationException.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/ClientRecreationException.java
@@ -63,18 +63,41 @@ public class ClientRecreationException extends RuntimeException {
     return new ClientRecreationException((SFException) e);
   }
 
+  // Stable substrings produced by the SDK for inner client-invalid errors. The SDK only exposes
+  // the outermost error code via getErrorCodeName(); on appendRow, that is "ChannelInvalidated"
+  // even when the root cause is client-invalid (the SDK includes the inner error in the message
+  // text but not as a Java cause). Match those substrings as a fallback.
+  private static final java.util.List<String> CLIENT_INVALID_INNER_MESSAGES =
+      java.util.List.of(
+          "is in an invalid state. Please close and re-create the client",
+          "pipe fail over error",
+          "client has been closed");
+
   /**
    * Checks if the given throwable represents a client-level invalidation error that requires client
    * recreation.
    *
    * @param e the exception to check (may be null)
-   * @return {@code true} if {@code e} is an {@link SFException} with a client-invalid error code
-   *     name; {@code false} otherwise
+   * @return {@code true} if {@code e} is an {@link SFException} whose outer error code is
+   *     client-invalid, or whose message contains an inner client-invalid signature
    */
   public static boolean isClientInvalidError(Throwable e) {
     if (!(e instanceof SFException)) {
       return false;
     }
-    return CLIENT_INVALID_ERROR_CODE_NAMES.contains(((SFException) e).getErrorCodeName());
+    SFException sf = (SFException) e;
+    if (CLIENT_INVALID_ERROR_CODE_NAMES.contains(sf.getErrorCodeName())) {
+      return true;
+    }
+    String message = sf.getMessage();
+    if (message == null) {
+      return false;
+    }
+    for (String marker : CLIENT_INVALID_INNER_MESSAGES) {
+      if (message.contains(marker)) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannel.java
@@ -50,6 +50,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.errors.RetriableException;
 import org.apache.kafka.connect.sink.SinkRecord;
 
 public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel {
@@ -80,7 +81,8 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
 
   private final String pipeName;
 
-  private final SnowflakeStreamingIngestClient streamingClient;
+  private volatile SnowflakeStreamingIngestClient streamingClient;
+  private final ClientRecreator clientRecreator;
   private final ExecutorService openChannelIoExecutor;
 
   private final StreamingErrorHandler streamingErrorHandler;
@@ -103,6 +105,7 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
       String channelName,
       String pipeName,
       SnowflakeStreamingIngestClient streamingClient,
+      ClientRecreator clientRecreator,
       ExecutorService openChannelIoExecutor,
       SnowflakeTelemetryService telemetryService,
       SnowflakeTelemetryChannelStatus snowflakeTelemetryChannelStatus,
@@ -116,6 +119,7 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
     this.channelName = channelName;
     this.pipeName = pipeName;
     this.streamingClient = streamingClient;
+    this.clientRecreator = clientRecreator;
     this.openChannelIoExecutor = openChannelIoExecutor;
     this.taskConfig = taskConfig;
     this.streamingErrorHandler = streamingErrorHandler;
@@ -229,7 +233,19 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
         () -> {
           LOGGER.info("Starting flush for channel: {}", this.channelName);
 
-          streamingClient.initiateFlush();
+          try {
+            streamingClient.initiateFlush();
+          } catch (SFException e) {
+            if (ClientRecreationException.isClientInvalidError(e)) {
+              LOGGER.warn(
+                  "Skipping flush for channel {}: client is invalid ({}). "
+                      + "Uncommitted data will be replayed on task restart.",
+                  this.channelName,
+                  e.getErrorCodeName());
+              return;
+            }
+            throw e;
+          }
 
           final long targetOffset = offsetTracker.getLastAppendRowsOffset();
           WaitForLastOffsetCommittedPolicy.getPolicy(
@@ -272,7 +288,8 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
         throw new BackpressureException(e);
       }
 
-      reopenChannel("APPEND_ROW_FALLBACK");
+      boolean clientInvalid = ClientRecreationException.isClientInvalidError(e);
+      reopenChannel(clientInvalid ? "CLIENT_RECREATION" : "APPEND_ROW_FALLBACK", clientInvalid);
       snowflakeTelemetryChannelStatus.incAppendRowFallbackCount();
       return false;
     }
@@ -300,11 +317,28 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
    *
    * @param reason Reason for the channel recovery. Used for logging.
    */
-  private synchronized void reopenChannel(final String reason) {
+  private synchronized void reopenChannel(final String reason, boolean recreateClient) {
     LOGGER.warn("{} Channel {} recovery initiated", reason, this.channelName);
 
     if (this.snowflakeTelemetryChannelStatus != null) {
       this.snowflakeTelemetryChannelStatus.incRecoveryCount();
+    }
+
+    if (recreateClient) {
+      try {
+        this.streamingClient = clientRecreator.recreate(this.streamingClient);
+        snowflakeTelemetryChannelStatus.incClientRecreationCount();
+      } catch (RuntimeException e) {
+        // Pool's Failsafe retries exhausted (3 × 5s by default). The pool closed the old
+        // client during recreate, so we cannot reopen the channel on the stale reference.
+        // Throw RetriableException so Kafka Connect retries put() after backoff.
+        LOGGER.warn(
+            "{} Channel {} client recreation failed; will retry on next put: {}",
+            reason,
+            this.channelName,
+            e.getMessage());
+        throw new RetriableException(e);
+      }
     }
 
     // Close old channel before reopening a new one. We don't want to wait for the channel
@@ -325,7 +359,23 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
       closeChannelWithoutFlushing(oldChannel);
     }
 
-    OpenChannelResult openChannelResult = openChannelForTable(channelName);
+    final OpenChannelResult openChannelResult;
+    try {
+      openChannelResult = openChannelForTable(channelName);
+    } catch (SFException e) {
+      // The fault that prompted recovery may still be in flight (e.g. ongoing pipe failover
+      // returning HTTP 410 on every API call). Don't fail the task — let Kafka Connect retry
+      // put() after backoff, by which time the fault should have cleared.
+      if (ClientRecreationException.isClientInvalidError(e)) {
+        LOGGER.warn(
+            "{} Channel {} reopen failed with client-invalid error; will retry on next put: {}",
+            reason,
+            this.channelName,
+            e.getMessage());
+        throw new RetriableException(e);
+      }
+      throw e;
+    }
     final long offsetRecoveredFromSnowflake = parseOrMigrateOffsetToken(openChannelResult);
 
     if (offsetRecoveredFromSnowflake == NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE) {

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/service/BatchOffsetFetcher.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/service/BatchOffsetFetcher.java
@@ -11,6 +11,7 @@ import com.snowflake.kafka.connector.internal.KCLogger;
 import com.snowflake.kafka.connector.internal.metrics.TaskMetrics;
 import com.snowflake.kafka.connector.internal.streaming.StreamingClientProperties;
 import com.snowflake.kafka.connector.internal.streaming.channel.TopicPartitionChannel;
+import com.snowflake.kafka.connector.internal.streaming.v2.ClientRecreationException;
 import com.snowflake.kafka.connector.internal.streaming.v2.client.StreamingClientPools;
 import java.util.Collection;
 import java.util.HashMap;
@@ -108,11 +109,20 @@ public class BatchOffsetFetcher {
           try {
             result.putAll(getCommittedOffsetsForPipe(pipeName, channelsByPartition));
           } catch (SFException e) {
-            LOGGER.error(
-                "Failed to fetch committed offsets for pipe: {}, skipping {} channel(s)",
-                pipeName,
-                channelsByPartition.size(),
-                e);
+            if (ClientRecreationException.isClientInvalidError(e)) {
+              LOGGER.warn(
+                  "Client is invalid for pipe: {}, skipping offset fetch for {} channel(s)."
+                      + " Client recreation will be triggered by the next appendRow on this pipe.",
+                  pipeName,
+                  channelsByPartition.size(),
+                  e);
+            } else {
+              LOGGER.error(
+                  "Failed to fetch committed offsets for pipe: {}, skipping {} channel(s)",
+                  pipeName,
+                  channelsByPartition.size(),
+                  e);
+            }
           }
         },
         ioExecutor);

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/service/PartitionChannelManager.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/service/PartitionChannelManager.java
@@ -14,6 +14,7 @@ import com.snowflake.kafka.connector.internal.streaming.StreamingClientPropertie
 import com.snowflake.kafka.connector.internal.streaming.StreamingErrorHandler;
 import com.snowflake.kafka.connector.internal.streaming.channel.TopicPartitionChannel;
 import com.snowflake.kafka.connector.internal.streaming.telemetry.SnowflakeTelemetryChannelStatus;
+import com.snowflake.kafka.connector.internal.streaming.v2.ClientRecreator;
 import com.snowflake.kafka.connector.internal.streaming.v2.SnowpipeStreamingPartitionChannel;
 import com.snowflake.kafka.connector.internal.streaming.v2.channel.PartitionOffsetTracker;
 import com.snowflake.kafka.connector.internal.streaming.v2.client.StreamingClientPools;
@@ -164,6 +165,16 @@ public class PartitionChannelManager {
             taskConfig,
             streamingClientProperties,
             taskMetrics);
+    final ClientRecreator clientRecreator =
+        invalidClient ->
+            StreamingClientPools.recreateClient(
+                taskConfig.getConnectorName(),
+                taskConfig.getTaskId(),
+                pipeName,
+                invalidClient,
+                taskConfig,
+                streamingClientProperties,
+                taskMetrics);
     final PartitionOffsetTracker offsetTracker =
         new PartitionOffsetTracker(topicPartition, this.sinkTaskContext, channelName);
 
@@ -208,6 +219,7 @@ public class PartitionChannelManager {
         channelName,
         pipeName,
         streamingClient,
+        clientRecreator,
         openChannelIoExecutor,
         this.telemetryService,
         telemetryChannelStatus,

--- a/src/main/java/com/snowflake/kafka/connector/internal/telemetry/TelemetryConstants.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/telemetry/TelemetryConstants.java
@@ -26,6 +26,7 @@ public final class TelemetryConstants {
   public static final String VALIDATION_FAILURE_COUNT = "validation_failure_count";
   public static final String ERROR_TOLERATED_COUNT = "error_tolerated_count";
   public static final String CHANNEL_RECOVERY_COUNT = "channel_recovery_count";
+  public static final String CLIENT_RECREATION_COUNT = "client_recreation_count";
   public static final String VALIDATION_DISABLED = "validation_disabled";
   public static final String ROWS_INSERTED_COUNT = "rows_inserted_count";
   public static final String ROWS_PARSED_COUNT = "rows_parsed_count";

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingErrorHandlerIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingErrorHandlerIT.java
@@ -299,6 +299,9 @@ class StreamingErrorHandlerIT {
         channelName,
         pipeName,
         new FakeSnowflakeStreamingIngestClient(pipeName, "test_connector"),
+        invalidClient -> {
+          throw new UnsupportedOperationException("ClientRecreator not wired in this IT");
+        },
         openChannelIoExecutor,
         mockTelemetryService,
         telemetryChannelStatus,

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/ClientRecreationExceptionTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/ClientRecreationExceptionTest.java
@@ -72,6 +72,34 @@ public class ClientRecreationExceptionTest {
     assertFalse(ClientRecreationException.isClientInvalidError(sfException));
   }
 
+  // The SDK wraps a client-invalid root cause inside a "ChannelInvalidated" outer error on
+  // appendRow, exposing the inner error only as a substring in getMessage(). Detect that.
+  @Test
+  void shouldRecognizeChannelInvalidatedWrappingInvalidClient() {
+    SFException sfException =
+        new SFException(
+            "ChannelInvalidated",
+            "Channel ... is in an invalid state. Inner Error: Client ... is in an invalid state."
+                + " Please close and re-create the client. Inner Error: HTTP 410",
+            400,
+            "stack");
+
+    assertTrue(ClientRecreationException.isClientInvalidError(sfException));
+  }
+
+  @Test
+  void shouldRecognizeChannelInvalidatedWrappingPipeFailedOver() {
+    SFException sfException =
+        new SFException(
+            "ChannelInvalidated",
+            "Channel ... Inner Error: HTTP request failed with a pipe fail over error for API"
+                + " get_channel_status_batch.",
+            400,
+            "stack");
+
+    assertTrue(ClientRecreationException.isClientInvalidError(sfException));
+  }
+
   @Test
   void shouldNotRecognizeNonSFException() {
     IllegalArgumentException nonSFException = new IllegalArgumentException("not an SFException");

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannelTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannelTest.java
@@ -363,6 +363,82 @@ class SnowpipeStreamingPartitionChannelTest {
     assertEquals(11, trackingClientSupplier.getTotalChannelsCreated());
   }
 
+  @Test
+  void insertRecord_clientInvalid_recreatesClientAndReopensChannel() {
+    TrackingIngestClientSupplier newClientSupplier = new TrackingIngestClientSupplier();
+    TrackingStreamingIngestClient newClient =
+        new TrackingStreamingIngestClient(pipeName, newClientSupplier);
+    AtomicInteger recreateCallCount = new AtomicInteger();
+    ClientRecreator clientRecreator =
+        invalidClient -> {
+          recreateCallCount.incrementAndGet();
+          return newClient;
+        };
+
+    SnowpipeStreamingPartitionChannel partitionChannel = createPartitionChannel(clientRecreator);
+    partitionChannel.getChannel();
+
+    trackingClientSupplier.setClientInvalidAppendRowFailures(1);
+    partitionChannel.insertRecord(buildValidRecord(0));
+
+    assertEquals(1, recreateCallCount.get());
+    assertEquals(1, newClientSupplier.getTotalChannelsCreated());
+  }
+
+  @Test
+  void insertRecord_clientInvalid_subsequentInsertsUseNewClient() {
+    TrackingIngestClientSupplier newClientSupplier = new TrackingIngestClientSupplier();
+    TrackingStreamingIngestClient newClient =
+        new TrackingStreamingIngestClient(pipeName, newClientSupplier);
+    ClientRecreator clientRecreator = invalidClient -> newClient;
+
+    SnowpipeStreamingPartitionChannel partitionChannel = createPartitionChannel(clientRecreator);
+    partitionChannel.getChannel();
+
+    trackingClientSupplier.setClientInvalidAppendRowFailures(1);
+    partitionChannel.insertRecord(buildValidRecord(0));
+    partitionChannel.insertRecord(buildValidRecord(1));
+    partitionChannel.insertRecord(buildValidRecord(2));
+
+    assertEquals(1, newClientSupplier.getTotalChannelsCreated());
+  }
+
+  @Test
+  void insertRecord_clientRecreateFails_throwsRetriableException() {
+    ClientRecreator clientRecreator =
+        invalidClient -> {
+          throw new RuntimeException("simulated pool failure: 3 attempts exhausted");
+        };
+
+    SnowpipeStreamingPartitionChannel partitionChannel = createPartitionChannel(clientRecreator);
+    partitionChannel.getChannel();
+
+    trackingClientSupplier.setClientInvalidAppendRowFailures(1);
+
+    assertThrows(
+        org.apache.kafka.connect.errors.RetriableException.class,
+        () -> partitionChannel.insertRecord(buildValidRecord(0)));
+  }
+
+  @Test
+  void insertRecord_channelOnlyError_doesNotRecreateClient() {
+    AtomicInteger recreateCallCount = new AtomicInteger();
+    ClientRecreator clientRecreator =
+        invalidClient -> {
+          recreateCallCount.incrementAndGet();
+          return invalidClient;
+        };
+
+    SnowpipeStreamingPartitionChannel partitionChannel = createPartitionChannel(clientRecreator);
+    partitionChannel.getChannel();
+
+    trackingClientSupplier.setNonRetryableAppendRowFailures(1);
+    partitionChannel.insertRecord(buildValidRecord(0));
+
+    assertEquals(0, recreateCallCount.get());
+    assertEquals(2, trackingClientSupplier.getTotalChannelsCreated());
+  }
+
   private SinkRecord buildValidRecord(long offset) {
     JsonConverter jsonConverter = new JsonConverter();
     jsonConverter.configure(Collections.singletonMap("schemas.enable", "false"), false);
@@ -376,6 +452,14 @@ class SnowpipeStreamingPartitionChannelTest {
   }
 
   private SnowpipeStreamingPartitionChannel createPartitionChannel() {
+    return createPartitionChannel(
+        invalidClient -> {
+          throw new UnsupportedOperationException("ClientRecreator not wired in this test");
+        });
+  }
+
+  private SnowpipeStreamingPartitionChannel createPartitionChannel(
+      ClientRecreator clientRecreator) {
     final TopicPartition topicPartition = new TopicPartition(TOPIC_NAME, PARTITION);
     final PartitionOffsetTracker offsetTracker =
         new PartitionOffsetTracker(topicPartition, sinkTaskContext, channelName);
@@ -404,6 +488,7 @@ class SnowpipeStreamingPartitionChannelTest {
         channelName,
         pipeName,
         trackingClient,
+        clientRecreator,
         openChannelIoExecutor,
         mockTelemetryService,
         telemetryChannelStatus,
@@ -485,6 +570,9 @@ class SnowpipeStreamingPartitionChannelTest {
         channelName,
         pipeName,
         trackingClient,
+        invalidClient -> {
+          throw new UnsupportedOperationException("ClientRecreator not wired in this test");
+        },
         openChannelIoExecutor,
         mockTelemetryService,
         telemetryChannelStatus,
@@ -579,6 +667,9 @@ class SnowpipeStreamingPartitionChannelTest {
             channelName,
             pipeName,
             trackingClient,
+            invalidClient -> {
+              throw new UnsupportedOperationException("ClientRecreator not wired in this test");
+            },
             openChannelIoExecutor,
             mockTelemetryService,
             telemetryChannelStatus,
@@ -718,6 +809,9 @@ class SnowpipeStreamingPartitionChannelTest {
         channelName,
         pipeName,
         trackingClient,
+        invalidClient -> {
+          throw new UnsupportedOperationException("ClientRecreator not wired in this test");
+        },
         openChannelIoExecutor,
         mockTelemetryService,
         telemetryChannelStatus,
@@ -951,6 +1045,7 @@ class SnowpipeStreamingPartitionChannelTest {
     private volatile boolean throwOnOpenChannel;
     private final AtomicInteger retryableAppendRowFailures = new AtomicInteger(0);
     private final AtomicInteger nonRetryableAppendRowFailures = new AtomicInteger(0);
+    private final AtomicInteger clientInvalidAppendRowFailures = new AtomicInteger(0);
     private volatile RuntimeException appendRowRuntimeException;
     private volatile CountDownLatch blockOnOpenChannel;
     private final List<Thread> openChannelThreads = Collections.synchronizedList(new ArrayList<>());
@@ -985,6 +1080,10 @@ class SnowpipeStreamingPartitionChannelTest {
 
     void setNonRetryableAppendRowFailures(int count) {
       this.nonRetryableAppendRowFailures.set(count);
+    }
+
+    void setClientInvalidAppendRowFailures(int count) {
+      this.clientInvalidAppendRowFailures.set(count);
     }
 
     void setAppendRowRuntimeException(RuntimeException exception) {
@@ -1194,6 +1293,9 @@ class SnowpipeStreamingPartitionChannelTest {
     public void appendRow(final Map<String, Object> row, final String offsetToken) {
       if (supplier.appendRowRuntimeException != null) {
         throw supplier.appendRowRuntimeException;
+      }
+      if (supplier.clientInvalidAppendRowFailures.getAndUpdate(n -> n > 0 ? n - 1 : 0) > 0) {
+        throw new SFException("InvalidClientError", "Test simulated client invalidation", 409, "");
       }
       if (supplier.retryableAppendRowFailures.getAndUpdate(n -> n > 0 ? n - 1 : 0) > 0) {
         throw new SFException("MemoryThresholdExceeded", "Test simulated backpressure", 0, "");


### PR DESCRIPTION
## Summary

Routes client-invalid SDK errors (`InvalidClientError`, `SfApiPipeFailedOverError`,
`ClosedClientError`) to a new `reopenChannel(reason, recreateClient=true)` branch that
swaps `streamingClient` via the pool's CAS before opening the new channel. Other
non-retryable `SFException`s continue to take the existing channel-reopen path.

`BatchOffsetFetcher` and `initiateFlush` now WARN-and-skip on client-invalid instead of
crashing the task — recreation happens lazily on the next `put()` cycle.

Reuses `ClientRecreator` and `ClientRecreationException` already merged via PR #1428;
reuses `StreamingClientPools.recreateClient` already merged via PR #1429.

## Test plan

- [x] Three new unit tests in `SnowpipeStreamingPartitionChannelTest` (recreate-on-client-invalid,
      subsequent-inserts-on-new-client, channel-only-error-does-not-recreate)
- [x] `ClientRecreationIT` cherry-picked from `bmikaili-channel-client-recreation-recovery`
- [ ] E2E (#1432) verifies the full pipe-failover recovery flow with mitmproxy 410 injection
