### PR TITLE
SNOW-3574225 thread-safe offset rewinds

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -338,6 +338,18 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
           initializingPartitions);
     }
 
+    Map<TopicPartition, Long> offsetsToRewindTo = new HashMap<>();
+
+    // Drain offset resets submitted by channel init / recovery on the IO thread.
+    // These partitions are skipped in this batch and rewound at the end.
+    // They will be processed normally in the next batch.
+    // This is so that sinkTaskContext.offset() is only ever called from this (task) thread.
+    Map<TopicPartition, Long> pendingResets = channelManager.drainPendingOffsetResets();
+    if (!pendingResets.isEmpty()) {
+      LOGGER.info("Draining {} pending offset resets: {}", pendingResets.size(), pendingResets);
+      offsetsToRewindTo.putAll(pendingResets);
+    }
+
     // If still in cooldown from a recent backpressure event, treat all partitions as
     // backpressured so we skip the entire batch and give the SDK time to drain.
     boolean skipAllPartitions = false;
@@ -347,7 +359,6 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
       skipAllPartitions = true;
     }
 
-    Map<TopicPartition, Long> offsetsOfFirstSkippedRecord = new HashMap<>();
     boolean newBackpressure = false;
     for (SinkRecord record : records) {
       // check if it needs to handle null value records
@@ -357,7 +368,7 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
 
       TopicPartition tp = new TopicPartition(record.topic(), record.kafkaPartition());
 
-      if (offsetsOfFirstSkippedRecord.containsKey(tp)) {
+      if (offsetsToRewindTo.containsKey(tp)) {
         // We've already skipped a record in this partition, so should also skip the remaining
         // records in this partition.
         continue;
@@ -365,13 +376,13 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
       if (skipAllPartitions || initializingPartitions.contains(tp)) {
         // Make sure we store the first record in each partition that we skipped so we can correctly
         // rewind the offset.
-        offsetsOfFirstSkippedRecord.putIfAbsent(tp, record.kafkaOffset());
+        offsetsToRewindTo.putIfAbsent(tp, record.kafkaOffset());
         continue;
       }
 
       try {
         if (!insert(record)) {
-          offsetsOfFirstSkippedRecord.putIfAbsent(tp, record.kafkaOffset());
+          offsetsToRewindTo.putIfAbsent(tp, record.kafkaOffset());
         }
       } catch (BackpressureException e) {
         LOGGER.warn(
@@ -380,7 +391,7 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
             tp,
             e.getMessage());
         taskMetrics.incBackpressureRewindCount();
-        offsetsOfFirstSkippedRecord.putIfAbsent(tp, record.kafkaOffset());
+        offsetsToRewindTo.putIfAbsent(tp, record.kafkaOffset());
         skipAllPartitions = true;
         newBackpressure = true;
       }
@@ -391,9 +402,9 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
       LOGGER.info("Backpressure cooldown set until {}", backpressureUntil);
     }
 
-    if (!offsetsOfFirstSkippedRecord.isEmpty()) {
-      LOGGER.info("Rewinding offsets for skipped partitions: {}", offsetsOfFirstSkippedRecord);
-      offsetsOfFirstSkippedRecord.forEach(sinkTaskContext::offset);
+    if (!offsetsToRewindTo.isEmpty()) {
+      LOGGER.info("Rewinding offsets for skipped partitions: {}", offsetsToRewindTo);
+      sinkTaskContext.offset(offsetsToRewindTo);
     }
   }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/channel/PartitionOffsetTracker.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/channel/PartitionOffsetTracker.java
@@ -155,6 +155,12 @@ public class PartitionOffsetTracker {
             ? consumerGroupOffset
             : offsetRecoveredFromSnowflake + 1L;
 
+    if (offsetToResetInKafka == NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE) {
+      return;
+    }
+
+    onOffsetReset.accept(offsetToResetInKafka);
+
     this.offsetPersistedInSnowflake.set(offsetRecoveredFromSnowflake);
     LOGGER.info(
         "Reset channel metadata after recovery offsetPersistedInSnowflake=[{}], channel=[{}]",
@@ -166,10 +172,6 @@ public class PartitionOffsetTracker {
     // batch-level skip is now handled by offsetsOfFirstSkippedRecord in SSV2.insert(Collection).
     // Remove together with isFirstRowInBatch in shouldProcess().
     needToSkipCurrentBatch = true;
-
-    if (offsetToResetInKafka != NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE) {
-      onOffsetReset.accept(offsetToResetInKafka);
-    }
   }
 
   public void setLatestConsumerGroupOffset(long consumerOffset) {

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/channel/PartitionOffsetTracker.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/channel/PartitionOffsetTracker.java
@@ -4,13 +4,16 @@ import static com.snowflake.kafka.connector.internal.streaming.channel.TopicPart
 
 import com.snowflake.kafka.connector.internal.KCLogger;
 import java.util.concurrent.atomic.AtomicLong;
-import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.connect.sink.SinkTaskContext;
+import java.util.function.Consumer;
 
 /**
- * Tracks all offset state for a single partition channel. This is a passive state holder -- it
- * makes no network calls. Offsets are updated during channel init/recovery, record processing in
- * `put`, and when processing channel statuses in `preCommit`.
+ * Tracks all offset state for a single partition channel. Offsets are updated during channel
+ * init/recovery, record processing in `put`, and when processing channel statuses in `preCommit`.
+ *
+ * <p>When {@link #initializeFromSnowflake} or {@link #resetAfterRecovery} compute a resume offset,
+ * the tracker fires the {@code onOffsetReset} callback supplied at construction. This callback
+ * writes to a {@code ConcurrentHashMap} in {@code PartitionChannelManager} — it does not call
+ * {@code SinkTaskContext} directly for thread safety.
  *
  * <h3>Threading model</h3>
  *
@@ -22,16 +25,20 @@ import org.apache.kafka.connect.sink.SinkTaskContext;
  * set-if-greater logic uses a CAS loop for atomicity. The three AtomicLong fields use atomic types
  * for two reasons: (1) their refs are exposed for telemetry reads from other threads, and (2)
  * {@code currentConsumerGroupOffset} is written by both the task thread and {@link
- * #setLatestConsumerGroupOffset}. The remaining fields ({@code lastAppendRowsOffset}, {@code
- * needToSkipCurrentBatch}) are only accessed from the task thread and need no synchronization.
+ * #setLatestConsumerGroupOffset}. The remaining field ({@code lastAppendRowsOffset}) is only
+ * accessed from the task thread and needs no synchronization.
  */
 public class PartitionOffsetTracker {
 
   private static final KCLogger LOGGER = new KCLogger(PartitionOffsetTracker.class.getName());
 
-  private final TopicPartition topicPartition;
-  private final SinkTaskContext sinkTaskContext;
   private final String channelName;
+
+  /**
+   * Fired when init or recovery computes a resume offset. Writes to the pending-offset-resets map
+   * in PartitionChannelManager; the task thread drains that map and calls sinkTaskContext.offset().
+   */
+  private final Consumer<Long> onOffsetReset;
 
   // Offset persisted in Snowflake, determined from the insertRows API / fetchOffsetToken calls.
   private final AtomicLong offsetPersistedInSnowflake =
@@ -54,14 +61,15 @@ public class PartitionOffsetTracker {
   // invalidated and offsets were reset in Kafka.
   private boolean needToSkipCurrentBatch = false;
 
-  public PartitionOffsetTracker(
-      TopicPartition topicPartition, SinkTaskContext sinkTaskContext, String channelName) {
-    this.topicPartition = topicPartition;
-    this.sinkTaskContext = sinkTaskContext;
+  public PartitionOffsetTracker(String channelName, Consumer<Long> onOffsetReset) {
     this.channelName = channelName;
+    this.onOffsetReset = onOffsetReset;
   }
 
-  /** Sets both persisted and processed offsets, and resets the Kafka consumer position. */
+  /**
+   * Sets both persisted and processed offsets from the Snowflake-committed offset. If the committed
+   * offset is valid, fires {@link #onOffsetReset} with {@code committedOffset + 1}.
+   */
   public void initializeFromSnowflake(long committedOffset) {
     LOGGER.info(
         "Initializing offsetPersistedInSnowflake=[{}], channel=[{}]", committedOffset, channelName);
@@ -70,7 +78,14 @@ public class PartitionOffsetTracker {
     LOGGER.info("Initializing processedOffset=[{}], channel=[{}]", committedOffset, channelName);
     this.processedOffset.set(committedOffset);
 
-    resetKafkaOffset(committedOffset);
+    if (committedOffset != NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE) {
+      onOffsetReset.accept(committedOffset + 1L);
+    } else {
+      LOGGER.info(
+          "TopicPartitionChannel:{}, offset token is NULL, will rely on Kafka to send us the"
+              + " correct offset instead",
+          channelName);
+    }
   }
 
   /**
@@ -127,14 +142,9 @@ public class PartitionOffsetTracker {
   }
 
   /**
-   * Resets offset state after a channel recovery (reopen). Resets the Kafka consumer position and
-   * marks the current batch for skipping so leftover rows are discarded.
-   *
-   * <p>If we don't get a valid offset token (because of a table recreation or channel inactivity),
-   * we will rely on Kafka to send us the correct offset.
-   *
-   * <p>The offset reset in Kafka is set to (offsetRecoveredFromSnowflake + 1) so that Kafka sends
-   * offsets starting from the next unprocessed record, avoiding data loss.
+   * Resets offset state after a channel recovery (reopen). Fires {@link #onOffsetReset} with the
+   * computed resume offset unless both the Snowflake offset and the consumer group offset are
+   * unknown.
    *
    * @param offsetRecoveredFromSnowflake the offset recovered from Snowflake after reopening
    */
@@ -145,12 +155,6 @@ public class PartitionOffsetTracker {
             ? consumerGroupOffset
             : offsetRecoveredFromSnowflake + 1L;
 
-    if (offsetToResetInKafka == NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE) {
-      return;
-    }
-
-    sinkTaskContext.offset(topicPartition, offsetToResetInKafka);
-
     this.offsetPersistedInSnowflake.set(offsetRecoveredFromSnowflake);
     LOGGER.info(
         "Reset channel metadata after recovery offsetPersistedInSnowflake=[{}], channel=[{}]",
@@ -158,7 +162,14 @@ public class PartitionOffsetTracker {
         channelName);
     this.processedOffset.set(offsetRecoveredFromSnowflake);
 
+    // TODO(SNOW-3574225): dead code - needToSkipCurrentBatch is never cleared because the
+    // batch-level skip is now handled by offsetsOfFirstSkippedRecord in SSV2.insert(Collection).
+    // Remove together with isFirstRowInBatch in shouldProcess().
     needToSkipCurrentBatch = true;
+
+    if (offsetToResetInKafka != NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE) {
+      onOffsetReset.accept(offsetToResetInKafka);
+    }
   }
 
   public void setLatestConsumerGroupOffset(long consumerOffset) {
@@ -207,16 +218,5 @@ public class PartitionOffsetTracker {
 
   public AtomicLong consumerGroupOffsetRef() {
     return currentConsumerGroupOffset;
-  }
-
-  private void resetKafkaOffset(long committedOffset) {
-    if (committedOffset != NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE) {
-      sinkTaskContext.offset(topicPartition, committedOffset + 1L);
-    } else {
-      LOGGER.info(
-          "TopicPartitionChannel:{}, offset token is NULL, will rely on Kafka to send us the"
-              + " correct offset instead",
-          channelName);
-    }
   }
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/service/PartitionChannelManager.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/service/PartitionChannelManager.java
@@ -20,12 +20,14 @@ import com.snowflake.kafka.connector.internal.streaming.v2.client.StreamingClien
 import com.snowflake.kafka.connector.internal.streaming.v2.migration.Ssv1MigrationMode;
 import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryService;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
+import java.util.function.Consumer;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.sink.SinkTaskContext;
 
@@ -60,6 +62,13 @@ public class PartitionChannelManager {
   private final PartitionChannelBuilder partitionChannelBuilder;
   private final Map<String, TopicPartitionChannel> partitionChannels;
   private final Map<String, Boolean> shouldEvolveSchemaCache = new ConcurrentHashMap<>();
+
+  /**
+   * Offset resets submitted by channel init / recovery on the IO thread. Drained by SSV2.insert on
+   * the task thread so that sinkTaskContext.offset() is only ever called from the task thread.
+   */
+  private final ConcurrentHashMap<TopicPartition, Long> pendingOffsetResets =
+      new ConcurrentHashMap<>();
 
   public PartitionChannelManager(
       SnowflakeTelemetryService telemetryService,
@@ -164,8 +173,9 @@ public class PartitionChannelManager {
             taskConfig,
             streamingClientProperties,
             taskMetrics);
+    Consumer<Long> onOffsetReset = offset -> pendingOffsetResets.put(topicPartition, offset);
     final PartitionOffsetTracker offsetTracker =
-        new PartitionOffsetTracker(topicPartition, this.sinkTaskContext, channelName);
+        new PartitionOffsetTracker(channelName, onOffsetReset);
 
     final SnowflakeTelemetryChannelStatus telemetryChannelStatus =
         new SnowflakeTelemetryChannelStatus(
@@ -316,6 +326,8 @@ public class PartitionChannelManager {
         taskConfig.getConnectorName(),
         taskConfig.getTaskId());
 
+    partitions.forEach(pendingOffsetResets::remove);
+
     CompletableFuture<?>[] futures =
         partitions.stream()
             .map(this::getChannel)
@@ -334,6 +346,27 @@ public class PartitionChannelManager {
         partitions.size(),
         partitionChannels.size(),
         partitionChannels.keySet().toString());
+  }
+
+  /**
+   * Atomically drains all pending offset resets submitted by channel init / recovery. Called from
+   * the task thread at the beginning of {@code SSV2.insert(Collection)}.
+   */
+  public Map<TopicPartition, Long> drainPendingOffsetResets() {
+    if (pendingOffsetResets.isEmpty()) {
+      return Map.of();
+    }
+    Map<TopicPartition, Long> drained = new HashMap<>();
+    pendingOffsetResets
+        .keySet()
+        .forEach(
+            tp -> {
+              Long offset = pendingOffsetResets.remove(tp);
+              if (offset != null) {
+                drained.put(tp, offset);
+              }
+            });
+    return drained;
   }
 
   /** Returns the channel for the given name, or empty if not found. */

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/service/PartitionChannelManager.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/service/PartitionChannelManager.java
@@ -386,6 +386,11 @@ public class PartitionChannelManager {
     return partitionChannels;
   }
 
+  @VisibleForTesting
+  void submitPendingOffsetReset(TopicPartition topicPartition, long offset) {
+    pendingOffsetResets.put(topicPartition, offset);
+  }
+
   /** Blocks until all partition channels have finished initialization. */
   @VisibleForTesting
   public void awaitAllPartitions() {

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2IT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2IT.java
@@ -825,6 +825,10 @@ public class SnowflakeSinkServiceV2IT extends SnowflakeSinkServiceV2BaseIT {
             .build();
     service2.startPartition(topicPartition);
     service2.awaitInitialization();
+
+    // Drain the pending init offset reset (see comment in the test below).
+    service2.insert(Collections.emptyList());
+
     offset = 1;
     // Create sink record
     SinkRecord record2 =
@@ -872,6 +876,11 @@ public class SnowflakeSinkServiceV2IT extends SnowflakeSinkServiceV2BaseIT {
             .build();
     service2.startPartition(topicPartition);
     service2.awaitInitialization();
+
+    // Drain the pending init offset reset so that the next insert() processes records normally.
+    // Channel init enqueues an offset reset in pendingOffsetResets; the first insert() drains it
+    // into offsetsToRewindTo, skipping the entire batch.
+    service2.insert(Collections.emptyList());
 
     final long startOffsetAlreadyInserted = 5;
     records =

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2RecoveryOffsetTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2RecoveryOffsetTest.java
@@ -29,6 +29,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -36,6 +37,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.function.Consumer;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.json.JsonConverter;
@@ -168,8 +170,12 @@ class SnowflakeSinkServiceV2RecoveryOffsetTest {
 
     // --- Build a real SSPC with mock SDK ---
 
-    PartitionOffsetTracker offsetTracker =
-        new PartitionOffsetTracker(tp, sinkTaskContext, channelName);
+    // Simulate the pendingOffsetResets map from PartitionChannelManager.
+    // The onOffsetReset callback writes here; drainPendingOffsetResets() drains it.
+    ConcurrentHashMap<TopicPartition, Long> pendingOffsetResets = new ConcurrentHashMap<>();
+    Consumer<Long> onOffsetReset = offset -> pendingOffsetResets.put(tp, offset);
+
+    PartitionOffsetTracker offsetTracker = new PartitionOffsetTracker(channelName, onOffsetReset);
     SnowflakeTelemetryChannelStatus telemetryStatus =
         new SnowflakeTelemetryChannelStatus(
             TOPIC,
@@ -200,11 +206,12 @@ class SnowflakeSinkServiceV2RecoveryOffsetTest {
 
     realChannel.awaitInitialization();
 
-    // After initialization, offset should be committedOffset + 1
+    // After initialization, the offset reset is pending (not yet applied to sinkTaskContext).
+    // It will be drained by SSV2.insert() at the start of the first batch.
     assertEquals(
         committedOffset + 1,
-        sinkTaskContext.offset(tp),
-        "Initialization should set offset to committedOffset + 1");
+        pendingOffsetResets.get(tp),
+        "Initialization should enqueue offset reset to committedOffset + 1");
 
     // --- Mock PartitionChannelManager to return the real channel ---
 
@@ -214,6 +221,25 @@ class SnowflakeSinkServiceV2RecoveryOffsetTest {
     Map<String, TopicPartitionChannel> channelMap = new ConcurrentHashMap<>();
     channelMap.put(channelName, realChannel);
     when(mockChannelManager.getPartitionChannels()).thenReturn(channelMap);
+    // Wire drainPendingOffsetResets to drain the real map (mirrors PartitionChannelManager)
+    when(mockChannelManager.drainPendingOffsetResets())
+        .thenAnswer(
+            invocation -> {
+              if (pendingOffsetResets.isEmpty()) {
+                return Map.of();
+              }
+              Map<TopicPartition, Long> drained = new HashMap<>();
+              pendingOffsetResets
+                  .keySet()
+                  .forEach(
+                      key -> {
+                        Long offset = pendingOffsetResets.remove(key);
+                        if (offset != null) {
+                          drained.put(key, offset);
+                        }
+                      });
+              return drained;
+            });
 
     // --- Wire SSV2 ---
 
@@ -230,32 +256,29 @@ class SnowflakeSinkServiceV2RecoveryOffsetTest {
             () -> mockChannelManager,
             TaskMetrics.noop());
 
-    // --- Batch 0: verify init offset was applied ---
-    // On master, initializeFromSnowflake calls sinkTaskContext.offset(tp, 51) directly.
-    // On fix branch, it enqueues in pendingOffsetResets and this empty batch drains it.
+    // --- Batch 0: drain the init offset reset ---
+    // initializeFromSnowflake enqueued offset 51 in pendingOffsetResets. The first insert()
+    // drains it into offsetsToRewindTo, skipping the (empty) batch and rewinding to 51.
     service.insert(Collections.emptyList());
-    assertEquals(committedOffset + 1, sinkTaskContext.offset(tp), "Init should set offset");
+    assertEquals(committedOffset + 1, sinkTaskContext.offset(tp), "Init drain should set offset");
 
     // --- Batch 1: records 51–85, appendRow fails at offset 80 ---
     //
+    // Top-of-batch drain: pendingOffsetResets is empty (init already drained).
     // Records 51–79 are appended successfully.
-    // Record 80 triggers SFException → recovery → resetAfterRecovery(50) calls
-    //   sinkTaskContext.offset(tp, 51) directly.
-    // insertRecord returns false for record 80 → SSV2 puts {tp: 80} in offsetsOfFirstSkippedRecord.
-    // Records 81–85 are skipped (tp already in offsetsOfFirstSkippedRecord).
-    // End of batch: sinkTaskContext.offset(tp, 80) OVERWRITES the recovery offset.
+    // Record 80 triggers SFException → recovery → resetAfterRecovery(50) enqueues offset 51
+    //   in pendingOffsetResets.
+    // insertRecord returns false for record 80 → SSV2 puts {tp: 80} in offsetsToRewindTo.
+    // Records 81–85 are skipped (tp already in offsetsToRewindTo).
+    // End of batch: sinkTaskContext.offset({tp: 80}). The recovery offset 51 is still pending.
 
     service.insert(buildRecordBatch(51, 85));
 
     // --- Batch 2: records 80–85 (what Kafka would re-deliver from offset 80) ---
     //
-    // On master: needToSkipCurrentBatch is reset on first record (isFirstRowInBatch=true),
-    //            all records process normally at offsets 80–85. No offset rewind occurs.
-    //            Offset stays at 80. Records 51–79 are permanently lost.
-    //
-    // On fix branch: pendingOffsetResets contains {tp: 51} from recovery, which is drained
-    //                into offsetsToRewindTo at the start of the batch. All records are
-    //                skipped. sinkTaskContext.offset({tp: 51}) is called.
+    // Top-of-batch drain: pendingOffsetResets has {tp: 51} → offsetsToRewindTo = {tp: 51}.
+    // All records are skipped (offsetsToRewindTo.containsKey(tp) is true).
+    // End of batch: sinkTaskContext.offset({tp: 51}). Recovery offset wins.
 
     service.insert(buildRecordBatch(80, 85));
 

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2RecoveryOffsetTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2RecoveryOffsetTest.java
@@ -1,0 +1,296 @@
+package com.snowflake.kafka.connector.internal.streaming;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.snowflake.ingest.streaming.ChannelStatus;
+import com.snowflake.ingest.streaming.OpenChannelResult;
+import com.snowflake.ingest.streaming.SFException;
+import com.snowflake.ingest.streaming.SnowflakeStreamingIngestChannel;
+import com.snowflake.ingest.streaming.SnowflakeStreamingIngestClient;
+import com.snowflake.kafka.connector.builder.SinkRecordBuilder;
+import com.snowflake.kafka.connector.config.SinkTaskConfig;
+import com.snowflake.kafka.connector.config.SinkTaskConfigTestBuilder;
+import com.snowflake.kafka.connector.config.SnowflakeValidation;
+import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
+import com.snowflake.kafka.connector.internal.metrics.TaskMetrics;
+import com.snowflake.kafka.connector.internal.streaming.channel.TopicPartitionChannel;
+import com.snowflake.kafka.connector.internal.streaming.telemetry.SnowflakeTelemetryChannelStatus;
+import com.snowflake.kafka.connector.internal.streaming.v2.SnowpipeStreamingPartitionChannel;
+import com.snowflake.kafka.connector.internal.streaming.v2.channel.PartitionOffsetTracker;
+import com.snowflake.kafka.connector.internal.streaming.v2.service.BatchOffsetFetcher;
+import com.snowflake.kafka.connector.internal.streaming.v2.service.PartitionChannelManager;
+import com.snowflake.kafka.connector.internal.streaming.v2.service.ThreadPools;
+import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryService;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.json.JsonConverter;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration test demonstrating the recovery offset overwrite bug.
+ *
+ * <p>When appendRow throws SFException, the recovery path ({@code reopenChannel} → {@code
+ * resetAfterRecovery}) calls {@code sinkTaskContext.offset(tp, committedOffset + 1)} to rewind
+ * Kafka to the correct resume point. However, after recovery returns, {@code
+ * SnowflakeSinkServiceV2.insert(Collection)} adds the failed record's offset to {@code
+ * offsetsOfFirstSkippedRecord}, which overwrites the recovery offset at the end of the batch. This
+ * causes records between the committed offset and the failed record's offset to be permanently
+ * lost.
+ *
+ * <p>This test should <b>FAIL</b> on master and <b>PASS</b> on the fix branch that moves offset
+ * resets to the task thread via {@code pendingOffsetResets}.
+ */
+class SnowflakeSinkServiceV2RecoveryOffsetTest {
+
+  private static final String TOPIC = "test_topic";
+  private static final String CONNECTOR_NAME = "test_connector";
+  private static final int PARTITION = 0;
+
+  private ExecutorService ioExecutor;
+
+  @BeforeEach
+  void setUp() {
+    ioExecutor = Executors.newSingleThreadExecutor();
+  }
+
+  @AfterEach
+  void tearDown() {
+    ioExecutor.shutdownNow();
+    ThreadPools.closeForTask(CONNECTOR_NAME);
+  }
+
+  /**
+   * Scenario:
+   *
+   * <ol>
+   *   <li>Channel is opened with committed offset 50 in Snowflake.
+   *   <li>Records 51–85 arrive in a single batch.
+   *   <li>Records 51–79 are successfully appended.
+   *   <li>Record 80 triggers a non-retryable SFException (channel invalidation).
+   *   <li>Recovery: channel is reopened, committed offset is still 50 → {@code
+   *       resetAfterRecovery(50)} calls {@code sinkTaskContext.offset(tp, 51)}.
+   *   <li>SSV2 adds offset 80 to {@code offsetsOfFirstSkippedRecord}.
+   *   <li>End of batch: {@code sinkTaskContext.offset(tp, 80)} overwrites the recovery offset.
+   *   <li>Batch 2 (records 80–85): on master, records process normally — records 51–79 are lost.
+   * </ol>
+   *
+   * <p>Expected: after two batches, the effective offset should be 51 (the recovery offset), not
+   * 80. Records 51–79 must be replayed.
+   */
+  @Test
+  void recoveryOffsetShouldNotBeOverwrittenBySkippedRecordOffset() {
+    TopicPartition tp = new TopicPartition(TOPIC, PARTITION);
+    String channelName = PartitionChannelManager.makeChannelName(CONNECTOR_NAME, TOPIC, PARTITION);
+    String pipeName = "test_pipe";
+    long committedOffset = 50L;
+    long failingOffset = 80L;
+
+    InMemorySinkTaskContext sinkTaskContext = new InMemorySinkTaskContext(Set.of(tp));
+
+    // --- SDK mocks ---
+
+    // First SDK channel: appendRow succeeds for offsets < failingOffset, throws at failingOffset
+    SnowflakeStreamingIngestChannel firstSdkChannel = mock(SnowflakeStreamingIngestChannel.class);
+    when(firstSdkChannel.isClosed()).thenReturn(false);
+    when(firstSdkChannel.getChannelName()).thenReturn(channelName);
+    when(firstSdkChannel.getFullyQualifiedChannelName()).thenReturn(channelName);
+    doAnswer(
+            invocation -> {
+              String offsetToken = invocation.getArgument(1);
+              if (String.valueOf(failingOffset).equals(offsetToken)) {
+                throw new SFException(
+                    "ChannelInvalidated", "simulated channel invalidation", 0, "");
+              }
+              return null;
+            })
+        .when(firstSdkChannel)
+        .appendRow(any(), any());
+
+    // Second SDK channel (after recovery): appendRow always succeeds
+    SnowflakeStreamingIngestChannel secondSdkChannel = mock(SnowflakeStreamingIngestChannel.class);
+    when(secondSdkChannel.isClosed()).thenReturn(false);
+    when(secondSdkChannel.getChannelName()).thenReturn(channelName);
+    when(secondSdkChannel.getFullyQualifiedChannelName()).thenReturn(channelName);
+
+    // Both openChannel calls return committed offset = 50
+    ChannelStatus statusWithCommittedOffset =
+        new ChannelStatus(
+            "db",
+            "schema",
+            pipeName,
+            channelName,
+            "SUCCESS",
+            String.valueOf(committedOffset),
+            Instant.now(),
+            0,
+            0,
+            0,
+            null,
+            null,
+            null,
+            null,
+            Instant.now());
+
+    SnowflakeStreamingIngestClient mockClient = mock(SnowflakeStreamingIngestClient.class);
+    when(mockClient.openChannel(channelName, null))
+        .thenReturn(new OpenChannelResult(firstSdkChannel, statusWithCommittedOffset))
+        .thenReturn(new OpenChannelResult(secondSdkChannel, statusWithCommittedOffset));
+
+    // --- Build configuration ---
+
+    SinkTaskConfig taskConfig =
+        SinkTaskConfigTestBuilder.builder()
+            .connectorName(CONNECTOR_NAME)
+            .taskId("0")
+            .validation(SnowflakeValidation.SERVER_SIDE)
+            .build();
+
+    SnowflakeTelemetryService mockTelemetry = mock(SnowflakeTelemetryService.class);
+    StreamingErrorHandler mockErrorHandler = mock(StreamingErrorHandler.class);
+
+    // --- Build a real SSPC with mock SDK ---
+
+    PartitionOffsetTracker offsetTracker =
+        new PartitionOffsetTracker(tp, sinkTaskContext, channelName);
+    SnowflakeTelemetryChannelStatus telemetryStatus =
+        new SnowflakeTelemetryChannelStatus(
+            TOPIC,
+            CONNECTOR_NAME,
+            channelName,
+            System.currentTimeMillis(),
+            Optional.empty(),
+            offsetTracker.persistedOffsetRef(),
+            offsetTracker.processedOffsetRef(),
+            offsetTracker.consumerGroupOffsetRef());
+
+    SnowpipeStreamingPartitionChannel realChannel =
+        new SnowpipeStreamingPartitionChannel(
+            TOPIC,
+            channelName,
+            pipeName,
+            mockClient,
+            ioExecutor,
+            mockTelemetry,
+            telemetryStatus,
+            offsetTracker,
+            taskConfig,
+            mockErrorHandler,
+            TaskMetrics.noop(),
+            false,
+            null,
+            Optional.empty());
+
+    realChannel.awaitInitialization();
+
+    // After initialization, offset should be committedOffset + 1
+    assertEquals(
+        committedOffset + 1,
+        sinkTaskContext.offset(tp),
+        "Initialization should set offset to committedOffset + 1");
+
+    // --- Mock PartitionChannelManager to return the real channel ---
+
+    PartitionChannelManager mockChannelManager = mock(PartitionChannelManager.class);
+    when(mockChannelManager.getChannel(tp)).thenReturn(Optional.of(realChannel));
+    when(mockChannelManager.getChannel(channelName)).thenReturn(Optional.of(realChannel));
+    Map<String, TopicPartitionChannel> channelMap = new ConcurrentHashMap<>();
+    channelMap.put(channelName, realChannel);
+    when(mockChannelManager.getPartitionChannels()).thenReturn(channelMap);
+
+    // --- Wire SSV2 ---
+
+    SnowflakeConnectionService mockConn = mock(SnowflakeConnectionService.class);
+    when(mockConn.isClosed()).thenReturn(false);
+
+    SnowflakeSinkServiceV2 service =
+        new SnowflakeSinkServiceV2(
+            mockConn,
+            taskConfig,
+            sinkTaskContext,
+            Optional.empty(),
+            () -> mock(BatchOffsetFetcher.class),
+            () -> mockChannelManager,
+            TaskMetrics.noop());
+
+    // --- Batch 0: verify init offset was applied ---
+    // On master, initializeFromSnowflake calls sinkTaskContext.offset(tp, 51) directly.
+    // On fix branch, it enqueues in pendingOffsetResets and this empty batch drains it.
+    service.insert(Collections.emptyList());
+    assertEquals(committedOffset + 1, sinkTaskContext.offset(tp), "Init should set offset");
+
+    // --- Batch 1: records 51–85, appendRow fails at offset 80 ---
+    //
+    // Records 51–79 are appended successfully.
+    // Record 80 triggers SFException → recovery → resetAfterRecovery(50) calls
+    //   sinkTaskContext.offset(tp, 51) directly.
+    // insertRecord returns false for record 80 → SSV2 puts {tp: 80} in offsetsOfFirstSkippedRecord.
+    // Records 81–85 are skipped (tp already in offsetsOfFirstSkippedRecord).
+    // End of batch: sinkTaskContext.offset(tp, 80) OVERWRITES the recovery offset.
+
+    service.insert(buildRecordBatch(51, 85));
+
+    // --- Batch 2: records 80–85 (what Kafka would re-deliver from offset 80) ---
+    //
+    // On master: needToSkipCurrentBatch is reset on first record (isFirstRowInBatch=true),
+    //            all records process normally at offsets 80–85. No offset rewind occurs.
+    //            Offset stays at 80. Records 51–79 are permanently lost.
+    //
+    // On fix branch: pendingOffsetResets contains {tp: 51} from recovery, which is drained
+    //                into offsetsToRewindTo at the start of the batch. All records are
+    //                skipped. sinkTaskContext.offset({tp: 51}) is called.
+
+    service.insert(buildRecordBatch(80, 85));
+
+    // --- Assertion ---
+
+    long expectedRecoveryOffset = committedOffset + 1; // 51
+    assertEquals(
+        expectedRecoveryOffset,
+        sinkTaskContext.offset(tp),
+        "After recovery, the effective offset should be the recovery offset ("
+            + expectedRecoveryOffset
+            + "), not the failed record's offset ("
+            + failingOffset
+            + "). If this assertion fails, records "
+            + expectedRecoveryOffset
+            + "–"
+            + (failingOffset - 1)
+            + " are permanently lost because resetAfterRecovery's offset was overwritten by"
+            + " offsetsOfFirstSkippedRecord.");
+  }
+
+  private List<SinkRecord> buildRecordBatch(long fromOffset, long toOffset) {
+    List<SinkRecord> records = new ArrayList<>();
+    JsonConverter jsonConverter = new JsonConverter();
+    jsonConverter.configure(Collections.singletonMap("schemas.enable", "false"), false);
+    for (long offset = fromOffset; offset <= toOffset; offset++) {
+      SchemaAndValue schemaAndValue =
+          jsonConverter.toConnectData(
+              TOPIC, "{\"name\": \"test\"}".getBytes(StandardCharsets.UTF_8));
+      records.add(
+          SinkRecordBuilder.forTopicPartition(TOPIC, PARTITION)
+              .withSchemaAndValue(schemaAndValue)
+              .withOffset(offset)
+              .build());
+    }
+    return records;
+  }
+}

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2Test.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2Test.java
@@ -55,6 +55,7 @@ class SnowflakeSinkServiceV2Test {
   @BeforeEach
   void setUp() {
     mockChannelManager = mock(PartitionChannelManager.class);
+    when(mockChannelManager.drainPendingOffsetResets()).thenReturn(Map.of());
     mockBatchOffsetFetcher = mock(BatchOffsetFetcher.class);
     mockSinkTaskContext = mock(SinkTaskContext.class);
 
@@ -89,10 +90,11 @@ class SnowflakeSinkServiceV2Test {
     service.insert(Collections.singletonList(record));
 
     verify(channel, never()).insertRecord(any(), anyBoolean());
-    verify(mockSinkTaskContext).offset(tp, 10);
+    verify(mockSinkTaskContext).offset(Map.of(tp, 10L));
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   void insertProcessesRecordsForReadyPartitions() {
     TopicPartition tp = new TopicPartition(TOPIC, 0);
     TopicPartitionChannel channel = mockChannel("ch_0", false);
@@ -102,7 +104,7 @@ class SnowflakeSinkServiceV2Test {
     service.insert(Collections.singletonList(record));
 
     verify(channel).insertRecord(record, true);
-    verify(mockSinkTaskContext, never()).offset(any(TopicPartition.class), any(Long.class));
+    verify(mockSinkTaskContext, never()).offset(any(Map.class));
   }
 
   @Test
@@ -122,8 +124,7 @@ class SnowflakeSinkServiceV2Test {
 
     verify(initChannel, never()).insertRecord(any(), anyBoolean());
     verify(readyChannel).insertRecord(records.get(1), true);
-    verify(mockSinkTaskContext).offset(tpInit, 100);
-    verify(mockSinkTaskContext, never()).offset(tpReady, 200);
+    verify(mockSinkTaskContext).offset(Map.of(tpInit, 100L));
   }
 
   @Test
@@ -137,9 +138,7 @@ class SnowflakeSinkServiceV2Test {
 
     service.insert(records);
 
-    verify(mockSinkTaskContext).offset(tp, 5);
-    verify(mockSinkTaskContext, never()).offset(tp, 6);
-    verify(mockSinkTaskContext, never()).offset(tp, 7);
+    verify(mockSinkTaskContext).offset(Map.of(tp, 5L));
   }
 
   // --- getCommittedOffsets() skip logic ---
@@ -209,7 +208,7 @@ class SnowflakeSinkServiceV2Test {
     service.insert(Collections.singletonList(record1));
 
     verify(channel, never()).insertRecord(any(), anyBoolean());
-    verify(mockSinkTaskContext).offset(tp, 10);
+    verify(mockSinkTaskContext).offset(Map.of(tp, 10L));
 
     // Channel finishes initializing — Kafka re-delivers from the rewound offset
     when(channel.isInitializing()).thenReturn(false);
@@ -306,9 +305,8 @@ class SnowflakeSinkServiceV2Test {
     verify(channel0).insertRecord(records.get(0), true);
     verify(channel1, never()).insertRecord(any(), anyBoolean());
 
-    // Both partitions rewound
-    verify(mockSinkTaskContext).offset(tp0, 100L);
-    verify(mockSinkTaskContext).offset(tp1, 200L);
+    // Both partitions rewound in one call
+    verify(mockSinkTaskContext).offset(Map.of(tp0, 100L, tp1, 200L));
   }
 
   @Test
@@ -338,8 +336,7 @@ class SnowflakeSinkServiceV2Test {
     verify(channel0, never()).insertRecord(records.get(2), false);
 
     // p1 rewound to the backpressured record; p0 rewound to the first skipped record
-    verify(mockSinkTaskContext).offset(tp1, 200L);
-    verify(mockSinkTaskContext).offset(tp0, 101L);
+    verify(mockSinkTaskContext).offset(Map.of(tp0, 101L, tp1, 200L));
   }
 
   @Test
@@ -368,8 +365,7 @@ class SnowflakeSinkServiceV2Test {
     verify(readyChannel).insertRecord(records.get(1), true);
 
     // Both partitions rewound via offsetsOfFirstSkippedRecord
-    verify(mockSinkTaskContext).offset(tpInit, 100L);
-    verify(mockSinkTaskContext).offset(tpReady, 200L);
+    verify(mockSinkTaskContext).offset(Map.of(tpInit, 100L, tpReady, 200L));
   }
 
   @Test
@@ -414,11 +410,11 @@ class SnowflakeSinkServiceV2Test {
     verify(channel1, never()).insertRecord(any(), anyBoolean());
 
     // All partitions rewound
-    verify(mockSinkTaskContext).offset(tp0, 100L);
-    verify(mockSinkTaskContext).offset(tp1, 200L);
+    verify(mockSinkTaskContext).offset(Map.of(tp0, 100L, tp1, 200L));
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   void insertResumesNormallyAfterCooldownExpires() {
     TopicPartition tp0 = new TopicPartition(TOPIC, 0);
     TopicPartitionChannel channel0 = mockChannel("ch_0", false);
@@ -431,7 +427,7 @@ class SnowflakeSinkServiceV2Test {
 
     // Normal processing resumes
     verify(channel0).insertRecord(any(), anyBoolean());
-    verify(mockSinkTaskContext, never()).offset(any(TopicPartition.class), any(Long.class));
+    verify(mockSinkTaskContext, never()).offset(any(Map.class));
   }
 
   // --- recovery skip logic ---
@@ -467,8 +463,7 @@ class SnowflakeSinkServiceV2Test {
     verify(channel1).insertRecord(records.get(1), true);
 
     // Only the recovering partition is rewound, to the triggering record's offset
-    verify(mockSinkTaskContext).offset(tp0, 100L);
-    verify(mockSinkTaskContext, never()).offset(tp1, 200L);
+    verify(mockSinkTaskContext).offset(Map.of(tp0, 100L));
   }
 
   @Test
@@ -490,7 +485,7 @@ class SnowflakeSinkServiceV2Test {
     verify(channel, never()).insertRecord(records.get(2), false);
 
     // Rewind to the record that triggered recovery
-    verify(mockSinkTaskContext).offset(tp, 101L);
+    verify(mockSinkTaskContext).offset(Map.of(tp, 101L));
   }
 
   // --- helpers ---

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingErrorHandlerIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingErrorHandlerIT.java
@@ -24,7 +24,6 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.errors.DataException;
@@ -50,7 +49,6 @@ class StreamingErrorHandlerIT {
   private String pipeName;
 
   private SnowflakeTelemetryService mockTelemetryService;
-  private InMemorySinkTaskContext sinkTaskContext;
   private ExecutorService openChannelIoExecutor;
 
   @BeforeEach
@@ -60,9 +58,6 @@ class StreamingErrorHandlerIT {
     pipeName = "test_pipe_" + uniqueId;
 
     mockTelemetryService = mock(SnowflakeTelemetryService.class);
-
-    sinkTaskContext =
-        new InMemorySinkTaskContext(Collections.singleton(new TopicPartition(TOPIC, PARTITION)));
     openChannelIoExecutor = Executors.newSingleThreadExecutor();
   }
 
@@ -280,9 +275,8 @@ class StreamingErrorHandlerIT {
     StreamingErrorHandler errorHandler =
         new StreamingErrorHandler(taskConfig, errorReporter, mockTelemetryService);
 
-    final TopicPartition topicPartition = new TopicPartition(TOPIC, PARTITION);
     final PartitionOffsetTracker offsetTracker =
-        new PartitionOffsetTracker(topicPartition, sinkTaskContext, channelName);
+        new PartitionOffsetTracker(channelName, offset -> {});
     final SnowflakeTelemetryChannelStatus telemetryChannelStatus =
         new SnowflakeTelemetryChannelStatus(
             "test_table",

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannelTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannelTest.java
@@ -360,9 +360,8 @@ class SnowpipeStreamingPartitionChannelTest {
   }
 
   private SnowpipeStreamingPartitionChannel createPartitionChannel() {
-    final TopicPartition topicPartition = new TopicPartition(TOPIC_NAME, PARTITION);
     final PartitionOffsetTracker offsetTracker =
-        new PartitionOffsetTracker(topicPartition, sinkTaskContext, channelName);
+        new PartitionOffsetTracker(channelName, offset -> {});
     final SnowflakeTelemetryChannelStatus telemetryChannelStatus =
         new SnowflakeTelemetryChannelStatus(
             TABLE_NAME,
@@ -441,9 +440,8 @@ class SnowpipeStreamingPartitionChannelTest {
     mockConnService = mock(SnowflakeConnectionService.class);
     when(mockConnService.describeTable(TABLE_NAME)).thenReturn(Optional.of(describeResult));
 
-    final TopicPartition topicPartition = new TopicPartition(TOPIC_NAME, PARTITION);
     final PartitionOffsetTracker offsetTracker =
-        new PartitionOffsetTracker(topicPartition, sinkTaskContext, channelName);
+        new PartitionOffsetTracker(channelName, offset -> {});
     final SnowflakeTelemetryChannelStatus telemetryChannelStatus =
         new SnowflakeTelemetryChannelStatus(
             TABLE_NAME,
@@ -534,9 +532,8 @@ class SnowpipeStreamingPartitionChannelTest {
     mockConnService = mock(SnowflakeConnectionService.class);
     when(mockConnService.describeTable(TABLE_NAME)).thenReturn(Optional.empty());
 
-    final TopicPartition topicPartition = new TopicPartition(TOPIC_NAME, PARTITION);
     final PartitionOffsetTracker offsetTracker =
-        new PartitionOffsetTracker(topicPartition, sinkTaskContext, channelName);
+        new PartitionOffsetTracker(channelName, offset -> {});
     final SnowflakeTelemetryChannelStatus telemetryChannelStatus =
         new SnowflakeTelemetryChannelStatus(
             TABLE_NAME,
@@ -673,9 +670,9 @@ class SnowpipeStreamingPartitionChannelTest {
 
   private SnowpipeStreamingPartitionChannel createPartitionChannelWithMigration(
       Ssv1MigrationMode migrationMode, SnowflakeConnectionService mockConn) {
-    final TopicPartition topicPartition = new TopicPartition(TOPIC_NAME, PARTITION);
+    TopicPartition tp = new TopicPartition(TOPIC_NAME, PARTITION);
     final PartitionOffsetTracker offsetTracker =
-        new PartitionOffsetTracker(topicPartition, sinkTaskContext, channelName);
+        new PartitionOffsetTracker(channelName, offset -> sinkTaskContext.offset(tp, offset));
     final SnowflakeTelemetryChannelStatus telemetryChannelStatus =
         new SnowflakeTelemetryChannelStatus(
             TABLE_NAME,

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/service/PartitionChannelManagerTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/service/PartitionChannelManagerTest.java
@@ -260,6 +260,56 @@ class PartitionChannelManagerTest {
     assertTrue(manager.getPartitionChannels().isEmpty());
   }
 
+  // --- drainPendingOffsetResets ---
+
+  @Test
+  void drainPendingOffsetResetsReturnsEmptyMapWhenNothingPending() {
+    assertTrue(manager.drainPendingOffsetResets().isEmpty());
+  }
+
+  @Test
+  void drainPendingOffsetResetsReturnsAndClearsPendingEntries() {
+    TopicPartition tp0 = new TopicPartition(TOPIC, 0);
+    TopicPartition tp1 = new TopicPartition(TOPIC, 1);
+
+    manager.submitPendingOffsetReset(tp0, 51L);
+    manager.submitPendingOffsetReset(tp1, 101L);
+
+    Map<TopicPartition, Long> drained = manager.drainPendingOffsetResets();
+
+    assertEquals(Map.of(tp0, 51L, tp1, 101L), drained);
+    assertTrue(manager.drainPendingOffsetResets().isEmpty(), "Second drain should be empty");
+  }
+
+  @Test
+  void drainPendingOffsetResetsLastWriteWinsForSamePartition() {
+    TopicPartition tp = new TopicPartition(TOPIC, 0);
+
+    manager.submitPendingOffsetReset(tp, 51L);
+    manager.submitPendingOffsetReset(tp, 71L);
+
+    Map<TopicPartition, Long> drained = manager.drainPendingOffsetResets();
+
+    assertEquals(71L, drained.get(tp), "Later recovery offset should win");
+    assertEquals(1, drained.size());
+  }
+
+  @Test
+  void closeClearsPendingOffsetResetsForClosedPartitions() {
+    TopicPartition tp0 = new TopicPartition(TOPIC, 0);
+    TopicPartition tp1 = new TopicPartition(TOPIC, 1);
+    startPartitions(tp0, tp1);
+
+    manager.submitPendingOffsetReset(tp0, 51L);
+    manager.submitPendingOffsetReset(tp1, 101L);
+
+    manager.close(Collections.singletonList(tp0));
+
+    Map<TopicPartition, Long> drained = manager.drainPendingOffsetResets();
+    assertFalse(drained.containsKey(tp0), "Closed partition should not appear in drain");
+    assertEquals(101L, drained.get(tp1));
+  }
+
   // --- helpers ---
 
   private void startSinglePartition(TopicPartition topicPartition) {


### PR DESCRIPTION
## Problem

When a channel is invalidated, `SinkTaskContext::offset` was called from two threads:
- main thread, at the end of `put`, to rewind the partition that was skipped
- channel IO thread, after the reopen, with the offset fetched from the Snowflake channel status.

This creates a race condition - if the `put`'s offset wins, the subsequent `put` may not receive some records because we didn't rewind far enough.

For example:
- record 80 fails due to a channel invalidation
- this and each subsequent `put` that receives records for this partition rewinds the partition to offset 80
- Snowflake channel open completes with a committed offset 70 while the `put` is running for this partition
  - the partition is rewound to the "recovery" offset 71 from the IO thread
  - at the end of `put`, the offset is rewound to 80 from the main thread
- records 71–79 are permanently lost because the consumer resumes from 80 instead of 71.

## Fix

Move offset resets off the IO thread and onto the task thread via a `ConcurrentHashMap<TopicPartition, Long>` in `PartitionChannelManager`:

1. `PartitionOffsetTracker` no longer calls `SinkTaskContext::offset`. Instead it takes a `Consumer<Long> onOffsetReset` callback that writes to the pending map.
2. `PartitionChannelManager.pendingOffsetResets` buffers offset resets from init/recovery (IO threads).
3. `SSV2.insert(Collection)` drains pending resets at the top of each batch into `offsetsToRewindTo` — these partitions are then skipped for the rest of the batch. At the end, a single `sinkTaskContext.offset(Map)` call applies all rewinds atomically.
4. `close()` clears pending resets for revoked partitions.

This ensures `sinkTaskContext.offset()` is only ever called from the task thread, and recovery offsets cannot be overwritten by the skip-tracking logic.