### PR TITLE
SNOW-3574225: Add client recreation for SDK pipe failover (HTTP 410)

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -421,6 +421,7 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
         .orElse(true)) {
       LOGGER.warn("Streaming channel doesn't exist or is closed for {}", topicPartition);
       startPartition(topicPartition);
+      return false;
     }
 
     TopicPartitionChannel channel =

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/telemetry/SnowflakeTelemetryChannelStatus.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/telemetry/SnowflakeTelemetryChannelStatus.java
@@ -58,6 +58,14 @@ public class SnowflakeTelemetryChannelStatus extends SnowflakeTelemetryBasicInfo
   // channel recovery counter (always tracked; also registered as JMX gauge if enabled)
   private final AtomicLong recoveryCount = new AtomicLong(0);
 
+  // Client recreation counters — incremented from openChannelWithClientRecovery when a
+  // client-invalid SDK error (HTTP 410 / pipe failover) triggers a swap of the streaming client.
+  // attempts is bumped on entry to the recreate branch; success/failure split records whether
+  // the underlying StreamingClientPools.recreateClient retry budget held.
+  private final AtomicLong clientRecreationAttemptCount = new AtomicLong(0);
+  private final AtomicLong clientRecreationSuccessCount = new AtomicLong(0);
+  private final AtomicLong clientRecreationFailureCount = new AtomicLong(0);
+
   // Aggregated count of client-side validation failures for this channel.
   // Reported in channel status telemetry on close, avoiding per-record telemetry overhead.
   private final AtomicLong validationFailureCount = new AtomicLong(0);
@@ -147,6 +155,15 @@ public class SnowflakeTelemetryChannelStatus extends SnowflakeTelemetryBasicInfo
     msg.put(TelemetryConstants.VALIDATION_FAILURE_COUNT, this.validationFailureCount.get());
     msg.put(TelemetryConstants.ERROR_TOLERATED_COUNT, this.errorToleratedCount.get());
     msg.put(TelemetryConstants.CHANNEL_RECOVERY_COUNT, this.recoveryCount.get());
+    msg.put(
+        TelemetryConstants.CLIENT_RECREATION_ATTEMPT_COUNT,
+        this.clientRecreationAttemptCount.get());
+    msg.put(
+        TelemetryConstants.CLIENT_RECREATION_SUCCESS_COUNT,
+        this.clientRecreationSuccessCount.get());
+    msg.put(
+        TelemetryConstants.CLIENT_RECREATION_FAILURE_COUNT,
+        this.clientRecreationFailureCount.get());
     msg.put(TelemetryConstants.VALIDATION_DISABLED, this.validationDisabled);
     msg.put(TelemetryConstants.ROWS_INSERTED_COUNT, this.rowsInsertedCount);
     msg.put(TelemetryConstants.ROWS_PARSED_COUNT, this.rowsParsedCount);
@@ -228,6 +245,36 @@ public class SnowflakeTelemetryChannelStatus extends SnowflakeTelemetryBasicInfo
   /** Increments the channel recovery counter. Thread-safe. */
   public void incRecoveryCount() {
     this.recoveryCount.incrementAndGet();
+  }
+
+  /** Increments the client recreation attempt counter. Thread-safe. */
+  public void incClientRecreationAttemptCount() {
+    this.clientRecreationAttemptCount.incrementAndGet();
+  }
+
+  /** Increments the client recreation success counter. Thread-safe. */
+  public void incClientRecreationSuccessCount() {
+    this.clientRecreationSuccessCount.incrementAndGet();
+  }
+
+  /** Increments the client recreation failure counter. Thread-safe. */
+  public void incClientRecreationFailureCount() {
+    this.clientRecreationFailureCount.incrementAndGet();
+  }
+
+  @VisibleForTesting
+  public long getClientRecreationAttemptCount() {
+    return this.clientRecreationAttemptCount.get();
+  }
+
+  @VisibleForTesting
+  public long getClientRecreationSuccessCount() {
+    return this.clientRecreationSuccessCount.get();
+  }
+
+  @VisibleForTesting
+  public long getClientRecreationFailureCount() {
+    return this.clientRecreationFailureCount.get();
   }
 
   /** Increments the validation failure counter. Thread-safe. */

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannel.java
@@ -89,7 +89,8 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
 
   private final String pipeName;
 
-  private final SnowflakeStreamingIngestClient streamingClient;
+  private volatile SnowflakeStreamingIngestClient streamingClient;
+  private final ClientRecreator clientRecreator;
   private final ExecutorService openChannelIoExecutor;
 
   private final StreamingErrorHandler streamingErrorHandler;
@@ -112,6 +113,7 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
       String channelName,
       String pipeName,
       SnowflakeStreamingIngestClient streamingClient,
+      ClientRecreator clientRecreator,
       ExecutorService openChannelIoExecutor,
       SnowflakeTelemetryService telemetryService,
       SnowflakeTelemetryChannelStatus snowflakeTelemetryChannelStatus,
@@ -125,6 +127,7 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
     this.channelName = channelName;
     this.pipeName = pipeName;
     this.streamingClient = streamingClient;
+    this.clientRecreator = clientRecreator;
     this.openChannelIoExecutor = openChannelIoExecutor;
     this.taskConfig = taskConfig;
     this.streamingErrorHandler = streamingErrorHandler;
@@ -145,7 +148,7 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
     this.channel =
         CompletableFuture.supplyAsync(
             () -> {
-              OpenChannelResult openChannelResult = openChannelForTable(channelName);
+              OpenChannelResult openChannelResult = openChannelWithClientRecovery(channelName);
               long offsetRecoveredFromSnowflake = parseOrMigrateOffsetToken(openChannelResult);
               offsetTracker.initializeFromSnowflake(offsetRecoveredFromSnowflake);
               return openChannelResult.getChannel();
@@ -234,7 +237,19 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
         () -> {
           LOGGER.info("Starting flush for channel: {}", this.channelName);
 
-          streamingClient.initiateFlush();
+          try {
+            streamingClient.initiateFlush();
+          } catch (SFException e) {
+            if (ClientRecreationException.isClientInvalidError(e)) {
+              LOGGER.warn(
+                  "Skipping flush for channel {}: client is invalid ({}). "
+                      + "Uncommitted data will be replayed on task restart.",
+                  this.channelName,
+                  e.getErrorCodeName());
+              return;
+            }
+            throw e;
+          }
 
           final long targetOffset = offsetTracker.getLastAppendRowsOffset();
           WaitForLastOffsetCommittedPolicy.getPolicy(
@@ -288,6 +303,12 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
    * short delay with jitter. Throws {@link ConnectException} if the circuit breaker ({@link
    * #MAX_CONSECUTIVE_RECOVERIES}) has been exceeded, which causes Kafka Connect to kill and restart
    * the task.
+   *
+   * <p>This circuit breaker only covers channel-side failures. Patience for SDK client recreation
+   * (pipe failover, HTTP 410) lives in {@link
+   * com.snowflake.kafka.connector.internal.streaming.v2.client.StreamingClientPools#recreateClient}
+   * — its Failsafe retry policy absorbs multi-minute failover windows, so this loop does not need
+   * its own large budget.
    */
   private void handleNonRetryableAppendRowFailure(SFException cause) {
     consecutiveRecoveryCount++;
@@ -342,8 +363,11 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
    * <p>If a valid offset is found from snowflake, we will reset the topicPartition with
    * (offsetReturnedFromSnowflake + 1).
    *
-   * @param reason Reason for the channel recovery. Used for logging.
-   * @return offset which was last present in Snowflake
+   * <p>Client recreation (for client-invalid errors like HTTP 410 pipe failover) is handled
+   * transparently by {@link #openChannelWithClientRecovery}, so callers no longer need to decide
+   * whether to swap the SDK client first.
+   *
+   * @param reason reason for the channel recovery, used for logging
    */
   private void reopenChannel(final String reason) {
     LOGGER.warn("{} Channel {} recovery initiated", reason, this.channelName);
@@ -376,7 +400,7 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
                 })
             .thenApply(
                 ignored -> {
-                  OpenChannelResult openChannelResult = openChannelForTable(channelName);
+                  OpenChannelResult openChannelResult = openChannelWithClientRecovery(channelName);
                   final long offsetRecoveredFromSnowflake =
                       parseOrMigrateOffsetToken(openChannelResult);
 
@@ -669,6 +693,57 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
    *
    * @return new channel which was fetched after open/reopen
    */
+  /**
+   * Opens a channel, recreating the SDK client once if the open fails with a client-invalid error.
+   *
+   * <p>This is the universal entry point for client recreation: every code path that needs a
+   * working channel (initial open in the constructor, recovery open in {@link #reopenChannel})
+   * funnels through here, so a stale {@code streamingClient} reference can never cause the channel
+   * future to stay permanently failed. Without this, when the connector hits a recoverable
+   * client-invalid error before {@code appendRow} ever runs (e.g. because {@code
+   * SnowflakeSinkServiceV2.insert(SinkRecord)} short-circuits on {@code isChannelClosed} → {@code
+   * startPartition} → {@code return false}), the appendRow-driven recovery loop is starved and the
+   * task spins forever rebuilding broken channels.
+   *
+   * <p>Single-shot retry at this layer by design — the patience for transient pipe-failover windows
+   * lives inside {@link
+   * com.snowflake.kafka.connector.internal.streaming.v2.client.StreamingClientPools#recreateClient}
+   * (multi-minute Failsafe budget with exponential backoff). If {@code recreate} still fails after
+   * that budget, it throws and we translate to {@link ConnectException} so Kafka Connect fails and
+   * restarts the task — at that point the fault is not transient.
+   */
+  private OpenChannelResult openChannelWithClientRecovery(final String channelName) {
+    try {
+      return openChannelForTable(channelName);
+    } catch (SFException e) {
+      if (!ClientRecreationException.isClientInvalidError(e)) {
+        throw e;
+      }
+      LOGGER.warn(
+          "Channel {} open failed with client-invalid error ({}); recreating client and retrying",
+          channelName,
+          e.getErrorCodeName());
+      snowflakeTelemetryChannelStatus.incClientRecreationAttemptCount();
+      try {
+        this.streamingClient = clientRecreator.recreate(this.streamingClient);
+      } catch (RuntimeException recreateFailure) {
+        snowflakeTelemetryChannelStatus.incClientRecreationFailureCount();
+        LOGGER.error(
+            "Channel {} client recreation exhausted its retry budget; failing task",
+            channelName,
+            recreateFailure);
+        throw new ConnectException(
+            String.format(
+                "Channel %s could not recreate the Snowpipe Streaming client."
+                    + " Check Snowflake service health.",
+                channelName),
+            recreateFailure);
+      }
+      snowflakeTelemetryChannelStatus.incClientRecreationSuccessCount();
+      return openChannelForTable(channelName);
+    }
+  }
+
   private OpenChannelResult openChannelForTable(final String channelName) {
     if (cancelled.get()) {
       throw new CancellationException("Channel " + channelName + " was cancelled before opening");
@@ -775,8 +850,13 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
   public boolean isChannelClosed() {
     try {
       return this.getChannel().isClosed();
+    } catch (ConnectException e) {
+      // Terminal failure (e.g. client recreation exhausted its retry budget). Propagate so
+      // SnowflakeSinkServiceV2.insert surfaces it to Kafka Connect rather than silently rebuilding
+      // the SSPC, which would otherwise hot-spin on the same fault.
+      throw e;
     } catch (RuntimeException e) {
-      // If the channel failed to initialize, we consider it closed.
+      // Transient init failure — treat as closed so the next put() triggers a fresh startPartition.
       LOGGER.warn(
           "Channel {} failed to initialize, treating as closed: {}", channelName, e.getMessage());
       return true;

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/client/StreamingClientPools.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/client/StreamingClientPools.java
@@ -153,58 +153,63 @@ public class StreamingClientPools {
   }
 
   /**
-   * Delay between client-creation retries. Pipe failover typically takes a few seconds to stabilize
-   * on the server side, and back-to-back retries with no delay would all hit the same in-flight
-   * failover window and fail before the server finishes.
-   *
-   * <p>Note: this delay is per-invocation. {@link #recreateClient} can be called concurrently by
-   * multiple {@link
-   * com.snowflake.kafka.connector.internal.streaming.v2.SnowpipeStreamingPartitionChannel}s on the
-   * same pipe. The pool's CAS dedupes to a single fresh client, but each caller runs its own
-   * Failsafe retry schedule — so from the pool's perspective, client creation can happen more than
-   * once per {@code CLIENT_CREATION_RETRY_DELAY} window across concurrent callers. This is
-   * acceptable: each individual channel still retries at ~5s cadence, so its total recovery window
-   * spans {@code MAX_CLIENT_CREATION_RETRIES * CLIENT_CREATION_RETRY_DELAY = ~15s}. When reading
-   * logs, expect to see overlapping retry schedules across channels on the same pipe during a
-   * failover event.
+   * Initial delay before the first recreate retry. Backoff doubles each attempt up to {@link
+   * #CLIENT_CREATION_MAX_DELAY}, with ±{@link #CLIENT_CREATION_JITTER_FACTOR} jitter to prevent
+   * concurrent partition channels from retrying in lockstep.
    */
-  private static final Duration CLIENT_CREATION_RETRY_DELAY = Duration.ofSeconds(5);
+  private static final Duration CLIENT_CREATION_BASE_DELAY = Duration.ofSeconds(1);
+
+  /** Cap on the exponential backoff delay between recreate retries. */
+  private static final Duration CLIENT_CREATION_MAX_DELAY = Duration.ofSeconds(30);
+
+  /** Jitter factor (±, 0.0–1.0) applied to each recreate retry delay. */
+  private static final double CLIENT_CREATION_JITTER_FACTOR = 0.2;
 
   /**
-   * Maximum retry attempts when a replacement client also fails with a client-invalid error during
-   * {@link #recreateClient}. Three attempts provide enough headroom for transient failover windows
-   * while keeping total blocking time bounded (each attempt creates a fresh SDK client).
+   * Total wall-clock budget for recreate retries before giving up. Sized for real SSv2
+   * pipe-failover propagation windows (observed 2–4 min) plus headroom. {@link #recreateClient}
+   * throws {@link ClientRecreationException} when exhausted; callers are expected to convert that
+   * to a {@link ConnectException} so Kafka Connect fails and restarts the task.
    */
-  private static final int MAX_CLIENT_CREATION_RETRIES = 3;
+  private static final Duration CLIENT_CREATION_MAX_DURATION = Duration.ofMinutes(6);
 
   /**
    * Retries replacement-client creation when the SDK reports a client-invalid error (e.g., pipe
    * failover still in flight). The pool evicts the failed entry on each attempt, so the retry
    * creates a fresh client. Non-client-invalid errors fall through immediately.
+   *
+   * <p>{@link #recreateClient} can be called concurrently by multiple {@link
+   * com.snowflake.kafka.connector.internal.streaming.v2.SnowpipeStreamingPartitionChannel}s on the
+   * same pipe. The pool's CAS dedupes to a single fresh client per round, but each caller runs its
+   * own Failsafe retry schedule. When reading logs, expect overlapping retry schedules across
+   * channels on the same pipe during a failover event.
    */
   private static RetryPolicy<SnowflakeStreamingIngestClient> recreateClientRetryPolicy(
       String pipeName) {
     return RetryPolicy.<SnowflakeStreamingIngestClient>builder()
         .handleIf(
             e -> e instanceof RuntimeException && ClientRecreationException.isClientInvalidError(e))
-        .withMaxAttempts(MAX_CLIENT_CREATION_RETRIES)
-        .withDelay(CLIENT_CREATION_RETRY_DELAY)
+        .withBackoff(CLIENT_CREATION_BASE_DELAY, CLIENT_CREATION_MAX_DELAY, 2.0)
+        .withJitter(CLIENT_CREATION_JITTER_FACTOR)
+        .withMaxAttempts(-1)
+        .withMaxDuration(CLIENT_CREATION_MAX_DURATION)
         .onRetry(
             event ->
                 LOGGER.warn(
                     "Replacement client for pipe {} failed with client-invalid error"
-                        + " (attempt {}/{}): {}. Retrying after {}.",
+                        + " (attempt {}, elapsed {}s / {}s budget): {}",
                     pipeName,
                     event.getAttemptCount(),
-                    MAX_CLIENT_CREATION_RETRIES,
-                    event.getLastException().getMessage(),
-                    CLIENT_CREATION_RETRY_DELAY))
+                    event.getElapsedTime().toSeconds(),
+                    CLIENT_CREATION_MAX_DURATION.toSeconds(),
+                    event.getLastException().getMessage()))
         .onRetriesExceeded(
             event ->
                 LOGGER.error(
-                    "Replacement client for pipe {} failed after {} attempts: {}",
+                    "Replacement client for pipe {} failed after {} attempts ({}s elapsed): {}",
                     pipeName,
                     event.getAttemptCount(),
+                    event.getElapsedTime().toSeconds(),
                     event.getException().getMessage()))
         .build();
   }

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/service/BatchOffsetFetcher.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/service/BatchOffsetFetcher.java
@@ -11,6 +11,7 @@ import com.snowflake.kafka.connector.internal.KCLogger;
 import com.snowflake.kafka.connector.internal.metrics.TaskMetrics;
 import com.snowflake.kafka.connector.internal.streaming.StreamingClientProperties;
 import com.snowflake.kafka.connector.internal.streaming.channel.TopicPartitionChannel;
+import com.snowflake.kafka.connector.internal.streaming.v2.ClientRecreationException;
 import com.snowflake.kafka.connector.internal.streaming.v2.client.StreamingClientPools;
 import java.util.Collection;
 import java.util.HashMap;
@@ -108,11 +109,20 @@ public class BatchOffsetFetcher {
           try {
             result.putAll(getCommittedOffsetsForPipe(pipeName, channelsByPartition));
           } catch (SFException e) {
-            LOGGER.error(
-                "Failed to fetch committed offsets for pipe: {}, skipping {} channel(s)",
-                pipeName,
-                channelsByPartition.size(),
-                e);
+            if (ClientRecreationException.isClientInvalidError(e)) {
+              LOGGER.warn(
+                  "Client is invalid for pipe: {}, skipping offset fetch for {} channel(s)."
+                      + " Client recreation will be triggered by the next appendRow on this pipe.",
+                  pipeName,
+                  channelsByPartition.size(),
+                  e);
+            } else {
+              LOGGER.error(
+                  "Failed to fetch committed offsets for pipe: {}, skipping {} channel(s)",
+                  pipeName,
+                  channelsByPartition.size(),
+                  e);
+            }
           }
         },
         ioExecutor);

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/service/PartitionChannelManager.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/service/PartitionChannelManager.java
@@ -14,6 +14,7 @@ import com.snowflake.kafka.connector.internal.streaming.StreamingClientPropertie
 import com.snowflake.kafka.connector.internal.streaming.StreamingErrorHandler;
 import com.snowflake.kafka.connector.internal.streaming.channel.TopicPartitionChannel;
 import com.snowflake.kafka.connector.internal.streaming.telemetry.SnowflakeTelemetryChannelStatus;
+import com.snowflake.kafka.connector.internal.streaming.v2.ClientRecreator;
 import com.snowflake.kafka.connector.internal.streaming.v2.SnowpipeStreamingPartitionChannel;
 import com.snowflake.kafka.connector.internal.streaming.v2.channel.PartitionOffsetTracker;
 import com.snowflake.kafka.connector.internal.streaming.v2.client.StreamingClientPools;
@@ -174,6 +175,16 @@ public class PartitionChannelManager {
             streamingClientProperties,
             taskMetrics);
     Consumer<Long> onOffsetReset = offset -> pendingOffsetResets.put(topicPartition, offset);
+    final ClientRecreator clientRecreator =
+        invalidClient ->
+            StreamingClientPools.recreateClient(
+                taskConfig.getConnectorName(),
+                taskConfig.getTaskId(),
+                pipeName,
+                invalidClient,
+                taskConfig,
+                streamingClientProperties,
+                taskMetrics);
     final PartitionOffsetTracker offsetTracker =
         new PartitionOffsetTracker(channelName, onOffsetReset);
 
@@ -218,6 +229,7 @@ public class PartitionChannelManager {
         channelName,
         pipeName,
         streamingClient,
+        clientRecreator,
         openChannelIoExecutor,
         this.telemetryService,
         telemetryChannelStatus,

--- a/src/main/java/com/snowflake/kafka/connector/internal/telemetry/TelemetryConstants.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/telemetry/TelemetryConstants.java
@@ -26,6 +26,12 @@ public final class TelemetryConstants {
   public static final String VALIDATION_FAILURE_COUNT = "validation_failure_count";
   public static final String ERROR_TOLERATED_COUNT = "error_tolerated_count";
   public static final String CHANNEL_RECOVERY_COUNT = "channel_recovery_count";
+  // Client recreation telemetry: attempts is the number of times openChannelWithClientRecovery
+  // tried to swap the SDK client; success/failure split records whether the underlying pool retry
+  // budget held. attempts == success + failure.
+  public static final String CLIENT_RECREATION_ATTEMPT_COUNT = "client_recreation_attempt_count";
+  public static final String CLIENT_RECREATION_SUCCESS_COUNT = "client_recreation_success_count";
+  public static final String CLIENT_RECREATION_FAILURE_COUNT = "client_recreation_failure_count";
   public static final String VALIDATION_DISABLED = "validation_disabled";
   public static final String ROWS_INSERTED_COUNT = "rows_inserted_count";
   public static final String ROWS_PARSED_COUNT = "rows_parsed_count";

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2IT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2IT.java
@@ -88,8 +88,13 @@ public class SnowflakeSinkServiceV2IT extends SnowflakeSinkServiceV2BaseIT {
     // Closing a partition == closing a channel
     service.close(Collections.singletonList(topicPartition));
 
-    // Lets insert a record when partition was closed.
-    // It should auto create the channel
+    // After close, the first insert short-circuits via SnowflakeSinkServiceV2#insert's
+    // "channel doesn't exist" branch: it kicks off async startPartition and returns false,
+    // which signals the caller to rewind the offset. In real Kafka the consumer redelivers
+    // on the next poll; here we simulate that by awaiting initialization and re-inserting
+    // explicitly.
+    service.insert(record1);
+    service.awaitInitialization();
     service.insert(record1);
 
     TestUtils.assertWithRetry(() -> service.getOffset(topicPartition) == 1, 5, 20);
@@ -136,7 +141,13 @@ public class SnowflakeSinkServiceV2IT extends SnowflakeSinkServiceV2BaseIT {
     // Closing a partition == closing a channel
     service.close(Collections.singletonList(topicPartition));
 
-    // it should skip this record1 since it will fetch offset token 0 from Snowflake
+    // After close, the first re-insert short-circuits via SnowflakeSinkServiceV2#insert's
+    // "channel doesn't exist" branch (async startPartition + rewind). The recreated channel
+    // recovers offset 0 from Snowflake, so re-inserting record1 (offset 0) is a deduped
+    // no-op while offset still advances to 1. In real Kafka the consumer redelivers on the
+    // next poll; here we simulate that by awaiting initialization and re-inserting.
+    service.insert(record1);
+    service.awaitInitialization();
     service.insert(record1);
 
     TestUtils.assertWithRetry(() -> service.getOffset(topicPartition) == 1, 5, 20);

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2RecoveryOffsetTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2RecoveryOffsetTest.java
@@ -193,6 +193,9 @@ class SnowflakeSinkServiceV2RecoveryOffsetTest {
             channelName,
             pipeName,
             mockClient,
+            invalidClient -> {
+              throw new UnsupportedOperationException("ClientRecreator not wired in this test");
+            },
             ioExecutor,
             mockTelemetry,
             telemetryStatus,

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingErrorHandlerIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingErrorHandlerIT.java
@@ -293,6 +293,9 @@ class StreamingErrorHandlerIT {
         channelName,
         pipeName,
         new FakeSnowflakeStreamingIngestClient(pipeName, "test_connector"),
+        invalidClient -> {
+          throw new UnsupportedOperationException("ClientRecreator not wired in this IT");
+        },
         openChannelIoExecutor,
         mockTelemetryService,
         telemetryChannelStatus,

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannelTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannelTest.java
@@ -312,34 +312,124 @@ class SnowpipeStreamingPartitionChannelTest {
 
   @Test
   void channelInvalidation_failsTaskAfterMaxConsecutiveRecoveries() {
-    // If the channel is permanently broken (every appendRow fails), the circuit breaker
-    // should trip after MAX_CONSECUTIVE_RECOVERIES (5) and throw ConnectException to
-    // kill the task — rather than silently dropping records forever.
-
+    // If the channel is permanently broken (every appendRow fails), the count-based recovery
+    // circuit breaker should trip and throw ConnectException to kill the task — rather than
+    // silently dropping records forever.
     SnowpipeStreamingPartitionChannel partitionChannel = createPartitionChannel();
     partitionChannel.getChannel();
     assertEquals(1, trackingClientSupplier.getTotalChannelsCreated());
 
-    // Every appendRow throws — channel is permanently invalid
+    // Every appendRow throws — channel is permanently invalid.
     trackingClientSupplier.setThrowOnAppendRow(true);
 
-    // The first 5 records trigger recovery attempts (channel reopening).
-    // The 6th record exceeds MAX_CONSECUTIVE_RECOVERIES and throws ConnectException.
     ConnectException thrown =
         assertThrows(
             ConnectException.class,
             () -> {
-              for (int i = 0; i < 20; i++) {
+              for (int i = 0; i < 1000; i++) {
                 partitionChannel.insertRecord(buildValidRecord(i));
               }
             });
 
     assertTrue(
-        thrown.getMessage().contains("failed after 5 consecutive recovery attempts"),
-        "Expected circuit breaker message, got: " + thrown.getMessage());
+        thrown.getMessage().contains("failed after"),
+        "Expected count-based budget message, got: " + thrown.getMessage());
+  }
 
-    // 1 initial + 5 recoveries = 6 channels created before the circuit breaker tripped
-    assertEquals(6, trackingClientSupplier.getTotalChannelsCreated());
+  @Test
+  void insertRecord_clientInvalid_recreatesClientAndReopensChannel() {
+    TrackingIngestClientSupplier newClientSupplier = new TrackingIngestClientSupplier();
+    TrackingStreamingIngestClient newClient =
+        new TrackingStreamingIngestClient(pipeName, newClientSupplier);
+    AtomicInteger recreateCallCount = new AtomicInteger();
+    ClientRecreator clientRecreator =
+        invalidClient -> {
+          recreateCallCount.incrementAndGet();
+          return newClient;
+        };
+
+    SnowpipeStreamingPartitionChannel partitionChannel = createPartitionChannel(clientRecreator);
+    partitionChannel.getChannel();
+
+    trackingClientSupplier.markClientInvalid();
+    partitionChannel.insertRecord(buildValidRecord(0));
+
+    assertEquals(1, recreateCallCount.get());
+    assertEquals(1, newClientSupplier.getTotalChannelsCreated());
+  }
+
+  @Test
+  void insertRecord_clientInvalid_subsequentInsertsUseNewClient() {
+    TrackingIngestClientSupplier newClientSupplier = new TrackingIngestClientSupplier();
+    TrackingStreamingIngestClient newClient =
+        new TrackingStreamingIngestClient(pipeName, newClientSupplier);
+    ClientRecreator clientRecreator = invalidClient -> newClient;
+
+    SnowpipeStreamingPartitionChannel partitionChannel = createPartitionChannel(clientRecreator);
+    partitionChannel.getChannel();
+
+    trackingClientSupplier.markClientInvalid();
+    partitionChannel.insertRecord(buildValidRecord(0));
+    partitionChannel.insertRecord(buildValidRecord(1));
+    partitionChannel.insertRecord(buildValidRecord(2));
+
+    assertEquals(1, newClientSupplier.getTotalChannelsCreated());
+  }
+
+  @Test
+  void insertRecord_clientRecreateFails_throwsConnectExceptionToFailTask() {
+    // When the pool's client recreation exhausts its retry budget (simulated here by the
+    // recreator throwing), openChannelWithClientRecovery translates that into a ConnectException
+    // so Kafka Connect fails and restarts the task — rather than spinning forever on a client
+    // that the SDK has already given up on.
+    AtomicInteger recreateCallCount = new AtomicInteger();
+    ClientRecreator clientRecreator =
+        invalidClient -> {
+          recreateCallCount.incrementAndGet();
+          // Simulates StreamingClientPools.recreateClient exhausting its Failsafe budget.
+          throw ClientRecreationException.wrap(
+              new SFException("InvalidClientError", "simulated failover exhausted", 410, ""));
+        };
+
+    SnowpipeStreamingPartitionChannel partitionChannel = createPartitionChannel(clientRecreator);
+    partitionChannel.getChannel();
+    SnowflakeTelemetryChannelStatus telemetry =
+        partitionChannel.getSnowflakeTelemetryChannelStatus();
+
+    trackingClientSupplier.markClientInvalid();
+    // First insert triggers the reopen path; recreate is invoked and throws, which fails the
+    // channel future. The next call (or any subsequent dereference of the future) surfaces the
+    // ConnectException to the task.
+    partitionChannel.insertRecord(buildValidRecord(0));
+
+    ConnectException thrown = assertThrows(ConnectException.class, partitionChannel::getChannel);
+    assertTrue(
+        thrown.getMessage().contains("could not recreate the Snowpipe Streaming client"),
+        "Expected recreate-failure message, got: " + thrown.getMessage());
+
+    assertEquals(1, recreateCallCount.get(), "recreate should have been attempted exactly once");
+    assertEquals(1, telemetry.getClientRecreationAttemptCount());
+    assertEquals(0, telemetry.getClientRecreationSuccessCount());
+    assertEquals(1, telemetry.getClientRecreationFailureCount());
+  }
+
+  @Test
+  void insertRecord_channelOnlyError_doesNotRecreateClient() {
+    AtomicInteger recreateCallCount = new AtomicInteger();
+    ClientRecreator clientRecreator =
+        invalidClient -> {
+          recreateCallCount.incrementAndGet();
+          return invalidClient;
+        };
+
+    SnowpipeStreamingPartitionChannel partitionChannel = createPartitionChannel(clientRecreator);
+    partitionChannel.getChannel();
+
+    trackingClientSupplier.setNonRetryableAppendRowFailures(1);
+    partitionChannel.insertRecord(buildValidRecord(0));
+
+    assertEquals(0, recreateCallCount.get());
+    assertEquals(2, trackingClientSupplier.getTotalChannelsCreated());
   }
 
   private SinkRecord buildValidRecord(long offset) {
@@ -355,6 +445,14 @@ class SnowpipeStreamingPartitionChannelTest {
   }
 
   private SnowpipeStreamingPartitionChannel createPartitionChannel() {
+    return createPartitionChannel(
+        invalidClient -> {
+          throw new UnsupportedOperationException("ClientRecreator not wired in this test");
+        });
+  }
+
+  private SnowpipeStreamingPartitionChannel createPartitionChannel(
+      ClientRecreator clientRecreator) {
     final PartitionOffsetTracker offsetTracker =
         new PartitionOffsetTracker(channelName, offset -> {});
     final SnowflakeTelemetryChannelStatus telemetryChannelStatus =
@@ -382,6 +480,7 @@ class SnowpipeStreamingPartitionChannelTest {
         channelName,
         pipeName,
         trackingClient,
+        clientRecreator,
         openChannelIoExecutor,
         mockTelemetryService,
         telemetryChannelStatus,
@@ -462,6 +561,9 @@ class SnowpipeStreamingPartitionChannelTest {
         channelName,
         pipeName,
         trackingClient,
+        invalidClient -> {
+          throw new UnsupportedOperationException("ClientRecreator not wired in this test");
+        },
         openChannelIoExecutor,
         mockTelemetryService,
         telemetryChannelStatus,
@@ -555,6 +657,9 @@ class SnowpipeStreamingPartitionChannelTest {
             channelName,
             pipeName,
             trackingClient,
+            invalidClient -> {
+              throw new UnsupportedOperationException("ClientRecreator not wired in this test");
+            },
             openChannelIoExecutor,
             mockTelemetryService,
             telemetryChannelStatus,
@@ -694,6 +799,9 @@ class SnowpipeStreamingPartitionChannelTest {
         channelName,
         pipeName,
         trackingClient,
+        invalidClient -> {
+          throw new UnsupportedOperationException("ClientRecreator not wired in this test");
+        },
         openChannelIoExecutor,
         mockTelemetryService,
         telemetryChannelStatus,
@@ -927,6 +1035,10 @@ class SnowpipeStreamingPartitionChannelTest {
     private volatile boolean throwOnOpenChannel;
     private final AtomicInteger retryableAppendRowFailures = new AtomicInteger(0);
     private final AtomicInteger nonRetryableAppendRowFailures = new AtomicInteger(0);
+    // Sticky "client is invalid" flag, mirroring real SDK behaviour: once the SDK marks a
+    // client invalid, every subsequent operation on it (appendRow, openChannel, getStatus, ...)
+    // throws a client-invalid SFException until the client is replaced via clientRecreator.
+    private volatile boolean clientInvalid;
     private volatile RuntimeException appendRowRuntimeException;
     private volatile CountDownLatch blockOnOpenChannel;
 
@@ -956,6 +1068,10 @@ class SnowpipeStreamingPartitionChannelTest {
 
     void setNonRetryableAppendRowFailures(int count) {
       this.nonRetryableAppendRowFailures.set(count);
+    }
+
+    void markClientInvalid() {
+      this.clientInvalid = true;
     }
 
     void setAppendRowRuntimeException(RuntimeException exception) {
@@ -991,6 +1107,9 @@ class SnowpipeStreamingPartitionChannelTest {
 
     @Override
     public OpenChannelResult openChannel(final String channelName, final String offsetToken) {
+      if (supplier.clientInvalid) {
+        throw new SFException("InvalidClientError", "Test simulated client invalidation", 409, "");
+      }
       if (supplier.throwOnOpenChannel) {
         throw new SFException("OpenChannelFailed", "Test simulated openChannel failure", 0, "");
       }
@@ -1164,6 +1283,9 @@ class SnowpipeStreamingPartitionChannelTest {
     public void appendRow(final Map<String, Object> row, final String offsetToken) {
       if (supplier.appendRowRuntimeException != null) {
         throw supplier.appendRowRuntimeException;
+      }
+      if (supplier.clientInvalid) {
+        throw new SFException("InvalidClientError", "Test simulated client invalidation", 409, "");
       }
       if (supplier.retryableAppendRowFailures.getAndUpdate(n -> n > 0 ? n - 1 : 0) > 0) {
         throw new SFException("MemoryThresholdExceeded", "Test simulated backpressure", 0, "");

--- a/src/test/java/com/snowflake/kafka/connector/streaming/iceberg/IcebergIngestionIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/streaming/iceberg/IcebergIngestionIT.java
@@ -65,6 +65,13 @@ public abstract class IcebergIngestionIT extends BaseIcebergIT {
             .withErrorReporter(kafkaRecordErrorReporter)
             .withSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(topicPartition)))
             .build();
+
+    // Mirror Kafka Connect's open(partitions) → put(records) lifecycle: start and await the channel
+    // before any insert. Without this, the first insert would short-circuit via the
+    // "channel doesn't exist" path in SnowflakeSinkServiceV2#insert and rewind the offsets, which
+    // these direct-call tests don't replay (no real Kafka consumer in the loop).
+    service.startPartition(topicPartition);
+    service.awaitInitialization();
   }
 
   @AfterEach


### PR DESCRIPTION
## Why

SSv2 pipe failover surfaces to the connector as an HTTP 410 / `InvalidClientError` `SFException`. Once a `SnowflakeStreamingIngestClient` is in this state, every subsequent SDK call on it fails the same way — the only path forward is to swap in a freshly-constructed client. Without in-process recovery the task either dies on the first failover or, worse, spins reopening channels against the dead client forever (observed in the e2e suite stuck at 300/900 rows).

## Recovery flow

Client recreation lives at a single seam — `openChannelWithClientRecovery` — that every channel open funnels through (initial open in the constructor and every `reopenChannel`). The flow per open is:

1. Call `openChannelForTable`.
2. If it throws an `SFException` that `ClientRecreationException.isClientInvalidError` recognises, call `clientRecreator.recreate(this.streamingClient)`. The pool does a CAS swap and runs a Failsafe policy with a wall-clock budget (multi-minute, exponential backoff + jitter) so concurrent partitions on the same pipe share a single recreation. If the budget is exhausted, `recreate` throws and `openChannelWithClientRecovery` translates it to `ConnectException` — KC then fails and restarts the task, which is the appropriate response when the fault is no longer transient.
3. Retry `openChannelForTable` once. A second client-invalid error propagates — at that point the failure is no longer transient client state either.

`appendRow` no longer makes its own recreation decision; its failure handler just calls `reopenChannel`, which goes through the same helper. The recovery decision exists in exactly one place.

Two operations don't fit the open-channel seam and handle the same error inline:

- `initiateFlush` (in SSPC) swallows client-invalid with a WARN. Uncommitted data is replayed on task restart — failing the explicit flush would surface a recoverable condition as a hard failure.
- `BatchOffsetFetcher.getCommittedOffsets` logs WARN + skip on client-invalid (vs. ERROR for other `SFException`s). The next `appendRow` on that pipe reopens its channel and picks up recreation through the seam.

## Invariants

**Process-or-rewind.** Within a single `put()`, a record is either appended to its channel or its partition is rewound (via `sinkTaskContext.offset()` from `startPartition`) — never both. `SnowflakeSinkServiceV2.insert` now `return false`s immediately after `startPartition`; previously it fell through and appended the record onto the freshly-created channel in the same call, racing with the deferred Kafka Connect seek.

**Single recreate per open.** Each individual open attempt asks the pool to recreate at most once; the pool's Failsafe loop owns the multi-attempt patience. The outer recovery loop (`appendRow` failure → `reopenChannel` → `openChannelWithClientRecovery`) will trigger another recreation on the next iteration if the first one returned a still-broken client, but no open call retries recreation in a tight loop.

## Alternatives considered

- **Keep recreation in the `appendRow` failure path.** This was the starting point and is exactly what causes the 300/900 starvation. When the client is invalid `isChannelClosed` returns true, so `insert` short-circuits to `startPartition` + `return false` and `appendRow` is never reached. The only recreation trigger never fires; new channels are continuously built on the same dead client.
- **Bridge the rewind window with `sinkTaskContext.pause()` / `resume()`.** Pursued against an earlier (wrong) hypothesis — a "pre-seek buffer race" between the deferred seek and Kafka Connect's poll buffer. The implementation didn't change the outcome and was reverted; the real issue was the invariant violation above.
- **Put the multi-minute retry budget on the `appendRow` recovery loop instead of inside `recreateClient`.** That bloated the per-task recovery time on every transient `SFException`, not just client-invalid ones, and conflated two distinct conditions (transient append failure vs. dead client). The patience now lives where the long wait is actually needed: the recreate call itself; `appendRow` recovery keeps its original short count-based circuit breaker.

## Aside: exponential backoff inside `recreateClient`

Independent of moving recreation to the open-channel seam: the pool's recreate retry policy is a wall-clock budget (multi-minute) with exponential backoff starting at 1 s and capped at 30 s, plus ±20% jitter so concurrent recreators on the same pipe don't retry in lockstep. Observed SSv2 failover propagation windows are 2–4 minutes; the budget covers that with headroom.