### PR TITLE
Fix duplicate-counting race in test_invalidation_offset_consistency

### DIFF
--- a/test/tests/test_channel_invalidation.py
+++ b/test/tests/test_channel_invalidation.py
@@ -443,7 +443,7 @@ def test_invalidation_offset_consistency(
 ):
     """Test 6: Verify offset consistency after invalidation recovery.
 
-    Checks the full offset range (0..max_offset) has no gaps. Duplicates are OK.
+    Checks the full offset range (0..max_offset) has no gaps and no duplicates.
     """
     topic = f"test_invalidation_offset_consistency{name_salt}"
     table_name = topic
@@ -476,25 +476,57 @@ def test_invalidation_offset_consistency(
     producer.stop_continuous()
     _assert_task_running(driver, connector.name)
 
-    # Verify offset integrity: the full range 0..max_offset must have no gaps.
-    # With the recordProcessed fix (SNOW-3344243), the offset rewind replays all
-    # records that were in-flight during the flush-failure window, so no data is lost.
-    cur = driver.snowflake_conn.cursor()
-    offsets = sorted(
-        row[0]
-        for row in cur.execute(
-            f"SELECT DISTINCT record_metadata:offset::int AS off "
-            f'FROM "{table_name}" ORDER BY off'
-        ).fetchall()
+    # Wait for the connector to commit every record it consumed before
+    # measuring. The connector's preCommit reports SSv2's
+    # latestCommittedOffsetToken + 1 as the Kafka offset that is safe to
+    # commit, so when the consumer group offset reaches records_produced,
+    # the streaming pipeline has finished landing every record we sent and
+    # the verification queries below see a stable table state without
+    # needing to retry.
+    target_kafka_offset = producer.records_produced  # one past max sent offset
+    deadline = time.monotonic() + 60
+    committed = None
+    while time.monotonic() < deadline:
+        committed = driver.get_consumer_group_offset(connector.name, topic, 0)
+        if committed is not None and committed >= target_kafka_offset:
+            break
+        time.sleep(1)
+    else:
+        raise AssertionError(
+            f"Connector did not commit through Kafka offset {target_kafka_offset - 1} "
+            f"within 60s; last consumer group offset={committed}"
+        )
+    logger.info(
+        f"Connector caught up: consumer group offset={committed} "
+        f"(target={target_kafka_offset})"
     )
 
-    total_rows = int(driver.select_number_of_records(table_name))
-    distinct_offsets = len(offsets)
-    max_offset = offsets[-1]
-
+    # Verify offset integrity: the full range 0..max_offset must have no gaps
+    # and no duplicates. With the recordProcessed fix (SNOW-3344243) the
+    # offset rewind replays all records that were in-flight during the flush
+    # window, so no data is lost; SSv2's offset tokens guarantee exactly-once
+    # so no record is committed twice. Read both metrics from a single SQL
+    # snapshot to avoid the inter-query race that previously made two
+    # back-to-back cursor.execute() calls observe different table states.
+    cur = driver.snowflake_conn.cursor()
+    total_rows, distinct_offsets, max_offset = cur.execute(
+        f"WITH t AS (SELECT record_metadata:offset::int AS off "
+        f'FROM "{table_name}") '
+        f"SELECT count(*), count(DISTINCT off), max(off) FROM t"
+    ).fetchone()
     logger.info(
         f"Offset check: {total_rows} total rows, {distinct_offsets} distinct offsets, "
         f"range [0..{max_offset}]"
+    )
+
+    offsets = sorted(
+        row[0]
+        for row in driver.snowflake_conn.cursor()
+        .execute(
+            f"SELECT DISTINCT record_metadata:offset::int AS off "
+            f'FROM "{table_name}" ORDER BY off'
+        )
+        .fetchall()
     )
 
     # No gaps in the full range 0..max_offset
@@ -506,9 +538,12 @@ def test_invalidation_offset_consistency(
         f"{sorted(missing)[:20]}{'...' if len(missing) > 20 else ''}"
     )
 
-    duplicates = total_rows - distinct_offsets
-    if duplicates > 0:
-        logger.info(f"Found {duplicates} duplicate rows (expected after recovery)")
+    # Snowpipe Streaming v2 provides exactly-once semantics via offset tokens, so
+    # the connector should never produce duplicate offsets after channel-recovery.
+    assert total_rows == distinct_offsets, (
+        f"Duplicate rows detected: {total_rows} total rows, "
+        f"{distinct_offsets} distinct offsets ({total_rows - distinct_offsets} duplicates)"
+    )
 
 
 @pytest.mark.parametrize("connector_version", ["v4"], indirect=True)


### PR DESCRIPTION
## Summary

The test was computing `duplicates = total_rows - distinct_offsets` from
**two separate `cursor.execute()` calls** (`SELECT DISTINCT ...` followed by
`SELECT count(*) ...`). Snowpipe Streaming v2 commits rows asynchronously, so
even with the producer stopped these two back-to-back queries can observe
different table states and produce phantom duplicates that don't actually
exist in the table.

## Reproduction

On master against an account with `SYSTEM$STREAMING_CHANNEL_INVALIDATE`
deployed (qa3), the test intermittently logs `Found N duplicate rows`. Same
wall-clock second:

| query | result |
|-------|--------|
| `SELECT DISTINCT off ...` (the test's first call) | 170 rows, range `[0..279]` |
| `SELECT count(*) ...` (the test's second call) | 200 |
| `SELECT count(*), count(DISTINCT off), max(off) ...` *(single snapshot)* | total=200, distinct=200, max=309 |
| `SELECT off, count(*) FROM t GROUP BY off HAVING c > 1` | `[]` |

No offset ever appears more than once. The 30-dupe count came entirely from
the first query seeing 30 fewer rows than the second one issued microseconds
later.

## Fix

Wait for the connector to commit every record we sent before measuring,
using the existing `driver.get_consumer_group_offset` helper. The connector's
`preCommit` reports SSv2's `latestCommittedOffsetToken + 1` as the safe-to-commit
Kafka offset, so when the consumer group offset reaches `producer.records_produced`
the streaming pipeline has finished landing every record we sent. Then read
`count(*)`, `count(DISTINCT off)`, and `max(off)` from a single SQL statement
so both metrics describe the same snapshot — no retry needed because the table
state is known to be stable.

Tighten the previously-tolerated `if duplicates > 0: log(...)` to
`assert total_rows == distinct_offsets`, since SSv2's offset tokens guarantee
exactly-once and the connector should never produce duplicate offsets after
channel-recovery.

## Verification

Built JAR from master HEAD (`0846f61c`) and ran the test 10 times in a row
against qa3. With the fix, **every run** waited until the connector caught
up, then read a self-consistent total/distinct that matched exactly:

```
RUN  1: total=200 distinct=200  consumer group offset=310 (target=310)
RUN  2: total=250 distinct=250  consumer group offset=360 (target=360)
RUN  3: total=250 distinct=250  consumer group offset=360 (target=360)
RUN  4: total=230 distinct=230  consumer group offset=360 (target=360)
RUN  5: total=250 distinct=250  consumer group offset=360 (target=360)
RUN  6: total=200 distinct=200  consumer group offset=310 (target=310)
RUN  7: total=200 distinct=200  consumer group offset=310 (target=310)
RUN  8: total=200 distinct=200  consumer group offset=310 (target=310)
RUN  9: total=200 distinct=200  consumer group offset=310 (target=310)
RUN 10: total=250 distinct=250  consumer group offset=360 (target=360)
```

All 10 runs fail on the **gap** assertion (unrelated, pre-existing master bug
— seek-overwrite race in `SnowflakeSinkServiceV2.insert()`). Once that bug
lands its own fix, the new `assert total_rows == distinct_offsets` will catch
any regression where the connector actually produces duplicate offsets after
recovery. Zero phantom-dup outcomes across the loop.

## Test plan

- [x] `ruff check` + `ruff format --check` clean
- [x] 10 consecutive runs against qa3: zero phantom-dup outcomes
- [ ] CI E2E run on PR
