### PR TITLE
bump snowpipe-streaming to 1.6.0

### DIFF
--- a/.github/actions/build-connector/action.yml
+++ b/.github/actions/build-connector/action.yml
@@ -5,6 +5,16 @@ inputs:
   platform:
     description: "Target platform: 'apache' or 'confluent'"
     required: true
+  snowpipe-streaming-version:
+    description: >
+      Optional override for the snowpipe-streaming SDK version. Leave empty
+      to use the POM default. Set to a specific version (e.g. '1.4.0') only
+      for jobs that require an older SDK — currently the mitmproxy
+      fault-injection job, which depends on plain-HTTP requests being
+      allowed by the SDK. Setting this also skips test compilation because
+      test sources track the SDK API surface of the default version.
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -33,3 +43,4 @@ runs:
       env:
         SNOWFLAKE_CREDENTIAL_FILE: "../profile.json"
         PLATFORM: ${{ inputs.platform }}
+        SNOWPIPE_STREAMING_VERSION_OVERRIDE: ${{ inputs.snowpipe-streaming-version }}

--- a/.github/workflows/end-to-end.yaml
+++ b/.github/workflows/end-to-end.yaml
@@ -121,6 +121,11 @@ jobs:
     - uses: ./.github/actions/build-connector
       with:
         platform: apache
+        # Pin to the last SDK version that allows plain-HTTP requests; later
+        # versions enforce HTTPS-only and reject the http://mitmproxy:8080
+        # destination used by these fault-injection tests. Tracking ticket:
+        # SNOW-3683451.
+        snowpipe-streaming-version: '1.4.0'
 
     - uses: ./.github/actions/run-e2e-tests
       with:

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,16 @@
         <commons-lang3.version>3.20.0</commons-lang3.version>
         <auto-value.version>1.11.1</auto-value.version>
 
+        <!--
+            Default to the latest released SDK. Overridden to 1.4.0 only by the
+            mitmproxy fault-injection E2E test (test_client_recreation.py) which
+            cannot run against 1.5.0+ — those versions enforce
+            reqwest::ClientBuilder::https_only(true) and reject the test's
+            http://mitmproxy:8080 destination at the request-builder layer.
+            Tracking ticket: SNOW-3683451.
+        -->
+        <snowpipe-streaming.version>1.6.0</snowpipe-streaming.version>
+
     </properties>
 
 
@@ -639,7 +649,7 @@
         <dependency>
             <groupId>com.snowflake</groupId>
             <artifactId>snowpipe-streaming</artifactId>
-            <version>1.4.0</version>
+            <version>${snowpipe-streaming.version}</version>
         </dependency>
 
     </dependencies>

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -80,6 +80,16 @@
         <commons-lang3.version>3.20.0</commons-lang3.version>
         <auto-value.version>1.11.1</auto-value.version>
 
+        <!--
+            Default to the latest released SDK. Overridden to 1.4.0 only by the
+            mitmproxy fault-injection E2E test (test_client_recreation.py) which
+            cannot run against 1.5.0+ — those versions enforce
+            reqwest::ClientBuilder::https_only(true) and reject the test's
+            http://mitmproxy:8080 destination at the request-builder layer.
+            Tracking ticket: SNOW-3683451.
+        -->
+        <snowpipe-streaming.version>1.6.0</snowpipe-streaming.version>
+
     </properties>
 
 
@@ -790,7 +800,7 @@
         <dependency>
             <groupId>com.snowflake</groupId>
             <artifactId>snowpipe-streaming</artifactId>
-            <version>1.4.0</version>
+            <version>${snowpipe-streaming.version}</version>
         </dependency>
 
     </dependencies>

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/FakeSnowflakeStreamingIngestClient.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/FakeSnowflakeStreamingIngestClient.java
@@ -4,6 +4,7 @@ import com.snowflake.ingest.streaming.ChannelStatus;
 import com.snowflake.ingest.streaming.ChannelStatusBatch;
 import com.snowflake.ingest.streaming.OpenChannelResult;
 import com.snowflake.ingest.streaming.SnowflakeStreamingIngestClient;
+import com.snowflake.ingest.streaming.SnowflakeStreamingIngestElasticChannel;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -132,6 +133,11 @@ public class FakeSnowflakeStreamingIngestClient implements SnowflakeStreamingIng
   @Override
   public String getClientName() {
     return clientName;
+  }
+
+  @Override
+  public SnowflakeStreamingIngestElasticChannel getElasticChannel() {
+    throw new UnsupportedOperationException();
   }
 
   public List<FakeSnowflakeStreamingIngestChannel> getOpenedChannels() {

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannelTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannelTest.java
@@ -21,6 +21,7 @@ import com.snowflake.ingest.streaming.OpenChannelResult;
 import com.snowflake.ingest.streaming.SFException;
 import com.snowflake.ingest.streaming.SnowflakeStreamingIngestChannel;
 import com.snowflake.ingest.streaming.SnowflakeStreamingIngestClient;
+import com.snowflake.ingest.streaming.SnowflakeStreamingIngestElasticChannel;
 import com.snowflake.kafka.connector.builder.SinkRecordBuilder;
 import com.snowflake.kafka.connector.config.SinkTaskConfig;
 import com.snowflake.kafka.connector.config.SinkTaskConfigTestBuilder;
@@ -1212,6 +1213,11 @@ class SnowpipeStreamingPartitionChannelTest {
 
     @Override
     public String getClientName() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SnowflakeStreamingIngestElasticChannel getElasticChannel() {
       throw new UnsupportedOperationException();
     }
   }

--- a/test/build_runtime_jar.sh
+++ b/test/build_runtime_jar.sh
@@ -26,6 +26,20 @@ if [[ -z "${BUILD_METHOD}" ]]; then
     BUILD_METHOD="verify"
 fi
 
+# Optional override for the snowpipe-streaming SDK version. Used by the
+# mitmproxy fault-injection job to pin to a version compatible with its
+# http:// reverse proxy. Empty -> POM default applies. When set, we also
+# skip test compilation because the test sources track the SDK API surface
+# of the default (latest) version.
+SDK_OVERRIDE_OPTS=()
+if [[ -n "${SNOWPIPE_STREAMING_VERSION_OVERRIDE}" ]]; then
+    SDK_OVERRIDE_OPTS=(
+      "-Dsnowpipe-streaming.version=${SNOWPIPE_STREAMING_VERSION_OVERRIDE}"
+      "-Dmaven.test.skip=true"
+    )
+    echo "=== Overriding snowpipe-streaming SDK version to ${SNOWPIPE_STREAMING_VERSION_OVERRIDE} ==="
+fi
+
 if [[ $BUILD_FOR_RUNTIME == "confluent" ]]; then
     POM_FILE_NAME="pom_confluent.xml"
 else
@@ -89,10 +103,10 @@ case $BUILD_METHOD in
 	  # skip Iceberg tests outside of AWS
 	  if [[ $BUILD_FOR_CLOUD == "AWS" ]]; then
 	    echo "Running integration tests against AWS cloud"
-	    mvn -f $POM_FILE_NAME verify -Dgpg.skip=true -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -P aws
+	    mvn -f $POM_FILE_NAME verify -Dgpg.skip=true -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 "${SDK_OVERRIDE_OPTS[@]}" -P aws
 	  else
 	    echo "Running integration tests against non-AWS cloud"
-	    mvn -f $POM_FILE_NAME verify -Dgpg.skip=true -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -P non-aws
+	    mvn -f $POM_FILE_NAME verify -Dgpg.skip=true -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 "${SDK_OVERRIDE_OPTS[@]}" -P non-aws
 	  fi
 		;;
 	package)
@@ -100,7 +114,7 @@ case $BUILD_METHOD in
 	  mvn -f $POM_FILE_NAME clean
 	  # mvn package with pom_confluent runs the kafka-connect-maven-plugin which creates a zip file
 	  # More information: https://docs.confluent.io/platform/current/connect/kafka-connect-maven-plugin/site/plugin-info.html
-    mvn -f $POM_FILE_NAME package -Dgpg.skip=true -DskipTests -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+    mvn -f $POM_FILE_NAME package -Dgpg.skip=true -DskipTests -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 "${SDK_OVERRIDE_OPTS[@]}"
 		;;
 	none)
 		echo -e "\n=== skip building, please make sure built connector exist ==="


### PR DESCRIPTION
## Summary

Bumps `com.snowflake:snowpipe-streaming` from 1.4.0 → 1.6.0 in `pom.xml` and `pom_confluent.xml`. The mitmproxy fault-injection E2E job stays on 1.4.0 because 1.5.0+ enforce `https_only(true)` in non-test builds, which rejects the test's `http://mitmproxy:8080` destination at the request-builder layer (`reqwest::Error { kind: Builder, source: BadScheme }`).

## How the override works

- POMs declare `<snowpipe-streaming.version>1.6.0</snowpipe-streaming.version>` and reference it via `${...}`. All builds default to 1.6.0.
- `test/build_runtime_jar.sh` reads `SNOWPIPE_STREAMING_VERSION_OVERRIDE`. When set, it appends `-Dsnowpipe-streaming.version=...` and `-Dmaven.test.skip=true` to every Maven invocation. Test compilation is skipped because the test fakes track the latest SDK API surface and don't compile against 1.4.0.
- `.github/actions/build-connector/action.yml` exposes an optional `snowpipe-streaming-version` input that flows through to the env var.
- Only the `fault_injection` job in `.github/workflows/end-to-end.yaml` sets `snowpipe-streaming-version: '1.4.0'`. Every other CI job (apache + confluent verify/package, default e2e suite, integration tests) runs against 1.6.0.

## Test fakes

`FakeSnowflakeStreamingIngestClient` and `TrackingStreamingIngestClient` (in `SnowpipeStreamingPartitionChannelTest`) gain a stub `getElasticChannel()` because 1.6.0 re-declares it on the `SnowflakeStreamingIngestClient` public interface. Stubs throw `UnsupportedOperationException`; nothing in the connector exercises elastic channels.

## Tracking & follow-up

- **SNOW-3683451** — drop the 1.4.0 pin once the SDK provides an escape hatch.
