### PR TITLE
Add connector version check opt-out

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/Constants.java
+++ b/src/main/java/com/snowflake/kafka/connector/Constants.java
@@ -38,6 +38,9 @@ public final class Constants {
     public static final String SNOWFLAKE_OPEN_CHANNEL_IO_THREADS =
         "snowflake.open.channel.io.threads";
     public static final int SNOWFLAKE_OPEN_CHANNEL_IO_THREADS_DEFAULT = 50;
+    public static final String SNOWFLAKE_CONNECTOR_VERSION_CHECK_ENABLED =
+        "snowflake.connector.version.check.enabled";
+    public static final boolean SNOWFLAKE_CONNECTOR_VERSION_CHECK_ENABLED_DEFAULT = true;
 
     // Validation
     public static final String SNOWFLAKE_VALIDATION = "snowflake.validation";

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeStreamingSinkConnector.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeStreamingSinkConnector.java
@@ -87,7 +87,9 @@ public class SnowflakeStreamingSinkConnector extends SinkConnector {
   public void start(final Map<String, String> parsedConfig) {
     LOGGER.info("SnowflakeStreamingSinkConnector:starting...");
 
-    Utils.checkConnectorVersion();
+    if (isConnectorVersionCheckEnabled(parsedConfig)) {
+      Utils.checkConnectorVersion();
+    }
 
     setupComplete = false;
     connectorStartTime = System.currentTimeMillis();
@@ -121,6 +123,15 @@ public class SnowflakeStreamingSinkConnector extends SinkConnector {
     setupComplete = true;
 
     LOGGER.info("SnowflakeStreamingSinkConnector:started");
+  }
+
+  static boolean isConnectorVersionCheckEnabled(final Map<String, String> parsedConfig) {
+    String configuredValue =
+        parsedConfig.get(KafkaConnectorConfigParams.SNOWFLAKE_CONNECTOR_VERSION_CHECK_ENABLED);
+    if (configuredValue == null) {
+      return KafkaConnectorConfigParams.SNOWFLAKE_CONNECTOR_VERSION_CHECK_ENABLED_DEFAULT;
+    }
+    return !Boolean.FALSE.toString().equalsIgnoreCase(configuredValue.trim());
   }
 
   /**

--- a/src/main/java/com/snowflake/kafka/connector/config/ConnectorConfigDefinition.java
+++ b/src/main/java/com/snowflake/kafka/connector/config/ConnectorConfigDefinition.java
@@ -499,6 +499,17 @@ public class ConnectorConfigDefinition {
             CONNECTOR_CONFIG_DOC,
             14,
             Width.NONE,
-            KafkaConnectorConfigParams.CACHE_PIPE_EXISTS_EXPIRE_MS);
+            KafkaConnectorConfigParams.CACHE_PIPE_EXISTS_EXPIRE_MS)
+        .define(
+            KafkaConnectorConfigParams.SNOWFLAKE_CONNECTOR_VERSION_CHECK_ENABLED,
+            BOOLEAN,
+            KafkaConnectorConfigParams.SNOWFLAKE_CONNECTOR_VERSION_CHECK_ENABLED_DEFAULT,
+            LOW,
+            "Whether to check the latest available connector version at startup. Set to false for"
+                + " deployments that do not allow outbound access to the Maven repository.",
+            CONNECTOR_CONFIG_DOC,
+            15,
+            Width.NONE,
+            KafkaConnectorConfigParams.SNOWFLAKE_CONNECTOR_VERSION_CHECK_ENABLED);
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/SnowflakeStreamingSinkConnectorTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/SnowflakeStreamingSinkConnectorTest.java
@@ -1,0 +1,37 @@
+package com.snowflake.kafka.connector;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public class SnowflakeStreamingSinkConnectorTest {
+
+  @Test
+  public void testConnectorVersionCheckDefaultsToEnabled() {
+    Map<String, String> config = new HashMap<>();
+
+    assertTrue(SnowflakeStreamingSinkConnector.isConnectorVersionCheckEnabled(config));
+  }
+
+  @Test
+  public void testConnectorVersionCheckCanBeDisabled() {
+    Map<String, String> config = new HashMap<>();
+    config.put(
+        KafkaConnectorConfigParams.SNOWFLAKE_CONNECTOR_VERSION_CHECK_ENABLED,
+        Boolean.FALSE.toString());
+
+    assertFalse(SnowflakeStreamingSinkConnector.isConnectorVersionCheckEnabled(config));
+  }
+
+  @Test
+  public void testConnectorVersionCheckOnlyDisablesOnExplicitFalse() {
+    Map<String, String> config = new HashMap<>();
+    config.put(KafkaConnectorConfigParams.SNOWFLAKE_CONNECTOR_VERSION_CHECK_ENABLED, "invalid");
+
+    assertTrue(SnowflakeStreamingSinkConnector.isConnectorVersionCheckEnabled(config));
+  }
+}

--- a/src/test/java/com/snowflake/kafka/connector/config/ConnectorVersionCheckConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/config/ConnectorVersionCheckConfigTest.java
@@ -1,0 +1,50 @@
+package com.snowflake.kafka.connector.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.common.config.ConfigDef;
+import org.junit.jupiter.api.Test;
+
+public class ConnectorVersionCheckConfigTest {
+
+  @Test
+  public void testConnectorVersionCheckConfigExists() {
+    ConfigDef configDef = ConnectorConfigDefinition.getConfig();
+    String key = KafkaConnectorConfigParams.SNOWFLAKE_CONNECTOR_VERSION_CHECK_ENABLED;
+
+    assertNotNull(
+        configDef.configKeys().get(key),
+        "snowflake.connector.version.check.enabled should be defined in config");
+  }
+
+  @Test
+  public void testConnectorVersionCheckDefaultsToEnabled() {
+    ConfigDef configDef = ConnectorConfigDefinition.getConfig();
+    String key = KafkaConnectorConfigParams.SNOWFLAKE_CONNECTOR_VERSION_CHECK_ENABLED;
+
+    Object defaultValue = configDef.configKeys().get(key).defaultValue;
+
+    assertEquals(
+        KafkaConnectorConfigParams.SNOWFLAKE_CONNECTOR_VERSION_CHECK_ENABLED_DEFAULT,
+        defaultValue,
+        "Connector version check should be enabled by default");
+  }
+
+  @Test
+  public void testConnectorVersionCheckCanBeDisabled() {
+    ConfigDef configDef = ConnectorConfigDefinition.getConfig();
+    String key = KafkaConnectorConfigParams.SNOWFLAKE_CONNECTOR_VERSION_CHECK_ENABLED;
+
+    Map<String, String> props = new HashMap<>();
+    props.put(key, "false");
+
+    Map<String, Object> parsed = configDef.parse(props);
+
+    assertEquals(
+        Boolean.FALSE, parsed.get(key), "Connector version check should be configurable");
+  }
+}


### PR DESCRIPTION
## 🧭 Summary

- Add `snowflake.connector.version.check.enabled`, a boolean connector config that defaults to `true`.
- Skip the startup connector version check only when the config is explicitly set to `false`.
- Add unit coverage for the config definition and startup gating behavior.

Related issue: #1195

## 🧪 Testing

- `git diff --check`
- Not run: `./format.sh` (local environment does not have a Java runtime)
- Not run: `mvn package -Dgpg.skip=true` (local environment does not have `mvn` or a Java runtime)