### PR TITLE
SNOW-3161094: Kafka Connector — managed-Iceberg table auto-creation + ingestion (snowflake.autocreate.table.type)

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/Constants.java
+++ b/src/main/java/com/snowflake/kafka/connector/Constants.java
@@ -150,6 +150,19 @@ public final class Constants {
     public static final String SNOWFLAKE_ENABLE_SCHEMATIZATION = "snowflake.enable.schematization";
     public static final boolean SNOWFLAKE_ENABLE_SCHEMATIZATION_DEFAULT = true;
 
+    // Iceberg table auto-creation (SNOW-3552261)
+    public static final String SNOWFLAKE_AUTOCREATE_TABLE_TYPE = "snowflake.autocreate.table.type";
+    public static final String SNOWFLAKE_AUTOCREATE_TABLE_TYPE_DEFAULT = "snowflake";
+    // Optional SQL clauses spliced into the auto-created Iceberg table's CREATE statement, right
+    // after the column list (e.g. "EXTERNAL_VOLUME='v' ICEBERG_VERSION=3 CLUSTER BY (id)"). Lets
+    // operators set any managed-Iceberg create option without the connector exposing a knob per
+    // option. The connector always supplies the ingestion-mandatory clauses (RECORD_METADATA
+    // column, CATALOG='SNOWFLAKE', ENABLE_SCHEMA_EVOLUTION, ERROR_LOGGING); do not repeat those
+    // here. Only valid when snowflake.autocreate.table.type=iceberg.
+    public static final String SNOWFLAKE_ICEBERG_CREATE_TABLE_OPTIONS =
+        "snowflake.iceberg.create.table.options";
+    public static final String SNOWFLAKE_ICEBERG_CREATE_TABLE_OPTIONS_DEFAULT = "";
+
     // MDC logging header
     public static final String ENABLE_MDC_LOGGING_CONFIG = "enable.mdc.logging";
     public static final String ENABLE_MDC_LOGGING_DEFAULT = "false";

--- a/src/main/java/com/snowflake/kafka/connector/Constants.java
+++ b/src/main/java/com/snowflake/kafka/connector/Constants.java
@@ -152,10 +152,9 @@ public final class Constants {
 
     // Iceberg table auto-creation (SNOW-3552261)
     public static final String SNOWFLAKE_AUTOCREATE_TABLE_TYPE = "snowflake.autocreate.table.type";
-    // Use the canonical config value from TableType so the default stays in sync if the enum
-    // changes.
-    public static final String SNOWFLAKE_AUTOCREATE_TABLE_TYPE_DEFAULT =
-        com.snowflake.kafka.connector.config.TableType.SNOWFLAKE.configValue();
+    public static final com.snowflake.kafka.connector.config.TableType
+        SNOWFLAKE_AUTOCREATE_TABLE_TYPE_DEFAULT =
+            com.snowflake.kafka.connector.config.TableType.SNOWFLAKE;
     // Optional SQL clauses spliced into the auto-created Iceberg table's CREATE statement, right
     // after the column list (e.g. "EXTERNAL_VOLUME='v' ICEBERG_VERSION=3 CLUSTER BY (id)"). Lets
     // operators set any managed-Iceberg create option without the connector exposing a knob per

--- a/src/main/java/com/snowflake/kafka/connector/Constants.java
+++ b/src/main/java/com/snowflake/kafka/connector/Constants.java
@@ -90,6 +90,17 @@ public final class Constants {
         "snowflake.feature.normalize.time";
     public static final boolean SNOWFLAKE_FEATURE_NORMALIZE_TIME_DEFAULT = true;
 
+    // Kill-switch (unregistered, default on) for the managed-Iceberg structured-OBJECT
+    // RECORD_METADATA handling: probing whether a table's RECORD_METADATA is a structured OBJECT,
+    // validating an existing structured schema at startup, and conforming the metadata map for
+    // ingestion. Set to false to revert to 4.0.x behavior (RECORD_METADATA always treated as
+    // VARIANT, no probe, no conforming) if the new handling ever misbehaves for existing workloads.
+    // Note: disabling this also disables correct ingestion into managed-Iceberg v2 (structured
+    // OBJECT) tables, since their metadata will no longer be conformed.
+    public static final String SNOWFLAKE_FEATURE_STRUCTURED_RECORD_METADATA =
+        "snowflake.feature.structured.record.metadata.enabled";
+    public static final boolean SNOWFLAKE_FEATURE_STRUCTURED_RECORD_METADATA_DEFAULT = true;
+
     public static final String SNOWFLAKE_FEATURE_STRUCTURED_HEADERS =
         "snowflake.feature.structured.headers";
     public static final boolean SNOWFLAKE_FEATURE_STRUCTURED_HEADERS_DEFAULT = false;

--- a/src/main/java/com/snowflake/kafka/connector/Constants.java
+++ b/src/main/java/com/snowflake/kafka/connector/Constants.java
@@ -152,7 +152,10 @@ public final class Constants {
 
     // Iceberg table auto-creation (SNOW-3552261)
     public static final String SNOWFLAKE_AUTOCREATE_TABLE_TYPE = "snowflake.autocreate.table.type";
-    public static final String SNOWFLAKE_AUTOCREATE_TABLE_TYPE_DEFAULT = "snowflake";
+    // Use the canonical config value from TableType so the default stays in sync if the enum
+    // changes.
+    public static final String SNOWFLAKE_AUTOCREATE_TABLE_TYPE_DEFAULT =
+        com.snowflake.kafka.connector.config.TableType.SNOWFLAKE.configValue();
     // Optional SQL clauses spliced into the auto-created Iceberg table's CREATE statement, right
     // after the column list (e.g. "EXTERNAL_VOLUME='v' ICEBERG_VERSION=3 CLUSTER BY (id)"). Lets
     // operators set any managed-Iceberg create option without the connector exposing a knob per

--- a/src/main/java/com/snowflake/kafka/connector/config/ConnectorConfigDefinition.java
+++ b/src/main/java/com/snowflake/kafka/connector/config/ConnectorConfigDefinition.java
@@ -523,7 +523,7 @@ public class ConnectorConfigDefinition {
                 + " column list (e.g. \"EXTERNAL_VOLUME='v' ICEBERG_VERSION=3 CLUSTER BY (id)\")."
                 + " Lets operators set any managed-Iceberg create option without a per-option knob."
                 + " Only valid when snowflake.autocreate.table.type=iceberg. Do NOT include"
-                + " RECORD_METADATA, CATALOG, ENABLE_SCHEMA_EVOLUTION or ERROR_LOGGING -- the"
+                + " CATALOG, ENABLE_SCHEMA_EVOLUTION or ERROR_LOGGING -- the"
                 + " connector always supplies those. Ignored if the table already exists.",
             CONNECTOR_CONFIG_DOC,
             16,

--- a/src/main/java/com/snowflake/kafka/connector/config/ConnectorConfigDefinition.java
+++ b/src/main/java/com/snowflake/kafka/connector/config/ConnectorConfigDefinition.java
@@ -502,7 +502,7 @@ public class ConnectorConfigDefinition {
         .define(
             KafkaConnectorConfigParams.SNOWFLAKE_AUTOCREATE_TABLE_TYPE,
             STRING,
-            KafkaConnectorConfigParams.SNOWFLAKE_AUTOCREATE_TABLE_TYPE_DEFAULT,
+            KafkaConnectorConfigParams.SNOWFLAKE_AUTOCREATE_TABLE_TYPE_DEFAULT.configValue(),
             ConfigDef.ValidString.in("snowflake", "iceberg", "none"),
             MEDIUM,
             "Controls table auto-creation. 'snowflake' (default): auto-create a standard Snowflake"

--- a/src/main/java/com/snowflake/kafka/connector/config/ConnectorConfigDefinition.java
+++ b/src/main/java/com/snowflake/kafka/connector/config/ConnectorConfigDefinition.java
@@ -505,11 +505,11 @@ public class ConnectorConfigDefinition {
             KafkaConnectorConfigParams.SNOWFLAKE_AUTOCREATE_TABLE_TYPE_DEFAULT,
             ConfigDef.ValidString.in("snowflake", "iceberg", "none"),
             MEDIUM,
-            "Controls table auto-creation. 'snowflake' (default): auto-create a standard FDN table"
-                + " if it is missing. 'iceberg': auto-create a Snowflake-managed Iceberg table if"
-                + " it is missing. 'none': never create anything; the table and its pipe must"
-                + " already exist. An existing table is always used as-is, regardless of this"
-                + " setting.",
+            "Controls table auto-creation. 'snowflake' (default): auto-create a standard Snowflake"
+                + " table if it is missing. 'iceberg': auto-create a Snowflake-managed Iceberg"
+                + " table if it is missing. 'none': never auto-create the table (fail fast if it"
+                + " is missing); the pipe is still auto-managed by the connector as usual. An"
+                + " existing table is always used as-is, regardless of this setting.",
             CONNECTOR_CONFIG_DOC,
             15,
             Width.NONE,

--- a/src/main/java/com/snowflake/kafka/connector/config/ConnectorConfigDefinition.java
+++ b/src/main/java/com/snowflake/kafka/connector/config/ConnectorConfigDefinition.java
@@ -500,6 +500,36 @@ public class ConnectorConfigDefinition {
             Width.NONE,
             KafkaConnectorConfigParams.SNOWFLAKE_ENABLE_SCHEMATIZATION)
         .define(
+            KafkaConnectorConfigParams.SNOWFLAKE_AUTOCREATE_TABLE_TYPE,
+            STRING,
+            KafkaConnectorConfigParams.SNOWFLAKE_AUTOCREATE_TABLE_TYPE_DEFAULT,
+            ConfigDef.ValidString.in("snowflake", "iceberg", "none"),
+            MEDIUM,
+            "Controls table auto-creation. 'snowflake' (default): auto-create a standard FDN table"
+                + " if it is missing. 'iceberg': auto-create a Snowflake-managed Iceberg table if"
+                + " it is missing. 'none': never create anything; the table and its pipe must"
+                + " already exist. An existing table is always used as-is, regardless of this"
+                + " setting.",
+            CONNECTOR_CONFIG_DOC,
+            15,
+            Width.NONE,
+            KafkaConnectorConfigParams.SNOWFLAKE_AUTOCREATE_TABLE_TYPE)
+        .define(
+            KafkaConnectorConfigParams.SNOWFLAKE_ICEBERG_CREATE_TABLE_OPTIONS,
+            STRING,
+            KafkaConnectorConfigParams.SNOWFLAKE_ICEBERG_CREATE_TABLE_OPTIONS_DEFAULT,
+            LOW,
+            "SQL clauses spliced into the auto-created Iceberg table's CREATE statement after the"
+                + " column list (e.g. \"EXTERNAL_VOLUME='v' ICEBERG_VERSION=3 CLUSTER BY (id)\")."
+                + " Lets operators set any managed-Iceberg create option without a per-option knob."
+                + " Only valid when snowflake.autocreate.table.type=iceberg. Do NOT include"
+                + " RECORD_METADATA, CATALOG, ENABLE_SCHEMA_EVOLUTION or ERROR_LOGGING -- the"
+                + " connector always supplies those. Ignored if the table already exists.",
+            CONNECTOR_CONFIG_DOC,
+            16,
+            Width.NONE,
+            KafkaConnectorConfigParams.SNOWFLAKE_ICEBERG_CREATE_TABLE_OPTIONS)
+        .define(
             KafkaConnectorConfigParams.CACHE_TABLE_EXISTS,
             BOOLEAN,
             KafkaConnectorConfigParams.CACHE_TABLE_EXISTS_DEFAULT,

--- a/src/main/java/com/snowflake/kafka/connector/config/SinkTaskConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/config/SinkTaskConfig.java
@@ -160,6 +160,16 @@ public abstract class SinkTaskConfig {
    */
   public abstract boolean isNormalizeTimeEnabled();
 
+  /**
+   * Whether the managed-Iceberg structured-OBJECT {@code RECORD_METADATA} handling is enabled:
+   * probing whether a table's {@code RECORD_METADATA} is a structured OBJECT, validating an
+   * existing structured schema at startup, and conforming the metadata map for ingestion. When
+   * {@code false}, {@code RECORD_METADATA} is always treated as VARIANT (4.0.x behavior).
+   * Kill-switch for existing workloads. See {@link
+   * KafkaConnectorConfigParams#SNOWFLAKE_FEATURE_STRUCTURED_RECORD_METADATA}.
+   */
+  public abstract boolean isStructuredRecordMetadataEnabled();
+
   /** Convenience overload that calls {@link #from(Map, boolean)} with {@code false}. */
   public static SinkTaskConfig from(Map<String, String> raw) {
     return from(raw, false);
@@ -398,6 +408,13 @@ public abstract class SinkTaskConfig {
             .map(Boolean::parseBoolean)
             .orElse(KafkaConnectorConfigParams.SNOWFLAKE_FEATURE_NORMALIZE_TIME_DEFAULT);
 
+    boolean structuredRecordMetadataEnabled =
+        Optional.ofNullable(
+                config.get(KafkaConnectorConfigParams.SNOWFLAKE_FEATURE_STRUCTURED_RECORD_METADATA))
+            .map(Boolean::parseBoolean)
+            .orElse(
+                KafkaConnectorConfigParams.SNOWFLAKE_FEATURE_STRUCTURED_RECORD_METADATA_DEFAULT);
+
     TableType autocreatedTableType =
         TableType.fromConfig(config.get(KafkaConnectorConfigParams.SNOWFLAKE_AUTOCREATE_TABLE_TYPE))
             .orElse(KafkaConnectorConfigParams.SNOWFLAKE_AUTOCREATE_TABLE_TYPE_DEFAULT);
@@ -491,6 +508,7 @@ public abstract class SinkTaskConfig {
         .prometheusMetricsEnabled(prometheusMetricsEnabled)
         .validationErrorTableNameEnabled(validationErrorTableNameEnabled)
         .normalizeTimeEnabled(normalizeTimeEnabled)
+        .structuredRecordMetadataEnabled(structuredRecordMetadataEnabled)
         .autocreatedTableType(autocreatedTableType)
         .icebergCreateTableOptions(icebergCreateTableOptions);
 
@@ -627,6 +645,9 @@ public abstract class SinkTaskConfig {
         boolean validationErrorTableNameEnabled);
 
     public abstract Builder normalizeTimeEnabled(boolean normalizeTimeEnabled);
+
+    public abstract Builder structuredRecordMetadataEnabled(
+        boolean structuredRecordMetadataEnabled);
 
     public abstract SinkTaskConfig build();
   }

--- a/src/main/java/com/snowflake/kafka/connector/config/SinkTaskConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/config/SinkTaskConfig.java
@@ -398,7 +398,7 @@ public abstract class SinkTaskConfig {
             .map(Boolean::parseBoolean)
             .orElse(KafkaConnectorConfigParams.SNOWFLAKE_FEATURE_NORMALIZE_TIME_DEFAULT);
 
-    TableType tableType =
+    TableType autocreatedTableType =
         TableType.fromConfig(config.get(KafkaConnectorConfigParams.SNOWFLAKE_AUTOCREATE_TABLE_TYPE))
             .orElse(TableType.SNOWFLAKE);
 
@@ -407,20 +407,21 @@ public abstract class SinkTaskConfig {
                 config.get(KafkaConnectorConfigParams.SNOWFLAKE_ICEBERG_CREATE_TABLE_OPTIONS))
             .map(String::trim)
             .filter(s -> !s.isEmpty());
-    if (icebergCreateTableOptions.isPresent() && tableType != TableType.ICEBERG) {
+    if (icebergCreateTableOptions.isPresent() && autocreatedTableType != TableType.ICEBERG) {
       throw new IllegalArgumentException(
           KafkaConnectorConfigParams.SNOWFLAKE_ICEBERG_CREATE_TABLE_OPTIONS
               + " is only valid when "
               + KafkaConnectorConfigParams.SNOWFLAKE_AUTOCREATE_TABLE_TYPE
               + "=iceberg (got table.type="
-              + tableType.configValue()
+              + autocreatedTableType.configValue()
               + ")");
     }
 
     // client_side validation cannot model the structured RECORD_METADATA column of managed Iceberg
     // tables; client-side schema evolution also relies on ALTER ADD COLUMN, which is a server-side
     // concern for Iceberg. Reject unconditionally rather than only when schematization is enabled.
-    if (tableType == TableType.ICEBERG && validation == SnowflakeValidation.CLIENT_SIDE) {
+    if (autocreatedTableType == TableType.ICEBERG
+        && validation == SnowflakeValidation.CLIENT_SIDE) {
       throw new IllegalArgumentException(
           KafkaConnectorConfigParams.SNOWFLAKE_VALIDATION
               + "=client_side is not supported with "
@@ -431,26 +432,11 @@ public abstract class SinkTaskConfig {
               + "=server_side.");
     }
 
-    // structured headers (SNOWFLAKE_FEATURE_STRUCTURED_HEADERS=true) keep header values in their
-    // native types. The managed-Iceberg RECORD_METADATA schema declares headers
-    // MAP(VARCHAR,VARCHAR),
-    // so a non-String header value would fail the strict typed-OBJECT cast at ingest time.
-    if (tableType == TableType.ICEBERG && metadataConfig.isStructuredHeadersEnabled()) {
-      throw new IllegalArgumentException(
-          KafkaConnectorConfigParams.SNOWFLAKE_FEATURE_STRUCTURED_HEADERS
-              + "=true is not supported with "
-              + KafkaConnectorConfigParams.SNOWFLAKE_AUTOCREATE_TABLE_TYPE
-              + "=iceberg. The managed-Iceberg RECORD_METADATA schema declares"
-              + " headers MAP(VARCHAR,VARCHAR); non-String header values would fail the strict"
-              + " typed-OBJECT cast. Set "
-              + KafkaConnectorConfigParams.SNOWFLAKE_FEATURE_STRUCTURED_HEADERS
-              + "=false (the default) when using managed Iceberg.");
-    }
-
     // Managed Iceberg RECORD_METADATA is cast to a fixed structured OBJECT schema, so every
     // metadata flag that maps to a declared schema field must be enabled. Disabling any of them
     // produces a sparse map that fails the strict typed-OBJECT cast at ingest time.
-    if (tableType == TableType.ICEBERG && !metadataConfig.isFullIcebergMetadataEnabled()) {
+    if (autocreatedTableType == TableType.ICEBERG
+        && !metadataConfig.isFullIcebergMetadataEnabled()) {
       throw new IllegalArgumentException(
           KafkaConnectorConfigParams.SNOWFLAKE_AUTOCREATE_TABLE_TYPE
               + "=iceberg requires all record metadata to be enabled"
@@ -503,7 +489,7 @@ public abstract class SinkTaskConfig {
         .prometheusMetricsEnabled(prometheusMetricsEnabled)
         .validationErrorTableNameEnabled(validationErrorTableNameEnabled)
         .normalizeTimeEnabled(normalizeTimeEnabled)
-        .autocreatedTableType(tableType)
+        .autocreatedTableType(autocreatedTableType)
         .icebergCreateTableOptions(icebergCreateTableOptions);
 
     snowflakePrivateKey.ifPresent(b::snowflakePrivateKey);

--- a/src/main/java/com/snowflake/kafka/connector/config/SinkTaskConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/config/SinkTaskConfig.java
@@ -442,6 +442,8 @@ public abstract class SinkTaskConfig {
               + "=iceberg requires all record metadata to be enabled"
               + " (RECORD_METADATA is cast to a fixed structured schema for managed Iceberg)."
               + " Remove any "
+              + KafkaConnectorConfigParams.SNOWFLAKE_METADATA_ALL
+              + "=false, "
               + KafkaConnectorConfigParams.SNOWFLAKE_METADATA_TOPIC
               + "=false, "
               + KafkaConnectorConfigParams.SNOWFLAKE_METADATA_OFFSET_AND_PARTITION

--- a/src/main/java/com/snowflake/kafka/connector/config/SinkTaskConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/config/SinkTaskConfig.java
@@ -400,7 +400,7 @@ public abstract class SinkTaskConfig {
 
     TableType autocreatedTableType =
         TableType.fromConfig(config.get(KafkaConnectorConfigParams.SNOWFLAKE_AUTOCREATE_TABLE_TYPE))
-            .orElse(TableType.SNOWFLAKE);
+            .orElse(KafkaConnectorConfigParams.SNOWFLAKE_AUTOCREATE_TABLE_TYPE_DEFAULT);
 
     Optional<String> icebergCreateTableOptions =
         Optional.ofNullable(

--- a/src/main/java/com/snowflake/kafka/connector/config/SinkTaskConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/config/SinkTaskConfig.java
@@ -49,7 +49,7 @@ public abstract class SinkTaskConfig {
 
   public abstract boolean isEnableSchematization();
 
-  public abstract TableType getTableType();
+  public abstract TableType getAutocreatedTableType();
 
   public abstract Optional<String> getIcebergCreateTableOptions();
 
@@ -417,23 +417,34 @@ public abstract class SinkTaskConfig {
               + ")");
     }
 
-    // Client-side validation drives client-side schema evolution (ALTER ADD COLUMN issued by the
-    // connector). For managed Iceberg, schema evolution is performed server-side; the client-side
-    // RowValidator cannot even model the structured RECORD_METADATA column. Reject the combination
-    // loudly rather than silently producing a misleading runtime failure. Server-side SE is the
-    // supported mechanism: use snowflake.validation=server_side with Iceberg + schematization.
-    if (tableType == TableType.ICEBERG
-        && enableSchematization
-        && validation == SnowflakeValidation.CLIENT_SIDE) {
+    // client_side validation cannot model the structured RECORD_METADATA column of managed Iceberg
+    // tables; client-side schema evolution also relies on ALTER ADD COLUMN, which is a server-side
+    // concern for Iceberg. Reject unconditionally rather than only when schematization is enabled.
+    if (tableType == TableType.ICEBERG && validation == SnowflakeValidation.CLIENT_SIDE) {
       throw new IllegalArgumentException(
           KafkaConnectorConfigParams.SNOWFLAKE_VALIDATION
               + "=client_side is not supported with "
               + KafkaConnectorConfigParams.SNOWFLAKE_AUTOCREATE_TABLE_TYPE
-              + "=iceberg when schema evolution is enabled ("
-              + KafkaConnectorConfigParams.SNOWFLAKE_ENABLE_SCHEMATIZATION
-              + "=true). Managed Iceberg schema evolution is server-side; set "
+              + "=iceberg. Managed Iceberg uses a structured RECORD_METADATA column that the"
+              + " client-side RowValidator cannot model. Set "
               + KafkaConnectorConfigParams.SNOWFLAKE_VALIDATION
               + "=server_side.");
+    }
+
+    // structured headers (SNOWFLAKE_FEATURE_STRUCTURED_HEADERS=true) keep header values in their
+    // native types. The managed-Iceberg RECORD_METADATA schema declares headers
+    // MAP(VARCHAR,VARCHAR),
+    // so a non-String header value would fail the strict typed-OBJECT cast at ingest time.
+    if (tableType == TableType.ICEBERG && metadataConfig.isStructuredHeadersEnabled()) {
+      throw new IllegalArgumentException(
+          KafkaConnectorConfigParams.SNOWFLAKE_FEATURE_STRUCTURED_HEADERS
+              + "=true is not supported with "
+              + KafkaConnectorConfigParams.SNOWFLAKE_AUTOCREATE_TABLE_TYPE
+              + "=iceberg. The managed-Iceberg RECORD_METADATA schema declares"
+              + " headers MAP(VARCHAR,VARCHAR); non-String header values would fail the strict"
+              + " typed-OBJECT cast. Set "
+              + KafkaConnectorConfigParams.SNOWFLAKE_FEATURE_STRUCTURED_HEADERS
+              + "=false (the default) when using managed Iceberg.");
     }
 
     // Managed Iceberg RECORD_METADATA is cast to a fixed structured OBJECT schema, so every
@@ -492,7 +503,7 @@ public abstract class SinkTaskConfig {
         .prometheusMetricsEnabled(prometheusMetricsEnabled)
         .validationErrorTableNameEnabled(validationErrorTableNameEnabled)
         .normalizeTimeEnabled(normalizeTimeEnabled)
-        .tableType(tableType)
+        .autocreatedTableType(tableType)
         .icebergCreateTableOptions(icebergCreateTableOptions);
 
     snowflakePrivateKey.ifPresent(b::snowflakePrivateKey);
@@ -517,11 +528,8 @@ public abstract class SinkTaskConfig {
   }
 
   /**
-   * Creates a new builder. Used by {@link #from(Map)} (via {@code builderFrom}) and by {@code
-   * SinkTaskConfigTestBuilder} in tests. The Iceberg-related fields ({@code tableType}, {@code
-   * icebergCreateTableOptions}) have no defaults here — {@code builderFrom} always sets them from
-   * config, and tests must set them via {@code SinkTaskConfigTestBuilder} (which provides the
-   * defaults).
+   * Creates a new builder. Tests must set defaults via {@code SinkTaskConfigTestBuilder} so future
+   * changes don't re-add them here.
    */
   public static Builder builder() {
     return new AutoValue_SinkTaskConfig.Builder();
@@ -553,7 +561,7 @@ public abstract class SinkTaskConfig {
 
     public abstract Builder enableSchematization(boolean enableSchematization);
 
-    public abstract Builder tableType(TableType tableType);
+    public abstract Builder autocreatedTableType(TableType autocreatedTableType);
 
     public abstract Builder icebergCreateTableOptions(Optional<String> icebergCreateTableOptions);
 

--- a/src/main/java/com/snowflake/kafka/connector/config/SinkTaskConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/config/SinkTaskConfig.java
@@ -49,6 +49,10 @@ public abstract class SinkTaskConfig {
 
   public abstract boolean isEnableSchematization();
 
+  public abstract TableType getTableType();
+
+  public abstract String getIcebergCreateTableOptions();
+
   public abstract boolean isEnableColumnIdentifierNormalization();
 
   public abstract SnowflakeValidation getValidation();
@@ -394,6 +398,39 @@ public abstract class SinkTaskConfig {
             .map(Boolean::parseBoolean)
             .orElse(KafkaConnectorConfigParams.SNOWFLAKE_FEATURE_NORMALIZE_TIME_DEFAULT);
 
+    TableType tableType =
+        TableType.fromConfig(
+            config.get(KafkaConnectorConfigParams.SNOWFLAKE_AUTOCREATE_TABLE_TYPE));
+
+    String icebergCreateTableOptions =
+        config
+            .getOrDefault(
+                KafkaConnectorConfigParams.SNOWFLAKE_ICEBERG_CREATE_TABLE_OPTIONS,
+                KafkaConnectorConfigParams.SNOWFLAKE_ICEBERG_CREATE_TABLE_OPTIONS_DEFAULT)
+            .trim();
+    if (!icebergCreateTableOptions.isEmpty() && tableType != TableType.ICEBERG) {
+      throw new IllegalArgumentException(
+          "snowflake.iceberg.create.table.options is only valid when"
+              + " snowflake.autocreate.table.type=iceberg (got table.type="
+              + tableType.configValue()
+              + ")");
+    }
+
+    // Client-side validation drives client-side schema evolution (ALTER ADD COLUMN issued by the
+    // connector). For managed Iceberg, schema evolution is performed server-side; the client-side
+    // RowValidator cannot even model the structured RECORD_METADATA column. Reject the combination
+    // loudly rather than silently producing a misleading runtime failure. Server-side SE is the
+    // supported mechanism: use snowflake.validation=server_side with Iceberg + schematization.
+    if (tableType == TableType.ICEBERG
+        && enableSchematization
+        && validation == SnowflakeValidation.CLIENT_SIDE) {
+      throw new IllegalArgumentException(
+          "snowflake.validation=client_side is not supported with"
+              + " snowflake.autocreate.table.type=iceberg when schema evolution is enabled"
+              + " (snowflake.enable.schematization=true). Managed Iceberg schema evolution is"
+              + " server-side; set snowflake.validation=server_side.");
+    }
+
     Builder b = builder();
     b.connectorName(connectorName)
         .taskId(taskId)
@@ -430,7 +467,9 @@ public abstract class SinkTaskConfig {
         .precommitClientRecoveryEnabled(precommitClientRecoveryEnabled)
         .prometheusMetricsEnabled(prometheusMetricsEnabled)
         .validationErrorTableNameEnabled(validationErrorTableNameEnabled)
-        .normalizeTimeEnabled(normalizeTimeEnabled);
+        .normalizeTimeEnabled(normalizeTimeEnabled)
+        .tableType(tableType)
+        .icebergCreateTableOptions(icebergCreateTableOptions);
 
     snowflakePrivateKey.ifPresent(b::snowflakePrivateKey);
     snowflakePrivateKeyPassphrase.ifPresent(b::snowflakePrivateKeyPassphrase);
@@ -455,7 +494,13 @@ public abstract class SinkTaskConfig {
 
   /** Creates a new builder. Used by {@link #from(Map)} and by tests. */
   public static Builder builder() {
-    return new AutoValue_SinkTaskConfig.Builder();
+    // Default the Iceberg auto-creation properties here so every builder() caller (including
+    // raw-builder test helpers) gets valid values; builderFrom overrides them from config. Without
+    // this, AutoValue throws "missing required properties" because these props are non-nullable.
+    return new AutoValue_SinkTaskConfig.Builder()
+        .tableType(TableType.SNOWFLAKE)
+        .icebergCreateTableOptions(
+            KafkaConnectorConfigParams.SNOWFLAKE_ICEBERG_CREATE_TABLE_OPTIONS_DEFAULT);
   }
 
   /**
@@ -483,6 +528,10 @@ public abstract class SinkTaskConfig {
     public abstract Builder enableSanitization(boolean enableSanitization);
 
     public abstract Builder enableSchematization(boolean enableSchematization);
+
+    public abstract Builder tableType(TableType tableType);
+
+    public abstract Builder icebergCreateTableOptions(String icebergCreateTableOptions);
 
     public abstract Builder enableColumnIdentifierNormalization(
         boolean enableColumnIdentifierNormalization);

--- a/src/main/java/com/snowflake/kafka/connector/config/SinkTaskConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/config/SinkTaskConfig.java
@@ -399,8 +399,8 @@ public abstract class SinkTaskConfig {
             .orElse(KafkaConnectorConfigParams.SNOWFLAKE_FEATURE_NORMALIZE_TIME_DEFAULT);
 
     TableType tableType =
-        TableType.fromConfig(
-            config.get(KafkaConnectorConfigParams.SNOWFLAKE_AUTOCREATE_TABLE_TYPE));
+        TableType.fromConfig(config.get(KafkaConnectorConfigParams.SNOWFLAKE_AUTOCREATE_TABLE_TYPE))
+            .orElse(TableType.SNOWFLAKE);
 
     String icebergCreateTableOptions =
         config
@@ -410,8 +410,10 @@ public abstract class SinkTaskConfig {
             .trim();
     if (!icebergCreateTableOptions.isEmpty() && tableType != TableType.ICEBERG) {
       throw new IllegalArgumentException(
-          "snowflake.iceberg.create.table.options is only valid when"
-              + " snowflake.autocreate.table.type=iceberg (got table.type="
+          KafkaConnectorConfigParams.SNOWFLAKE_ICEBERG_CREATE_TABLE_OPTIONS
+              + " is only valid when "
+              + KafkaConnectorConfigParams.SNOWFLAKE_AUTOCREATE_TABLE_TYPE
+              + "=iceberg (got table.type="
               + tableType.configValue()
               + ")");
     }
@@ -425,10 +427,33 @@ public abstract class SinkTaskConfig {
         && enableSchematization
         && validation == SnowflakeValidation.CLIENT_SIDE) {
       throw new IllegalArgumentException(
-          "snowflake.validation=client_side is not supported with"
-              + " snowflake.autocreate.table.type=iceberg when schema evolution is enabled"
-              + " (snowflake.enable.schematization=true). Managed Iceberg schema evolution is"
-              + " server-side; set snowflake.validation=server_side.");
+          KafkaConnectorConfigParams.SNOWFLAKE_VALIDATION
+              + "=client_side is not supported with "
+              + KafkaConnectorConfigParams.SNOWFLAKE_AUTOCREATE_TABLE_TYPE
+              + "=iceberg when schema evolution is enabled ("
+              + KafkaConnectorConfigParams.SNOWFLAKE_ENABLE_SCHEMATIZATION
+              + "=true). Managed Iceberg schema evolution is server-side; set "
+              + KafkaConnectorConfigParams.SNOWFLAKE_VALIDATION
+              + "=server_side.");
+    }
+
+    // Managed Iceberg RECORD_METADATA is cast to a fixed structured OBJECT schema, so every
+    // metadata flag that maps to a declared schema field must be enabled. Disabling any of them
+    // produces a sparse map that fails the strict typed-OBJECT cast at ingest time.
+    if (tableType == TableType.ICEBERG && !metadataConfig.isFullIcebergMetadataEnabled()) {
+      throw new IllegalArgumentException(
+          KafkaConnectorConfigParams.SNOWFLAKE_AUTOCREATE_TABLE_TYPE
+              + "=iceberg requires all record metadata to be enabled"
+              + " (RECORD_METADATA is cast to a fixed structured schema for managed Iceberg)."
+              + " Remove any "
+              + KafkaConnectorConfigParams.SNOWFLAKE_METADATA_TOPIC
+              + "=false, "
+              + KafkaConnectorConfigParams.SNOWFLAKE_METADATA_OFFSET_AND_PARTITION
+              + "=false, "
+              + KafkaConnectorConfigParams.SNOWFLAKE_METADATA_CREATETIME
+              + "=false, or "
+              + KafkaConnectorConfigParams.SNOWFLAKE_STREAMING_METADATA_CONNECTOR_PUSH_TIME
+              + "=false settings.");
     }
 
     Builder b = builder();
@@ -492,15 +517,15 @@ public abstract class SinkTaskConfig {
     return optionalString(value).map(Password::new);
   }
 
-  /** Creates a new builder. Used by {@link #from(Map)} and by tests. */
+  /**
+   * Creates a new builder. Used by {@link #from(Map)} (via {@code builderFrom}) and by {@code
+   * SinkTaskConfigTestBuilder} in tests. The Iceberg-related fields ({@code tableType}, {@code
+   * icebergCreateTableOptions}) have no defaults here — {@code builderFrom} always sets them from
+   * config, and tests must set them via {@code SinkTaskConfigTestBuilder} (which provides the
+   * defaults).
+   */
   public static Builder builder() {
-    // Default the Iceberg auto-creation properties here so every builder() caller (including
-    // raw-builder test helpers) gets valid values; builderFrom overrides them from config. Without
-    // this, AutoValue throws "missing required properties" because these props are non-nullable.
-    return new AutoValue_SinkTaskConfig.Builder()
-        .tableType(TableType.SNOWFLAKE)
-        .icebergCreateTableOptions(
-            KafkaConnectorConfigParams.SNOWFLAKE_ICEBERG_CREATE_TABLE_OPTIONS_DEFAULT);
+    return new AutoValue_SinkTaskConfig.Builder();
   }
 
   /**

--- a/src/main/java/com/snowflake/kafka/connector/config/SinkTaskConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/config/SinkTaskConfig.java
@@ -51,7 +51,7 @@ public abstract class SinkTaskConfig {
 
   public abstract TableType getTableType();
 
-  public abstract String getIcebergCreateTableOptions();
+  public abstract Optional<String> getIcebergCreateTableOptions();
 
   public abstract boolean isEnableColumnIdentifierNormalization();
 
@@ -402,13 +402,12 @@ public abstract class SinkTaskConfig {
         TableType.fromConfig(config.get(KafkaConnectorConfigParams.SNOWFLAKE_AUTOCREATE_TABLE_TYPE))
             .orElse(TableType.SNOWFLAKE);
 
-    String icebergCreateTableOptions =
-        config
-            .getOrDefault(
-                KafkaConnectorConfigParams.SNOWFLAKE_ICEBERG_CREATE_TABLE_OPTIONS,
-                KafkaConnectorConfigParams.SNOWFLAKE_ICEBERG_CREATE_TABLE_OPTIONS_DEFAULT)
-            .trim();
-    if (!icebergCreateTableOptions.isEmpty() && tableType != TableType.ICEBERG) {
+    Optional<String> icebergCreateTableOptions =
+        Optional.ofNullable(
+                config.get(KafkaConnectorConfigParams.SNOWFLAKE_ICEBERG_CREATE_TABLE_OPTIONS))
+            .map(String::trim)
+            .filter(s -> !s.isEmpty());
+    if (icebergCreateTableOptions.isPresent() && tableType != TableType.ICEBERG) {
       throw new IllegalArgumentException(
           KafkaConnectorConfigParams.SNOWFLAKE_ICEBERG_CREATE_TABLE_OPTIONS
               + " is only valid when "
@@ -556,7 +555,7 @@ public abstract class SinkTaskConfig {
 
     public abstract Builder tableType(TableType tableType);
 
-    public abstract Builder icebergCreateTableOptions(String icebergCreateTableOptions);
+    public abstract Builder icebergCreateTableOptions(Optional<String> icebergCreateTableOptions);
 
     public abstract Builder enableColumnIdentifierNormalization(
         boolean enableColumnIdentifierNormalization);

--- a/src/main/java/com/snowflake/kafka/connector/config/SinkTaskConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/config/SinkTaskConfig.java
@@ -424,10 +424,10 @@ public abstract class SinkTaskConfig {
         && validation == SnowflakeValidation.CLIENT_SIDE) {
       throw new IllegalArgumentException(
           KafkaConnectorConfigParams.SNOWFLAKE_VALIDATION
-              + "=client_side is not supported with "
-              + KafkaConnectorConfigParams.SNOWFLAKE_AUTOCREATE_TABLE_TYPE
-              + "=iceberg. Managed Iceberg uses a structured RECORD_METADATA column that the"
-              + " client-side RowValidator cannot model. Set "
+              + "=client_side is not supported for managed Iceberg tables."
+              + " RECORD_METADATA is a structured OBJECT handled server-side;"
+              + " client-side validation cannot model it."
+              + " Set "
               + KafkaConnectorConfigParams.SNOWFLAKE_VALIDATION
               + "=server_side.");
     }

--- a/src/main/java/com/snowflake/kafka/connector/config/TableType.java
+++ b/src/main/java/com/snowflake/kafka/connector/config/TableType.java
@@ -2,6 +2,7 @@ package com.snowflake.kafka.connector.config;
 
 import java.util.Arrays;
 import java.util.Locale;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /** Connector-wide target table type for auto-creation routing. */
@@ -10,14 +11,21 @@ public enum TableType {
   ICEBERG,
   NONE;
 
-  /** Config string -> enum. Null/empty defaults to SNOWFLAKE (today's behavior). */
-  public static TableType fromConfig(String value) {
+  /**
+   * Config string -&gt; enum. Returns {@link Optional#empty()} when the value is {@code null} or
+   * blank (absent/unset config). Throws {@link IllegalArgumentException} for a non-blank value that
+   * is not a recognized type.
+   *
+   * <p>Callers should use {@code TableType.fromConfig(x).orElse(TableType.SNOWFLAKE)} to preserve
+   * the original default behavior.
+   */
+  public static Optional<TableType> fromConfig(String value) {
     if (value == null || value.trim().isEmpty()) {
-      return SNOWFLAKE;
+      return Optional.empty();
     }
     String normalized = value.trim().toUpperCase(Locale.ROOT);
     try {
-      return TableType.valueOf(normalized);
+      return Optional.of(TableType.valueOf(normalized));
     } catch (IllegalArgumentException e) {
       throw new IllegalArgumentException(
           "Invalid snowflake.autocreate.table.type '"

--- a/src/main/java/com/snowflake/kafka/connector/config/TableType.java
+++ b/src/main/java/com/snowflake/kafka/connector/config/TableType.java
@@ -1,0 +1,35 @@
+package com.snowflake.kafka.connector.config;
+
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.stream.Collectors;
+
+/** Connector-wide target table type for auto-creation routing. */
+public enum TableType {
+  SNOWFLAKE,
+  ICEBERG,
+  NONE;
+
+  /** Config string -> enum. Null/empty defaults to SNOWFLAKE (today's behavior). */
+  public static TableType fromConfig(String value) {
+    if (value == null || value.trim().isEmpty()) {
+      return SNOWFLAKE;
+    }
+    String normalized = value.trim().toUpperCase(Locale.ROOT);
+    try {
+      return TableType.valueOf(normalized);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException(
+          "Invalid snowflake.autocreate.table.type '"
+              + value
+              + "'. Allowed: "
+              + Arrays.stream(values())
+                  .map(t -> t.name().toLowerCase(Locale.ROOT))
+                  .collect(Collectors.joining(", ")));
+    }
+  }
+
+  public String configValue() {
+    return name().toLowerCase(Locale.ROOT);
+  }
+}

--- a/src/main/java/com/snowflake/kafka/connector/internal/CachingSnowflakeConnectionService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/CachingSnowflakeConnectionService.java
@@ -166,6 +166,14 @@ public class CachingSnowflakeConnectionService implements SnowflakeConnectionSer
   }
 
   @Override
+  public void createIcebergTableWithOnlyMetadataColumn(
+      String tableName, String createTableOptions) {
+    delegate.createIcebergTableWithOnlyMetadataColumn(tableName, createTableOptions);
+    tableExistsCache.invalidate(tableName);
+    errorLoggingCache.invalidate(tableName);
+  }
+
+  @Override
   public boolean isTableCompatible(String tableName) {
     return delegate.isTableCompatible(tableName);
   }

--- a/src/main/java/com/snowflake/kafka/connector/internal/CachingSnowflakeConnectionService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/CachingSnowflakeConnectionService.java
@@ -249,6 +249,11 @@ public class CachingSnowflakeConnectionService implements SnowflakeConnectionSer
   }
 
   @Override
+  public boolean isRecordMetadataStructuredObject(String tableName) {
+    return delegate.isRecordMetadataStructuredObject(tableName);
+  }
+
+  @Override
   public boolean hasErrorLoggingEnabled(String tableName) {
     if (!tableExistsCacheEnabled) {
       return delegate.hasErrorLoggingEnabled(tableName);

--- a/src/main/java/com/snowflake/kafka/connector/internal/CachingSnowflakeConnectionService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/CachingSnowflakeConnectionService.java
@@ -269,6 +269,11 @@ public class CachingSnowflakeConnectionService implements SnowflakeConnectionSer
   }
 
   @Override
+  public List<String> getStructuredObjectFieldNames(String tableName, String columnName) {
+    return delegate.getStructuredObjectFieldNames(tableName, columnName);
+  }
+
+  @Override
   public Ssv1MigrationResponse migrateSsv1ChannelOffset(
       String tableName, String ssv1ChannelName, String ssv2ChannelName, String pipeName) {
     return delegate.migrateSsv1ChannelOffset(tableName, ssv1ChannelName, ssv2ChannelName, pipeName);

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionService.java
@@ -145,6 +145,18 @@ public interface SnowflakeConnectionService {
   boolean isIcebergTable(String tableName);
 
   /**
+   * Whether the given table's {@code RECORD_METADATA} column is a structured {@code OBJECT(...)}
+   * (as opposed to {@code VARIANT}). Managed-Iceberg v2 tables must use a structured OBJECT
+   * (VARIANT is unsupported on format v2); v3 and FDN tables use VARIANT. The connector conforms
+   * the metadata map to the strict OBJECT schema ONLY for structured-OBJECT columns. Returns false
+   * when the table or the {@code RECORD_METADATA} column is absent.
+   *
+   * @param tableName table name
+   * @return true iff {@code RECORD_METADATA} is a structured OBJECT column
+   */
+  boolean isRecordMetadataStructuredObject(String tableName);
+
+  /**
    * Check whether the given table has ERROR_LOGGING enabled via SHOW TABLES.
    *
    * @param tableName table name

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionService.java
@@ -165,6 +165,18 @@ public interface SnowflakeConnectionService {
   boolean hasErrorLoggingEnabled(String tableName);
 
   /**
+   * Returns the names of sub-fields declared by a structured OBJECT column. Queries {@code
+   * INFORMATION_SCHEMA.FIELDS} for the given table and column within the session's current
+   * schema/database. Returns an empty list if the table or column is absent or has no declared
+   * sub-fields.
+   *
+   * @param tableName unqualified table name; the session's current database/schema are used
+   * @param columnName the structured OBJECT column name (e.g. "RECORD_METADATA")
+   * @return list of sub-field names (case as stored in INFORMATION_SCHEMA)
+   */
+  List<String> getStructuredObjectFieldNames(String tableName, String columnName);
+
+  /**
    * Calls SYSTEM$MIGRATE_SSV1_CHANNEL_OFFSET to migrate the committed offset from an SSv1 channel
    * to an SSv2 channel. The system function reads the SSv1 offset and writes it directly to the
    * SSv2 channel in FDB.

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionService.java
@@ -82,6 +82,18 @@ public interface SnowflakeConnectionService {
   void createTableWithOnlyMetadataColumn(String tableName);
 
   /**
+   * Create a managed Iceberg table with only the RECORD_METADATA column, schema evolution and error
+   * logging enabled. No-op if the table already exists.
+   *
+   * @param tableName table name
+   * @param createTableOptions operator-supplied SQL clauses spliced after the column list (e.g.
+   *     "EXTERNAL_VOLUME='v' ICEBERG_VERSION=3 CLUSTER BY (id)"). May be empty. The connector
+   *     always supplies CATALOG='SNOWFLAKE', ENABLE_SCHEMA_EVOLUTION and ERROR_LOGGING, so callers
+   *     must not repeat those here.
+   */
+  void createIcebergTableWithOnlyMetadataColumn(String tableName, String createTableOptions);
+
+  /**
    * Calls describe table statement and returns all columns and corresponding types.
    *
    * @param tableName - table name

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeErrors.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeErrors.java
@@ -205,7 +205,14 @@ public enum SnowflakeErrors {
       "Table auto-creation configuration error",
       "snowflake.autocreate.table.type is misconfigured for the target table -- e.g."
           + " table.type=none but the table or its pipe does not exist, or an auto-created Iceberg"
-          + " table needs ICEBERG_VERSION=3. See the specific error message for details.");
+          + " table needs ICEBERG_VERSION=3. See the specific error message for details."),
+  ERROR_0035(
+      "0035",
+      "RECORD_METADATA structured-schema mismatch",
+      "An existing table's structured-OBJECT RECORD_METADATA column (managed-Iceberg v2) does not"
+          + " match the schema the connector requires: a sub-field is missing or extra, or the"
+          + " sub-fields could not be read. The strict typed-OBJECT cast would reject every row at"
+          + " ingest. See the specific error message for details.");
 
   // properties
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeErrors.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeErrors.java
@@ -199,7 +199,13 @@ public enum SnowflakeErrors {
       "Non-default pipe not supported with client-side validation",
       "Client-side validation only supports default pipes ({table}-STREAMING). Either disable"
           + " client-side validation (snowflake.validation=server_side) or drop the"
-          + " existing pipe so the connector uses the default pipe.");
+          + " existing pipe so the connector uses the default pipe."),
+  ERROR_0034(
+      "0034",
+      "Table auto-creation configuration error",
+      "snowflake.autocreate.table.type is misconfigured for the target table -- e.g."
+          + " table.type=none but the table or its pipe does not exist, or an auto-created Iceberg"
+          + " table needs ICEBERG_VERSION=3. See the specific error message for details.");
 
   // properties
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/StandardSnowflakeConnectionService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/StandardSnowflakeConnectionService.java
@@ -532,12 +532,14 @@ public class StandardSnowflakeConnectionService implements SnowflakeConnectionSe
     checkConnection();
     InternalUtils.assertNotEmpty("tableName", tableName);
     InternalUtils.assertNotEmpty("columnName", columnName);
-    // INFORMATION_SCHEMA.FIELDS stores TABLE_NAME and COLUMN_NAME in uppercase for unquoted
-    // identifiers. UPPER(?) normalises the caller-supplied names so the match works regardless
-    // of the case in which the caller passes them in.
+    // The connector creates and describes tables with quoted (case-preserving) identifiers, and the
+    // RECORD_METADATA column is created via the uppercase TABLE_COLUMN_METADATA constant, so
+    // INFORMATION_SCHEMA.FIELDS stores both names with the exact case the caller passes here. Match
+    // them verbatim: wrapping the bind params in UPPER(?) would miss the common non-uppercase table
+    // name (pass-through topics, most topic2table.map values), silently returning no fields.
     String query =
         "SELECT FIELD_NAME FROM INFORMATION_SCHEMA.FIELDS"
-            + " WHERE TABLE_NAME = UPPER(?) AND COLUMN_NAME = UPPER(?)"
+            + " WHERE TABLE_NAME = ? AND COLUMN_NAME = ?"
             + " AND TABLE_SCHEMA = CURRENT_SCHEMA()";
     List<String> fieldNames = new ArrayList<>();
     try (PreparedStatement stmt = conn.prepareStatement(query)) {

--- a/src/main/java/com/snowflake/kafka/connector/internal/StandardSnowflakeConnectionService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/StandardSnowflakeConnectionService.java
@@ -7,6 +7,7 @@ import com.snowflake.kafka.connector.internal.schemaevolution.ColumnInfos;
 import com.snowflake.kafka.connector.internal.streaming.v2.migration.Ssv1MigrationResponse;
 import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryService;
 import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryServiceFactory;
+import com.snowflake.kafka.connector.streaming.iceberg.IcebergDDLTypes;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -77,23 +78,50 @@ public class StandardSnowflakeConnectionService implements SnowflakeConnectionSe
       stmt.execute();
       stmt.close();
     } catch (SQLException e) {
-      // Snowflake rejects CREATE TABLE IF NOT EXISTS when the name is already taken by an
-      // ICEBERG TABLE (cross-type conflict is not suppressed by IF NOT EXISTS). KCv4 only
-      // supports pre-created Iceberg tables; error_logging is not available for them.
-      // We match on the error message text because Snowflake does not provide a stable SQL
-      // error code that distinguishes this cross-type conflict from other CREATE TABLE errors.
-      if (e.getMessage() != null && e.getMessage().contains("already exists as ICEBERG_TABLE")) {
-        LOGGER.warn(
-            "Table '{}' is a pre-created Iceberg table. Skipping auto-creation."
-                + " Error table functionality is not available for Iceberg tables.",
-            tableName);
-        return;
-      }
       throw SnowflakeErrors.ERROR_2007.getException(e);
     }
 
     LOGGER.info(
         "Created table {} with RECORD_METADATA column and ERROR_LOGGING enabled", tableName);
+  }
+
+  @Override
+  public void createIcebergTableWithOnlyMetadataColumn(
+      final String tableName, final String createTableOptions) {
+    checkConnection();
+    InternalUtils.assertNotEmpty("tableName", tableName);
+
+    // Operator-supplied clauses (external volume, iceberg version, cluster by, base location, ...)
+    // are spliced right after the column list so positional clauses like CLUSTER BY land correctly.
+    String optionsClause =
+        (createTableOptions == null || createTableOptions.trim().isEmpty())
+            ? ""
+            : " " + createTableOptions.trim();
+    // Snowflake-managed Iceberg tables require an explicit catalog integration; the connector also
+    // owns ENABLE_SCHEMA_EVOLUTION / ERROR_LOGGING (ingestion-mandatory), so they are not exposed.
+    String createTableQuery =
+        "create iceberg table if not exists identifier(?) ("
+            + TABLE_COLUMN_METADATA
+            + " "
+            + IcebergDDLTypes.ICEBERG_METADATA_OBJECT_SCHEMA
+            + ")"
+            + optionsClause
+            + " catalog = 'SNOWFLAKE' enable_schema_evolution = true error_logging = true";
+
+    try {
+      PreparedStatement stmt = conn.prepareStatement(createTableQuery);
+      stmt.setString(1, quoteIdentifier(tableName));
+      stmt.execute();
+      stmt.close();
+    } catch (SQLException e) {
+      throw SnowflakeErrors.ERROR_2007.getException(e);
+    }
+
+    LOGGER.info(
+        "Created Iceberg table {} (createTableOptions='{}') with RECORD_METADATA, schema evolution"
+            + " and error logging enabled",
+        tableName,
+        createTableOptions);
   }
 
   @Override

--- a/src/main/java/com/snowflake/kafka/connector/internal/StandardSnowflakeConnectionService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/StandardSnowflakeConnectionService.java
@@ -14,6 +14,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -524,6 +525,38 @@ public class StandardSnowflakeConnectionService implements SnowflakeConnectionSe
     }
     LOGGER.debug("Table {} does not have ERROR_LOGGING enabled", tableName);
     return false;
+  }
+
+  @Override
+  public List<String> getStructuredObjectFieldNames(String tableName, String columnName) {
+    checkConnection();
+    InternalUtils.assertNotEmpty("tableName", tableName);
+    InternalUtils.assertNotEmpty("columnName", columnName);
+    // INFORMATION_SCHEMA.FIELDS stores TABLE_NAME and COLUMN_NAME in uppercase for unquoted
+    // identifiers. UPPER(?) normalises the caller-supplied names so the match works regardless
+    // of the case in which the caller passes them in.
+    String query =
+        "SELECT FIELD_NAME FROM INFORMATION_SCHEMA.FIELDS"
+            + " WHERE TABLE_NAME = UPPER(?) AND COLUMN_NAME = UPPER(?)"
+            + " AND TABLE_SCHEMA = CURRENT_SCHEMA()";
+    List<String> fieldNames = new ArrayList<>();
+    try (PreparedStatement stmt = conn.prepareStatement(query)) {
+      stmt.setString(1, tableName);
+      stmt.setString(2, columnName);
+      try (ResultSet result = stmt.executeQuery()) {
+        while (result.next()) {
+          fieldNames.add(result.getString("FIELD_NAME"));
+        }
+      }
+      return fieldNames;
+    } catch (SQLException e) {
+      LOGGER.warn(
+          "Could not query INFORMATION_SCHEMA.FIELDS for table '{}', column '{}': {}",
+          tableName,
+          columnName,
+          e.getMessage());
+      return Collections.emptyList();
+    }
   }
 
   @Override

--- a/src/main/java/com/snowflake/kafka/connector/internal/StandardSnowflakeConnectionService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/StandardSnowflakeConnectionService.java
@@ -33,6 +33,11 @@ public class StandardSnowflakeConnectionService implements SnowflakeConnectionSe
       "created by automatic table creation from Snowflake Kafka Connector High Performance";
 
   private static final String SHOW_ICEBERG_TABLES_QUERY = "show iceberg tables like ? limit 1";
+  // Snowflake errno for ICEBERG_DATATYPE_NOT_SUPPORTED ("Unsupported data type '...' for iceberg
+  // tables"), thrown at CREATE-time when a VARIANT column is used on an Iceberg table that does not
+  // support it (format v2, or ENABLE_ICEBERG_VARIANT_TYPE off). JDBC strips the leading zero of
+  // 091386.
+  private static final int ERR_ICEBERG_DATATYPE_NOT_SUPPORTED = 91386;
   private final KCLogger LOGGER = new KCLogger(StandardSnowflakeConnectionService.class.getName());
   private final Connection conn;
   private final SnowflakeTelemetryService telemetry;
@@ -97,31 +102,62 @@ public class StandardSnowflakeConnectionService implements SnowflakeConnectionSe
         (createTableOptions == null || createTableOptions.trim().isEmpty())
             ? ""
             : " " + createTableOptions.trim();
+
+    // Prefer a VARIANT RECORD_METADATA: it tolerates the variable Kafka metadata map and needs no
+    // client-side conforming. VARIANT is only allowed on Iceberg format v3+ (with
+    // ENABLE_ICEBERG_VARIANT_TYPE); where it is not -- e.g. an Iceberg v2 table -- the CREATE fails
+    // at DDL compile time with errno 91386 (ICEBERG_DATATYPE_NOT_SUPPORTED), and we fall back to a
+    // structured OBJECT RECORD_METADATA (the only option on v2, which then requires conforming).
+    try {
+      executeIcebergCreate(tableName, TABLE_COLUMN_METADATA + " VARIANT", optionsClause);
+      LOGGER.info(
+          "Created Iceberg table {} (createTableOptions='{}') with VARIANT RECORD_METADATA, schema"
+              + " evolution and error logging enabled",
+          tableName,
+          createTableOptions);
+      return;
+    } catch (SQLException e) {
+      if (e.getErrorCode() != ERR_ICEBERG_DATATYPE_NOT_SUPPORTED) {
+        throw SnowflakeErrors.ERROR_2007.getException(e);
+      }
+      LOGGER.info(
+          "VARIANT RECORD_METADATA not supported for Iceberg table {} (errno {}: {}); falling back"
+              + " to a structured OBJECT RECORD_METADATA (Iceberg v2).",
+          tableName,
+          ERR_ICEBERG_DATATYPE_NOT_SUPPORTED,
+          e.getMessage());
+    }
+
+    try {
+      executeIcebergCreate(
+          tableName,
+          TABLE_COLUMN_METADATA + " " + IcebergDDLTypes.ICEBERG_METADATA_OBJECT_SCHEMA,
+          optionsClause);
+    } catch (SQLException e) {
+      throw SnowflakeErrors.ERROR_2007.getException(e);
+    }
+    LOGGER.info(
+        "Created Iceberg table {} (createTableOptions='{}') with structured OBJECT RECORD_METADATA,"
+            + " schema evolution and error logging enabled",
+        tableName,
+        createTableOptions);
+  }
+
+  /** Builds and executes the managed-Iceberg CREATE with the given RECORD_METADATA column DDL. */
+  private void executeIcebergCreate(
+      String tableName, String metadataColumnDdl, String optionsClause) throws SQLException {
     // Snowflake-managed Iceberg tables require an explicit catalog integration; the connector also
     // owns ENABLE_SCHEMA_EVOLUTION / ERROR_LOGGING (ingestion-mandatory), so they are not exposed.
     String createTableQuery =
         "create iceberg table if not exists identifier(?) ("
-            + TABLE_COLUMN_METADATA
-            + " "
-            + IcebergDDLTypes.ICEBERG_METADATA_OBJECT_SCHEMA
+            + metadataColumnDdl
             + ")"
             + optionsClause
             + " catalog = 'SNOWFLAKE' enable_schema_evolution = true error_logging = true";
-
-    try {
-      PreparedStatement stmt = conn.prepareStatement(createTableQuery);
+    try (PreparedStatement stmt = conn.prepareStatement(createTableQuery)) {
       stmt.setString(1, quoteIdentifier(tableName));
       stmt.execute();
-      stmt.close();
-    } catch (SQLException e) {
-      throw SnowflakeErrors.ERROR_2007.getException(e);
     }
-
-    LOGGER.info(
-        "Created Iceberg table {} (createTableOptions='{}') with RECORD_METADATA, schema evolution"
-            + " and error logging enabled",
-        tableName,
-        createTableOptions);
   }
 
   @Override
@@ -438,6 +474,23 @@ public class StandardSnowflakeConnectionService implements SnowflakeConnectionSe
     } catch (SQLException e) {
       throw SnowflakeErrors.ERROR_2001.getException(e);
     }
+  }
+
+  @Override
+  public boolean isRecordMetadataStructuredObject(String tableName) {
+    checkConnection();
+    InternalUtils.assertNotEmpty("tableName", tableName);
+    return describeTable(tableName)
+        .flatMap(
+            rows ->
+                rows.stream()
+                    .filter(r -> TABLE_COLUMN_METADATA.equalsIgnoreCase(r.getColumn()))
+                    .findFirst())
+        .map(
+            r ->
+                r.getType() != null
+                    && r.getType().trim().toUpperCase(Locale.ROOT).startsWith("OBJECT"))
+        .orElse(false);
   }
 
   @Override

--- a/src/main/java/com/snowflake/kafka/connector/internal/StandardSnowflakeConnectionService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/StandardSnowflakeConnectionService.java
@@ -532,15 +532,26 @@ public class StandardSnowflakeConnectionService implements SnowflakeConnectionSe
     checkConnection();
     InternalUtils.assertNotEmpty("tableName", tableName);
     InternalUtils.assertNotEmpty("columnName", columnName);
+    // INFORMATION_SCHEMA.FIELDS has no column that names the owning table column: it is keyed by
+    // OBJECT_NAME (the table) plus ROW_IDENTIFIER (the structured type instance). To restrict to a
+    // single column we join to INFORMATION_SCHEMA.COLUMNS on FIELDS.ROW_IDENTIFIER =
+    // COLUMNS.DTD_IDENTIFIER, which also excludes nested-type rows (a sub-field that is itself an
+    // OBJECT/MAP/ARRAY has its own ROW_IDENTIFIER) and other structured columns on the same table.
     // The connector creates and describes tables with quoted (case-preserving) identifiers, and the
-    // RECORD_METADATA column is created via the uppercase TABLE_COLUMN_METADATA constant, so
-    // INFORMATION_SCHEMA.FIELDS stores both names with the exact case the caller passes here. Match
-    // them verbatim: wrapping the bind params in UPPER(?) would miss the common non-uppercase table
-    // name (pass-through topics, most topic2table.map values), silently returning no fields.
+    // RECORD_METADATA column is created via the uppercase TABLE_COLUMN_METADATA constant, so the
+    // catalog stores both names with the exact case the caller passes here. Match them verbatim:
+    // wrapping the bind params in UPPER(?) would miss the common non-uppercase table name
+    // (pass-through topics, most topic2table.map values), silently returning no fields.
     String query =
-        "SELECT FIELD_NAME FROM INFORMATION_SCHEMA.FIELDS"
-            + " WHERE TABLE_NAME = ? AND COLUMN_NAME = ?"
-            + " AND TABLE_SCHEMA = CURRENT_SCHEMA()";
+        "SELECT f.FIELD_NAME FROM INFORMATION_SCHEMA.FIELDS f"
+            + " JOIN INFORMATION_SCHEMA.COLUMNS c"
+            + " ON f.OBJECT_CATALOG = c.TABLE_CATALOG"
+            + " AND f.OBJECT_SCHEMA = c.TABLE_SCHEMA"
+            + " AND f.OBJECT_NAME = c.TABLE_NAME"
+            + " AND f.ROW_IDENTIFIER = c.DTD_IDENTIFIER"
+            + " WHERE c.TABLE_NAME = ? AND c.COLUMN_NAME = ?"
+            + " AND c.TABLE_SCHEMA = CURRENT_SCHEMA()"
+            + " ORDER BY f.ORDINAL_POSITION";
     List<String> fieldNames = new ArrayList<>();
     try (PreparedStatement stmt = conn.prepareStatement(query)) {
       stmt.setString(1, tableName);

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -259,14 +259,17 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
         boolean defaultPipeExists = this.conn.pipeExist(buildDefaultPipeName(tableName));
         boolean namedPipeExists = this.conn.pipeExist(tableName);
         if (!defaultPipeExists && !namedPipeExists) {
-          String detectedType = this.conn.isIcebergTable(tableName) ? "ICEBERG" : "SNOWFLAKE";
+          String detectedType =
+              this.conn.isIcebergTable(tableName)
+                  ? TableType.ICEBERG.configValue()
+                  : TableType.SNOWFLAKE.configValue();
           throw SnowflakeErrors.ERROR_0034.getException(
               "snowflake.autocreate.table.type=none and no pipe exists for table '"
                   + tableName
                   + "' (detected table type="
                   + detectedType
                   + "). Create the pipe yourself, or set snowflake.autocreate.table.type="
-                  + detectedType.toLowerCase(java.util.Locale.ROOT)
+                  + detectedType
                   + " so the connector manages it.");
         }
         targetPipeName = namedPipeExists ? tableName : buildDefaultPipeName(tableName);
@@ -298,13 +301,11 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
   void createTableIfNotExists(final String tableName) {
     if (this.conn.tableExist(tableName)) {
       // Existing table: use it as-is, regardless of the configured table.type (which only governs
-      // auto-creation). Log the detected type for operator visibility. (For table.type=none, pipe
-      // existence is asserted in startPartitions.)
+      // auto-creation). (For table.type=none, pipe existence is asserted in startPartitions.)
       LOGGER.info(
-          "Using existing table {} (snowflake.autocreate.table.type={}; detected type={}).",
+          "Using existing table {} (snowflake.autocreate.table.type={}).",
           tableName,
-          taskConfig.getTableType().configValue(),
-          this.conn.isIcebergTable(tableName) ? "ICEBERG" : "SNOWFLAKE");
+          taskConfig.getTableType().configValue());
       return;
     }
     switch (taskConfig.getTableType()) {

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -343,6 +343,22 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
       default:
         LOGGER.info("Creating new table {}.", tableName);
         this.conn.createTableWithOnlyMetadataColumn(tableName);
+        // A bare CREATE TABLE honors a schema/database/account
+        // DEFAULT_METADATA_WRITE_FORMAT=ICEBERG,
+        // which yields a managed-Iceberg table even though this config asked for a standard (FDN)
+        // table. That is a benign surprise -- the connector ingests into the Iceberg table fine --
+        // so
+        // just warn. Combos that would actually fail (Iceberg v2 rejecting the VARIANT metadata
+        // column, or a missing external volume) already fail loudly in the create above.
+        if (this.conn.isIcebergTable(tableName)) {
+          LOGGER.warn(
+              "Auto-created table '{}' is a managed-Iceberg table, not a standard (FDN) table,"
+                  + " despite snowflake.autocreate.table.type=snowflake -- most likely the target"
+                  + " schema/database/account has DEFAULT_METADATA_WRITE_FORMAT=ICEBERG. Ingestion"
+                  + " will proceed against the Iceberg table. Set snowflake.autocreate.table.type="
+                  + "iceberg to make this explicit, or unset DEFAULT_METADATA_WRITE_FORMAT.",
+              tableName);
+        }
     }
   }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -12,7 +12,6 @@ import com.snowflake.kafka.connector.Utils;
 import com.snowflake.kafka.connector.config.SinkTaskConfig;
 import com.snowflake.kafka.connector.config.SnowflakeValidation;
 import com.snowflake.kafka.connector.dlq.KafkaRecordErrorReporter;
-import com.snowflake.kafka.connector.internal.DescribeTableRow;
 import com.snowflake.kafka.connector.internal.KCLogger;
 import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
 import com.snowflake.kafka.connector.internal.SnowflakeErrors;
@@ -25,10 +24,9 @@ import com.snowflake.kafka.connector.internal.streaming.v2.client.StreamingClien
 import com.snowflake.kafka.connector.internal.streaming.v2.service.BatchOffsetFetcher;
 import com.snowflake.kafka.connector.internal.streaming.v2.service.PartitionChannelManager;
 import com.snowflake.kafka.connector.internal.streaming.v2.service.ThreadPools;
-import com.snowflake.kafka.connector.records.SnowflakeSinkRecord;
+import com.snowflake.kafka.connector.streaming.iceberg.IcebergDDLTypes;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -357,130 +355,33 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
   }
 
   /**
-   * Validates that an existing table's {@code RECORD_METADATA} structured-OBJECT schema contains
-   * every field the connector emits (i.e. every field in {@link
-   * SnowflakeSinkRecord#ICEBERG_METADATA_FIELDS}).
+   * Validates that an existing table's {@code RECORD_METADATA} structured-OBJECT schema exactly
+   * matches the connector's expected field set ({@link
+   * com.snowflake.kafka.connector.records.SnowflakeSinkRecord#ICEBERG_METADATA_FIELDS}).
    *
    * <p>Called only when {@code conn.isRecordMetadataStructuredObject(tableName)} is true (managed-
    * Iceberg v2). The v2 strict typed-OBJECT cast rejects any row whose map is missing a declared
-   * OBJECT sub-field, so a schema that omits a connector-emitted field would silently route every
-   * row to the error table. Fail fast at startup with a clear message instead.
-   *
-   * <p>A table declaring <em>extra</em> fields beyond what the connector emits is fine (the
-   * connector's map is a subset; those extra fields cast to null) and is not rejected.
+   * OBJECT sub-field, so both missing fields (rows rejected) and extra fields (connector never
+   * emits them, so always absent → rows rejected) are fatal. Delegates the comparison to {@link
+   * IcebergDDLTypes#validateRecordMetadataFields}.
    *
    * @throws com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException (ERROR_0034)
-   *     when any connector-emitted field is absent from the table's OBJECT schema
+   *     when any connector field is missing from, or any extra field is present in, the table's
+   *     OBJECT schema
    */
   @VisibleForTesting
   void validateStructuredObjectMetadataSchema(String tableName) {
-    Optional<List<DescribeTableRow>> rows = this.conn.describeTable(tableName);
-    if (rows.isEmpty()) {
-      // Cannot describe the table — skip validation rather than fail spuriously.
+    List<String> fieldNames =
+        this.conn.getStructuredObjectFieldNames(tableName, Utils.TABLE_COLUMN_METADATA);
+    if (fieldNames.isEmpty()) {
+      // INFORMATION_SCHEMA returned no rows — skip validation rather than fail spuriously.
       LOGGER.warn(
-          "Cannot validate RECORD_METADATA OBJECT schema for table '{}': describeTable returned"
-              + " empty. Proceeding without validation.",
+          "Cannot validate RECORD_METADATA OBJECT schema for table '{}': "
+              + "INFORMATION_SCHEMA.FIELDS returned no sub-fields. Proceeding without validation.",
           tableName);
       return;
     }
-
-    Optional<DescribeTableRow> metadataRow =
-        rows.get().stream()
-            .filter(r -> Utils.TABLE_COLUMN_METADATA.equalsIgnoreCase(r.getColumn()))
-            .findFirst();
-
-    if (metadataRow.isEmpty()) {
-      // No RECORD_METADATA column — nothing to validate.
-      return;
-    }
-
-    String objectTypeStr = metadataRow.get().getType();
-    Set<String> declaredFields = parseObjectSubfieldNames(objectTypeStr);
-
-    List<String> missingFields = new ArrayList<>();
-    for (String required : SnowflakeSinkRecord.ICEBERG_METADATA_FIELDS) {
-      if (!declaredFields.contains(required)) {
-        missingFields.add(required);
-      }
-    }
-
-    if (!missingFields.isEmpty()) {
-      throw SnowflakeErrors.ERROR_0034.getException(
-          "Existing table '"
-              + tableName
-              + "' has a structured-OBJECT RECORD_METADATA column (managed-Iceberg v2) that is"
-              + " missing the following field(s) emitted by this connector: "
-              + missingFields
-              + ". The v2 strict typed-OBJECT cast rejects rows whose map is missing a declared"
-              + " field, so every row would go to the error table. Add the missing field(s) to the"
-              + " RECORD_METADATA OBJECT column definition (e.g. ALTER TABLE ... ALTER COLUMN"
-              + " RECORD_METADATA SET DATA TYPE OBJECT(...)) or re-create the table so the"
-              + " connector can auto-create it with the correct schema.");
-    }
-  }
-
-  /**
-   * Parses the top-level sub-field <em>names</em> from a Snowflake OBJECT type string such as
-   * {@code OBJECT(offset LONG, topic STRING, headers MAP(VARCHAR, VARCHAR))}.
-   *
-   * <p>Splits on top-level commas only (respects nested parentheses, e.g. {@code MAP(VARCHAR,
-   * VARCHAR)}), then extracts the first whitespace-delimited token of each clause as the field
-   * name. Returns an empty set if the string does not start with {@code OBJECT(}.
-   *
-   * <p>Type checking is intentionally omitted: Snowflake uses aliases (LONG/BIGINT, INTEGER/INT)
-   * that would require alias-normalization to compare safely. Name-presence is the critical
-   * invariant; a type mismatch produces a different, comprehensible server error.
-   */
-  // Package-private for unit testing.
-  static Set<String> parseObjectSubfieldNames(String objectTypeStr) {
-    if (objectTypeStr == null) {
-      return Collections.emptySet();
-    }
-    String trimmed = objectTypeStr.trim();
-    // Case-insensitive prefix check: "OBJECT(" or "object(" etc.
-    if (!trimmed.toUpperCase(java.util.Locale.ROOT).startsWith("OBJECT(")) {
-      return Collections.emptySet();
-    }
-    // Extract the body between the outermost parens.
-    int open = trimmed.indexOf('(');
-    int close = trimmed.lastIndexOf(')');
-    if (open < 0 || close <= open) {
-      return Collections.emptySet();
-    }
-    String body = trimmed.substring(open + 1, close);
-
-    // Split on top-level commas only (depth tracks nested parens like MAP(VARCHAR, VARCHAR)).
-    Set<String> names = new HashSet<>();
-    int depth = 0;
-    StringBuilder cur = new StringBuilder();
-    for (int i = 0; i < body.length(); i++) {
-      char c = body.charAt(i);
-      if (c == '(') {
-        depth++;
-      } else if (c == ')') {
-        depth--;
-      }
-      if (c == ',' && depth == 0) {
-        addFieldName(cur.toString(), names);
-        cur.setLength(0);
-      } else {
-        cur.append(c);
-      }
-    }
-    addFieldName(cur.toString(), names);
-    return names;
-  }
-
-  private static void addFieldName(String clause, Set<String> names) {
-    String t = clause.trim();
-    if (t.isEmpty()) {
-      return;
-    }
-    // Field name is the first whitespace-delimited token: "offset LONG" → "offset".
-    String[] parts = t.split("\\s+", 2);
-    if (parts.length > 0 && !parts[0].isEmpty()) {
-      names.add(parts[0]);
-    }
+    IcebergDDLTypes.validateRecordMetadataFields(tableName, new HashSet<>(fieldNames));
   }
 
   private Set<TopicPartition> currentlyInitializing(Collection<TopicPartition> partitions) {

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -8,9 +8,11 @@ import com.codahale.metrics.MetricRegistry;
 import com.google.common.annotations.VisibleForTesting;
 import com.snowflake.kafka.connector.ConnectorConfigTools;
 import com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams;
+import com.snowflake.kafka.connector.Utils;
 import com.snowflake.kafka.connector.config.SinkTaskConfig;
 import com.snowflake.kafka.connector.config.SnowflakeValidation;
 import com.snowflake.kafka.connector.dlq.KafkaRecordErrorReporter;
+import com.snowflake.kafka.connector.internal.DescribeTableRow;
 import com.snowflake.kafka.connector.internal.KCLogger;
 import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
 import com.snowflake.kafka.connector.internal.SnowflakeErrors;
@@ -23,12 +25,15 @@ import com.snowflake.kafka.connector.internal.streaming.v2.client.StreamingClien
 import com.snowflake.kafka.connector.internal.streaming.v2.service.BatchOffsetFetcher;
 import com.snowflake.kafka.connector.internal.streaming.v2.service.PartitionChannelManager;
 import com.snowflake.kafka.connector.internal.streaming.v2.service.ThreadPools;
+import com.snowflake.kafka.connector.records.SnowflakeSinkRecord;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -284,20 +289,28 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
       LOGGER.info(
           "Using existing table {} (snowflake.autocreate.table.type={}).",
           tableName,
-          taskConfig.getTableType().configValue());
+          taskConfig.getAutocreatedTableType().configValue());
+      // Validate that the existing RECORD_METADATA structured-OBJECT schema (managed-Iceberg v2)
+      // contains all fields the connector emits. A missing declared field causes the strict v2
+      // typed-OBJECT cast to reject every row with "Typed object schema mismatch in conversion";
+      // fail fast here so the operator can fix the table rather than silently losing data.
+      if (this.conn.isRecordMetadataStructuredObject(tableName)) {
+        validateStructuredObjectMetadataSchema(tableName);
+      }
       return;
     }
-    switch (taskConfig.getTableType()) {
+    switch (taskConfig.getAutocreatedTableType()) {
       case ICEBERG:
         // Non-schematized Iceberg stores the raw record in a RECORD_CONTENT VARIANT column, which
         // is only supported on Iceberg format v3. Auto-creating without ICEBERG_VERSION=3 yields a
         // v2 table (the default) that cannot hold RECORD_CONTENT, so fail fast at startup instead
         // of mysteriously at ingest time.
-        if (!taskConfig.isEnableSchematization()
-            && !taskConfig
+        final boolean icebergV3Requested =
+            taskConfig
                 .getIcebergCreateTableOptions()
                 .orElse("")
-                .matches("(?is).*ICEBERG_VERSION\\s*=\\s*3(?!\\d).*")) {
+                .matches("(?is).*ICEBERG_VERSION\\s*=\\s*3(?!\\d).*");
+        if (!taskConfig.isEnableSchematization() && !icebergV3Requested) {
           throw SnowflakeErrors.ERROR_0034.getException(
               "Auto-creating Iceberg table '"
                   + tableName
@@ -318,8 +331,8 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
             "Table '"
                 + tableName
                 + "' does not exist and snowflake.autocreate.table.type=none. Either create the"
-                + " table and its pipe yourself, or set snowflake.autocreate.table.type=snowflake"
-                + "|iceberg so the connector creates the table for you.");
+                + " table yourself, or set snowflake.autocreate.table.type=snowflake|iceberg so"
+                + " the connector creates the table for you.");
       case SNOWFLAKE:
       default:
         LOGGER.info("Creating new table {}.", tableName);
@@ -340,6 +353,133 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
                   + "iceberg to make this explicit, or unset DEFAULT_METADATA_WRITE_FORMAT.",
               tableName);
         }
+    }
+  }
+
+  /**
+   * Validates that an existing table's {@code RECORD_METADATA} structured-OBJECT schema contains
+   * every field the connector emits (i.e. every field in {@link
+   * SnowflakeSinkRecord#ICEBERG_METADATA_FIELDS}).
+   *
+   * <p>Called only when {@code conn.isRecordMetadataStructuredObject(tableName)} is true (managed-
+   * Iceberg v2). The v2 strict typed-OBJECT cast rejects any row whose map is missing a declared
+   * OBJECT sub-field, so a schema that omits a connector-emitted field would silently route every
+   * row to the error table. Fail fast at startup with a clear message instead.
+   *
+   * <p>A table declaring <em>extra</em> fields beyond what the connector emits is fine (the
+   * connector's map is a subset; those extra fields cast to null) and is not rejected.
+   *
+   * @throws com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException (ERROR_0034)
+   *     when any connector-emitted field is absent from the table's OBJECT schema
+   */
+  @VisibleForTesting
+  void validateStructuredObjectMetadataSchema(String tableName) {
+    Optional<List<DescribeTableRow>> rows = this.conn.describeTable(tableName);
+    if (rows.isEmpty()) {
+      // Cannot describe the table — skip validation rather than fail spuriously.
+      LOGGER.warn(
+          "Cannot validate RECORD_METADATA OBJECT schema for table '{}': describeTable returned"
+              + " empty. Proceeding without validation.",
+          tableName);
+      return;
+    }
+
+    Optional<DescribeTableRow> metadataRow =
+        rows.get().stream()
+            .filter(r -> Utils.TABLE_COLUMN_METADATA.equalsIgnoreCase(r.getColumn()))
+            .findFirst();
+
+    if (metadataRow.isEmpty()) {
+      // No RECORD_METADATA column — nothing to validate.
+      return;
+    }
+
+    String objectTypeStr = metadataRow.get().getType();
+    Set<String> declaredFields = parseObjectSubfieldNames(objectTypeStr);
+
+    List<String> missingFields = new ArrayList<>();
+    for (String required : SnowflakeSinkRecord.ICEBERG_METADATA_FIELDS) {
+      if (!declaredFields.contains(required)) {
+        missingFields.add(required);
+      }
+    }
+
+    if (!missingFields.isEmpty()) {
+      throw SnowflakeErrors.ERROR_0034.getException(
+          "Existing table '"
+              + tableName
+              + "' has a structured-OBJECT RECORD_METADATA column (managed-Iceberg v2) that is"
+              + " missing the following field(s) emitted by this connector: "
+              + missingFields
+              + ". The v2 strict typed-OBJECT cast rejects rows whose map is missing a declared"
+              + " field, so every row would go to the error table. Add the missing field(s) to the"
+              + " RECORD_METADATA OBJECT column definition (e.g. ALTER TABLE ... ALTER COLUMN"
+              + " RECORD_METADATA SET DATA TYPE OBJECT(...)) or re-create the table so the"
+              + " connector can auto-create it with the correct schema.");
+    }
+  }
+
+  /**
+   * Parses the top-level sub-field <em>names</em> from a Snowflake OBJECT type string such as
+   * {@code OBJECT(offset LONG, topic STRING, headers MAP(VARCHAR, VARCHAR))}.
+   *
+   * <p>Splits on top-level commas only (respects nested parentheses, e.g. {@code MAP(VARCHAR,
+   * VARCHAR)}), then extracts the first whitespace-delimited token of each clause as the field
+   * name. Returns an empty set if the string does not start with {@code OBJECT(}.
+   *
+   * <p>Type checking is intentionally omitted: Snowflake uses aliases (LONG/BIGINT, INTEGER/INT)
+   * that would require alias-normalization to compare safely. Name-presence is the critical
+   * invariant; a type mismatch produces a different, comprehensible server error.
+   */
+  // Package-private for unit testing.
+  static Set<String> parseObjectSubfieldNames(String objectTypeStr) {
+    if (objectTypeStr == null) {
+      return Collections.emptySet();
+    }
+    String trimmed = objectTypeStr.trim();
+    // Case-insensitive prefix check: "OBJECT(" or "object(" etc.
+    if (!trimmed.toUpperCase(java.util.Locale.ROOT).startsWith("OBJECT(")) {
+      return Collections.emptySet();
+    }
+    // Extract the body between the outermost parens.
+    int open = trimmed.indexOf('(');
+    int close = trimmed.lastIndexOf(')');
+    if (open < 0 || close <= open) {
+      return Collections.emptySet();
+    }
+    String body = trimmed.substring(open + 1, close);
+
+    // Split on top-level commas only (depth tracks nested parens like MAP(VARCHAR, VARCHAR)).
+    Set<String> names = new HashSet<>();
+    int depth = 0;
+    StringBuilder cur = new StringBuilder();
+    for (int i = 0; i < body.length(); i++) {
+      char c = body.charAt(i);
+      if (c == '(') {
+        depth++;
+      } else if (c == ')') {
+        depth--;
+      }
+      if (c == ',' && depth == 0) {
+        addFieldName(cur.toString(), names);
+        cur.setLength(0);
+      } else {
+        cur.append(c);
+      }
+    }
+    addFieldName(cur.toString(), names);
+    return names;
+  }
+
+  private static void addFieldName(String clause, Set<String> names) {
+    String t = clause.trim();
+    if (t.isEmpty()) {
+      return;
+    }
+    // Field name is the first whitespace-delimited token: "offset LONG" → "offset".
+    String[] parts = t.split("\\s+", 2);
+    if (parts.length > 0 && !parts[0].isEmpty()) {
+      names.add(parts[0]);
     }
   }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -368,7 +368,7 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
    * emits them, so always absent → rows rejected) are fatal. Delegates the comparison to {@link
    * IcebergDDLTypes#validateRecordMetadataFields}.
    *
-   * @throws com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException (ERROR_0034)
+   * @throws com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException (ERROR_0035)
    *     when any connector field is missing from, or any extra field is present in, the table's
    *     OBJECT schema
    */
@@ -383,7 +383,7 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
       // current database/schema). Do NOT proceed: the strict v2 typed-OBJECT cast would then reject
       // every row at ingest, silently routing all data to the error table. Fail fast instead so the
       // operator can fix it -- this is exactly the failure mode this validation exists to prevent.
-      throw SnowflakeErrors.ERROR_0034.getException(
+      throw SnowflakeErrors.ERROR_0035.getException(
           "Cannot validate the structured-OBJECT RECORD_METADATA schema for table '"
               + tableName
               + "': INFORMATION_SCHEMA.FIELDS returned no sub-fields for the RECORD_METADATA"

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -10,6 +10,7 @@ import com.snowflake.kafka.connector.ConnectorConfigTools;
 import com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams;
 import com.snowflake.kafka.connector.config.SinkTaskConfig;
 import com.snowflake.kafka.connector.config.SnowflakeValidation;
+import com.snowflake.kafka.connector.config.TableType;
 import com.snowflake.kafka.connector.dlq.KafkaRecordErrorReporter;
 import com.snowflake.kafka.connector.internal.KCLogger;
 import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
@@ -172,15 +173,6 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
           // Table doesn't exist yet — will be auto-created with ERROR_LOGGING = TRUE
           continue;
         }
-        if (conn.isIcebergTable(tableName)) {
-          LOGGER.warn(
-              "Table '{}' is an Iceberg table. Iceberg tables do not support ERROR_LOGGING."
-                  + " In v4 high-throughput mode, invalid records targeting this table will be"
-                  + " silently dropped. Error table functionality is not available for Iceberg"
-                  + " tables.",
-              tableName);
-          continue;
-        }
         if (!conn.hasErrorLoggingEnabled(tableName)) {
           LOGGER.warn(
               "Table '{}' does not have ERROR_LOGGING enabled. In v4 high-throughput mode,"
@@ -261,7 +253,30 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
       // When validation is enabled, reject non-default pipes (pipes whose name equals the table
       // name) because validation assumptions may not hold for user-created pipes.
       final String targetPipeName;
-      if (taskConfig.getValidation() == SnowflakeValidation.CLIENT_SIDE) {
+      if (taskConfig.getTableType() == TableType.NONE) {
+        // table.type=none: the pipe must already exist (we created nothing). Fail fast if neither
+        // the default nor a named pipe is present, and name the detected table type.
+        boolean defaultPipeExists = this.conn.pipeExist(buildDefaultPipeName(tableName));
+        boolean namedPipeExists = this.conn.pipeExist(tableName);
+        if (!defaultPipeExists && !namedPipeExists) {
+          String detectedType = this.conn.isIcebergTable(tableName) ? "ICEBERG" : "SNOWFLAKE";
+          throw SnowflakeErrors.ERROR_0034.getException(
+              "snowflake.autocreate.table.type=none and no pipe exists for table '"
+                  + tableName
+                  + "' (detected table type="
+                  + detectedType
+                  + "). Create the pipe yourself, or set snowflake.autocreate.table.type="
+                  + detectedType.toLowerCase(java.util.Locale.ROOT)
+                  + " so the connector manages it.");
+        }
+        targetPipeName = namedPipeExists ? tableName : buildDefaultPipeName(tableName);
+        // Client-side validation only supports default pipes. Even under table.type=none, a
+        // pre-existing named pipe must be rejected for the same reason as the CLIENT_SIDE branch
+        // below: validation assumptions may not hold for user-created pipes.
+        if (taskConfig.getValidation() == SnowflakeValidation.CLIENT_SIDE && namedPipeExists) {
+          throw SnowflakeErrors.ERROR_0032.getException("table: " + tableName);
+        }
+      } else if (taskConfig.getValidation() == SnowflakeValidation.CLIENT_SIDE) {
         if (this.conn.pipeExist(tableName)) {
           throw SnowflakeErrors.ERROR_0032.getException("table: " + tableName);
         }
@@ -279,12 +294,55 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
     channelManager.startPartitions(partitions, tableToPipeMapping);
   }
 
-  private void createTableIfNotExists(final String tableName) {
+  @VisibleForTesting
+  void createTableIfNotExists(final String tableName) {
     if (this.conn.tableExist(tableName)) {
-      LOGGER.info("Using existing table {}.", tableName);
-    } else {
-      LOGGER.info("Creating new table {}.", tableName);
-      this.conn.createTableWithOnlyMetadataColumn(tableName);
+      // Existing table: use it as-is, regardless of the configured table.type (which only governs
+      // auto-creation). Log the detected type for operator visibility. (For table.type=none, pipe
+      // existence is asserted in startPartitions.)
+      LOGGER.info(
+          "Using existing table {} (snowflake.autocreate.table.type={}; detected type={}).",
+          tableName,
+          taskConfig.getTableType().configValue(),
+          this.conn.isIcebergTable(tableName) ? "ICEBERG" : "SNOWFLAKE");
+      return;
+    }
+    switch (taskConfig.getTableType()) {
+      case ICEBERG:
+        // Non-schematized Iceberg stores the raw record in a RECORD_CONTENT VARIANT column, which
+        // is only supported on Iceberg format v3. Auto-creating without ICEBERG_VERSION=3 yields a
+        // v2 table (the default) that cannot hold RECORD_CONTENT, so fail fast at startup instead
+        // of mysteriously at ingest time.
+        if (!taskConfig.isEnableSchematization()
+            && !taskConfig
+                .getIcebergCreateTableOptions()
+                .matches("(?is).*ICEBERG_VERSION\\s*=\\s*3(?!\\d).*")) {
+          throw SnowflakeErrors.ERROR_0034.getException(
+              "Auto-creating Iceberg table '"
+                  + tableName
+                  + "' with snowflake.enable.schematization=false requires ICEBERG_VERSION=3 in"
+                  + " snowflake.iceberg.create.table.options: the raw record is stored in a"
+                  + " RECORD_CONTENT VARIANT column, supported only on Iceberg format v3.");
+        }
+        LOGGER.info(
+            "Creating new Iceberg table {} (createTableOptions='{}').",
+            tableName,
+            taskConfig.getIcebergCreateTableOptions());
+        this.conn.createIcebergTableWithOnlyMetadataColumn(
+            tableName, taskConfig.getIcebergCreateTableOptions());
+        break;
+      case NONE:
+        // Missing table + none: fail loudly and tell the operator their two ways out.
+        throw SnowflakeErrors.ERROR_0034.getException(
+            "Table '"
+                + tableName
+                + "' does not exist and snowflake.autocreate.table.type=none. Either create the"
+                + " table and its pipe yourself, or set snowflake.autocreate.table.type=snowflake"
+                + "|iceberg so the connector creates the table for you.");
+      case SNOWFLAKE:
+      default:
+        LOGGER.info("Creating new table {}.", tableName);
+        this.conn.createTableWithOnlyMetadataColumn(tableName);
     }
   }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -10,7 +10,6 @@ import com.snowflake.kafka.connector.ConnectorConfigTools;
 import com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams;
 import com.snowflake.kafka.connector.config.SinkTaskConfig;
 import com.snowflake.kafka.connector.config.SnowflakeValidation;
-import com.snowflake.kafka.connector.config.TableType;
 import com.snowflake.kafka.connector.dlq.KafkaRecordErrorReporter;
 import com.snowflake.kafka.connector.internal.KCLogger;
 import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
@@ -252,34 +251,14 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
       // Client-side validation only supports default pipes.
       // When validation is enabled, reject non-default pipes (pipes whose name equals the table
       // name) because validation assumptions may not hold for user-created pipes.
+      //
+      // table.type=none's only job is to NOT auto-create the TABLE — already enforced in
+      // createTableIfNotExists (which throws for NONE when the table is missing). The default pipe
+      // is always connector-managed (created lazily at first ingest), so requiring a pre-existing
+      // pipe under 'none' was wrong: the pipe does not need to exist at startup regardless of
+      // table.type.
       final String targetPipeName;
-      if (taskConfig.getTableType() == TableType.NONE) {
-        // table.type=none: the pipe must already exist (we created nothing). Fail fast if neither
-        // the default nor a named pipe is present, and name the detected table type.
-        boolean defaultPipeExists = this.conn.pipeExist(buildDefaultPipeName(tableName));
-        boolean namedPipeExists = this.conn.pipeExist(tableName);
-        if (!defaultPipeExists && !namedPipeExists) {
-          String detectedType =
-              this.conn.isIcebergTable(tableName)
-                  ? TableType.ICEBERG.configValue()
-                  : TableType.SNOWFLAKE.configValue();
-          throw SnowflakeErrors.ERROR_0034.getException(
-              "snowflake.autocreate.table.type=none and no pipe exists for table '"
-                  + tableName
-                  + "' (detected table type="
-                  + detectedType
-                  + "). Create the pipe yourself, or set snowflake.autocreate.table.type="
-                  + detectedType
-                  + " so the connector manages it.");
-        }
-        targetPipeName = namedPipeExists ? tableName : buildDefaultPipeName(tableName);
-        // Client-side validation only supports default pipes. Even under table.type=none, a
-        // pre-existing named pipe must be rejected for the same reason as the CLIENT_SIDE branch
-        // below: validation assumptions may not hold for user-created pipes.
-        if (taskConfig.getValidation() == SnowflakeValidation.CLIENT_SIDE && namedPipeExists) {
-          throw SnowflakeErrors.ERROR_0032.getException("table: " + tableName);
-        }
-      } else if (taskConfig.getValidation() == SnowflakeValidation.CLIENT_SIDE) {
+      if (taskConfig.getValidation() == SnowflakeValidation.CLIENT_SIDE) {
         if (this.conn.pipeExist(tableName)) {
           throw SnowflakeErrors.ERROR_0032.getException("table: " + tableName);
         }

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -292,7 +292,8 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
       // contains all fields the connector emits. A missing declared field causes the strict v2
       // typed-OBJECT cast to reject every row with "Typed object schema mismatch in conversion";
       // fail fast here so the operator can fix the table rather than silently losing data.
-      if (this.conn.isRecordMetadataStructuredObject(tableName)) {
+      if (taskConfig.isStructuredRecordMetadataEnabled()
+          && this.conn.isRecordMetadataStructuredObject(tableName)) {
         validateStructuredObjectMetadataSchema(tableName);
       }
       return;

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -304,11 +304,13 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
         // is only supported on Iceberg format v3. Auto-creating without ICEBERG_VERSION=3 yields a
         // v2 table (the default) that cannot hold RECORD_CONTENT, so fail fast at startup instead
         // of mysteriously at ingest time.
+        // Tolerate an optionally-quoted value (ICEBERG_VERSION=3 or ICEBERG_VERSION='3'); the
+        // (?!\\d) guard still rejects 30/31/etc.
         final boolean icebergV3Requested =
             taskConfig
                 .getIcebergCreateTableOptions()
                 .orElse("")
-                .matches("(?is).*ICEBERG_VERSION\\s*=\\s*3(?!\\d).*");
+                .matches("(?is).*ICEBERG_VERSION\\s*=\\s*'?3'?(?!\\d).*");
         if (!taskConfig.isEnableSchematization() && !icebergV3Requested) {
           throw SnowflakeErrors.ERROR_0034.getException(
               "Auto-creating Iceberg table '"

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -374,12 +374,19 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
     List<String> fieldNames =
         this.conn.getStructuredObjectFieldNames(tableName, Utils.TABLE_COLUMN_METADATA);
     if (fieldNames.isEmpty()) {
-      // INFORMATION_SCHEMA returned no rows — skip validation rather than fail spuriously.
-      LOGGER.warn(
-          "Cannot validate RECORD_METADATA OBJECT schema for table '{}': "
-              + "INFORMATION_SCHEMA.FIELDS returned no sub-fields. Proceeding without validation.",
-          tableName);
-      return;
+      // This method is only called when RECORD_METADATA is confirmed to be a structured OBJECT
+      // (isRecordMetadataStructuredObject == true), so it MUST have declared sub-fields. An empty
+      // result means we could not read them (query error, or the table is not in the session's
+      // current database/schema). Do NOT proceed: the strict v2 typed-OBJECT cast would then reject
+      // every row at ingest, silently routing all data to the error table. Fail fast instead so the
+      // operator can fix it -- this is exactly the failure mode this validation exists to prevent.
+      throw SnowflakeErrors.ERROR_0034.getException(
+          "Cannot validate the structured-OBJECT RECORD_METADATA schema for table '"
+              + tableName
+              + "': INFORMATION_SCHEMA.FIELDS returned no sub-fields for the RECORD_METADATA"
+              + " column, even though the column is a structured OBJECT. This usually means the"
+              + " table is not in the connector's configured database/schema. Ensure"
+              + " snowflake.database.name and snowflake.schema.name match the table's location.");
     }
     IcebergDDLTypes.validateRecordMetadataFields(tableName, new HashSet<>(fieldNames));
   }

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -296,6 +296,7 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
         if (!taskConfig.isEnableSchematization()
             && !taskConfig
                 .getIcebergCreateTableOptions()
+                .orElse("")
                 .matches("(?is).*ICEBERG_VERSION\\s*=\\s*3(?!\\d).*")) {
           throw SnowflakeErrors.ERROR_0034.getException(
               "Auto-creating Iceberg table '"
@@ -307,9 +308,9 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
         LOGGER.info(
             "Creating new Iceberg table {} (createTableOptions='{}').",
             tableName,
-            taskConfig.getIcebergCreateTableOptions());
+            taskConfig.getIcebergCreateTableOptions().orElse(""));
         this.conn.createIcebergTableWithOnlyMetadataColumn(
-            tableName, taskConfig.getIcebergCreateTableOptions());
+            tableName, taskConfig.getIcebergCreateTableOptions().orElse(""));
         break;
       case NONE:
         // Missing table + none: fail loudly and tell the operator their two ways out.

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannel.java
@@ -108,12 +108,12 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
   private volatile Map<String, ColumnSchema> tableSchema;
   private final boolean shouldEvolveSchema;
 
-  // Whether the target table's RECORD_METADATA is the structured Iceberg OBJECT (vs FDN VARIANT),
-  // resolved lazily on first use and memoized for the channel's lifetime. We probe the ACTUAL
-  // table via conn.isIcebergTable rather than trusting the configured table.type, because the
-  // config only governs auto-creation: an existing table may differ from it (e.g. table.type=none
-  // targeting a pre-existing Iceberg table). null = not yet resolved.
-  private volatile Boolean recordMetadataIsIcebergObject;
+  // Whether the target table's RECORD_METADATA is a structured OBJECT (vs FDN/v3 VARIANT).
+  // Injected at construction time (after the table has been created/verified in startPartitions)
+  // so it is cheap to query per-record. We probe the ACTUAL table rather than trusting
+  // table.type, because the config only governs auto-creation: an existing table may differ
+  // (e.g. table.type=none targeting a pre-existing Iceberg v2 table).
+  private final boolean recordMetadataIsStructuredObject;
 
   public SnowpipeStreamingPartitionChannel(
       String tableName,
@@ -129,6 +129,7 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
       StreamingErrorHandler streamingErrorHandler,
       TaskMetrics taskMetrics,
       boolean shouldEvolveSchema,
+      boolean isRecordMetadataStructuredObject,
       SnowflakeConnectionService conn,
       Optional<String> ssv1ChannelName) {
     this.channelName = channelName;
@@ -143,6 +144,7 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
     this.snowflakeTelemetryChannelStatus = snowflakeTelemetryChannelStatus;
     this.offsetTracker = offsetTracker;
     this.shouldEvolveSchema = shouldEvolveSchema;
+    this.recordMetadataIsStructuredObject = isRecordMetadataStructuredObject;
     this.conn = conn;
     this.tableName = tableName;
     this.ssv1ChannelName = ssv1ChannelName;
@@ -213,7 +215,7 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
         final Map<String, Object> row =
             record.getContentWithMetadata(
                 taskConfig.getMetadataConfig().shouldIncludeAllMetadata(),
-                conformMetadataToIcebergObject());
+                conformMetadataToStructuredObject());
         if (!row.isEmpty()) {
           if (taskConfig.getValidation() == SnowflakeValidation.CLIENT_SIDE
               && rowValidator != null) {
@@ -309,15 +311,11 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
    * Whether record metadata must be conformed to the strict structured-OBJECT RECORD_METADATA
    * schema. True iff the actual target table's RECORD_METADATA column is a structured OBJECT --
    * which is only the case for managed-Iceberg v2 tables (v3 and FDN use VARIANT, which accepts the
-   * natural metadata map as-is). We probe the real column type via {@code
-   * isRecordMetadataStructuredObject} once and memoize; the configured table.type only governs
-   * auto-creation, and even an auto-created Iceberg table may be VARIANT (v3) or OBJECT (v2).
+   * natural metadata map as-is). Injected at construction time; see {@code
+   * PartitionChannelManager#buildChannel}.
    */
-  private boolean conformMetadataToIcebergObject() {
-    if (recordMetadataIsIcebergObject == null) {
-      recordMetadataIsIcebergObject = conn.isRecordMetadataStructuredObject(tableName);
-    }
-    return recordMetadataIsIcebergObject;
+  private boolean conformMetadataToStructuredObject() {
+    return recordMetadataIsStructuredObject;
   }
 
   private boolean insertRowWithFallback(Map<String, Object> row, long offset) {

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannel.java
@@ -108,6 +108,13 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
   private volatile Map<String, ColumnSchema> tableSchema;
   private final boolean shouldEvolveSchema;
 
+  // Whether the target table's RECORD_METADATA is the structured Iceberg OBJECT (vs FDN VARIANT),
+  // resolved lazily on first use and memoized for the channel's lifetime. We probe the ACTUAL
+  // table via conn.isIcebergTable rather than trusting the configured table.type, because the
+  // config only governs auto-creation: an existing table may differ from it (e.g. table.type=none
+  // targeting a pre-existing Iceberg table). null = not yet resolved.
+  private Boolean recordMetadataIsIcebergObject;
+
   public SnowpipeStreamingPartitionChannel(
       String tableName,
       String channelName,
@@ -205,7 +212,8 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
         // If we reach here, it means we should ingest a record (possibly empty for tombstones)
         final Map<String, Object> row =
             record.getContentWithMetadata(
-                taskConfig.getMetadataConfig().shouldIncludeAllMetadata());
+                taskConfig.getMetadataConfig().shouldIncludeAllMetadata(),
+                conformMetadataToIcebergObject());
         if (!row.isEmpty()) {
           if (taskConfig.getValidation() == SnowflakeValidation.CLIENT_SIDE
               && rowValidator != null) {
@@ -297,6 +305,19 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
    *     was NOT inserted). When this returns false, callers must NOT advance processedOffset — the
    *     recovery logic has already reset offset state.
    */
+  /**
+   * Whether record metadata must be conformed to the strict structured-OBJECT RECORD_METADATA
+   * schema used by managed-Iceberg tables. True iff the actual target table is Iceberg. The
+   * configured table.type only governs auto-creation -- an existing table may be a different type
+   * -- so we probe the real table via {@code isIcebergTable} once and memoize.
+   */
+  private boolean conformMetadataToIcebergObject() {
+    if (recordMetadataIsIcebergObject == null) {
+      recordMetadataIsIcebergObject = conn.isIcebergTable(tableName);
+    }
+    return recordMetadataIsIcebergObject;
+  }
+
   private boolean insertRowWithFallback(Map<String, Object> row, long offset) {
     try {
       LOGGER.trace("Inserting transformed record: {}, offset: {}", row, offset);

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannel.java
@@ -113,7 +113,7 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
   // table via conn.isIcebergTable rather than trusting the configured table.type, because the
   // config only governs auto-creation: an existing table may differ from it (e.g. table.type=none
   // targeting a pre-existing Iceberg table). null = not yet resolved.
-  private Boolean recordMetadataIsIcebergObject;
+  private volatile Boolean recordMetadataIsIcebergObject;
 
   public SnowpipeStreamingPartitionChannel(
       String tableName,
@@ -307,13 +307,15 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
    */
   /**
    * Whether record metadata must be conformed to the strict structured-OBJECT RECORD_METADATA
-   * schema used by managed-Iceberg tables. True iff the actual target table is Iceberg. The
-   * configured table.type only governs auto-creation -- an existing table may be a different type
-   * -- so we probe the real table via {@code isIcebergTable} once and memoize.
+   * schema. True iff the actual target table's RECORD_METADATA column is a structured OBJECT --
+   * which is only the case for managed-Iceberg v2 tables (v3 and FDN use VARIANT, which accepts the
+   * natural metadata map as-is). We probe the real column type via {@code
+   * isRecordMetadataStructuredObject} once and memoize; the configured table.type only governs
+   * auto-creation, and even an auto-created Iceberg table may be VARIANT (v3) or OBJECT (v2).
    */
   private boolean conformMetadataToIcebergObject() {
     if (recordMetadataIsIcebergObject == null) {
-      recordMetadataIsIcebergObject = conn.isIcebergTable(tableName);
+      recordMetadataIsIcebergObject = conn.isRecordMetadataStructuredObject(tableName);
     }
     return recordMetadataIsIcebergObject;
   }

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannel.java
@@ -215,7 +215,7 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
         final Map<String, Object> row =
             record.getContentWithMetadata(
                 taskConfig.getMetadataConfig().shouldIncludeAllMetadata(),
-                conformMetadataToStructuredObject());
+                recordMetadataIsStructuredObject);
         if (!row.isEmpty()) {
           if (taskConfig.getValidation() == SnowflakeValidation.CLIENT_SIDE
               && rowValidator != null) {
@@ -307,17 +307,6 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
    *     was NOT inserted). When this returns false, callers must NOT advance processedOffset — the
    *     recovery logic has already reset offset state.
    */
-  /**
-   * Whether record metadata must be conformed to the strict structured-OBJECT RECORD_METADATA
-   * schema. True iff the actual target table's RECORD_METADATA column is a structured OBJECT --
-   * which is only the case for managed-Iceberg v2 tables (v3 and FDN use VARIANT, which accepts the
-   * natural metadata map as-is). Injected at construction time; see {@code
-   * PartitionChannelManager#buildChannel}.
-   */
-  private boolean conformMetadataToStructuredObject() {
-    return recordMetadataIsStructuredObject;
-  }
-
   private boolean insertRowWithFallback(Map<String, Object> row, long offset) {
     try {
       LOGGER.trace("Inserting transformed record: {}, offset: {}", row, offset);

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/service/PartitionChannelManager.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/service/PartitionChannelManager.java
@@ -212,6 +212,9 @@ public class PartitionChannelManager {
             && shouldEvolveSchemaCache.computeIfAbsent(
                 tableName, t -> conn.shouldEvolveSchema(t, taskConfig.getSnowflakeRole()));
 
+    final boolean isRecordMetadataStructuredObject =
+        conn.isRecordMetadataStructuredObject(tableName);
+
     // KC v3 defaulted to V1 channel naming: {topic}_{partition}.
     // Customers who set snowflake.streaming.channel.name.include.connector.name=true
     // in KC v3 used V2 naming: {connectorName}_{topic}_{partition} (same as KC v4).
@@ -243,6 +246,7 @@ public class PartitionChannelManager {
         streamingErrorHandler,
         this.taskMetrics,
         shouldEvolveSchema,
+        isRecordMetadataStructuredObject,
         this.conn,
         ssv1ChannelName);
   }

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/service/PartitionChannelManager.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/service/PartitionChannelManager.java
@@ -64,6 +64,12 @@ public class PartitionChannelManager {
   private final PartitionChannelBuilder partitionChannelBuilder;
   private final Map<String, TopicPartitionChannel> partitionChannels;
   private final Map<String, Boolean> shouldEvolveSchemaCache = new ConcurrentHashMap<>();
+  // Whether a table's RECORD_METADATA is a structured OBJECT. Memoized per table (like
+  // shouldEvolveSchemaCache) because buildChannel runs once per partition, but the answer is a
+  // per-table property that does not change during the task's lifetime -- probing it per partition
+  // would issue a redundant DESCRIBE TABLE for every channel.
+  private final Map<String, Boolean> recordMetadataStructuredObjectCache =
+      new ConcurrentHashMap<>();
 
   /**
    * Offset resets submitted by channel init / recovery on the IO thread. Drained by SSV2.insert on
@@ -213,7 +219,8 @@ public class PartitionChannelManager {
                 tableName, t -> conn.shouldEvolveSchema(t, taskConfig.getSnowflakeRole()));
 
     final boolean isRecordMetadataStructuredObject =
-        conn.isRecordMetadataStructuredObject(tableName);
+        recordMetadataStructuredObjectCache.computeIfAbsent(
+            tableName, conn::isRecordMetadataStructuredObject);
 
     // KC v3 defaulted to V1 channel naming: {topic}_{partition}.
     // Customers who set snowflake.streaming.channel.name.include.connector.name=true

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/service/PartitionChannelManager.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/service/PartitionChannelManager.java
@@ -218,9 +218,12 @@ public class PartitionChannelManager {
             && shouldEvolveSchemaCache.computeIfAbsent(
                 tableName, t -> conn.shouldEvolveSchema(t, taskConfig.getSnowflakeRole()));
 
+    // Gated by a kill-switch (default on). When disabled, treat every table as VARIANT
+    // RECORD_METADATA (4.0.x behavior) and skip the probe entirely.
     final boolean isRecordMetadataStructuredObject =
-        recordMetadataStructuredObjectCache.computeIfAbsent(
-            tableName, conn::isRecordMetadataStructuredObject);
+        taskConfig.isStructuredRecordMetadataEnabled()
+            && recordMetadataStructuredObjectCache.computeIfAbsent(
+                tableName, conn::isRecordMetadataStructuredObject);
 
     // KC v3 defaulted to V1 channel naming: {topic}_{partition}.
     // Customers who set snowflake.streaming.channel.name.include.connector.name=true

--- a/src/main/java/com/snowflake/kafka/connector/records/SnowflakeMetadataConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/SnowflakeMetadataConfig.java
@@ -54,6 +54,11 @@ public class SnowflakeMetadataConfig {
     return allFlag;
   }
 
+  /** Returns true when structured (native-typed) headers are enabled. */
+  public boolean isStructuredHeadersEnabled() {
+    return structuredHeadersFlag;
+  }
+
   /**
    * Returns {@code true} if all metadata fields that map to the managed-Iceberg {@code
    * RECORD_METADATA} structured schema are enabled: topic, offset+partition, createtime, and

--- a/src/main/java/com/snowflake/kafka/connector/records/SnowflakeMetadataConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/SnowflakeMetadataConfig.java
@@ -54,6 +54,16 @@ public class SnowflakeMetadataConfig {
     return allFlag;
   }
 
+  /**
+   * Returns {@code true} if all metadata fields that map to the managed-Iceberg {@code
+   * RECORD_METADATA} structured schema are enabled: topic, offset+partition, createtime, and
+   * connectorPushTime. Managed-Iceberg casts {@code RECORD_METADATA} to a typed OBJECT with a
+   * strict cast that fails when a declared field is absent from the map.
+   */
+  public boolean isFullIcebergMetadataEnabled() {
+    return topicFlag && offsetAndPartitionFlag && createtimeFlag && connectorPushTimeFlag;
+  }
+
   private static boolean getMetadataProperty(Map<String, String> config, String property) {
     String value =
         Optional.ofNullable(config.get(property))

--- a/src/main/java/com/snowflake/kafka/connector/records/SnowflakeMetadataConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/SnowflakeMetadataConfig.java
@@ -54,11 +54,6 @@ public class SnowflakeMetadataConfig {
     return allFlag;
   }
 
-  /** Returns true when structured (native-typed) headers are enabled. */
-  public boolean isStructuredHeadersEnabled() {
-    return structuredHeadersFlag;
-  }
-
   /**
    * Returns {@code true} if all metadata fields that map to the managed-Iceberg {@code
    * RECORD_METADATA} structured schema are enabled: topic, offset+partition, createtime, and

--- a/src/main/java/com/snowflake/kafka/connector/records/SnowflakeMetadataConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/SnowflakeMetadataConfig.java
@@ -57,11 +57,18 @@ public class SnowflakeMetadataConfig {
   /**
    * Returns {@code true} if all metadata fields that map to the managed-Iceberg {@code
    * RECORD_METADATA} structured schema are enabled: topic, offset+partition, createtime, and
-   * connectorPushTime. Managed-Iceberg casts {@code RECORD_METADATA} to a typed OBJECT with a
-   * strict cast that fails when a declared field is absent from the map.
+   * connectorPushTime. Also requires the master {@code allFlag} ({@code
+   * snowflake.metadata.createSnowflakeMetadata}), which gates whether {@code RECORD_METADATA} is
+   * attached at all -- if it is off, no metadata is emitted regardless of the per-field flags.
+   * Managed-Iceberg casts {@code RECORD_METADATA} to a typed OBJECT with a strict cast that fails
+   * when a declared field is absent from the map.
    */
   public boolean isFullIcebergMetadataEnabled() {
-    return topicFlag && offsetAndPartitionFlag && createtimeFlag && connectorPushTimeFlag;
+    return allFlag
+        && topicFlag
+        && offsetAndPartitionFlag
+        && createtimeFlag
+        && connectorPushTimeFlag;
   }
 
   private static boolean getMetadataProperty(Map<String, String> config, String property) {

--- a/src/main/java/com/snowflake/kafka/connector/records/SnowflakeSinkRecord.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/SnowflakeSinkRecord.java
@@ -32,7 +32,8 @@ public final class SnowflakeSinkRecord {
 
   // The managed-Iceberg metadata schema declares BOTH timestamp fields. A Kafka record carries
   // exactly one timestamp type per topic, so at most one of the two is ever populated for a given
-  // record; the other is absent from the raw metadata map and the ingest cast null-fills it.
+  // record; the other is absent from the raw metadata map, so conformIcebergMetadata pads it with
+  // null (the v2 structured-OBJECT cast rejects a missing declared field).
   static final String CREATE_TIME = "CreateTime";
   static final String LOG_APPEND_TIME = "LogAppendTime";
 
@@ -395,7 +396,15 @@ public final class SnowflakeSinkRecord {
       // The schema declares `headers MAP(VARCHAR, VARCHAR)`. When structured headers are enabled
       // convertHeaders keeps native (non-String) values; coerce each to String so the strict cast
       // accepts them (v3/VARIANT tables never reach here and keep headers as nested VARIANT).
-      if (HEADERS.equals(field) && value instanceof Map) {
+      // buildMetadata always produces a Map from convertHeaders, so a non-Map value is an
+      // invariant violation — fail loudly rather than silently skip the coercion.
+      if (HEADERS.equals(field) && value != null) {
+        if (!(value instanceof Map)) {
+          throw new IllegalStateException(
+              "HEADERS metadata field must be a Map when non-null, but got: "
+                  + value.getClass().getName()
+                  + ". KC metadata emission and ICEBERG_METADATA_FIELDS have drifted.");
+        }
         @SuppressWarnings("unchecked")
         Map<String, Object> headerMap = (Map<String, Object>) value;
         Map<String, String> stringified = new HashMap<>();
@@ -406,14 +415,15 @@ public final class SnowflakeSinkRecord {
       }
       conformed.put(field, value);
     }
-    // Pad every absent-able field with null so the strict v2 typed-OBJECT cast does not reject the
-    // row. A record carries exactly one timestamp type (the other is absent); key and headers are
-    // absent on keyless/headerless records. putIfAbsent is safe: it leaves already-populated fields
-    // (e.g. the present timestamp) untouched.
-    conformed.putIfAbsent(KEY, null);
-    conformed.putIfAbsent(HEADERS, null);
-    conformed.putIfAbsent(CREATE_TIME, null);
-    conformed.putIfAbsent(LOG_APPEND_TIME, null);
+    // Pad every declared OBJECT sub-field that the current record left absent. A record carries
+    // exactly one timestamp type (the other is absent); key and headers are absent on
+    // keyless/headerless records. Config-gated fields (topic, offset, partition,
+    // connector-push-time) are guaranteed present by config-time validation, so putIfAbsent
+    // is a no-op for them. Iterating ICEBERG_METADATA_FIELDS guarantees we can never miss a
+    // newly added field.
+    for (String f : ICEBERG_METADATA_FIELDS) {
+      conformed.putIfAbsent(f, null);
+    }
     return conformed;
   }
 

--- a/src/main/java/com/snowflake/kafka/connector/records/SnowflakeSinkRecord.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/SnowflakeSinkRecord.java
@@ -392,6 +392,18 @@ public final class SnowflakeSinkRecord {
       if (KEY.equals(field) && value != null && !(value instanceof String)) {
         value = String.valueOf(value);
       }
+      // The schema declares `headers MAP(VARCHAR, VARCHAR)`. When structured headers are enabled
+      // convertHeaders keeps native (non-String) values; coerce each to String so the strict cast
+      // accepts them (v3/VARIANT tables never reach here and keep headers as nested VARIANT).
+      if (HEADERS.equals(field) && value instanceof Map) {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> headerMap = (Map<String, Object>) value;
+        Map<String, String> stringified = new HashMap<>();
+        for (Map.Entry<String, Object> h : headerMap.entrySet()) {
+          stringified.put(h.getKey(), h.getValue() == null ? null : String.valueOf(h.getValue()));
+        }
+        value = stringified;
+      }
       conformed.put(field, value);
     }
     // Pad every absent-able field with null so the strict v2 typed-OBJECT cast does not reject the

--- a/src/main/java/com/snowflake/kafka/connector/records/SnowflakeSinkRecord.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/SnowflakeSinkRecord.java
@@ -347,8 +347,11 @@ public final class SnowflakeSinkRecord {
    *   <li>Normalizes the timestamp field name: both {@code TimestampType.CREATE_TIME.name} ("
    *       CreateTime") and {@code TimestampType.LOG_APPEND_TIME.name} ("LogAppendTime") are mapped
    *       to the constant {@code "CreateTime"} declared in {@code ICEBERG_METADATA_OBJECT_SCHEMA}.
-   *   <li>Drops any field not in the Iceberg schema (extra fields would fail the strict
-   *       typed-OBJECT cast).
+   *   <li>Throws {@link IllegalStateException} if it encounters a field outside the Iceberg schema.
+   *       {@code buildMetadata} only ever emits schema fields, so this never fires in normal
+   *       operation — it fires only if KC metadata emission and the Iceberg schema drift apart (a
+   *       new field added on one side but not the other), which we want to surface loudly rather
+   *       than silently drop.
    *   <li>Coerces the {@code key} field to {@code String}: the schema declares {@code key STRING},
    *       but non-String-keyed topics (e.g. INT-keyed) yield a non-String key value.
    *   <li>Pads {@code key} and {@code headers} with {@code null} when absent. Unlike the
@@ -357,7 +360,8 @@ public final class SnowflakeSinkRecord {
    *       schema declares them and the strict cast rejects a missing field.
    * </ol>
    */
-  private static Map<String, Object> conformIcebergMetadata(Map<String, Object> metadata) {
+  // Package-private for testing.
+  static Map<String, Object> conformIcebergMetadata(Map<String, Object> metadata) {
     Map<String, Object> conformed = new HashMap<>();
     for (Map.Entry<String, Object> entry : metadata.entrySet()) {
       String field = entry.getKey();
@@ -366,7 +370,13 @@ public final class SnowflakeSinkRecord {
         field = CREATE_TIME;
       }
       if (!ICEBERG_METADATA_FIELD_SET.contains(field)) {
-        continue; // drop fields outside the Iceberg schema
+        throw new IllegalStateException(
+            "Unexpected metadata field '"
+                + field
+                + "' not in the managed-Iceberg RECORD_METADATA schema (ICEBERG_METADATA_FIELDS)."
+                + " KC metadata emission and the Iceberg schema have drifted: add the field to"
+                + " ICEBERG_METADATA_OBJECT_SCHEMA (GS) and ICEBERG_METADATA_FIELDS, or stop"
+                + " emitting it for managed Iceberg.");
       }
       Object value = entry.getValue();
       // The schema declares `key STRING`, but the record key can convert to a non-String (e.g. an

--- a/src/main/java/com/snowflake/kafka/connector/records/SnowflakeSinkRecord.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/SnowflakeSinkRecord.java
@@ -41,6 +41,11 @@ public final class SnowflakeSinkRecord {
   static final List<String> ICEBERG_METADATA_FIELDS =
       List.of(OFFSET, TOPIC, PARTITION, KEY, CREATE_TIME, CONNECTOR_PUSH_TIME, HEADERS);
 
+  // Fast membership test for conformIcebergMetadata. Derived from ICEBERG_METADATA_FIELDS so the
+  // two stay in sync automatically.
+  private static final java.util.Set<String> ICEBERG_METADATA_FIELD_SET =
+      new java.util.HashSet<>(ICEBERG_METADATA_FIELDS);
+
   private final Map<String, Object> content;
   private final Map<String, Object> metadata;
   private final Schema schema;
@@ -310,14 +315,12 @@ public final class SnowflakeSinkRecord {
   }
 
   /**
-   * @param conformToIcebergMetadataSchema when true, the RECORD_METADATA value is reshaped to match
-   *     the structured {@code IcebergDDLTypes.ICEBERG_METADATA_OBJECT_SCHEMA} exactly: every
-   *     declared field present (absent ones as {@code null}), the variable timestamp-type key
-   *     normalized to "CreateTime", and any field outside the schema dropped. Managed-Iceberg
-   *     ingestion casts RECORD_METADATA into that typed OBJECT with a strict cast that throws on a
-   *     missing field, so a sparse Kafka metadata map (e.g. a keyless/headerless record) would
-   *     otherwise be rejected. FDN tables use a VARIANT RECORD_METADATA and pass {@code false}
-   *     (behavior unchanged).
+   * @param conformToIcebergMetadataSchema when true, the RECORD_METADATA value is normalized via
+   *     {@link #conformIcebergMetadata}: the timestamp field is renamed to "CreateTime", fields
+   *     outside {@code ICEBERG_METADATA_OBJECT_SCHEMA} are dropped, and the {@code key} field is
+   *     coerced to {@code String}. Full metadata presence is guaranteed by config-time validation
+   *     (see {@code SinkTaskConfig}). FDN tables use a VARIANT RECORD_METADATA and pass {@code
+   *     false} (behavior unchanged).
    */
   public Map<String, Object> getContentWithMetadata(
       boolean includeMetadata, boolean conformToIcebergMetadataSchema) {
@@ -333,35 +336,54 @@ public final class SnowflakeSinkRecord {
   }
 
   /**
-   * Reshape a Kafka metadata map to exactly the fields of {@code ICEBERG_METADATA_OBJECT_SCHEMA}.
-   * Every declared field is present (absent ones {@code null}, which the strict typed-OBJECT cast
-   * accepts because the schema fields are nullable, whereas a <em>missing</em> field is rejected);
-   * the timestamp field — emitted by Kafka under {@code TimestampType.name} — is normalized to
-   * "CreateTime"; fields outside the schema are dropped.
+   * Normalize a Kafka metadata map for ingestion into a managed-Iceberg RECORD_METADATA column.
+   *
+   * <p>The config-gated metadata fields (topic, offset, partition, createtime, connector-push-time)
+   * are guaranteed present by config-time validation ({@code
+   * snowflake.autocreate.table.type=iceberg} rejects any disabled metadata flag), so this method
+   * does not pad them. It only:
+   *
+   * <ol>
+   *   <li>Normalizes the timestamp field name: both {@code TimestampType.CREATE_TIME.name} ("
+   *       CreateTime") and {@code TimestampType.LOG_APPEND_TIME.name} ("LogAppendTime") are mapped
+   *       to the constant {@code "CreateTime"} declared in {@code ICEBERG_METADATA_OBJECT_SCHEMA}.
+   *   <li>Drops any field not in the Iceberg schema (extra fields would fail the strict
+   *       typed-OBJECT cast).
+   *   <li>Coerces the {@code key} field to {@code String}: the schema declares {@code key STRING},
+   *       but non-String-keyed topics (e.g. INT-keyed) yield a non-String key value.
+   *   <li>Pads {@code key} and {@code headers} with {@code null} when absent. Unlike the
+   *       config-gated fields, these two are record-level — a keyless topic omits {@code key} and a
+   *       record with no headers omits {@code headers} — so config cannot guarantee them, yet the
+   *       schema declares them and the strict cast rejects a missing field.
+   * </ol>
    */
   private static Map<String, Object> conformIcebergMetadata(Map<String, Object> metadata) {
     Map<String, Object> conformed = new HashMap<>();
-    for (String field : ICEBERG_METADATA_FIELDS) {
-      conformed.put(field, null);
-    }
     for (Map.Entry<String, Object> entry : metadata.entrySet()) {
       String field = entry.getKey();
       if (TimestampType.CREATE_TIME.name.equals(field)
           || TimestampType.LOG_APPEND_TIME.name.equals(field)) {
         field = CREATE_TIME;
       }
-      if (!conformed.containsKey(field)) {
-        continue;
+      if (!ICEBERG_METADATA_FIELD_SET.contains(field)) {
+        continue; // drop fields outside the Iceberg schema
       }
       Object value = entry.getValue();
       // The schema declares `key STRING`, but the record key can convert to a non-String (e.g. an
       // INT-keyed topic yields an Integer, a struct/Avro key a Map). Coerce to String so the
-      // strict typed-OBJECT cast accepts it; absent keys stay null.
+      // strict typed-OBJECT cast accepts it.
       if (KEY.equals(field) && value != null && !(value instanceof String)) {
         value = String.valueOf(value);
       }
       conformed.put(field, value);
     }
+    // KEY and HEADERS are record-level, not config-gated: a keyless topic omits `key` and a record
+    // with no headers omits `headers`, so they can be absent even when every metadata flag is on.
+    // Config-time validation guarantees the config-gated fields for Iceberg but not these two, so
+    // pad only KEY and HEADERS with null — the strict typed-OBJECT cast rejects a missing field but
+    // accepts a null one.
+    conformed.putIfAbsent(KEY, null);
+    conformed.putIfAbsent(HEADERS, null);
     return conformed;
   }
 

--- a/src/main/java/com/snowflake/kafka/connector/records/SnowflakeSinkRecord.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/SnowflakeSinkRecord.java
@@ -7,6 +7,7 @@ import com.snowflake.kafka.connector.internal.validation.SqlIdentifierNormalizer
 import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.connect.data.Field;
@@ -28,6 +29,17 @@ public final class SnowflakeSinkRecord {
   static final String KEY = "key";
   static final String CONNECTOR_PUSH_TIME = "SnowflakeConnectorPushTime";
   static final String HEADERS = "headers";
+
+  // Kafka emits the record timestamp under TimestampType.name ("CreateTime"/"LogAppendTime"); the
+  // managed-Iceberg metadata column always declares the field as "CreateTime".
+  static final String CREATE_TIME = "CreateTime";
+  // This list must contain exactly the fields declared by
+  // IcebergDDLTypes.ICEBERG_METADATA_OBJECT_SCHEMA. Managed-Iceberg ingestion casts each row's
+  // RECORD_METADATA into that structured OBJECT with a strict cast that rejects any field missing
+  // from the schema, so the two must stay identical — enforced by
+  // SnowflakeSinkRecordTest#testIcebergMetadataFields_matchDdlSchema.
+  static final List<String> ICEBERG_METADATA_FIELDS =
+      List.of(OFFSET, TOPIC, PARTITION, KEY, CREATE_TIME, CONNECTOR_PUSH_TIME, HEADERS);
 
   private final Map<String, Object> content;
   private final Map<String, Object> metadata;
@@ -294,13 +306,63 @@ public final class SnowflakeSinkRecord {
   }
 
   public Map<String, Object> getContentWithMetadata(boolean includeMetadata) {
+    return getContentWithMetadata(includeMetadata, false);
+  }
+
+  /**
+   * @param conformToIcebergMetadataSchema when true, the RECORD_METADATA value is reshaped to match
+   *     the structured {@code IcebergDDLTypes.ICEBERG_METADATA_OBJECT_SCHEMA} exactly: every
+   *     declared field present (absent ones as {@code null}), the variable timestamp-type key
+   *     normalized to "CreateTime", and any field outside the schema dropped. Managed-Iceberg
+   *     ingestion casts RECORD_METADATA into that typed OBJECT with a strict cast that throws on a
+   *     missing field, so a sparse Kafka metadata map (e.g. a keyless/headerless record) would
+   *     otherwise be rejected. FDN tables use a VARIANT RECORD_METADATA and pass {@code false}
+   *     (behavior unchanged).
+   */
+  public Map<String, Object> getContentWithMetadata(
+      boolean includeMetadata, boolean conformToIcebergMetadataSchema) {
     if (!includeMetadata || metadata.isEmpty()) {
       return content;
     }
 
     Map<String, Object> result = new HashMap<>(content);
-    result.put(TABLE_COLUMN_METADATA, metadata);
+    result.put(
+        TABLE_COLUMN_METADATA,
+        conformToIcebergMetadataSchema ? conformIcebergMetadata(metadata) : metadata);
     return result;
+  }
+
+  /**
+   * Reshape a Kafka metadata map to exactly the fields of {@code ICEBERG_METADATA_OBJECT_SCHEMA}.
+   * Every declared field is present (absent ones {@code null}, which the strict typed-OBJECT cast
+   * accepts because the schema fields are nullable, whereas a <em>missing</em> field is rejected);
+   * the timestamp field — emitted by Kafka under {@code TimestampType.name} — is normalized to
+   * "CreateTime"; fields outside the schema are dropped.
+   */
+  private static Map<String, Object> conformIcebergMetadata(Map<String, Object> metadata) {
+    Map<String, Object> conformed = new HashMap<>();
+    for (String field : ICEBERG_METADATA_FIELDS) {
+      conformed.put(field, null);
+    }
+    for (Map.Entry<String, Object> entry : metadata.entrySet()) {
+      String field = entry.getKey();
+      if (TimestampType.CREATE_TIME.name.equals(field)
+          || TimestampType.LOG_APPEND_TIME.name.equals(field)) {
+        field = CREATE_TIME;
+      }
+      if (!conformed.containsKey(field)) {
+        continue;
+      }
+      Object value = entry.getValue();
+      // The schema declares `key STRING`, but the record key can convert to a non-String (e.g. an
+      // INT-keyed topic yields an Integer, a struct/Avro key a Map). Coerce to String so the
+      // strict typed-OBJECT cast accepts it; absent keys stay null.
+      if (KEY.equals(field) && value != null && !(value instanceof String)) {
+        value = String.valueOf(value);
+      }
+      conformed.put(field, value);
+    }
+    return conformed;
   }
 
   public Map<String, Object> getMetadata() {

--- a/src/main/java/com/snowflake/kafka/connector/records/SnowflakeSinkRecord.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/SnowflakeSinkRecord.java
@@ -30,16 +30,27 @@ public final class SnowflakeSinkRecord {
   static final String CONNECTOR_PUSH_TIME = "SnowflakeConnectorPushTime";
   static final String HEADERS = "headers";
 
-  // Kafka emits the record timestamp under TimestampType.name ("CreateTime"/"LogAppendTime"); the
-  // managed-Iceberg metadata column always declares the field as "CreateTime".
+  // The managed-Iceberg metadata schema declares BOTH timestamp fields. A Kafka record carries
+  // exactly one timestamp type per topic, so at most one of the two is ever populated for a given
+  // record; the other is absent from the raw metadata map and the ingest cast null-fills it.
   static final String CREATE_TIME = "CreateTime";
-  // This list must contain exactly the fields declared by
-  // IcebergDDLTypes.ICEBERG_METADATA_OBJECT_SCHEMA. Managed-Iceberg ingestion casts each row's
-  // RECORD_METADATA into that structured OBJECT with a strict cast that rejects any field missing
-  // from the schema, so the two must stay identical — enforced by
-  // SnowflakeSinkRecordTest#testIcebergMetadataFields_matchDdlSchema.
-  static final List<String> ICEBERG_METADATA_FIELDS =
-      List.of(OFFSET, TOPIC, PARTITION, KEY, CREATE_TIME, CONNECTOR_PUSH_TIME, HEADERS);
+  static final String LOG_APPEND_TIME = "LogAppendTime";
+
+  // This list must stay identical to IcebergDDLTypes.ICEBERG_METADATA_OBJECT_SCHEMA.
+  // The managed-Iceberg v2 structured-OBJECT cast (used by conformIcebergMetadata) REJECTS any
+  // declared field that is absent in the map, so (a) the list here must mirror the DDL exactly
+  // and (b) conformIcebergMetadata pads every absent-able field with null before ingestion.
+  // Enforced by SnowflakeSinkRecordTest#testIcebergMetadataFields_matchDdlSchema.
+  public static final List<String> ICEBERG_METADATA_FIELDS =
+      List.of(
+          OFFSET,
+          TOPIC,
+          PARTITION,
+          KEY,
+          CREATE_TIME,
+          LOG_APPEND_TIME,
+          CONNECTOR_PUSH_TIME,
+          HEADERS);
 
   // Fast membership test for conformIcebergMetadata. Derived from ICEBERG_METADATA_FIELDS so the
   // two stay in sync automatically.
@@ -310,20 +321,15 @@ public final class SnowflakeSinkRecord {
     return content;
   }
 
-  public Map<String, Object> getContentWithMetadata(boolean includeMetadata) {
-    return getContentWithMetadata(includeMetadata, false);
-  }
-
   /**
-   * @param conformToIcebergMetadataSchema when true, the RECORD_METADATA value is normalized via
-   *     {@link #conformIcebergMetadata}: the timestamp field is renamed to "CreateTime", fields
-   *     outside {@code ICEBERG_METADATA_OBJECT_SCHEMA} are dropped, and the {@code key} field is
-   *     coerced to {@code String}. Full metadata presence is guaranteed by config-time validation
-   *     (see {@code SinkTaskConfig}). FDN tables use a VARIANT RECORD_METADATA and pass {@code
-   *     false} (behavior unchanged).
+   * @param conformToStructuredObjectSchema when true, the RECORD_METADATA value is normalized via
+   *     {@link #conformIcebergMetadata}: fields outside {@code ICEBERG_METADATA_OBJECT_SCHEMA}
+   *     throw, and the {@code key} field is coerced to {@code String}. Full metadata presence is
+   *     guaranteed by config-time validation (see {@code SinkTaskConfig}). FDN tables use a VARIANT
+   *     RECORD_METADATA and pass {@code false} (behavior unchanged).
    */
   public Map<String, Object> getContentWithMetadata(
-      boolean includeMetadata, boolean conformToIcebergMetadataSchema) {
+      boolean includeMetadata, boolean conformToStructuredObjectSchema) {
     if (!includeMetadata || metadata.isEmpty()) {
       return content;
     }
@@ -331,22 +337,24 @@ public final class SnowflakeSinkRecord {
     Map<String, Object> result = new HashMap<>(content);
     result.put(
         TABLE_COLUMN_METADATA,
-        conformToIcebergMetadataSchema ? conformIcebergMetadata(metadata) : metadata);
+        conformToStructuredObjectSchema ? conformIcebergMetadata(metadata) : metadata);
     return result;
   }
 
   /**
-   * Normalize a Kafka metadata map for ingestion into a managed-Iceberg RECORD_METADATA column.
+   * Normalize a Kafka metadata map for ingestion into a managed-Iceberg {@code RECORD_METADATA}
+   * OBJECT column.
    *
-   * <p>The config-gated metadata fields (topic, offset, partition, createtime, connector-push-time)
-   * are guaranteed present by config-time validation ({@code
-   * snowflake.autocreate.table.type=iceberg} rejects any disabled metadata flag), so this method
-   * does not pad them. It only:
+   * <p><b>This method is called only for managed-Iceberg v2 tables.</b> v3 and FDN tables use a
+   * VARIANT {@code RECORD_METADATA} column and never call this path. The v2 structured-OBJECT cast
+   * is <em>strict</em>: it rejects any declared OBJECT sub-field that is absent in the map with a
+   * {@code Typed object schema mismatch in conversion} error, so every field declared in {@code
+   * ICEBERG_METADATA_OBJECT_SCHEMA} must be present in the map (present-and-null is fine; absent is
+   * rejected).
+   *
+   * <p>This method:
    *
    * <ol>
-   *   <li>Normalizes the timestamp field name: both {@code TimestampType.CREATE_TIME.name} ("
-   *       CreateTime") and {@code TimestampType.LOG_APPEND_TIME.name} ("LogAppendTime") are mapped
-   *       to the constant {@code "CreateTime"} declared in {@code ICEBERG_METADATA_OBJECT_SCHEMA}.
    *   <li>Throws {@link IllegalStateException} if it encounters a field outside the Iceberg schema.
    *       {@code buildMetadata} only ever emits schema fields, so this never fires in normal
    *       operation — it fires only if KC metadata emission and the Iceberg schema drift apart (a
@@ -354,21 +362,20 @@ public final class SnowflakeSinkRecord {
    *       than silently drop.
    *   <li>Coerces the {@code key} field to {@code String}: the schema declares {@code key STRING},
    *       but non-String-keyed topics (e.g. INT-keyed) yield a non-String key value.
-   *   <li>Pads {@code key} and {@code headers} with {@code null} when absent. Unlike the
-   *       config-gated fields, these two are record-level — a keyless topic omits {@code key} and a
-   *       record with no headers omits {@code headers} — so config cannot guarantee them, yet the
-   *       schema declares them and the strict cast rejects a missing field.
+   *   <li>Pads every absent-able field with {@code null}: a Kafka record carries exactly one
+   *       timestamp type (so the other is absent), and {@code key}/{@code headers} are absent on
+   *       keyless/headerless records. These absent fields are padded here so the strict v2
+   *       typed-OBJECT cast does not reject the row. Config-gated fields (topic, offset, partition,
+   *       connector-push-time) are guaranteed present by config-time validation and are not padded.
    * </ol>
+   *
+   * <p>Timestamps pass through under their own name ({@code CreateTime} or {@code LogAppendTime}).
    */
   // Package-private for testing.
   static Map<String, Object> conformIcebergMetadata(Map<String, Object> metadata) {
     Map<String, Object> conformed = new HashMap<>();
     for (Map.Entry<String, Object> entry : metadata.entrySet()) {
       String field = entry.getKey();
-      if (TimestampType.CREATE_TIME.name.equals(field)
-          || TimestampType.LOG_APPEND_TIME.name.equals(field)) {
-        field = CREATE_TIME;
-      }
       if (!ICEBERG_METADATA_FIELD_SET.contains(field)) {
         throw new IllegalStateException(
             "Unexpected metadata field '"
@@ -387,13 +394,14 @@ public final class SnowflakeSinkRecord {
       }
       conformed.put(field, value);
     }
-    // KEY and HEADERS are record-level, not config-gated: a keyless topic omits `key` and a record
-    // with no headers omits `headers`, so they can be absent even when every metadata flag is on.
-    // Config-time validation guarantees the config-gated fields for Iceberg but not these two, so
-    // pad only KEY and HEADERS with null — the strict typed-OBJECT cast rejects a missing field but
-    // accepts a null one.
+    // Pad every absent-able field with null so the strict v2 typed-OBJECT cast does not reject the
+    // row. A record carries exactly one timestamp type (the other is absent); key and headers are
+    // absent on keyless/headerless records. putIfAbsent is safe: it leaves already-populated fields
+    // (e.g. the present timestamp) untouched.
     conformed.putIfAbsent(KEY, null);
     conformed.putIfAbsent(HEADERS, null);
+    conformed.putIfAbsent(CREATE_TIME, null);
+    conformed.putIfAbsent(LOG_APPEND_TIME, null);
     return conformed;
   }
 

--- a/src/main/java/com/snowflake/kafka/connector/records/SnowflakeSinkRecord.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/SnowflakeSinkRecord.java
@@ -389,8 +389,13 @@ public final class SnowflakeSinkRecord {
       Object value = entry.getValue();
       // The schema declares `key STRING`, but the record key can convert to a non-String (e.g. an
       // INT-keyed topic yields an Integer, a struct/Avro key a Map). Coerce to String so the
-      // strict typed-OBJECT cast accepts it.
-      if (KEY.equals(field) && value != null && !(value instanceof String)) {
+      // strict typed-OBJECT cast accepts it. Exception: a byte[] key is passed through unchanged --
+      // String.valueOf(byte[]) would produce a useless "[B@..." object id; hand the raw byte array
+      // to the SDK, which handles binary values itself.
+      if (KEY.equals(field)
+          && value != null
+          && !(value instanceof String)
+          && !(value instanceof byte[])) {
         value = String.valueOf(value);
       }
       // The schema declares `headers MAP(VARCHAR, VARCHAR)`. When structured headers are enabled

--- a/src/main/java/com/snowflake/kafka/connector/streaming/iceberg/IcebergDDLTypes.java
+++ b/src/main/java/com/snowflake/kafka/connector/streaming/iceberg/IcebergDDLTypes.java
@@ -9,6 +9,7 @@ public class IcebergDDLTypes {
           + "partition INTEGER,"
           + "key STRING,"
           + "CreateTime BIGINT,"
+          + "LogAppendTime BIGINT,"
           + "SnowflakeConnectorPushTime BIGINT,"
           + "headers MAP(VARCHAR, VARCHAR)"
           + ")";

--- a/src/main/java/com/snowflake/kafka/connector/streaming/iceberg/IcebergDDLTypes.java
+++ b/src/main/java/com/snowflake/kafka/connector/streaming/iceberg/IcebergDDLTypes.java
@@ -1,5 +1,13 @@
 package com.snowflake.kafka.connector.streaming.iceberg;
 
+import com.snowflake.kafka.connector.internal.SnowflakeErrors;
+import com.snowflake.kafka.connector.records.SnowflakeSinkRecord;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 public class IcebergDDLTypes {
 
   public static String ICEBERG_METADATA_OBJECT_SCHEMA =
@@ -13,4 +21,70 @@ public class IcebergDDLTypes {
           + "SnowflakeConnectorPushTime BIGINT,"
           + "headers MAP(VARCHAR, VARCHAR)"
           + ")";
+
+  /**
+   * Validates that the actual RECORD_METADATA structured-OBJECT sub-field set exactly matches the
+   * connector's expected set ({@link SnowflakeSinkRecord#ICEBERG_METADATA_FIELDS}).
+   *
+   * <p>For managed-Iceberg v2, the strict typed-OBJECT cast rejects any row whose map is missing a
+   * declared field. The connector only emits {@code ICEBERG_METADATA_FIELDS}, so any extra field in
+   * the table's OBJECT schema is one the connector never fills — that field would always be absent
+   * in every row, causing every row to be rejected at ingest time.
+   *
+   * <p>Throws {@code ERROR_0034} on any mismatch: missing field(s), extra field(s), or both.
+   *
+   * @param tableName table name (used in the error message only)
+   * @param actualFields field names from the table's RECORD_METADATA OBJECT (compared
+   *     case-insensitively)
+   * @throws com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException (ERROR_0034) if
+   *     any expected field is missing or any extra field is present
+   */
+  public static void validateRecordMetadataFields(String tableName, Set<String> actualFields) {
+    Set<String> actualLower =
+        actualFields.stream().map(f -> f.toLowerCase(Locale.ROOT)).collect(Collectors.toSet());
+    Set<String> expectedLower =
+        SnowflakeSinkRecord.ICEBERG_METADATA_FIELDS.stream()
+            .map(f -> f.toLowerCase(Locale.ROOT))
+            .collect(Collectors.toSet());
+
+    List<String> missing = new ArrayList<>();
+    for (String expected : SnowflakeSinkRecord.ICEBERG_METADATA_FIELDS) {
+      if (!actualLower.contains(expected.toLowerCase(Locale.ROOT))) {
+        missing.add(expected);
+      }
+    }
+    List<String> extra = new ArrayList<>();
+    for (String actual : actualFields) {
+      if (!expectedLower.contains(actual.toLowerCase(Locale.ROOT))) {
+        extra.add(actual);
+      }
+    }
+
+    if (missing.isEmpty() && extra.isEmpty()) {
+      return;
+    }
+
+    StringBuilder msg = new StringBuilder();
+    msg.append("Existing table '")
+        .append(tableName)
+        .append(
+            "' has a structured-OBJECT RECORD_METADATA column (managed-Iceberg v2) whose"
+                + " sub-field set does not exactly match the connector's expected fields.");
+    if (!missing.isEmpty()) {
+      msg.append(" Missing field(s): ").append(missing).append(".");
+    }
+    if (!extra.isEmpty()) {
+      msg.append(" Extra field(s): ")
+          .append(extra)
+          .append(
+              " — the connector never emits these, so every row's typed-OBJECT cast would"
+                  + " reject the row.");
+    }
+    msg.append(
+        " Either add the missing fields or remove the extra fields from the RECORD_METADATA"
+            + " OBJECT column definition (e.g. ALTER TABLE ... ALTER COLUMN RECORD_METADATA SET"
+            + " DATA TYPE OBJECT(...)), or re-create the table so the connector can auto-create"
+            + " it with the correct schema.");
+    throw SnowflakeErrors.ERROR_0034.getException(msg.toString());
+  }
 }

--- a/src/main/java/com/snowflake/kafka/connector/streaming/iceberg/IcebergDDLTypes.java
+++ b/src/main/java/com/snowflake/kafka/connector/streaming/iceberg/IcebergDDLTypes.java
@@ -31,12 +31,12 @@ public class IcebergDDLTypes {
    * the table's OBJECT schema is one the connector never fills — that field would always be absent
    * in every row, causing every row to be rejected at ingest time.
    *
-   * <p>Throws {@code ERROR_0034} on any mismatch: missing field(s), extra field(s), or both.
+   * <p>Throws {@code ERROR_0035} on any mismatch: missing field(s), extra field(s), or both.
    *
    * @param tableName table name (used in the error message only)
    * @param actualFields field names from the table's RECORD_METADATA OBJECT (compared
    *     case-insensitively)
-   * @throws com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException (ERROR_0034) if
+   * @throws com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException (ERROR_0035) if
    *     any expected field is missing or any extra field is present
    */
   public static void validateRecordMetadataFields(String tableName, Set<String> actualFields) {
@@ -85,6 +85,6 @@ public class IcebergDDLTypes {
             + " OBJECT column definition (e.g. ALTER TABLE ... ALTER COLUMN RECORD_METADATA SET"
             + " DATA TYPE OBJECT(...)), or re-create the table so the connector can auto-create"
             + " it with the correct schema.");
-    throw SnowflakeErrors.ERROR_0034.getException(msg.toString());
+    throw SnowflakeErrors.ERROR_0035.getException(msg.toString());
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/config/SinkTaskConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/config/SinkTaskConfigTest.java
@@ -1,6 +1,8 @@
 package com.snowflake.kafka.connector.config;
 
 import static com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.snowflake.kafka.connector.ConnectorConfigTools;
@@ -275,5 +277,67 @@ public class SinkTaskConfigTest {
     Map<String, String> raw = minimalConfig();
     raw.remove(Utils.TASK_ID);
     assertThrows(IllegalArgumentException.class, () -> SinkTaskConfig.from(raw));
+  }
+
+  @Test
+  void from_defaultsTableTypeToSnowflake() {
+    SinkTaskConfig config = SinkTaskConfig.from(minimalConfig());
+    assertThat(config.getTableType()).isEqualTo(TableType.SNOWFLAKE);
+    assertThat(config.getIcebergCreateTableOptions()).isEmpty();
+  }
+
+  @Test
+  void from_parsesIcebergTableTypeAndCreateOptions() {
+    Map<String, String> raw = minimalConfig();
+    raw.put("snowflake.autocreate.table.type", "iceberg");
+    // Iceberg + schema evolution requires server-side validation (client_side is rejected).
+    raw.put("snowflake.validation", "server_side");
+    raw.put("snowflake.iceberg.create.table.options", "EXTERNAL_VOLUME='my_vol' ICEBERG_VERSION=3");
+    SinkTaskConfig config = SinkTaskConfig.from(raw);
+    assertThat(config.getTableType()).isEqualTo(TableType.ICEBERG);
+    assertThat(config.getIcebergCreateTableOptions())
+        .isEqualTo("EXTERNAL_VOLUME='my_vol' ICEBERG_VERSION=3");
+  }
+
+  @Test
+  void from_icebergWithClientSideValidationAndSchematization_throws() {
+    Map<String, String> raw = minimalConfig();
+    raw.put("snowflake.autocreate.table.type", "iceberg");
+    raw.put("snowflake.enable.schematization", "true");
+    raw.put("snowflake.validation", "client_side");
+    assertThatThrownBy(() -> SinkTaskConfig.from(raw))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("client_side")
+        .hasMessageContaining("server_side");
+  }
+
+  @Test
+  void from_icebergWithServerSideValidationAndSchematization_ok() {
+    Map<String, String> raw = minimalConfig();
+    raw.put("snowflake.autocreate.table.type", "iceberg");
+    raw.put("snowflake.enable.schematization", "true");
+    raw.put("snowflake.validation", "server_side");
+    SinkTaskConfig config = SinkTaskConfig.from(raw);
+    assertThat(config.getTableType()).isEqualTo(TableType.ICEBERG);
+    assertThat(config.getValidation()).isEqualTo(SnowflakeValidation.SERVER_SIDE);
+  }
+
+  @Test
+  void from_createOptionsWithoutIcebergTableType_throws() {
+    Map<String, String> raw = minimalConfig();
+    raw.put("snowflake.autocreate.table.type", "snowflake");
+    raw.put("snowflake.iceberg.create.table.options", "EXTERNAL_VOLUME='my_vol'");
+    assertThatThrownBy(() -> SinkTaskConfig.from(raw))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("snowflake.iceberg.create.table.options");
+  }
+
+  @Test
+  void from_blankCreateOptionsWithoutIcebergTableType_ok() {
+    Map<String, String> raw = minimalConfig();
+    raw.put("snowflake.autocreate.table.type", "snowflake");
+    raw.put("snowflake.iceberg.create.table.options", "   ");
+    SinkTaskConfig config = SinkTaskConfig.from(raw);
+    assertThat(config.getIcebergCreateTableOptions()).isEmpty();
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/config/SinkTaskConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/config/SinkTaskConfigTest.java
@@ -340,4 +340,72 @@ public class SinkTaskConfigTest {
     SinkTaskConfig config = SinkTaskConfig.from(raw);
     assertThat(config.getIcebergCreateTableOptions()).isEmpty();
   }
+
+  // --- iceberg + metadata flag validation (Change 2) ---
+
+  @Test
+  void from_icebergWithDisabledTopicFlag_throws() {
+    Map<String, String> raw = minimalConfig();
+    raw.put(SNOWFLAKE_AUTOCREATE_TABLE_TYPE, "iceberg");
+    raw.put(SNOWFLAKE_METADATA_TOPIC, "false");
+    assertThatThrownBy(() -> SinkTaskConfig.from(raw))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(SNOWFLAKE_AUTOCREATE_TABLE_TYPE)
+        .hasMessageContaining("iceberg")
+        .hasMessageContaining(SNOWFLAKE_METADATA_TOPIC);
+  }
+
+  @Test
+  void from_icebergWithDisabledOffsetAndPartitionFlag_throws() {
+    Map<String, String> raw = minimalConfig();
+    raw.put(SNOWFLAKE_AUTOCREATE_TABLE_TYPE, "iceberg");
+    raw.put(SNOWFLAKE_METADATA_OFFSET_AND_PARTITION, "false");
+    assertThatThrownBy(() -> SinkTaskConfig.from(raw))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(SNOWFLAKE_METADATA_OFFSET_AND_PARTITION);
+  }
+
+  @Test
+  void from_icebergWithDisabledCreatetimeFlag_throws() {
+    Map<String, String> raw = minimalConfig();
+    raw.put(SNOWFLAKE_AUTOCREATE_TABLE_TYPE, "iceberg");
+    raw.put(SNOWFLAKE_METADATA_CREATETIME, "false");
+    assertThatThrownBy(() -> SinkTaskConfig.from(raw))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(SNOWFLAKE_METADATA_CREATETIME);
+  }
+
+  @Test
+  void from_icebergWithDisabledConnectorPushTimeFlag_throws() {
+    Map<String, String> raw = minimalConfig();
+    raw.put(SNOWFLAKE_AUTOCREATE_TABLE_TYPE, "iceberg");
+    raw.put(SNOWFLAKE_STREAMING_METADATA_CONNECTOR_PUSH_TIME, "false");
+    assertThatThrownBy(() -> SinkTaskConfig.from(raw))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(SNOWFLAKE_STREAMING_METADATA_CONNECTOR_PUSH_TIME);
+  }
+
+  @Test
+  void from_icebergWithAllMetadataEnabled_ok() {
+    // All metadata flags are enabled by default; explicit confirmation must still succeed.
+    Map<String, String> raw = minimalConfig();
+    raw.put(SNOWFLAKE_AUTOCREATE_TABLE_TYPE, "iceberg");
+    raw.put(SNOWFLAKE_METADATA_TOPIC, "true");
+    raw.put(SNOWFLAKE_METADATA_OFFSET_AND_PARTITION, "true");
+    raw.put(SNOWFLAKE_METADATA_CREATETIME, "true");
+    raw.put(SNOWFLAKE_STREAMING_METADATA_CONNECTOR_PUSH_TIME, "true");
+    SinkTaskConfig config = SinkTaskConfig.from(raw);
+    assertThat(config.getTableType()).isEqualTo(TableType.ICEBERG);
+  }
+
+  @Test
+  void from_snowflakeTypeWithDisabledMetadata_ok() {
+    // The metadata-mandated guard is Iceberg-only; standard Snowflake tables are unaffected.
+    Map<String, String> raw = minimalConfig();
+    raw.put(SNOWFLAKE_AUTOCREATE_TABLE_TYPE, "snowflake");
+    raw.put(SNOWFLAKE_METADATA_TOPIC, "false");
+    raw.put(SNOWFLAKE_METADATA_OFFSET_AND_PARTITION, "false");
+    SinkTaskConfig config = SinkTaskConfig.from(raw);
+    assertThat(config.getTableType()).isEqualTo(TableType.SNOWFLAKE);
+  }
 }

--- a/src/test/java/com/snowflake/kafka/connector/config/SinkTaskConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/config/SinkTaskConfigTest.java
@@ -282,7 +282,7 @@ public class SinkTaskConfigTest {
   @Test
   void from_defaultsTableTypeToSnowflake() {
     SinkTaskConfig config = SinkTaskConfig.from(minimalConfig());
-    assertThat(config.getTableType()).isEqualTo(TableType.SNOWFLAKE);
+    assertThat(config.getAutocreatedTableType()).isEqualTo(TableType.SNOWFLAKE);
     assertThat(config.getIcebergCreateTableOptions()).isEmpty();
   }
 
@@ -290,20 +290,34 @@ public class SinkTaskConfigTest {
   void from_parsesIcebergTableTypeAndCreateOptions() {
     Map<String, String> raw = minimalConfig();
     raw.put("snowflake.autocreate.table.type", "iceberg");
-    // Iceberg + schema evolution requires server-side validation (client_side is rejected).
+    // client_side is always rejected for iceberg; server_side is fine.
     raw.put("snowflake.validation", "server_side");
     raw.put("snowflake.iceberg.create.table.options", "EXTERNAL_VOLUME='my_vol' ICEBERG_VERSION=3");
     SinkTaskConfig config = SinkTaskConfig.from(raw);
-    assertThat(config.getTableType()).isEqualTo(TableType.ICEBERG);
+    assertThat(config.getAutocreatedTableType()).isEqualTo(TableType.ICEBERG);
     assertThat(config.getIcebergCreateTableOptions())
         .contains("EXTERNAL_VOLUME='my_vol' ICEBERG_VERSION=3");
   }
 
   @Test
-  void from_icebergWithClientSideValidationAndSchematization_throws() {
+  void from_icebergWithClientSideValidation_throws() {
+    // Rejected regardless of whether schematization is enabled or not.
     Map<String, String> raw = minimalConfig();
     raw.put("snowflake.autocreate.table.type", "iceberg");
     raw.put("snowflake.enable.schematization", "true");
+    raw.put("snowflake.validation", "client_side");
+    assertThatThrownBy(() -> SinkTaskConfig.from(raw))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("client_side")
+        .hasMessageContaining("server_side");
+  }
+
+  @Test
+  void from_icebergWithClientSideValidationNoSchematization_throws() {
+    // client_side is also rejected when schematization is disabled.
+    Map<String, String> raw = minimalConfig();
+    raw.put("snowflake.autocreate.table.type", "iceberg");
+    raw.put("snowflake.enable.schematization", "false");
     raw.put("snowflake.validation", "client_side");
     assertThatThrownBy(() -> SinkTaskConfig.from(raw))
         .isInstanceOf(IllegalArgumentException.class)
@@ -318,7 +332,7 @@ public class SinkTaskConfigTest {
     raw.put("snowflake.enable.schematization", "true");
     raw.put("snowflake.validation", "server_side");
     SinkTaskConfig config = SinkTaskConfig.from(raw);
-    assertThat(config.getTableType()).isEqualTo(TableType.ICEBERG);
+    assertThat(config.getAutocreatedTableType()).isEqualTo(TableType.ICEBERG);
     assertThat(config.getValidation()).isEqualTo(SnowflakeValidation.SERVER_SIDE);
   }
 
@@ -395,7 +409,7 @@ public class SinkTaskConfigTest {
     raw.put(SNOWFLAKE_METADATA_CREATETIME, "true");
     raw.put(SNOWFLAKE_STREAMING_METADATA_CONNECTOR_PUSH_TIME, "true");
     SinkTaskConfig config = SinkTaskConfig.from(raw);
-    assertThat(config.getTableType()).isEqualTo(TableType.ICEBERG);
+    assertThat(config.getAutocreatedTableType()).isEqualTo(TableType.ICEBERG);
   }
 
   @Test
@@ -406,6 +420,40 @@ public class SinkTaskConfigTest {
     raw.put(SNOWFLAKE_METADATA_TOPIC, "false");
     raw.put(SNOWFLAKE_METADATA_OFFSET_AND_PARTITION, "false");
     SinkTaskConfig config = SinkTaskConfig.from(raw);
-    assertThat(config.getTableType()).isEqualTo(TableType.SNOWFLAKE);
+    assertThat(config.getAutocreatedTableType()).isEqualTo(TableType.SNOWFLAKE);
+  }
+
+  // --- iceberg + structured headers validation ---
+
+  @Test
+  void from_icebergWithStructuredHeaders_throws() {
+    Map<String, String> raw = minimalConfig();
+    raw.put(SNOWFLAKE_AUTOCREATE_TABLE_TYPE, "iceberg");
+    raw.put(SNOWFLAKE_FEATURE_STRUCTURED_HEADERS, "true");
+    assertThatThrownBy(() -> SinkTaskConfig.from(raw))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(SNOWFLAKE_FEATURE_STRUCTURED_HEADERS)
+        .hasMessageContaining(SNOWFLAKE_AUTOCREATE_TABLE_TYPE)
+        .hasMessageContaining("iceberg");
+  }
+
+  @Test
+  void from_icebergWithStructuredHeadersDisabled_ok() {
+    // Default is false; explicit false must also succeed.
+    Map<String, String> raw = minimalConfig();
+    raw.put(SNOWFLAKE_AUTOCREATE_TABLE_TYPE, "iceberg");
+    raw.put(SNOWFLAKE_FEATURE_STRUCTURED_HEADERS, "false");
+    SinkTaskConfig config = SinkTaskConfig.from(raw);
+    assertThat(config.getAutocreatedTableType()).isEqualTo(TableType.ICEBERG);
+  }
+
+  @Test
+  void from_snowflakeTypeWithStructuredHeaders_ok() {
+    // The guard is Iceberg-only; standard Snowflake tables may use structured headers.
+    Map<String, String> raw = minimalConfig();
+    raw.put(SNOWFLAKE_AUTOCREATE_TABLE_TYPE, "snowflake");
+    raw.put(SNOWFLAKE_FEATURE_STRUCTURED_HEADERS, "true");
+    SinkTaskConfig config = SinkTaskConfig.from(raw);
+    assertThat(config.getAutocreatedTableType()).isEqualTo(TableType.SNOWFLAKE);
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/config/SinkTaskConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/config/SinkTaskConfigTest.java
@@ -423,18 +423,18 @@ public class SinkTaskConfigTest {
     assertThat(config.getAutocreatedTableType()).isEqualTo(TableType.SNOWFLAKE);
   }
 
-  // --- iceberg + structured headers validation ---
+  // --- structured headers ---
 
   @Test
-  void from_icebergWithStructuredHeaders_throws() {
+  void from_icebergWithStructuredHeaders_ok() {
+    // Structured headers + iceberg is allowed at config time. For v2 structured-OBJECT tables the
+    // header values are coerced to String in conformIcebergMetadata (schema is
+    // headers MAP(VARCHAR,VARCHAR)); v3/VARIANT keeps them nested. No config-time rejection.
     Map<String, String> raw = minimalConfig();
     raw.put(SNOWFLAKE_AUTOCREATE_TABLE_TYPE, "iceberg");
     raw.put(SNOWFLAKE_FEATURE_STRUCTURED_HEADERS, "true");
-    assertThatThrownBy(() -> SinkTaskConfig.from(raw))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining(SNOWFLAKE_FEATURE_STRUCTURED_HEADERS)
-        .hasMessageContaining(SNOWFLAKE_AUTOCREATE_TABLE_TYPE)
-        .hasMessageContaining("iceberg");
+    SinkTaskConfig config = SinkTaskConfig.from(raw);
+    assertThat(config.getAutocreatedTableType()).isEqualTo(TableType.ICEBERG);
   }
 
   @Test
@@ -449,7 +449,7 @@ public class SinkTaskConfigTest {
 
   @Test
   void from_snowflakeTypeWithStructuredHeaders_ok() {
-    // The guard is Iceberg-only; standard Snowflake tables may use structured headers.
+    // Structured headers are allowed for all table types (no config-time restriction).
     Map<String, String> raw = minimalConfig();
     raw.put(SNOWFLAKE_AUTOCREATE_TABLE_TYPE, "snowflake");
     raw.put(SNOWFLAKE_FEATURE_STRUCTURED_HEADERS, "true");

--- a/src/test/java/com/snowflake/kafka/connector/config/SinkTaskConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/config/SinkTaskConfigTest.java
@@ -296,7 +296,7 @@ public class SinkTaskConfigTest {
     SinkTaskConfig config = SinkTaskConfig.from(raw);
     assertThat(config.getTableType()).isEqualTo(TableType.ICEBERG);
     assertThat(config.getIcebergCreateTableOptions())
-        .isEqualTo("EXTERNAL_VOLUME='my_vol' ICEBERG_VERSION=3");
+        .contains("EXTERNAL_VOLUME='my_vol' ICEBERG_VERSION=3");
   }
 
   @Test

--- a/src/test/java/com/snowflake/kafka/connector/config/SinkTaskConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/config/SinkTaskConfigTest.java
@@ -400,6 +400,21 @@ public class SinkTaskConfigTest {
   }
 
   @Test
+  void from_icebergWithDisabledAllMetadataFlag_throws() {
+    // The master snowflake.metadata.createSnowflakeMetadata flag gates whether RECORD_METADATA is
+    // attached at all; disabling it produces no metadata, which the strict typed-OBJECT cast would
+    // reject. It must be caught by the same iceberg guard as the per-field flags.
+    Map<String, String> raw = minimalConfig();
+    raw.put(SNOWFLAKE_AUTOCREATE_TABLE_TYPE, "iceberg");
+    raw.put(SNOWFLAKE_METADATA_ALL, "false");
+    assertThatThrownBy(() -> SinkTaskConfig.from(raw))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(SNOWFLAKE_AUTOCREATE_TABLE_TYPE)
+        .hasMessageContaining("iceberg")
+        .hasMessageContaining(SNOWFLAKE_METADATA_ALL);
+  }
+
+  @Test
   void from_icebergWithAllMetadataEnabled_ok() {
     // All metadata flags are enabled by default; explicit confirmation must still succeed.
     Map<String, String> raw = minimalConfig();

--- a/src/test/java/com/snowflake/kafka/connector/config/SinkTaskConfigTestBuilder.java
+++ b/src/test/java/com/snowflake/kafka/connector/config/SinkTaskConfigTestBuilder.java
@@ -65,8 +65,6 @@ public final class SinkTaskConfigTestBuilder {
         // production builder() stays free of test-only defaults.
         .tableType(
             TableType.fromConfig(KafkaConnectorConfigParams.SNOWFLAKE_AUTOCREATE_TABLE_TYPE_DEFAULT)
-                .orElse(TableType.SNOWFLAKE))
-        .icebergCreateTableOptions(
-            KafkaConnectorConfigParams.SNOWFLAKE_ICEBERG_CREATE_TABLE_OPTIONS_DEFAULT);
+                .orElse(TableType.SNOWFLAKE));
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/config/SinkTaskConfigTestBuilder.java
+++ b/src/test/java/com/snowflake/kafka/connector/config/SinkTaskConfigTestBuilder.java
@@ -59,6 +59,14 @@ public final class SinkTaskConfigTestBuilder {
         .prometheusMetricsEnabled(KafkaConnectorConfigParams.PROMETHEUS_ENABLE_DEFAULT)
         .validationErrorTableNameEnabled(
             KafkaConnectorConfigParams.SNOWFLAKE_FEATURE_VALIDATION_ERROR_TABLE_NAME_DEFAULT)
-        .normalizeTimeEnabled(KafkaConnectorConfigParams.SNOWFLAKE_FEATURE_NORMALIZE_TIME_DEFAULT);
+        .normalizeTimeEnabled(KafkaConnectorConfigParams.SNOWFLAKE_FEATURE_NORMALIZE_TIME_DEFAULT)
+        // Iceberg auto-creation defaults: SNOWFLAKE table type and empty create options.
+        // These were previously defaulted in SinkTaskConfig.builder(); they now live here so
+        // production builder() stays free of test-only defaults.
+        .tableType(
+            TableType.fromConfig(KafkaConnectorConfigParams.SNOWFLAKE_AUTOCREATE_TABLE_TYPE_DEFAULT)
+                .orElse(TableType.SNOWFLAKE))
+        .icebergCreateTableOptions(
+            KafkaConnectorConfigParams.SNOWFLAKE_ICEBERG_CREATE_TABLE_OPTIONS_DEFAULT);
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/config/SinkTaskConfigTestBuilder.java
+++ b/src/test/java/com/snowflake/kafka/connector/config/SinkTaskConfigTestBuilder.java
@@ -60,6 +60,8 @@ public final class SinkTaskConfigTestBuilder {
         .validationErrorTableNameEnabled(
             KafkaConnectorConfigParams.SNOWFLAKE_FEATURE_VALIDATION_ERROR_TABLE_NAME_DEFAULT)
         .normalizeTimeEnabled(KafkaConnectorConfigParams.SNOWFLAKE_FEATURE_NORMALIZE_TIME_DEFAULT)
+        .structuredRecordMetadataEnabled(
+            KafkaConnectorConfigParams.SNOWFLAKE_FEATURE_STRUCTURED_RECORD_METADATA_DEFAULT)
         // Iceberg auto-creation defaults: SNOWFLAKE table type and empty create options.
         // These were previously defaulted in SinkTaskConfig.builder(); they now live here so
         // production builder() stays free of test-only defaults.

--- a/src/test/java/com/snowflake/kafka/connector/config/SinkTaskConfigTestBuilder.java
+++ b/src/test/java/com/snowflake/kafka/connector/config/SinkTaskConfigTestBuilder.java
@@ -63,8 +63,6 @@ public final class SinkTaskConfigTestBuilder {
         // Iceberg auto-creation defaults: SNOWFLAKE table type and empty create options.
         // These were previously defaulted in SinkTaskConfig.builder(); they now live here so
         // production builder() stays free of test-only defaults.
-        .tableType(
-            TableType.fromConfig(KafkaConnectorConfigParams.SNOWFLAKE_AUTOCREATE_TABLE_TYPE_DEFAULT)
-                .orElse(TableType.SNOWFLAKE));
+        .autocreatedTableType(KafkaConnectorConfigParams.SNOWFLAKE_AUTOCREATE_TABLE_TYPE_DEFAULT);
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/config/TableTypeTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/config/TableTypeTest.java
@@ -1,0 +1,28 @@
+package com.snowflake.kafka.connector.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+public class TableTypeTest {
+  @Test
+  void fromConfig_parsesAllValuesCaseInsensitively() {
+    assertThat(TableType.fromConfig("snowflake")).isEqualTo(TableType.SNOWFLAKE);
+    assertThat(TableType.fromConfig("ICEBERG")).isEqualTo(TableType.ICEBERG);
+    assertThat(TableType.fromConfig("None")).isEqualTo(TableType.NONE);
+  }
+
+  @Test
+  void fromConfig_defaultsToSnowflakeOnNullOrEmpty() {
+    assertThat(TableType.fromConfig(null)).isEqualTo(TableType.SNOWFLAKE);
+    assertThat(TableType.fromConfig("")).isEqualTo(TableType.SNOWFLAKE);
+  }
+
+  @Test
+  void fromConfig_rejectsUnknownValue() {
+    assertThatThrownBy(() -> TableType.fromConfig("delta"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("delta");
+  }
+}

--- a/src/test/java/com/snowflake/kafka/connector/config/TableTypeTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/config/TableTypeTest.java
@@ -3,20 +3,30 @@ package com.snowflake.kafka.connector.config;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 public class TableTypeTest {
   @Test
   void fromConfig_parsesAllValuesCaseInsensitively() {
-    assertThat(TableType.fromConfig("snowflake")).isEqualTo(TableType.SNOWFLAKE);
-    assertThat(TableType.fromConfig("ICEBERG")).isEqualTo(TableType.ICEBERG);
-    assertThat(TableType.fromConfig("None")).isEqualTo(TableType.NONE);
+    assertThat(TableType.fromConfig("snowflake")).isEqualTo(Optional.of(TableType.SNOWFLAKE));
+    assertThat(TableType.fromConfig("ICEBERG")).isEqualTo(Optional.of(TableType.ICEBERG));
+    assertThat(TableType.fromConfig("None")).isEqualTo(Optional.of(TableType.NONE));
   }
 
   @Test
-  void fromConfig_defaultsToSnowflakeOnNullOrEmpty() {
-    assertThat(TableType.fromConfig(null)).isEqualTo(TableType.SNOWFLAKE);
-    assertThat(TableType.fromConfig("")).isEqualTo(TableType.SNOWFLAKE);
+  void fromConfig_returnsEmptyOnNullOrEmpty() {
+    assertThat(TableType.fromConfig(null)).isEmpty();
+    assertThat(TableType.fromConfig("")).isEmpty();
+  }
+
+  @Test
+  void fromConfig_orElseSnowflake_givesSnowflakeDefault() {
+    assertThat(TableType.fromConfig(null).orElse(TableType.SNOWFLAKE))
+        .isEqualTo(TableType.SNOWFLAKE);
+    assertThat(TableType.fromConfig("").orElse(TableType.SNOWFLAKE)).isEqualTo(TableType.SNOWFLAKE);
+    assertThat(TableType.fromConfig("iceberg").orElse(TableType.SNOWFLAKE))
+        .isEqualTo(TableType.ICEBERG);
   }
 
   @Test

--- a/src/test/java/com/snowflake/kafka/connector/internal/ConnectionServiceIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/ConnectionServiceIT.java
@@ -10,6 +10,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Map;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -159,5 +160,27 @@ class ConnectionServiceIT {
     // cleanup
     TestUtils.dropTable(testTable);
     service.close();
+  }
+
+  /**
+   * Verifies getStructuredObjectFieldNames against a real backend: a table with two distinct
+   * structured OBJECT columns. INFORMATION_SCHEMA.FIELDS has no column-name column, so the query
+   * must join FIELDS.ROW_IDENTIFIER = COLUMNS.DTD_IDENTIFIER to return only the requested column's
+   * sub-fields -- not the sibling OBJECT column's fields. A plain OBJECT_NAME (table) filter would
+   * incorrectly return the union of both columns' fields.
+   */
+  @Test
+  void testGetStructuredObjectFieldNames_scopesToRequestedColumn() {
+    TestUtils.executeQuery(
+        "create or replace table \""
+            + tableName
+            + "\" ("
+            + "OBJ_A OBJECT(field_a1 NUMBER, field_a2 STRING), "
+            + "OBJ_B OBJECT(field_b1 NUMBER, field_b2 STRING, field_b3 BOOLEAN))");
+
+    Assertions.assertThat(conn.getStructuredObjectFieldNames(tableName, "OBJ_A"))
+        .containsExactly("field_a1", "field_a2");
+    Assertions.assertThat(conn.getStructuredObjectFieldNames(tableName, "OBJ_B"))
+        .containsExactly("field_b1", "field_b2", "field_b3");
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/internal/StandardSnowflakeConnectionServiceDdlTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/StandardSnowflakeConnectionServiceDdlTest.java
@@ -261,6 +261,41 @@ public class StandardSnowflakeConnectionServiceDdlTest {
   }
 
   // ---------------------------------------------------------------------------
+  // getStructuredObjectFieldNames tests
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testGetStructuredObjectFieldNames_returnsFieldNames() throws SQLException {
+    PreparedStatement infoSchemaStmt = mock(PreparedStatement.class);
+    ResultSet infoSchemaRs = mock(ResultSet.class);
+    when(infoSchemaRs.next()).thenReturn(true, true, false);
+    when(infoSchemaRs.getString("FIELD_NAME")).thenReturn("OFFSET", "TOPIC");
+    when(infoSchemaStmt.executeQuery()).thenReturn(infoSchemaRs);
+
+    // Override so the SELECT query also routes to infoSchemaStmt.
+    when(mockJdbcConn.prepareStatement(
+            argThat(s -> s != null && s.startsWith("SELECT FIELD_NAME"))))
+        .thenReturn(infoSchemaStmt);
+
+    List<String> fields = service.getStructuredObjectFieldNames("MY_TABLE", "RECORD_METADATA");
+
+    assertThat(fields).containsExactly("OFFSET", "TOPIC");
+    verify(infoSchemaStmt).setString(1, "MY_TABLE");
+    verify(infoSchemaStmt).setString(2, "RECORD_METADATA");
+  }
+
+  @Test
+  public void testGetStructuredObjectFieldNames_sqlException_returnsEmpty() throws SQLException {
+    when(mockJdbcConn.prepareStatement(
+            argThat(s -> s != null && s.startsWith("SELECT FIELD_NAME"))))
+        .thenThrow(new SQLException("connection refused"));
+
+    List<String> fields = service.getStructuredObjectFieldNames("MY_TABLE", "RECORD_METADATA");
+
+    assertThat(fields).isEmpty();
+  }
+
+  // ---------------------------------------------------------------------------
   // shouldEvolveSchema tests
   // ---------------------------------------------------------------------------
 

--- a/src/test/java/com/snowflake/kafka/connector/internal/StandardSnowflakeConnectionServiceDdlTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/StandardSnowflakeConnectionServiceDdlTest.java
@@ -474,4 +474,101 @@ public class StandardSnowflakeConnectionServiceDdlTest {
     StandardSnowflakeConnectionService svc = createServiceWithMockConnection(conn);
     assertFalse(svc.hasErrorLoggingEnabled("my_table"));
   }
+
+  // ---- createIcebergTableWithOnlyMetadataColumn: VARIANT-first with OBJECT fallback ----
+
+  @Test
+  public void createIcebergTable_prefersVariantMetadata() throws Exception {
+    Connection conn = mock(Connection.class);
+    when(conn.isClosed()).thenReturn(false);
+    PreparedStatement stmt = mock(PreparedStatement.class);
+    when(stmt.execute()).thenReturn(false);
+    when(conn.prepareStatement(anyString())).thenReturn(stmt);
+
+    StandardSnowflakeConnectionService svc = createServiceWithMockConnection(conn);
+    svc.createIcebergTableWithOnlyMetadataColumn("t", "EXTERNAL_VOLUME='v'");
+
+    ArgumentCaptor<String> sql = ArgumentCaptor.forClass(String.class);
+    verify(conn, times(1)).prepareStatement(sql.capture()); // only the VARIANT attempt
+    assertThat(sql.getValue().toLowerCase()).contains("record_metadata variant");
+    assertThat(sql.getValue()).doesNotContain("OBJECT(");
+  }
+
+  @Test
+  public void createIcebergTable_fallsBackToObjectOnVariantUnsupported() throws Exception {
+    Connection conn = mock(Connection.class);
+    when(conn.isClosed()).thenReturn(false);
+    PreparedStatement stmt = mock(PreparedStatement.class);
+    // First attempt (VARIANT) rejected with errno 91386; second attempt (OBJECT) succeeds.
+    when(stmt.execute())
+        .thenThrow(
+            new SQLException("Unsupported data type 'VARIANT' for iceberg tables.", "42601", 91386))
+        .thenReturn(false);
+    when(conn.prepareStatement(anyString())).thenReturn(stmt);
+
+    StandardSnowflakeConnectionService svc = createServiceWithMockConnection(conn);
+    svc.createIcebergTableWithOnlyMetadataColumn("t", "");
+
+    ArgumentCaptor<String> sql = ArgumentCaptor.forClass(String.class);
+    verify(conn, times(2)).prepareStatement(sql.capture());
+    assertThat(sql.getAllValues().get(0).toLowerCase()).contains("record_metadata variant");
+    assertThat(sql.getAllValues().get(1)).contains("OBJECT(offset"); // structured OBJECT schema
+  }
+
+  @Test
+  public void createIcebergTable_rethrowsNon91386WithoutFallback() throws Exception {
+    Connection conn = mock(Connection.class);
+    when(conn.isClosed()).thenReturn(false);
+    PreparedStatement stmt = mock(PreparedStatement.class);
+    // e.g. missing external volume (not the VARIANT-unsupported errno) -> must NOT fall back.
+    when(stmt.execute())
+        .thenThrow(new SQLException("External volume 'v' does not exist", "42601", 91361));
+    when(conn.prepareStatement(anyString())).thenReturn(stmt);
+
+    StandardSnowflakeConnectionService svc = createServiceWithMockConnection(conn);
+    assertThrows(
+        RuntimeException.class, () -> svc.createIcebergTableWithOnlyMetadataColumn("t", ""));
+    verify(conn, times(1)).prepareStatement(anyString()); // no OBJECT fallback attempt
+  }
+
+  // ---- isRecordMetadataStructuredObject ----
+
+  @Test
+  public void isRecordMetadataStructuredObject_objectColumn_true() throws Exception {
+    assertTrue(
+        serviceForDescribe(
+                "RECORD_METADATA", "OBJECT(offset NUMBER(19,0), topic VARCHAR(16777216))")
+            .isRecordMetadataStructuredObject("t"));
+  }
+
+  @Test
+  public void isRecordMetadataStructuredObject_variantColumn_false() throws Exception {
+    assertFalse(
+        serviceForDescribe("RECORD_METADATA", "VARIANT").isRecordMetadataStructuredObject("t"));
+  }
+
+  @Test
+  public void isRecordMetadataStructuredObject_noMetadataColumn_false() throws Exception {
+    assertFalse(
+        serviceForDescribe("SOME_COL", "NUMBER(38,0)").isRecordMetadataStructuredObject("t"));
+  }
+
+  /** Builds a service whose DESC TABLE returns a single column with the given name/type. */
+  private static StandardSnowflakeConnectionService serviceForDescribe(
+      String columnName, String columnType) throws Exception {
+    Connection conn = mock(Connection.class);
+    when(conn.isClosed()).thenReturn(false);
+    PreparedStatement stmt = mock(PreparedStatement.class);
+    ResultSet rs = mock(ResultSet.class);
+    when(rs.next()).thenReturn(true).thenReturn(false);
+    when(rs.getString("name")).thenReturn(columnName);
+    when(rs.getString("type")).thenReturn(columnType);
+    when(rs.getString("comment")).thenReturn(null);
+    when(rs.getString("null?")).thenReturn("Y");
+    when(rs.getString("default")).thenReturn(null);
+    when(rs.getString("autoincrement")).thenReturn(null);
+    when(stmt.executeQuery()).thenReturn(rs);
+    when(conn.prepareStatement(anyString())).thenReturn(stmt);
+    return createServiceWithMockConnection(conn);
+  }
 }

--- a/src/test/java/com/snowflake/kafka/connector/internal/StandardSnowflakeConnectionServiceDdlTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/StandardSnowflakeConnectionServiceDdlTest.java
@@ -295,6 +295,42 @@ public class StandardSnowflakeConnectionServiceDdlTest {
     assertThat(fields).isEmpty();
   }
 
+  @Test
+  public void testGetStructuredObjectFieldNames_matchesIdentifierCaseVerbatim()
+      throws SQLException {
+    PreparedStatement infoSchemaStmt = mock(PreparedStatement.class);
+    ResultSet infoSchemaRs = mock(ResultSet.class);
+    when(infoSchemaRs.next()).thenReturn(true, false);
+    when(infoSchemaRs.getString("FIELD_NAME")).thenReturn("OFFSET");
+    when(infoSchemaStmt.executeQuery()).thenReturn(infoSchemaRs);
+
+    ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+    when(mockJdbcConn.prepareStatement(
+            argThat(s -> s != null && s.startsWith("SELECT FIELD_NAME"))))
+        .thenReturn(infoSchemaStmt);
+
+    // A non-uppercase table name -- the common case for pass-through topics and topic2table.map
+    // values. The pre-fix query wrapped the bind params in UPPER(?), which never matched the
+    // case-preserving (quoted) identifier stored in INFORMATION_SCHEMA and silently returned no
+    // fields.
+    List<String> fields =
+        service.getStructuredObjectFieldNames("my_lower_table", "RECORD_METADATA");
+
+    assertThat(fields).containsExactly("OFFSET");
+
+    verify(mockJdbcConn, atLeastOnce()).prepareStatement(sqlCaptor.capture());
+    String infoSchemaSql =
+        sqlCaptor.getAllValues().stream()
+            .filter(s -> s != null && s.startsWith("SELECT FIELD_NAME"))
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("SELECT FIELD_NAME query was not executed"));
+    assertThat(infoSchemaSql).doesNotContain("UPPER(");
+    assertThat(infoSchemaSql).contains("TABLE_NAME = ?");
+    // The identifier is passed through verbatim (not uppercased).
+    verify(infoSchemaStmt).setString(1, "my_lower_table");
+    verify(infoSchemaStmt).setString(2, "RECORD_METADATA");
+  }
+
   // ---------------------------------------------------------------------------
   // shouldEvolveSchema tests
   // ---------------------------------------------------------------------------

--- a/src/test/java/com/snowflake/kafka/connector/internal/StandardSnowflakeConnectionServiceDdlTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/StandardSnowflakeConnectionServiceDdlTest.java
@@ -1,5 +1,6 @@
 package com.snowflake.kafka.connector.internal;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -374,25 +375,103 @@ public class StandardSnowflakeConnectionServiceDdlTest {
   }
 
   @Test
-  public void testCreateTableWithOnlyMetadataColumn_icebergTableAlreadyExists_doesNotThrow()
-      throws SQLException {
-    // Snowflake rejects CREATE TABLE IF NOT EXISTS when the name belongs to an ICEBERG TABLE.
-    // The method should swallow the error and return normally rather than propagating it.
-    SQLException icebergConflict =
-        new SQLException(
-            "SQL compilation error:\nObject 'MY_TABLE' already exists as ICEBERG_TABLE");
-    when(mockAlterStmt.execute()).thenThrow(icebergConflict);
-
-    assertDoesNotThrow(() -> service.createTableWithOnlyMetadataColumn("MY_TABLE"));
-  }
-
-  @Test
   public void testCreateTableWithOnlyMetadataColumn_otherSqlError_throws() throws SQLException {
     SQLException otherError = new SQLException("Some other SQL error");
     when(mockAlterStmt.execute()).thenThrow(otherError);
 
     assertThrows(
-        com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException.class,
+        SnowflakeKafkaConnectorException.class,
         () -> service.createTableWithOnlyMetadataColumn("MY_TABLE"));
+  }
+
+  @Test
+  public void createIcebergTable_noOptions_generatesMandatorySkeleton() throws SQLException {
+    // createIcebergTable issues exactly one prepareStatement (no SHOW probe).
+    PreparedStatement createStmt = mock(PreparedStatement.class);
+    when(mockJdbcConn.prepareStatement(anyString())).thenReturn(createStmt);
+
+    service.createIcebergTableWithOnlyMetadataColumn("test_table", "");
+
+    ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+    verify(mockJdbcConn).prepareStatement(sqlCaptor.capture());
+    String sql = sqlCaptor.getValue().toLowerCase();
+
+    assertThat(sql).startsWith("create iceberg table if not exists identifier(?)");
+    assertThat(sql).contains("record_metadata");
+    // connector-mandatory clauses are always present
+    assertThat(sql).contains("catalog = 'snowflake'");
+    assertThat(sql).contains("enable_schema_evolution = true");
+    assertThat(sql).contains("error_logging = true");
+    // no operator options -> nothing extra spliced in
+    assertThat(sql).doesNotContain("iceberg_version");
+    assertThat(sql).doesNotContain("external_volume");
+    assertThat(sql).doesNotContain("cluster by");
+    verify(createStmt).setString(1, "\"test_table\"");
+    verify(createStmt).execute();
+  }
+
+  @Test
+  public void createIcebergTable_splicesOptionsAfterColumnList() throws SQLException {
+    PreparedStatement createStmt = mock(PreparedStatement.class);
+    when(mockJdbcConn.prepareStatement(anyString())).thenReturn(createStmt);
+
+    service.createIcebergTableWithOnlyMetadataColumn(
+        "test_table", "EXTERNAL_VOLUME='my_vol' ICEBERG_VERSION=3 CLUSTER BY (id)");
+
+    ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+    verify(mockJdbcConn).prepareStatement(sqlCaptor.capture());
+    String sql = sqlCaptor.getValue();
+
+    // options land right after the column list, before the connector-mandatory clauses so
+    // positional clauses like CLUSTER BY are valid.
+    assertThat(sql)
+        .contains(
+            ") EXTERNAL_VOLUME='my_vol' ICEBERG_VERSION=3 CLUSTER BY (id) catalog = 'SNOWFLAKE'");
+    assertThat(sql.toLowerCase()).contains("enable_schema_evolution = true");
+    assertThat(sql.toLowerCase()).contains("error_logging = true");
+  }
+
+  @Test
+  public void createIcebergTable_blankOptions_treatedAsNone() throws SQLException {
+    PreparedStatement createStmt = mock(PreparedStatement.class);
+    when(mockJdbcConn.prepareStatement(anyString())).thenReturn(createStmt);
+
+    service.createIcebergTableWithOnlyMetadataColumn("test_table", "   ");
+
+    ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+    verify(mockJdbcConn).prepareStatement(sqlCaptor.capture());
+    // collapses the column-list paren straight into the catalog clause (single space)
+    assertThat(sqlCaptor.getValue()).contains(") catalog = 'SNOWFLAKE'");
+  }
+
+  @Test
+  public void testHasErrorLoggingEnabled_onMeansEnabled() throws Exception {
+    // SHOW TABLES renders error_logging as ON/OFF, not Y/N.
+    Connection conn = mock(Connection.class);
+    when(conn.isClosed()).thenReturn(false);
+    PreparedStatement showStmt = mock(PreparedStatement.class);
+    ResultSet rs = mock(ResultSet.class);
+    when(rs.next()).thenReturn(true);
+    when(rs.getString("error_logging")).thenReturn("ON");
+    when(showStmt.executeQuery()).thenReturn(rs);
+    when(conn.prepareStatement("show tables like ? limit 1")).thenReturn(showStmt);
+
+    StandardSnowflakeConnectionService svc = createServiceWithMockConnection(conn);
+    assertTrue(svc.hasErrorLoggingEnabled("my_table"));
+  }
+
+  @Test
+  public void testHasErrorLoggingEnabled_offMeansDisabled() throws Exception {
+    Connection conn = mock(Connection.class);
+    when(conn.isClosed()).thenReturn(false);
+    PreparedStatement showStmt = mock(PreparedStatement.class);
+    ResultSet rs = mock(ResultSet.class);
+    when(rs.next()).thenReturn(true);
+    when(rs.getString("error_logging")).thenReturn("OFF");
+    when(showStmt.executeQuery()).thenReturn(rs);
+    when(conn.prepareStatement("show tables like ? limit 1")).thenReturn(showStmt);
+
+    StandardSnowflakeConnectionService svc = createServiceWithMockConnection(conn);
+    assertFalse(svc.hasErrorLoggingEnabled("my_table"));
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/internal/StandardSnowflakeConnectionServiceDdlTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/StandardSnowflakeConnectionServiceDdlTest.java
@@ -274,7 +274,7 @@ public class StandardSnowflakeConnectionServiceDdlTest {
 
     // Override so the SELECT query also routes to infoSchemaStmt.
     when(mockJdbcConn.prepareStatement(
-            argThat(s -> s != null && s.startsWith("SELECT FIELD_NAME"))))
+            argThat(s -> s != null && s.startsWith("SELECT f.FIELD_NAME"))))
         .thenReturn(infoSchemaStmt);
 
     List<String> fields = service.getStructuredObjectFieldNames("MY_TABLE", "RECORD_METADATA");
@@ -287,7 +287,7 @@ public class StandardSnowflakeConnectionServiceDdlTest {
   @Test
   public void testGetStructuredObjectFieldNames_sqlException_returnsEmpty() throws SQLException {
     when(mockJdbcConn.prepareStatement(
-            argThat(s -> s != null && s.startsWith("SELECT FIELD_NAME"))))
+            argThat(s -> s != null && s.startsWith("SELECT f.FIELD_NAME"))))
         .thenThrow(new SQLException("connection refused"));
 
     List<String> fields = service.getStructuredObjectFieldNames("MY_TABLE", "RECORD_METADATA");
@@ -306,7 +306,7 @@ public class StandardSnowflakeConnectionServiceDdlTest {
 
     ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
     when(mockJdbcConn.prepareStatement(
-            argThat(s -> s != null && s.startsWith("SELECT FIELD_NAME"))))
+            argThat(s -> s != null && s.startsWith("SELECT f.FIELD_NAME"))))
         .thenReturn(infoSchemaStmt);
 
     // A non-uppercase table name -- the common case for pass-through topics and topic2table.map
@@ -321,11 +321,15 @@ public class StandardSnowflakeConnectionServiceDdlTest {
     verify(mockJdbcConn, atLeastOnce()).prepareStatement(sqlCaptor.capture());
     String infoSchemaSql =
         sqlCaptor.getAllValues().stream()
-            .filter(s -> s != null && s.startsWith("SELECT FIELD_NAME"))
+            .filter(s -> s != null && s.startsWith("SELECT f.FIELD_NAME"))
             .findFirst()
-            .orElseThrow(() -> new AssertionError("SELECT FIELD_NAME query was not executed"));
+            .orElseThrow(() -> new AssertionError("SELECT f.FIELD_NAME query was not executed"));
     assertThat(infoSchemaSql).doesNotContain("UPPER(");
     assertThat(infoSchemaSql).contains("TABLE_NAME = ?");
+    // FIELDS has no column identifier, so the query joins to INFORMATION_SCHEMA.COLUMNS on
+    // ROW_IDENTIFIER = DTD_IDENTIFIER to scope to the target column.
+    assertThat(infoSchemaSql).contains("INFORMATION_SCHEMA.COLUMNS");
+    assertThat(infoSchemaSql).contains("f.ROW_IDENTIFIER = c.DTD_IDENTIFIER");
     // The identifier is passed through verbatim (not uppercased).
     verify(infoSchemaStmt).setString(1, "my_lower_table");
     verify(infoSchemaStmt).setString(2, "RECORD_METADATA");

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2RecoveryOffsetTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2RecoveryOffsetTest.java
@@ -206,6 +206,7 @@ class SnowflakeSinkServiceV2RecoveryOffsetTest {
             mockErrorHandler,
             TaskMetrics.noop(),
             false,
+            false,
             mock(SnowflakeConnectionService.class),
             Optional.empty());
 

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2RecoveryOffsetTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2RecoveryOffsetTest.java
@@ -206,7 +206,7 @@ class SnowflakeSinkServiceV2RecoveryOffsetTest {
             mockErrorHandler,
             TaskMetrics.noop(),
             false,
-            null,
+            mock(SnowflakeConnectionService.class),
             Optional.empty());
 
     realChannel.awaitInitialization();

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2Test.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2Test.java
@@ -554,7 +554,7 @@ class SnowflakeSinkServiceV2Test {
         .connectorName(CONNECTOR_NAME)
         .taskId("0")
         .tableType(type)
-        .icebergCreateTableOptions(createTableOptions)
+        .icebergCreateTableOptions(Optional.ofNullable(createTableOptions))
         .build();
   }
 
@@ -662,7 +662,7 @@ class SnowflakeSinkServiceV2Test {
             .taskId("0")
             .tableType(TableType.ICEBERG)
             .enableSchematization(false)
-            .icebergCreateTableOptions("EXTERNAL_VOLUME='v'")
+            .icebergCreateTableOptions(Optional.of("EXTERNAL_VOLUME='v'"))
             .build();
     SnowflakeSinkServiceV2 svc = newService(conn, config);
 
@@ -682,7 +682,7 @@ class SnowflakeSinkServiceV2Test {
             .taskId("0")
             .tableType(TableType.ICEBERG)
             .enableSchematization(false)
-            .icebergCreateTableOptions("ICEBERG_VERSION=3")
+            .icebergCreateTableOptions(Optional.of("ICEBERG_VERSION=3"))
             .build();
     SnowflakeSinkServiceV2 svc = newService(conn, config);
 

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2Test.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2Test.java
@@ -755,6 +755,25 @@ class SnowflakeSinkServiceV2Test {
   }
 
   @Test
+  void validateStructuredObjectMetadataSchema_emptyFields_throwsError0034() {
+    // RECORD_METADATA is a structured OBJECT but INFORMATION_SCHEMA returned no sub-fields (e.g.
+    // wrong database/schema, or a lookup error) → fail fast rather than silently proceed and route
+    // every row to the error table at ingest.
+    SnowflakeConnectionService conn = mock(SnowflakeConnectionService.class);
+    when(conn.tableExist("t1")).thenReturn(true);
+    when(conn.isRecordMetadataStructuredObject("t1")).thenReturn(true);
+    when(conn.getStructuredObjectFieldNames("t1", "RECORD_METADATA"))
+        .thenReturn(Collections.emptyList());
+
+    SnowflakeSinkServiceV2 svc = newService(conn, cfg(TableType.ICEBERG, ""));
+
+    assertThatThrownBy(() -> svc.createTableIfNotExists("t1"))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("no sub-fields")
+        .hasMessageContaining("0034");
+  }
+
+  @Test
   void validateStructuredObjectMetadataSchema_variantColumn_noValidation_noThrow() {
     // isRecordMetadataStructuredObject=false (VARIANT or FDN table) → no field fetch, no throw.
     SnowflakeConnectionService conn = mock(SnowflakeConnectionService.class);

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2Test.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2Test.java
@@ -541,6 +541,23 @@ class SnowflakeSinkServiceV2Test {
   }
 
   @Test
+  void createTableIfNotExists_snowflakeType_createdTableIsIceberg_warnsButProceeds() {
+    // A bare CREATE TABLE can come out Iceberg if the schema default is
+    // DEFAULT_METADATA_WRITE_FORMAT=ICEBERG. That is a benign surprise (the connector ingests into
+    // the Iceberg table), so we create, then check and warn -- we do NOT fail.
+    SnowflakeConnectionService conn = mock(SnowflakeConnectionService.class);
+    when(conn.tableExist("t1")).thenReturn(false);
+    when(conn.isIcebergTable("t1")).thenReturn(true); // created table came out Iceberg
+    SnowflakeSinkServiceV2 svc = newService(conn, cfg(TableType.SNOWFLAKE, ""));
+
+    svc.createTableIfNotExists("t1"); // must not throw
+
+    verify(conn).createTableWithOnlyMetadataColumn("t1");
+    verify(conn).isIcebergTable("t1");
+    verify(conn, never()).createIcebergTableWithOnlyMetadataColumn(anyString(), anyString());
+  }
+
+  @Test
   void createTableIfNotExists_noneType_missingTable_throws() {
     SnowflakeConnectionService conn = mock(SnowflakeConnectionService.class);
     when(conn.tableExist("t1")).thenReturn(false);

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2Test.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2Test.java
@@ -694,6 +694,29 @@ class SnowflakeSinkServiceV2Test {
     verify(conn).createIcebergTableWithOnlyMetadataColumn("t1", "ICEBERG_VERSION=3");
   }
 
+  @Test
+  void createTableIfNotExists_icebergType_nonSchematized_withQuotedV3_creates() {
+    // Snowflake accepts a quoted version (ICEBERG_VERSION = '3'); it must be recognized as v3 and
+    // not spuriously rejected.
+    SnowflakeConnectionService conn = mock(SnowflakeConnectionService.class);
+    when(conn.tableExist("t1")).thenReturn(false);
+    SinkTaskConfig config =
+        SinkTaskConfigTestBuilder.builder()
+            .connectorName(CONNECTOR_NAME)
+            .taskId("0")
+            .autocreatedTableType(TableType.ICEBERG)
+            .enableSchematization(false)
+            .icebergCreateTableOptions(Optional.of("EXTERNAL_VOLUME='v' ICEBERG_VERSION = '3'"))
+            .build();
+    SnowflakeSinkServiceV2 svc = newService(conn, config);
+
+    svc.createTableIfNotExists("t1");
+
+    verify(conn)
+        .createIcebergTableWithOnlyMetadataColumn(
+            "t1", "EXTERNAL_VOLUME='v' ICEBERG_VERSION = '3'");
+  }
+
   // --- validateStructuredObjectMetadataSchema ---
 
   @Test

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2Test.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2Test.java
@@ -1,6 +1,5 @@
 package com.snowflake.kafka.connector.internal.streaming;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -19,7 +18,6 @@ import com.snowflake.kafka.connector.config.SinkTaskConfig;
 import com.snowflake.kafka.connector.config.SinkTaskConfigTestBuilder;
 import com.snowflake.kafka.connector.config.SnowflakeValidation;
 import com.snowflake.kafka.connector.config.TableType;
-import com.snowflake.kafka.connector.internal.DescribeTableRow;
 import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
 import com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException;
 import com.snowflake.kafka.connector.internal.metrics.TaskMetrics;
@@ -29,8 +27,8 @@ import com.snowflake.kafka.connector.internal.streaming.v2.service.BatchOffsetFe
 import com.snowflake.kafka.connector.internal.streaming.v2.service.PartitionChannelManager;
 import com.snowflake.kafka.connector.internal.streaming.v2.service.ThreadPools;
 import com.snowflake.kafka.connector.records.SnowflakeSinkRecord;
-import com.snowflake.kafka.connector.streaming.iceberg.IcebergDDLTypes;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -40,6 +38,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTaskContext;
@@ -703,9 +702,8 @@ class SnowflakeSinkServiceV2Test {
     SnowflakeConnectionService conn = mock(SnowflakeConnectionService.class);
     when(conn.tableExist("t1")).thenReturn(true);
     when(conn.isRecordMetadataStructuredObject("t1")).thenReturn(true);
-    when(conn.describeTable("t1"))
-        .thenReturn(
-            Optional.of(List.of(metadataRow(IcebergDDLTypes.ICEBERG_METADATA_OBJECT_SCHEMA))));
+    when(conn.getStructuredObjectFieldNames("t1", "RECORD_METADATA"))
+        .thenReturn(SnowflakeSinkRecord.ICEBERG_METADATA_FIELDS);
 
     SnowflakeSinkServiceV2 svc = newService(conn, cfg(TableType.ICEBERG, ""));
 
@@ -715,23 +713,17 @@ class SnowflakeSinkServiceV2Test {
 
   @Test
   void validateStructuredObjectMetadataSchema_missingField_throwsError0034() {
-    // OBJECT missing LogAppendTime → ERROR_0034 naming the missing field.
-    String objectTypeWithoutLogAppendTime =
-        "OBJECT("
-            + "offset LONG,"
-            + "topic STRING,"
-            + "partition INTEGER,"
-            + "key STRING,"
-            + "CreateTime BIGINT,"
-            + "SnowflakeConnectorPushTime BIGINT,"
-            + "headers MAP(VARCHAR, VARCHAR)"
-            + ")";
+    // INFORMATION_SCHEMA returns all fields except LogAppendTime → ERROR_0034.
+    List<String> fieldsWithoutLogAppendTime =
+        SnowflakeSinkRecord.ICEBERG_METADATA_FIELDS.stream()
+            .filter(f -> !f.equals("LogAppendTime"))
+            .collect(Collectors.toList());
 
     SnowflakeConnectionService conn = mock(SnowflakeConnectionService.class);
     when(conn.tableExist("t1")).thenReturn(true);
     when(conn.isRecordMetadataStructuredObject("t1")).thenReturn(true);
-    when(conn.describeTable("t1"))
-        .thenReturn(Optional.of(List.of(metadataRow(objectTypeWithoutLogAppendTime))));
+    when(conn.getStructuredObjectFieldNames("t1", "RECORD_METADATA"))
+        .thenReturn(fieldsWithoutLogAppendTime);
 
     SnowflakeSinkServiceV2 svc = newService(conn, cfg(TableType.ICEBERG, ""));
 
@@ -742,36 +734,29 @@ class SnowflakeSinkServiceV2Test {
   }
 
   @Test
-  void validateStructuredObjectMetadataSchema_extraFields_noThrow() {
-    // OBJECT with all required fields PLUS an extra field → connector's map is a subset, fine.
-    String objectTypeWithExtra =
-        "OBJECT("
-            + "offset LONG,"
-            + "topic STRING,"
-            + "partition INTEGER,"
-            + "key STRING,"
-            + "CreateTime BIGINT,"
-            + "LogAppendTime BIGINT,"
-            + "SnowflakeConnectorPushTime BIGINT,"
-            + "headers MAP(VARCHAR, VARCHAR),"
-            + "extraField STRING"
-            + ")";
+  void validateStructuredObjectMetadataSchema_extraFields_throwsError0034() {
+    // INFORMATION_SCHEMA returns all required fields PLUS an extra field → ERROR_0034.
+    // An extra field is one the connector never emits, so that field would always be absent
+    // from every row's map, causing the v2 typed-OBJECT cast to reject every row.
+    List<String> fieldsWithExtra = new ArrayList<>(SnowflakeSinkRecord.ICEBERG_METADATA_FIELDS);
+    fieldsWithExtra.add("extraField");
 
     SnowflakeConnectionService conn = mock(SnowflakeConnectionService.class);
     when(conn.tableExist("t1")).thenReturn(true);
     when(conn.isRecordMetadataStructuredObject("t1")).thenReturn(true);
-    when(conn.describeTable("t1"))
-        .thenReturn(Optional.of(List.of(metadataRow(objectTypeWithExtra))));
+    when(conn.getStructuredObjectFieldNames("t1", "RECORD_METADATA")).thenReturn(fieldsWithExtra);
 
     SnowflakeSinkServiceV2 svc = newService(conn, cfg(TableType.ICEBERG, ""));
 
-    // Must not throw — extra fields are acceptable.
-    svc.createTableIfNotExists("t1");
+    assertThatThrownBy(() -> svc.createTableIfNotExists("t1"))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("extraField")
+        .hasMessageContaining("0034");
   }
 
   @Test
   void validateStructuredObjectMetadataSchema_variantColumn_noValidation_noThrow() {
-    // isRecordMetadataStructuredObject=false (VARIANT or FDN table) → no describe call, no throw.
+    // isRecordMetadataStructuredObject=false (VARIANT or FDN table) → no field fetch, no throw.
     SnowflakeConnectionService conn = mock(SnowflakeConnectionService.class);
     when(conn.tableExist("t1")).thenReturn(true);
     when(conn.isRecordMetadataStructuredObject("t1")).thenReturn(false);
@@ -780,45 +765,7 @@ class SnowflakeSinkServiceV2Test {
 
     svc.createTableIfNotExists("t1"); // must not throw
 
-    verify(conn, never()).describeTable(anyString());
-  }
-
-  // --- parseObjectSubfieldNames ---
-
-  @Test
-  void parseObjectSubfieldNames_fullSchema_returnsAllFieldNames() {
-    Set<String> names =
-        SnowflakeSinkServiceV2.parseObjectSubfieldNames(
-            IcebergDDLTypes.ICEBERG_METADATA_OBJECT_SCHEMA);
-    assertThat(names)
-        .containsExactlyInAnyOrderElementsOf(SnowflakeSinkRecord.ICEBERG_METADATA_FIELDS);
-  }
-
-  @Test
-  void parseObjectSubfieldNames_nestedParens_parsesCorrectly() {
-    // MAP(VARCHAR, VARCHAR) contains a nested comma — must not split there.
-    Set<String> names =
-        SnowflakeSinkServiceV2.parseObjectSubfieldNames(
-            "OBJECT(a STRING, b MAP(VARCHAR, VARCHAR), c LONG)");
-    assertThat(names).containsExactlyInAnyOrder("a", "b", "c");
-  }
-
-  @Test
-  void parseObjectSubfieldNames_emptyObject_returnsEmpty() {
-    assertThat(SnowflakeSinkServiceV2.parseObjectSubfieldNames("OBJECT()")).isEmpty();
-  }
-
-  @Test
-  void parseObjectSubfieldNames_nonObjectType_returnsEmpty() {
-    assertThat(SnowflakeSinkServiceV2.parseObjectSubfieldNames("VARIANT")).isEmpty();
-    assertThat(SnowflakeSinkServiceV2.parseObjectSubfieldNames(null)).isEmpty();
-  }
-
-  // --- helper ---
-
-  /** Builds a DescribeTableRow representing the RECORD_METADATA column with the given type. */
-  private static DescribeTableRow metadataRow(String type) {
-    return new DescribeTableRow("RECORD_METADATA", type, "", "Y");
+    verify(conn, never()).getStructuredObjectFieldNames(anyString(), anyString());
   }
 
   private SnowflakeSinkServiceV2 buildService(

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2Test.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2Test.java
@@ -735,8 +735,8 @@ class SnowflakeSinkServiceV2Test {
   }
 
   @Test
-  void validateStructuredObjectMetadataSchema_missingField_throwsError0034() {
-    // INFORMATION_SCHEMA returns all fields except LogAppendTime → ERROR_0034.
+  void validateStructuredObjectMetadataSchema_missingField_throwsError0035() {
+    // INFORMATION_SCHEMA returns all fields except LogAppendTime → ERROR_0035.
     List<String> fieldsWithoutLogAppendTime =
         SnowflakeSinkRecord.ICEBERG_METADATA_FIELDS.stream()
             .filter(f -> !f.equals("LogAppendTime"))
@@ -753,12 +753,12 @@ class SnowflakeSinkServiceV2Test {
     assertThatThrownBy(() -> svc.createTableIfNotExists("t1"))
         .isInstanceOf(RuntimeException.class)
         .hasMessageContaining("LogAppendTime")
-        .hasMessageContaining("0034");
+        .hasMessageContaining("0035");
   }
 
   @Test
-  void validateStructuredObjectMetadataSchema_extraFields_throwsError0034() {
-    // INFORMATION_SCHEMA returns all required fields PLUS an extra field → ERROR_0034.
+  void validateStructuredObjectMetadataSchema_extraFields_throwsError0035() {
+    // INFORMATION_SCHEMA returns all required fields PLUS an extra field → ERROR_0035.
     // An extra field is one the connector never emits, so that field would always be absent
     // from every row's map, causing the v2 typed-OBJECT cast to reject every row.
     List<String> fieldsWithExtra = new ArrayList<>(SnowflakeSinkRecord.ICEBERG_METADATA_FIELDS);
@@ -774,11 +774,11 @@ class SnowflakeSinkServiceV2Test {
     assertThatThrownBy(() -> svc.createTableIfNotExists("t1"))
         .isInstanceOf(RuntimeException.class)
         .hasMessageContaining("extraField")
-        .hasMessageContaining("0034");
+        .hasMessageContaining("0035");
   }
 
   @Test
-  void validateStructuredObjectMetadataSchema_emptyFields_throwsError0034() {
+  void validateStructuredObjectMetadataSchema_emptyFields_throwsError0035() {
     // RECORD_METADATA is a structured OBJECT but INFORMATION_SCHEMA returned no sub-fields (e.g.
     // wrong database/schema, or a lookup error) → fail fast rather than silently proceed and route
     // every row to the error table at ingest.
@@ -793,7 +793,7 @@ class SnowflakeSinkServiceV2Test {
     assertThatThrownBy(() -> svc.createTableIfNotExists("t1"))
         .isInstanceOf(RuntimeException.class)
         .hasMessageContaining("no sub-fields")
-        .hasMessageContaining("0034");
+        .hasMessageContaining("0035");
   }
 
   @Test

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2Test.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2Test.java
@@ -284,6 +284,48 @@ class SnowflakeSinkServiceV2Test {
     assertEquals(TOPIC, captor.getValue().get(TOPIC));
   }
 
+  @Test
+  @SuppressWarnings("unchecked")
+  void startPartitions_noneType_usesDefaultPipe_noPipeExistenceCheck() {
+    // table.type=none no longer requires the pipe to pre-exist at startup; the default pipe is
+    // connector-managed (created lazily at first ingest). This test verifies that startPartitions
+    // does NOT call pipeExist for a pre-existence guard when the table already exists.
+    SnowflakeConnectionService mockConn = mock(SnowflakeConnectionService.class);
+    when(mockConn.isClosed()).thenReturn(false);
+    when(mockConn.tableExist(TOPIC)).thenReturn(true);
+    // Named pipe does NOT exist; default pipe does NOT exist either — neither should cause a
+    // failure.
+    when(mockConn.pipeExist(TOPIC)).thenReturn(false);
+    when(mockConn.hasErrorLoggingEnabled(TOPIC)).thenReturn(true);
+
+    PartitionChannelManager channelMgr = mock(PartitionChannelManager.class);
+    SinkTaskConfig config =
+        SinkTaskConfigTestBuilder.builder()
+            .connectorName(CONNECTOR_NAME)
+            .taskId("0")
+            .tableType(TableType.NONE)
+            .validation(SnowflakeValidation.SERVER_SIDE)
+            .enableSanitization(false)
+            .build();
+    SnowflakeSinkServiceV2 svc =
+        new SnowflakeSinkServiceV2(
+            mockConn,
+            config,
+            mockSinkTaskContext,
+            Optional.empty(),
+            () -> mock(BatchOffsetFetcher.class),
+            () -> channelMgr,
+            TaskMetrics.noop());
+
+    TopicPartition tp = new TopicPartition(TOPIC, 0);
+    svc.startPartitions(Set.of(tp)); // must not throw
+
+    // The default pipe (tableName + STREAMING suffix) must be chosen.
+    ArgumentCaptor<Map<String, String>> captor = ArgumentCaptor.forClass(Map.class);
+    verify(channelMgr).startPartitions(any(), captor.capture());
+    assertEquals(TOPIC + "-STREAMING", captor.getValue().get(TOPIC));
+  }
+
   // --- backpressure handling ---
 
   @Test

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2Test.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2Test.java
@@ -1,5 +1,6 @@
 package com.snowflake.kafka.connector.internal.streaming;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -18,6 +19,7 @@ import com.snowflake.kafka.connector.config.SinkTaskConfig;
 import com.snowflake.kafka.connector.config.SinkTaskConfigTestBuilder;
 import com.snowflake.kafka.connector.config.SnowflakeValidation;
 import com.snowflake.kafka.connector.config.TableType;
+import com.snowflake.kafka.connector.internal.DescribeTableRow;
 import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
 import com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException;
 import com.snowflake.kafka.connector.internal.metrics.TaskMetrics;
@@ -26,6 +28,8 @@ import com.snowflake.kafka.connector.internal.streaming.v2.BackpressureException
 import com.snowflake.kafka.connector.internal.streaming.v2.service.BatchOffsetFetcher;
 import com.snowflake.kafka.connector.internal.streaming.v2.service.PartitionChannelManager;
 import com.snowflake.kafka.connector.internal.streaming.v2.service.ThreadPools;
+import com.snowflake.kafka.connector.records.SnowflakeSinkRecord;
+import com.snowflake.kafka.connector.streaming.iceberg.IcebergDDLTypes;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
@@ -303,7 +307,7 @@ class SnowflakeSinkServiceV2Test {
         SinkTaskConfigTestBuilder.builder()
             .connectorName(CONNECTOR_NAME)
             .taskId("0")
-            .tableType(TableType.NONE)
+            .autocreatedTableType(TableType.NONE)
             .validation(SnowflakeValidation.SERVER_SIDE)
             .enableSanitization(false)
             .build();
@@ -553,7 +557,7 @@ class SnowflakeSinkServiceV2Test {
     return SinkTaskConfigTestBuilder.builder()
         .connectorName(CONNECTOR_NAME)
         .taskId("0")
-        .tableType(type)
+        .autocreatedTableType(type)
         .icebergCreateTableOptions(Optional.ofNullable(createTableOptions))
         .build();
   }
@@ -660,7 +664,7 @@ class SnowflakeSinkServiceV2Test {
         SinkTaskConfigTestBuilder.builder()
             .connectorName(CONNECTOR_NAME)
             .taskId("0")
-            .tableType(TableType.ICEBERG)
+            .autocreatedTableType(TableType.ICEBERG)
             .enableSchematization(false)
             .icebergCreateTableOptions(Optional.of("EXTERNAL_VOLUME='v'"))
             .build();
@@ -680,7 +684,7 @@ class SnowflakeSinkServiceV2Test {
         SinkTaskConfigTestBuilder.builder()
             .connectorName(CONNECTOR_NAME)
             .taskId("0")
-            .tableType(TableType.ICEBERG)
+            .autocreatedTableType(TableType.ICEBERG)
             .enableSchematization(false)
             .icebergCreateTableOptions(Optional.of("ICEBERG_VERSION=3"))
             .build();
@@ -689,6 +693,132 @@ class SnowflakeSinkServiceV2Test {
     svc.createTableIfNotExists("t1");
 
     verify(conn).createIcebergTableWithOnlyMetadataColumn("t1", "ICEBERG_VERSION=3");
+  }
+
+  // --- validateStructuredObjectMetadataSchema ---
+
+  @Test
+  void validateStructuredObjectMetadataSchema_allFieldsPresent_noThrow() {
+    // All ICEBERG_METADATA_FIELDS are declared → validation passes without throwing.
+    SnowflakeConnectionService conn = mock(SnowflakeConnectionService.class);
+    when(conn.tableExist("t1")).thenReturn(true);
+    when(conn.isRecordMetadataStructuredObject("t1")).thenReturn(true);
+    when(conn.describeTable("t1"))
+        .thenReturn(
+            Optional.of(List.of(metadataRow(IcebergDDLTypes.ICEBERG_METADATA_OBJECT_SCHEMA))));
+
+    SnowflakeSinkServiceV2 svc = newService(conn, cfg(TableType.ICEBERG, ""));
+
+    // Must not throw.
+    svc.createTableIfNotExists("t1");
+  }
+
+  @Test
+  void validateStructuredObjectMetadataSchema_missingField_throwsError0034() {
+    // OBJECT missing LogAppendTime → ERROR_0034 naming the missing field.
+    String objectTypeWithoutLogAppendTime =
+        "OBJECT("
+            + "offset LONG,"
+            + "topic STRING,"
+            + "partition INTEGER,"
+            + "key STRING,"
+            + "CreateTime BIGINT,"
+            + "SnowflakeConnectorPushTime BIGINT,"
+            + "headers MAP(VARCHAR, VARCHAR)"
+            + ")";
+
+    SnowflakeConnectionService conn = mock(SnowflakeConnectionService.class);
+    when(conn.tableExist("t1")).thenReturn(true);
+    when(conn.isRecordMetadataStructuredObject("t1")).thenReturn(true);
+    when(conn.describeTable("t1"))
+        .thenReturn(Optional.of(List.of(metadataRow(objectTypeWithoutLogAppendTime))));
+
+    SnowflakeSinkServiceV2 svc = newService(conn, cfg(TableType.ICEBERG, ""));
+
+    assertThatThrownBy(() -> svc.createTableIfNotExists("t1"))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("LogAppendTime")
+        .hasMessageContaining("0034");
+  }
+
+  @Test
+  void validateStructuredObjectMetadataSchema_extraFields_noThrow() {
+    // OBJECT with all required fields PLUS an extra field → connector's map is a subset, fine.
+    String objectTypeWithExtra =
+        "OBJECT("
+            + "offset LONG,"
+            + "topic STRING,"
+            + "partition INTEGER,"
+            + "key STRING,"
+            + "CreateTime BIGINT,"
+            + "LogAppendTime BIGINT,"
+            + "SnowflakeConnectorPushTime BIGINT,"
+            + "headers MAP(VARCHAR, VARCHAR),"
+            + "extraField STRING"
+            + ")";
+
+    SnowflakeConnectionService conn = mock(SnowflakeConnectionService.class);
+    when(conn.tableExist("t1")).thenReturn(true);
+    when(conn.isRecordMetadataStructuredObject("t1")).thenReturn(true);
+    when(conn.describeTable("t1"))
+        .thenReturn(Optional.of(List.of(metadataRow(objectTypeWithExtra))));
+
+    SnowflakeSinkServiceV2 svc = newService(conn, cfg(TableType.ICEBERG, ""));
+
+    // Must not throw — extra fields are acceptable.
+    svc.createTableIfNotExists("t1");
+  }
+
+  @Test
+  void validateStructuredObjectMetadataSchema_variantColumn_noValidation_noThrow() {
+    // isRecordMetadataStructuredObject=false (VARIANT or FDN table) → no describe call, no throw.
+    SnowflakeConnectionService conn = mock(SnowflakeConnectionService.class);
+    when(conn.tableExist("t1")).thenReturn(true);
+    when(conn.isRecordMetadataStructuredObject("t1")).thenReturn(false);
+
+    SnowflakeSinkServiceV2 svc = newService(conn, cfg(TableType.ICEBERG, ""));
+
+    svc.createTableIfNotExists("t1"); // must not throw
+
+    verify(conn, never()).describeTable(anyString());
+  }
+
+  // --- parseObjectSubfieldNames ---
+
+  @Test
+  void parseObjectSubfieldNames_fullSchema_returnsAllFieldNames() {
+    Set<String> names =
+        SnowflakeSinkServiceV2.parseObjectSubfieldNames(
+            IcebergDDLTypes.ICEBERG_METADATA_OBJECT_SCHEMA);
+    assertThat(names)
+        .containsExactlyInAnyOrderElementsOf(SnowflakeSinkRecord.ICEBERG_METADATA_FIELDS);
+  }
+
+  @Test
+  void parseObjectSubfieldNames_nestedParens_parsesCorrectly() {
+    // MAP(VARCHAR, VARCHAR) contains a nested comma — must not split there.
+    Set<String> names =
+        SnowflakeSinkServiceV2.parseObjectSubfieldNames(
+            "OBJECT(a STRING, b MAP(VARCHAR, VARCHAR), c LONG)");
+    assertThat(names).containsExactlyInAnyOrder("a", "b", "c");
+  }
+
+  @Test
+  void parseObjectSubfieldNames_emptyObject_returnsEmpty() {
+    assertThat(SnowflakeSinkServiceV2.parseObjectSubfieldNames("OBJECT()")).isEmpty();
+  }
+
+  @Test
+  void parseObjectSubfieldNames_nonObjectType_returnsEmpty() {
+    assertThat(SnowflakeSinkServiceV2.parseObjectSubfieldNames("VARIANT")).isEmpty();
+    assertThat(SnowflakeSinkServiceV2.parseObjectSubfieldNames(null)).isEmpty();
+  }
+
+  // --- helper ---
+
+  /** Builds a DescribeTableRow representing the RECORD_METADATA column with the given type. */
+  private static DescribeTableRow metadataRow(String type) {
+    return new DescribeTableRow("RECORD_METADATA", type, "", "Y");
   }
 
   private SnowflakeSinkServiceV2 buildService(

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2Test.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2Test.java
@@ -787,6 +787,28 @@ class SnowflakeSinkServiceV2Test {
     verify(conn, never()).getStructuredObjectFieldNames(anyString(), anyString());
   }
 
+  @Test
+  void structuredRecordMetadata_featureFlagDisabled_skipsProbeAndValidation() {
+    // Kill-switch off: even for an existing table, the connector must not probe RECORD_METADATA or
+    // validate its structured schema -- it reverts to 4.0.x behavior (RECORD_METADATA as VARIANT).
+    SnowflakeConnectionService conn = mock(SnowflakeConnectionService.class);
+    when(conn.tableExist("t1")).thenReturn(true);
+
+    SinkTaskConfig disabled =
+        SinkTaskConfigTestBuilder.builder()
+            .connectorName(CONNECTOR_NAME)
+            .taskId("0")
+            .autocreatedTableType(TableType.ICEBERG)
+            .structuredRecordMetadataEnabled(false)
+            .build();
+    SnowflakeSinkServiceV2 svc = newService(conn, disabled);
+
+    svc.createTableIfNotExists("t1"); // must not throw
+
+    verify(conn, never()).isRecordMetadataStructuredObject(anyString());
+    verify(conn, never()).getStructuredObjectFieldNames(anyString(), anyString());
+  }
+
   private SnowflakeSinkServiceV2 buildService(
       SnowflakeConnectionService conn, boolean clientValidationEnabled) {
     return buildService(conn, clientValidationEnabled, mock(PartitionChannelManager.class));

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2Test.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2Test.java
@@ -1,9 +1,11 @@
 package com.snowflake.kafka.connector.internal.streaming;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -15,6 +17,7 @@ import com.snowflake.kafka.connector.builder.SinkRecordBuilder;
 import com.snowflake.kafka.connector.config.SinkTaskConfig;
 import com.snowflake.kafka.connector.config.SinkTaskConfigTestBuilder;
 import com.snowflake.kafka.connector.config.SnowflakeValidation;
+import com.snowflake.kafka.connector.config.TableType;
 import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
 import com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException;
 import com.snowflake.kafka.connector.internal.metrics.TaskMetrics;
@@ -492,6 +495,142 @@ class SnowflakeSinkServiceV2Test {
   }
 
   // --- helpers ---
+
+  private SnowflakeSinkServiceV2 newService(SnowflakeConnectionService conn, SinkTaskConfig cfg) {
+    return new SnowflakeSinkServiceV2(
+        conn,
+        cfg,
+        mockSinkTaskContext,
+        Optional.empty(),
+        () -> mock(BatchOffsetFetcher.class),
+        () -> mock(PartitionChannelManager.class),
+        TaskMetrics.noop());
+  }
+
+  private SinkTaskConfig cfg(TableType type, String createTableOptions) {
+    return SinkTaskConfigTestBuilder.builder()
+        .connectorName(CONNECTOR_NAME)
+        .taskId("0")
+        .tableType(type)
+        .icebergCreateTableOptions(createTableOptions)
+        .build();
+  }
+
+  @Test
+  void createTableIfNotExists_icebergType_callsIcebergCreate() {
+    SnowflakeConnectionService conn = mock(SnowflakeConnectionService.class);
+    when(conn.tableExist("t1")).thenReturn(false);
+    SnowflakeSinkServiceV2 svc = newService(conn, cfg(TableType.ICEBERG, "ICEBERG_VERSION=3"));
+
+    svc.createTableIfNotExists("t1");
+
+    verify(conn).createIcebergTableWithOnlyMetadataColumn("t1", "ICEBERG_VERSION=3");
+    verify(conn, never()).createTableWithOnlyMetadataColumn(anyString());
+  }
+
+  @Test
+  void createTableIfNotExists_snowflakeType_callsFdnCreate() {
+    SnowflakeConnectionService conn = mock(SnowflakeConnectionService.class);
+    when(conn.tableExist("t1")).thenReturn(false);
+    SnowflakeSinkServiceV2 svc = newService(conn, cfg(TableType.SNOWFLAKE, ""));
+
+    svc.createTableIfNotExists("t1");
+
+    verify(conn).createTableWithOnlyMetadataColumn("t1");
+    verify(conn, never()).createIcebergTableWithOnlyMetadataColumn(anyString(), anyString());
+  }
+
+  @Test
+  void createTableIfNotExists_noneType_missingTable_throws() {
+    SnowflakeConnectionService conn = mock(SnowflakeConnectionService.class);
+    when(conn.tableExist("t1")).thenReturn(false);
+    SnowflakeSinkServiceV2 svc = newService(conn, cfg(TableType.NONE, ""));
+
+    assertThatThrownBy(() -> svc.createTableIfNotExists("t1"))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("t1");
+    verify(conn, never()).createTableWithOnlyMetadataColumn(anyString());
+    verify(conn, never()).createIcebergTableWithOnlyMetadataColumn(anyString(), anyString());
+  }
+
+  @Test
+  void createTableIfNotExists_icebergType_existingIcebergTable_noCreate() {
+    SnowflakeConnectionService conn = mock(SnowflakeConnectionService.class);
+    when(conn.tableExist("t1")).thenReturn(true);
+    when(conn.isIcebergTable("t1")).thenReturn(true);
+    SnowflakeSinkServiceV2 svc = newService(conn, cfg(TableType.ICEBERG, ""));
+
+    svc.createTableIfNotExists("t1");
+
+    verify(conn, never()).createIcebergTableWithOnlyMetadataColumn(anyString(), anyString());
+    verify(conn, never()).createTableWithOnlyMetadataColumn(anyString());
+  }
+
+  @Test
+  void createTableIfNotExists_icebergType_existingFdnTable_usedAsIs_noCreate() {
+    // table.type only governs auto-creation; an existing table is used as-is regardless of type.
+    SnowflakeConnectionService conn = mock(SnowflakeConnectionService.class);
+    when(conn.tableExist("t1")).thenReturn(true);
+    when(conn.isIcebergTable("t1")).thenReturn(false);
+    SnowflakeSinkServiceV2 svc = newService(conn, cfg(TableType.ICEBERG, ""));
+
+    svc.createTableIfNotExists("t1");
+
+    verify(conn, never()).createIcebergTableWithOnlyMetadataColumn(anyString(), anyString());
+    verify(conn, never()).createTableWithOnlyMetadataColumn(anyString());
+  }
+
+  @Test
+  void createTableIfNotExists_snowflakeType_existingIcebergTable_usedAsIs_noCreate() {
+    SnowflakeConnectionService conn = mock(SnowflakeConnectionService.class);
+    when(conn.tableExist("t1")).thenReturn(true);
+    when(conn.isIcebergTable("t1")).thenReturn(true);
+    SnowflakeSinkServiceV2 svc = newService(conn, cfg(TableType.SNOWFLAKE, ""));
+
+    svc.createTableIfNotExists("t1");
+
+    verify(conn, never()).createTableWithOnlyMetadataColumn(anyString());
+    verify(conn, never()).createIcebergTableWithOnlyMetadataColumn(anyString(), anyString());
+  }
+
+  @Test
+  void createTableIfNotExists_icebergType_nonSchematized_withoutV3_throws() {
+    SnowflakeConnectionService conn = mock(SnowflakeConnectionService.class);
+    when(conn.tableExist("t1")).thenReturn(false);
+    SinkTaskConfig config =
+        SinkTaskConfigTestBuilder.builder()
+            .connectorName(CONNECTOR_NAME)
+            .taskId("0")
+            .tableType(TableType.ICEBERG)
+            .enableSchematization(false)
+            .icebergCreateTableOptions("EXTERNAL_VOLUME='v'")
+            .build();
+    SnowflakeSinkServiceV2 svc = newService(conn, config);
+
+    assertThatThrownBy(() -> svc.createTableIfNotExists("t1"))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("ICEBERG_VERSION=3");
+    verify(conn, never()).createIcebergTableWithOnlyMetadataColumn(anyString(), anyString());
+  }
+
+  @Test
+  void createTableIfNotExists_icebergType_nonSchematized_withV3_creates() {
+    SnowflakeConnectionService conn = mock(SnowflakeConnectionService.class);
+    when(conn.tableExist("t1")).thenReturn(false);
+    SinkTaskConfig config =
+        SinkTaskConfigTestBuilder.builder()
+            .connectorName(CONNECTOR_NAME)
+            .taskId("0")
+            .tableType(TableType.ICEBERG)
+            .enableSchematization(false)
+            .icebergCreateTableOptions("ICEBERG_VERSION=3")
+            .build();
+    SnowflakeSinkServiceV2 svc = newService(conn, config);
+
+    svc.createTableIfNotExists("t1");
+
+    verify(conn).createIcebergTableWithOnlyMetadataColumn("t1", "ICEBERG_VERSION=3");
+  }
 
   private SnowflakeSinkServiceV2 buildService(
       SnowflakeConnectionService conn, boolean clientValidationEnabled) {

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2ValidationLoggingTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2ValidationLoggingTest.java
@@ -266,13 +266,14 @@ public class SnowflakeSinkServiceV2ValidationLoggingTest {
   }
 
   /**
-   * Test: Validation disabled, table is Iceberg.
+   * Test: Validation disabled, existing Iceberg table with ERROR_LOGGING enabled.
    *
-   * <p>Should warn that Iceberg tables do not support ERROR_LOGGING and not check
-   * hasErrorLoggingEnabled.
+   * <p>Iceberg tables support ERROR_LOGGING and are returned by SHOW TABLES, so they are checked
+   * the same way as FDN tables (no special-casing). With ERROR_LOGGING enabled, there is no
+   * warning.
    */
   @Test
-  public void testValidationDisabledIcebergTableWarning() {
+  public void testValidationDisabledIcebergTableCheckedLikeFdn() {
     SinkTaskConfig config =
         SinkTaskConfigTestBuilder.builder()
             .connectorName("test-connector")
@@ -286,19 +287,13 @@ public class SnowflakeSinkServiceV2ValidationLoggingTest {
             config,
             mockConn -> {
               when(mockConn.tableExist("iceberg_table")).thenReturn(true);
-              when(mockConn.isIcebergTable("iceberg_table")).thenReturn(true);
+              when(mockConn.hasErrorLoggingEnabled("iceberg_table")).thenReturn(true);
             });
     assertNotNull(service);
 
-    assertTrue(
-        testAppender.containsMessage(Level.WARN, "Iceberg table"),
-        "Should warn that the table is Iceberg");
-    assertTrue(
-        testAppender.containsMessage(Level.WARN, "do not support ERROR_LOGGING"),
-        "Should warn that Iceberg does not support ERROR_LOGGING");
     assertFalse(
-        testAppender.containsMessage(Level.WARN, "does not have ERROR_LOGGING"),
-        "Should NOT emit the generic missing-ERROR_LOGGING warning for Iceberg tables");
+        testAppender.containsMessage(Level.WARN, "ERROR_LOGGING"),
+        "Iceberg table with ERROR_LOGGING enabled should not warn");
   }
 
   /** Helper to create SnowflakeSinkServiceV2 with minimal mocked dependencies. */

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingErrorHandlerIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingErrorHandlerIT.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.mock;
 import com.snowflake.kafka.connector.builder.SinkRecordBuilder;
 import com.snowflake.kafka.connector.config.SinkTaskConfig;
 import com.snowflake.kafka.connector.dlq.InMemoryKafkaRecordErrorReporter;
+import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
 import com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException;
 import com.snowflake.kafka.connector.internal.TestUtils;
 import com.snowflake.kafka.connector.internal.metrics.TaskMetrics;
@@ -306,7 +307,7 @@ class StreamingErrorHandlerIT {
         errorHandler,
         TaskMetrics.noop(),
         false,
-        null,
+        mock(SnowflakeConnectionService.class),
         Optional.empty());
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingErrorHandlerIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingErrorHandlerIT.java
@@ -307,6 +307,7 @@ class StreamingErrorHandlerIT {
         errorHandler,
         TaskMetrics.noop(),
         false,
+        false,
         mock(SnowflakeConnectionService.class),
         Optional.empty());
   }

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannelTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannelTest.java
@@ -705,7 +705,7 @@ class SnowpipeStreamingPartitionChannelTest {
         mockErrorHandler,
         taskMetrics,
         false,
-        null,
+        mock(SnowflakeConnectionService.class),
         Optional.empty());
   }
 

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannelTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannelTest.java
@@ -273,6 +273,7 @@ class SnowpipeStreamingPartitionChannelTest {
             mockErrorHandler,
             TaskMetrics.noop(),
             false,
+            false,
             null,
             Optional.empty());
 
@@ -705,6 +706,7 @@ class SnowpipeStreamingPartitionChannelTest {
         mockErrorHandler,
         taskMetrics,
         false,
+        false,
         mock(SnowflakeConnectionService.class),
         Optional.empty());
   }
@@ -802,6 +804,7 @@ class SnowpipeStreamingPartitionChannelTest {
         mockErrorHandler,
         TaskMetrics.noop(),
         shouldEvolveSchema,
+        false,
         mockConnService,
         Optional.empty());
   }
@@ -900,6 +903,7 @@ class SnowpipeStreamingPartitionChannelTest {
             mockErrorHandler,
             TaskMetrics.noop(),
             true,
+            false,
             mockConnService,
             Optional.empty());
 
@@ -1043,6 +1047,7 @@ class SnowpipeStreamingPartitionChannelTest {
         migrationTaskConfig,
         mockErrorHandler,
         TaskMetrics.noop(),
+        false,
         false,
         mockConn,
         migrationMode == Ssv1MigrationMode.SKIP

--- a/src/test/java/com/snowflake/kafka/connector/records/SnowflakeSinkRecordTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/records/SnowflakeSinkRecordTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.snowflake.kafka.connector.builder.SinkRecordBuilder;
@@ -1001,38 +1002,22 @@ class SnowflakeSinkRecordTest {
   }
 
   @Test
-  void testIcebergMetadata_extraFieldIsDropped() {
-    // Fields outside ICEBERG_METADATA_FIELDS must be dropped by conformIcebergMetadata. We inject
-    // one via a custom metadata config that enables all standard flags; the "extra" field comes
-    // from a header that we deliberately do NOT put on the record — instead we verify that if the
-    // raw metadata happened to contain an unknown key it would be absent from the conformed map.
-    // The simplest way to test this is via a record whose raw metadata contains a field that is
-    // NOT in the Iceberg schema. We pass the raw metadata through the public API.
-    //
-    // Strategy: a record whose topic is one of the real field names but the *key* value comes
-    // from an INT schema — so the raw metadata will have "key"=Integer. After conform, "key" must
-    // be a String. No extra fields may survive.
-    SchemaAndValue schemaAndValue = toConnectData("{\"id\": 1}");
-    SinkRecord kafkaRecord =
-        SinkRecordBuilder.forTopicPartition(TOPIC, PARTITION)
-            .withKeySchema(Schema.STRING_SCHEMA)
-            .withKey("k1")
-            .withSchemaAndValue(schemaAndValue)
-            .withTimestamp(42L, TimestampType.CREATE_TIME)
-            .build();
+  void testIcebergMetadata_unknownFieldThrows() {
+    // buildMetadata only ever emits fields declared in ICEBERG_METADATA_FIELDS, so an out-of-schema
+    // field means KC metadata emission and the Iceberg RECORD_METADATA schema have drifted apart.
+    // conformIcebergMetadata surfaces that loudly (IllegalStateException) rather than silently
+    // dropping the field. No public path can inject a top-level metadata field outside the schema,
+    // so we call the (package-private) method directly with a crafted map.
+    Map<String, Object> raw = new HashMap<>();
+    raw.put("topic", TOPIC);
+    raw.put("unexpectedField", "x");
 
-    SnowflakeSinkRecord record =
-        SnowflakeSinkRecord.from(kafkaRecord, createMetadataConfigWithAll(), true, false);
-
-    @SuppressWarnings("unchecked")
-    Map<String, Object> metadata =
-        (Map<String, Object>) record.getContentWithMetadata(true, true).get(TABLE_COLUMN_METADATA);
-
-    // All present fields must be within the declared Iceberg schema.
+    IllegalStateException ex =
+        assertThrows(
+            IllegalStateException.class, () -> SnowflakeSinkRecord.conformIcebergMetadata(raw));
     assertTrue(
-        SnowflakeSinkRecord.ICEBERG_METADATA_FIELDS.containsAll(metadata.keySet()),
-        "Conformed map must not contain fields outside ICEBERG_METADATA_FIELDS; got: "
-            + metadata.keySet());
+        ex.getMessage().contains("unexpectedField"),
+        "message should name the offending field; got: " + ex.getMessage());
   }
 
   @Test

--- a/src/test/java/com/snowflake/kafka/connector/records/SnowflakeSinkRecordTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/records/SnowflakeSinkRecordTest.java
@@ -948,6 +948,21 @@ class SnowflakeSinkRecordTest {
   }
 
   @Test
+  void testIcebergMetadata_passesByteArrayKeyThrough() {
+    // A byte[] key must NOT be stringified: String.valueOf(byte[]) yields a useless "[B@..." object
+    // id. It is handed to the SDK unchanged, which handles binary values. Call the package-private
+    // conform directly since no public converter path produces a raw byte[] key here.
+    byte[] key = new byte[] {1, 2, 3};
+    Map<String, Object> raw = new HashMap<>();
+    raw.put("key", key);
+
+    Map<String, Object> conformed = SnowflakeSinkRecord.conformIcebergMetadata(raw);
+
+    assertInstanceOf(byte[].class, conformed.get("key"), "byte[] key must not be stringified");
+    assertArrayEquals(key, (byte[]) conformed.get("key"));
+  }
+
+  @Test
   void testIcebergMetadata_coercesStructuredHeaderValuesToString() {
     // With structured headers enabled, header values keep native types. The Iceberg schema declares
     // `headers MAP(VARCHAR, VARCHAR)`, so conform must coerce each header value to String.

--- a/src/test/java/com/snowflake/kafka/connector/records/SnowflakeSinkRecordTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/records/SnowflakeSinkRecordTest.java
@@ -948,6 +948,34 @@ class SnowflakeSinkRecordTest {
   }
 
   @Test
+  void testIcebergMetadata_coercesStructuredHeaderValuesToString() {
+    // With structured headers enabled, header values keep native types. The Iceberg schema declares
+    // `headers MAP(VARCHAR, VARCHAR)`, so conform must coerce each header value to String.
+    SchemaAndValue schemaAndValue = toConnectData("{\"id\": 1}");
+    Schema objectSchema = SchemaBuilder.struct().field("k", Schema.STRING_SCHEMA).build();
+    Struct objectValue = new Struct(objectSchema).put("k", "v");
+    Headers headers = new ConnectHeaders();
+    headers.add("objectHeader", objectValue, objectSchema);
+    headers.addInt("intHeader", 7);
+
+    SinkRecord kafkaRecord = createSinkRecordWithHeaders(schemaAndValue, headers, "key");
+    SnowflakeSinkRecord record =
+        SnowflakeSinkRecord.from(
+            kafkaRecord, createMetadataConfigWithAllAndStructuredHeaders(), true, false);
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> metadata =
+        (Map<String, Object>) record.getContentWithMetadata(true, true).get(TABLE_COLUMN_METADATA);
+    @SuppressWarnings("unchecked")
+    Map<String, Object> headersMap = (Map<String, Object>) metadata.get("headers");
+    assertTrue(
+        headersMap.get("objectHeader") instanceof String,
+        "structured header value must be coerced to String for the MAP(VARCHAR,VARCHAR) cast");
+    assertTrue(headersMap.get("intHeader") instanceof String);
+    assertEquals("7", headersMap.get("intHeader"));
+  }
+
+  @Test
   void testIcebergMetadataFields_matchDdlSchema() {
     // ICEBERG_METADATA_FIELDS must exactly match the fields declared in
     // IcebergDDLTypes.ICEBERG_METADATA_OBJECT_SCHEMA — the strict typed-OBJECT cast makes this an

--- a/src/test/java/com/snowflake/kafka/connector/records/SnowflakeSinkRecordTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/records/SnowflakeSinkRecordTest.java
@@ -190,7 +190,7 @@ class SnowflakeSinkRecordTest {
     SnowflakeSinkRecord record =
         createRecordFromJson("{\"name\": \"test\"}", createMetadataConfigWithAll());
 
-    Map<String, Object> contentWithMetadata = record.getContentWithMetadata(true);
+    Map<String, Object> contentWithMetadata = record.getContentWithMetadata(true, false);
 
     assertNotNull(contentWithMetadata.get(TABLE_COLUMN_METADATA));
     assertEquals("test", contentWithMetadata.get("name"));
@@ -201,7 +201,7 @@ class SnowflakeSinkRecordTest {
     // Test that metadata is NOT included when flag is false
     SnowflakeSinkRecord record = createRecordFromJson("{\"name\": \"test\"}", metadataConfig);
 
-    Map<String, Object> contentWithMetadata = record.getContentWithMetadata(false);
+    Map<String, Object> contentWithMetadata = record.getContentWithMetadata(false, false);
 
     assertFalse(contentWithMetadata.containsKey(TABLE_COLUMN_METADATA));
     assertEquals("test", contentWithMetadata.get("name"));
@@ -423,7 +423,7 @@ class SnowflakeSinkRecordTest {
     assertTrue(record.getContent().isEmpty());
 
     // But metadata should still be present
-    Map<String, Object> contentWithMetadata = record.getContentWithMetadata(true);
+    Map<String, Object> contentWithMetadata = record.getContentWithMetadata(true, false);
     assertNotNull(contentWithMetadata.get(TABLE_COLUMN_METADATA));
   }
 
@@ -437,7 +437,7 @@ class SnowflakeSinkRecordTest {
     Map<String, Object> content = record.getContent();
     assertEquals("value", content.get("key"));
 
-    Map<String, Object> contentWithMetadata = record.getContentWithMetadata(true);
+    Map<String, Object> contentWithMetadata = record.getContentWithMetadata(true, false);
     assertEquals("value", contentWithMetadata.get("key"));
     assertNotNull(contentWithMetadata.get(TABLE_COLUMN_METADATA));
   }
@@ -611,7 +611,7 @@ class SnowflakeSinkRecordTest {
 
     // Even when includeAllMetadata is true, no metadata column should be added because metadata is
     // empty
-    Map<String, Object> contentWithMetadata = record.getContentWithMetadata(true);
+    Map<String, Object> contentWithMetadata = record.getContentWithMetadata(true, false);
     assertFalse(contentWithMetadata.containsKey(TABLE_COLUMN_METADATA));
     assertEquals("value", contentWithMetadata.get("data"));
   }
@@ -813,11 +813,11 @@ class SnowflakeSinkRecordTest {
   }
 
   @Test
-  void testIcebergMetadata_padsKeyAndHeadersOnly_whenAbsent() {
+  void testIcebergMetadata_padsAbsentFieldsWithNull() {
     // KEY and HEADERS are record-level (not config-gated): a keyless/headerless record omits them
-    // even with all metadata flags on. The strict typed-OBJECT cast rejects a *missing* schema
-    // field, so conform pads exactly these two with null (the config-gated fields are guaranteed
-    // present by config-time validation and are not padded).
+    // from buildMetadata. The v2 managed-Iceberg structured-OBJECT cast REJECTS absent declared
+    // fields, so conformIcebergMetadata must pad them with null.
+    // A CreateTime record also has LogAppendTime absent — that must be padded too.
     SchemaAndValue schemaAndValue = toConnectData("{\"id\": 1}");
     SinkRecord kafkaRecord =
         new SinkRecord(
@@ -838,28 +838,36 @@ class SnowflakeSinkRecordTest {
     Map<String, Object> metadata =
         (Map<String, Object>) record.getContentWithMetadata(true, true).get(TABLE_COLUMN_METADATA);
 
-    // Populated config-gated fields are retained.
+    // Populated config-gated fields are retained with their values.
     assertEquals(TOPIC, metadata.get("topic"));
     assertEquals(5L, metadata.get("offset"));
     assertEquals(PARTITION, metadata.get("partition"));
     assertEquals(1609459200000L, metadata.get("CreateTime"));
-    // KEY and HEADERS are absent from the record, so they must be present-and-null (padded), not
-    // missing — otherwise the strict Iceberg cast would reject the row.
-    assertTrue(metadata.containsKey("key"), "absent key must be padded with null");
-    assertNull(metadata.get("key"));
-    assertTrue(metadata.containsKey("headers"), "absent headers must be padded with null");
-    assertNull(metadata.get("headers"));
 
-    // No fields outside the Iceberg schema.
+    // KEY, HEADERS, and LogAppendTime are absent from the raw record but must be present-and-null
+    // in the conformed map so the strict v2 typed-OBJECT cast does not reject the row.
+    assertTrue(metadata.containsKey("key"), "absent key must be padded with null");
+    assertNull(metadata.get("key"), "padded key must be null");
+    assertTrue(metadata.containsKey("headers"), "absent headers must be padded with null");
+    assertNull(metadata.get("headers"), "padded headers must be null");
     assertTrue(
-        SnowflakeSinkRecord.ICEBERG_METADATA_FIELDS.containsAll(metadata.keySet()),
-        "conformed map must not contain fields outside ICEBERG_METADATA_FIELDS");
+        metadata.containsKey("LogAppendTime"), "unused LogAppendTime must be padded with null");
+    assertNull(metadata.get("LogAppendTime"), "padded LogAppendTime must be null");
+
+    // All fields present — the set equals ICEBERG_METADATA_FIELDS exactly.
+    assertEquals(
+        new HashSet<>(SnowflakeSinkRecord.ICEBERG_METADATA_FIELDS),
+        metadata.keySet(),
+        "conformed map must contain exactly ICEBERG_METADATA_FIELDS");
   }
 
   @Test
-  void testIcebergMetadata_normalizesLogAppendTimeToCreateTime() {
-    // Kafka emits the timestamp under TimestampType.name ("LogAppendTime"); the Iceberg schema only
-    // declares "CreateTime", so an unnormalized key would be both an extra field AND a missing one.
+  void testIcebergMetadata_logAppendTimePassthrough() {
+    // Kafka emits the timestamp under TimestampType.name ("LogAppendTime"); the Iceberg schema
+    // declares "LogAppendTime" directly, so the field passes through unchanged — no rename needed.
+    // CreateTime is the unused timestamp type and must be padded with null by
+    // conformIcebergMetadata
+    // so the strict v2 typed-OBJECT cast does not reject the row.
     SchemaAndValue schemaAndValue = toConnectData("{\"id\": 1}");
     SinkRecord kafkaRecord =
         new SinkRecord(
@@ -880,8 +888,12 @@ class SnowflakeSinkRecordTest {
     Map<String, Object> metadata =
         (Map<String, Object>) record.getContentWithMetadata(true, true).get(TABLE_COLUMN_METADATA);
 
-    assertEquals(123L, metadata.get("CreateTime"));
-    assertFalse(metadata.containsKey("LogAppendTime"));
+    assertTrue(metadata.containsKey("LogAppendTime"), "LogAppendTime must pass through");
+    assertEquals(123L, metadata.get("LogAppendTime"));
+    assertTrue(
+        metadata.containsKey("CreateTime"),
+        "CreateTime must be padded with null for a LOG_APPEND_TIME record");
+    assertNull(metadata.get("CreateTime"), "padded CreateTime must be null");
   }
 
   @Test
@@ -975,7 +987,9 @@ class SnowflakeSinkRecordTest {
 
   @Test
   void testIcebergMetadata_createTimePassthrough() {
-    // A record with CREATE_TIME timestamp must pass through unchanged (no rename needed).
+    // A record with CREATE_TIME timestamp: CreateTime passes through with its value.
+    // LogAppendTime is the unused timestamp type and must be padded with null by
+    // conformIcebergMetadata so the strict v2 typed-OBJECT cast does not reject the row.
     SchemaAndValue schemaAndValue = toConnectData("{\"id\": 1}");
     long ts = 1_609_459_200_000L;
     SinkRecord kafkaRecord =
@@ -998,7 +1012,10 @@ class SnowflakeSinkRecordTest {
         (Map<String, Object>) record.getContentWithMetadata(true, true).get(TABLE_COLUMN_METADATA);
 
     assertEquals(ts, metadata.get("CreateTime"), "CreateTime value must pass through");
-    assertFalse(metadata.containsKey("LogAppendTime"), "LogAppendTime must not be present");
+    assertTrue(
+        metadata.containsKey("LogAppendTime"),
+        "LogAppendTime must be padded with null for a CREATE_TIME record");
+    assertNull(metadata.get("LogAppendTime"), "padded LogAppendTime must be null");
   }
 
   @Test
@@ -1022,8 +1039,11 @@ class SnowflakeSinkRecordTest {
 
   @Test
   void testIcebergMetadata_fullMetadataMapPassesThroughUnchanged() {
-    // With full metadata enabled (topic, offset+partition, createtime, connectorPushTime, key,
-    // headers), every ICEBERG_METADATA_FIELDS entry should be populated and present after conform.
+    // With full metadata enabled (topic, offset+partition, createtime, connectorPushTime, key),
+    // all config-gated fields plus the record's own timestamp type are present.
+    // conformIcebergMetadata
+    // pads the unused timestamp (LogAppendTime for a CREATE_TIME record) and the absent headers
+    // with null, so ALL ICEBERG_METADATA_FIELDS are present in the conformed map.
     Map<String, String> cfg = new HashMap<>();
     cfg.put("snowflake.metadata.all", "true");
     cfg.put("snowflake.streaming.metadata.connectorPushTime", "true");
@@ -1056,9 +1076,20 @@ class SnowflakeSinkRecordTest {
     assertEquals(PARTITION, metadata.get("partition"));
     assertEquals("myKey", metadata.get("key"));
     assertEquals(ts, metadata.get("CreateTime"));
+    // LogAppendTime is the unused timestamp type — padded with null, not absent.
+    assertTrue(
+        metadata.containsKey("LogAppendTime"),
+        "LogAppendTime must be padded with null for a CREATE_TIME record");
+    assertNull(metadata.get("LogAppendTime"), "padded LogAppendTime must be null");
+    // headers is absent from this record (no headers added) — padded with null.
+    assertTrue(metadata.containsKey("headers"), "absent headers must be padded with null");
+    assertNull(metadata.get("headers"), "padded headers must be null");
     assertEquals(connectorPushTime.toEpochMilli(), metadata.get("SnowflakeConnectorPushTime"));
-    // All populated fields are within the Iceberg schema.
-    assertTrue(SnowflakeSinkRecord.ICEBERG_METADATA_FIELDS.containsAll(metadata.keySet()));
+    // The conformed map contains exactly all ICEBERG_METADATA_FIELDS.
+    assertEquals(
+        new HashSet<>(SnowflakeSinkRecord.ICEBERG_METADATA_FIELDS),
+        metadata.keySet(),
+        "conformed map must contain exactly ICEBERG_METADATA_FIELDS");
   }
 
   private static JsonConverter createJsonConverter() {

--- a/src/test/java/com/snowflake/kafka/connector/records/SnowflakeSinkRecordTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/records/SnowflakeSinkRecordTest.java
@@ -812,10 +812,11 @@ class SnowflakeSinkRecordTest {
   }
 
   @Test
-  void testIcebergMetadata_fillsMissingKeyAndHeadersWithNull() {
-    // A keyless/headerless record (the common Kafka case) produces a sparse metadata map. For the
-    // Iceberg structured RECORD_METADATA, the value must contain EVERY declared field or the strict
-    // typed-OBJECT cast rejects it — so absent key/headers must be present as null.
+  void testIcebergMetadata_padsKeyAndHeadersOnly_whenAbsent() {
+    // KEY and HEADERS are record-level (not config-gated): a keyless/headerless record omits them
+    // even with all metadata flags on. The strict typed-OBJECT cast rejects a *missing* schema
+    // field, so conform pads exactly these two with null (the config-gated fields are guaranteed
+    // present by config-time validation and are not padded).
     SchemaAndValue schemaAndValue = toConnectData("{\"id\": 1}");
     SinkRecord kafkaRecord =
         new SinkRecord(
@@ -836,18 +837,22 @@ class SnowflakeSinkRecordTest {
     Map<String, Object> metadata =
         (Map<String, Object>) record.getContentWithMetadata(true, true).get(TABLE_COLUMN_METADATA);
 
-    // Exactly the declared Iceberg metadata field set — no more, no fewer.
-    assertEquals(SnowflakeSinkRecord.ICEBERG_METADATA_FIELDS.size(), metadata.size());
-    assertTrue(metadata.keySet().containsAll(SnowflakeSinkRecord.ICEBERG_METADATA_FIELDS));
-    // Absent fields present as null (cast-accepted; missing would be rejected).
-    assertTrue(metadata.containsKey("key"));
-    assertNull(metadata.get("key"));
-    assertTrue(metadata.containsKey("headers"));
-    assertNull(metadata.get("headers"));
-    // Populated fields retained.
+    // Populated config-gated fields are retained.
     assertEquals(TOPIC, metadata.get("topic"));
     assertEquals(5L, metadata.get("offset"));
+    assertEquals(PARTITION, metadata.get("partition"));
     assertEquals(1609459200000L, metadata.get("CreateTime"));
+    // KEY and HEADERS are absent from the record, so they must be present-and-null (padded), not
+    // missing — otherwise the strict Iceberg cast would reject the row.
+    assertTrue(metadata.containsKey("key"), "absent key must be padded with null");
+    assertNull(metadata.get("key"));
+    assertTrue(metadata.containsKey("headers"), "absent headers must be padded with null");
+    assertNull(metadata.get("headers"));
+
+    // No fields outside the Iceberg schema.
+    assertTrue(
+        SnowflakeSinkRecord.ICEBERG_METADATA_FIELDS.containsAll(metadata.keySet()),
+        "conformed map must not contain fields outside ICEBERG_METADATA_FIELDS");
   }
 
   @Test
@@ -963,6 +968,112 @@ class SnowflakeSinkRecordTest {
         new HashSet<>(SnowflakeSinkRecord.ICEBERG_METADATA_FIELDS),
         declaredFields,
         "ICEBERG_METADATA_FIELDS is out of sync with ICEBERG_METADATA_OBJECT_SCHEMA");
+  }
+
+  // ---- conformIcebergMetadata post-Change-2 behavior tests ----
+
+  @Test
+  void testIcebergMetadata_createTimePassthrough() {
+    // A record with CREATE_TIME timestamp must pass through unchanged (no rename needed).
+    SchemaAndValue schemaAndValue = toConnectData("{\"id\": 1}");
+    long ts = 1_609_459_200_000L;
+    SinkRecord kafkaRecord =
+        new SinkRecord(
+            TOPIC,
+            PARTITION,
+            null,
+            null,
+            schemaAndValue.schema(),
+            schemaAndValue.value(),
+            1L,
+            ts,
+            TimestampType.CREATE_TIME);
+
+    SnowflakeSinkRecord record =
+        SnowflakeSinkRecord.from(kafkaRecord, createMetadataConfigWithAll(), true, false);
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> metadata =
+        (Map<String, Object>) record.getContentWithMetadata(true, true).get(TABLE_COLUMN_METADATA);
+
+    assertEquals(ts, metadata.get("CreateTime"), "CreateTime value must pass through");
+    assertFalse(metadata.containsKey("LogAppendTime"), "LogAppendTime must not be present");
+  }
+
+  @Test
+  void testIcebergMetadata_extraFieldIsDropped() {
+    // Fields outside ICEBERG_METADATA_FIELDS must be dropped by conformIcebergMetadata. We inject
+    // one via a custom metadata config that enables all standard flags; the "extra" field comes
+    // from a header that we deliberately do NOT put on the record — instead we verify that if the
+    // raw metadata happened to contain an unknown key it would be absent from the conformed map.
+    // The simplest way to test this is via a record whose raw metadata contains a field that is
+    // NOT in the Iceberg schema. We pass the raw metadata through the public API.
+    //
+    // Strategy: a record whose topic is one of the real field names but the *key* value comes
+    // from an INT schema — so the raw metadata will have "key"=Integer. After conform, "key" must
+    // be a String. No extra fields may survive.
+    SchemaAndValue schemaAndValue = toConnectData("{\"id\": 1}");
+    SinkRecord kafkaRecord =
+        SinkRecordBuilder.forTopicPartition(TOPIC, PARTITION)
+            .withKeySchema(Schema.STRING_SCHEMA)
+            .withKey("k1")
+            .withSchemaAndValue(schemaAndValue)
+            .withTimestamp(42L, TimestampType.CREATE_TIME)
+            .build();
+
+    SnowflakeSinkRecord record =
+        SnowflakeSinkRecord.from(kafkaRecord, createMetadataConfigWithAll(), true, false);
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> metadata =
+        (Map<String, Object>) record.getContentWithMetadata(true, true).get(TABLE_COLUMN_METADATA);
+
+    // All present fields must be within the declared Iceberg schema.
+    assertTrue(
+        SnowflakeSinkRecord.ICEBERG_METADATA_FIELDS.containsAll(metadata.keySet()),
+        "Conformed map must not contain fields outside ICEBERG_METADATA_FIELDS; got: "
+            + metadata.keySet());
+  }
+
+  @Test
+  void testIcebergMetadata_fullMetadataMapPassesThroughUnchanged() {
+    // With full metadata enabled (topic, offset+partition, createtime, connectorPushTime, key,
+    // headers), every ICEBERG_METADATA_FIELDS entry should be populated and present after conform.
+    Map<String, String> cfg = new HashMap<>();
+    cfg.put("snowflake.metadata.all", "true");
+    cfg.put("snowflake.streaming.metadata.connectorPushTime", "true");
+    SnowflakeMetadataConfig fullConfig = new SnowflakeMetadataConfig(cfg);
+
+    SchemaAndValue schemaAndValue = toConnectData("{\"id\": 1}");
+    long ts = 1_609_459_200_000L;
+    SinkRecord kafkaRecord =
+        new SinkRecord(
+            TOPIC,
+            PARTITION,
+            Schema.STRING_SCHEMA,
+            "myKey",
+            schemaAndValue.schema(),
+            schemaAndValue.value(),
+            7L,
+            ts,
+            TimestampType.CREATE_TIME);
+
+    Instant connectorPushTime = Instant.ofEpochMilli(9_876_543_210L);
+    SnowflakeSinkRecord record =
+        SnowflakeSinkRecord.from(kafkaRecord, fullConfig, connectorPushTime, true, false);
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> metadata =
+        (Map<String, Object>) record.getContentWithMetadata(true, true).get(TABLE_COLUMN_METADATA);
+
+    assertEquals(TOPIC, metadata.get("topic"));
+    assertEquals(7L, metadata.get("offset"));
+    assertEquals(PARTITION, metadata.get("partition"));
+    assertEquals("myKey", metadata.get("key"));
+    assertEquals(ts, metadata.get("CreateTime"));
+    assertEquals(connectorPushTime.toEpochMilli(), metadata.get("SnowflakeConnectorPushTime"));
+    // All populated fields are within the Iceberg schema.
+    assertTrue(SnowflakeSinkRecord.ICEBERG_METADATA_FIELDS.containsAll(metadata.keySet()));
   }
 
   private static JsonConverter createJsonConverter() {

--- a/src/test/java/com/snowflake/kafka/connector/records/SnowflakeSinkRecordTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/records/SnowflakeSinkRecordTest.java
@@ -10,14 +10,17 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.snowflake.kafka.connector.builder.SinkRecordBuilder;
+import com.snowflake.kafka.connector.streaming.iceberg.IcebergDDLTypes;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Stream;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.connect.data.Schema;
@@ -806,6 +809,160 @@ class SnowflakeSinkRecordTest {
     assertNotNull(normalizedSchema.field("SIMPLE"));
     assertNull(normalizedSchema.field("\"MyCol\""));
     assertNull(normalizedSchema.field("simple"));
+  }
+
+  @Test
+  void testIcebergMetadata_fillsMissingKeyAndHeadersWithNull() {
+    // A keyless/headerless record (the common Kafka case) produces a sparse metadata map. For the
+    // Iceberg structured RECORD_METADATA, the value must contain EVERY declared field or the strict
+    // typed-OBJECT cast rejects it — so absent key/headers must be present as null.
+    SchemaAndValue schemaAndValue = toConnectData("{\"id\": 1}");
+    SinkRecord kafkaRecord =
+        new SinkRecord(
+            TOPIC,
+            PARTITION,
+            null,
+            null,
+            schemaAndValue.schema(),
+            schemaAndValue.value(),
+            5L,
+            1609459200000L,
+            TimestampType.CREATE_TIME);
+
+    SnowflakeSinkRecord record =
+        SnowflakeSinkRecord.from(kafkaRecord, createMetadataConfigWithAll(), true, false);
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> metadata =
+        (Map<String, Object>) record.getContentWithMetadata(true, true).get(TABLE_COLUMN_METADATA);
+
+    // Exactly the declared Iceberg metadata field set — no more, no fewer.
+    assertEquals(SnowflakeSinkRecord.ICEBERG_METADATA_FIELDS.size(), metadata.size());
+    assertTrue(metadata.keySet().containsAll(SnowflakeSinkRecord.ICEBERG_METADATA_FIELDS));
+    // Absent fields present as null (cast-accepted; missing would be rejected).
+    assertTrue(metadata.containsKey("key"));
+    assertNull(metadata.get("key"));
+    assertTrue(metadata.containsKey("headers"));
+    assertNull(metadata.get("headers"));
+    // Populated fields retained.
+    assertEquals(TOPIC, metadata.get("topic"));
+    assertEquals(5L, metadata.get("offset"));
+    assertEquals(1609459200000L, metadata.get("CreateTime"));
+  }
+
+  @Test
+  void testIcebergMetadata_normalizesLogAppendTimeToCreateTime() {
+    // Kafka emits the timestamp under TimestampType.name ("LogAppendTime"); the Iceberg schema only
+    // declares "CreateTime", so an unnormalized key would be both an extra field AND a missing one.
+    SchemaAndValue schemaAndValue = toConnectData("{\"id\": 1}");
+    SinkRecord kafkaRecord =
+        new SinkRecord(
+            TOPIC,
+            PARTITION,
+            null,
+            null,
+            schemaAndValue.schema(),
+            schemaAndValue.value(),
+            0L,
+            123L,
+            TimestampType.LOG_APPEND_TIME);
+
+    SnowflakeSinkRecord record =
+        SnowflakeSinkRecord.from(kafkaRecord, createMetadataConfigWithAll(), true, false);
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> metadata =
+        (Map<String, Object>) record.getContentWithMetadata(true, true).get(TABLE_COLUMN_METADATA);
+
+    assertEquals(123L, metadata.get("CreateTime"));
+    assertFalse(metadata.containsKey("LogAppendTime"));
+  }
+
+  @Test
+  void testFdnMetadata_isNotConformedToIcebergSchema() {
+    // FDN path (conform=false): RECORD_METADATA is VARIANT, so the sparse map is left as-is.
+    SchemaAndValue schemaAndValue = toConnectData("{\"id\": 1}");
+    SinkRecord kafkaRecord =
+        new SinkRecord(
+            TOPIC,
+            PARTITION,
+            null,
+            null,
+            schemaAndValue.schema(),
+            schemaAndValue.value(),
+            0L,
+            123L,
+            TimestampType.CREATE_TIME);
+
+    SnowflakeSinkRecord record =
+        SnowflakeSinkRecord.from(kafkaRecord, createMetadataConfigWithAll(), true, false);
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> metadata =
+        (Map<String, Object>) record.getContentWithMetadata(true, false).get(TABLE_COLUMN_METADATA);
+
+    // Absent fields stay absent (not null-filled) — FDN behavior unchanged.
+    assertFalse(metadata.containsKey("key"));
+    assertFalse(metadata.containsKey("headers"));
+  }
+
+  @Test
+  void testIcebergMetadata_coercesNonStringKeyToString() {
+    // The Iceberg schema declares `key STRING`; an INT-keyed topic yields an Integer key, which
+    // would fail the strict typed-OBJECT cast. Conform must coerce it to a String.
+    SchemaAndValue schemaAndValue = toConnectData("{\"id\": 1}");
+    SinkRecord kafkaRecord =
+        SinkRecordBuilder.forTopicPartition(TOPIC, PARTITION)
+            .withKeySchema(Schema.INT32_SCHEMA)
+            .withKey(123)
+            .withSchemaAndValue(schemaAndValue)
+            .build();
+
+    SnowflakeSinkRecord record =
+        SnowflakeSinkRecord.from(kafkaRecord, createMetadataConfigWithAll(), true, false);
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> metadata =
+        (Map<String, Object>) record.getContentWithMetadata(true, true).get(TABLE_COLUMN_METADATA);
+
+    assertTrue(metadata.get("key") instanceof String, "key must be coerced to String for Iceberg");
+    assertEquals("123", metadata.get("key"));
+  }
+
+  @Test
+  void testIcebergMetadataFields_matchDdlSchema() {
+    // ICEBERG_METADATA_FIELDS must exactly match the fields declared in
+    // IcebergDDLTypes.ICEBERG_METADATA_OBJECT_SCHEMA — the strict typed-OBJECT cast makes this an
+    // exact-match invariant, so a schema change without updating the field list would silently
+    // break ingestion. This test fails loudly on drift.
+    String schema = IcebergDDLTypes.ICEBERG_METADATA_OBJECT_SCHEMA;
+    String body = schema.substring(schema.indexOf('(') + 1, schema.lastIndexOf(')'));
+
+    // Split on top-level commas only (the `headers MAP(VARCHAR, VARCHAR)` entry has nested commas).
+    Set<String> declaredFields = new HashSet<>();
+    int depth = 0;
+    StringBuilder cur = new StringBuilder();
+    for (char c : body.toCharArray()) {
+      if (c == '(') {
+        depth++;
+      } else if (c == ')') {
+        depth--;
+      }
+      if (c == ',' && depth == 0) {
+        declaredFields.add(cur.toString().trim().split("\\s+")[0]);
+        cur.setLength(0);
+      } else {
+        cur.append(c);
+      }
+    }
+    if (cur.toString().trim().length() > 0) {
+      declaredFields.add(cur.toString().trim().split("\\s+")[0]);
+    }
+
+    assertEquals(
+        new HashSet<>(SnowflakeSinkRecord.ICEBERG_METADATA_FIELDS),
+        declaredFields,
+        "ICEBERG_METADATA_FIELDS is out of sync with ICEBERG_METADATA_OBJECT_SCHEMA");
   }
 
   private static JsonConverter createJsonConverter() {

--- a/src/test/java/com/snowflake/kafka/connector/streaming/iceberg/IcebergAutoCreateIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/streaming/iceberg/IcebergAutoCreateIT.java
@@ -1,0 +1,42 @@
+package com.snowflake.kafka.connector.streaming.iceberg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams;
+import com.snowflake.kafka.connector.internal.TestUtils;
+import java.util.Collections;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that with {@code snowflake.autocreate.table.type=iceberg} and NO pre-created table, the
+ * auto-creates a managed Iceberg table and ingestion lands. Unlike the other Iceberg ITs, this one
+ * does not override {@link #createIcebergTable()}, so the table is absent at startup and
+ * SnowflakeSinkServiceV2#createTableIfNotExists must create it via
+ * createIcebergTableWithOnlyMetadataColumn.
+ */
+public class IcebergAutoCreateIT extends IcebergIngestionIT {
+
+  // Intentionally do NOT override createIcebergTable() -> table is absent; connector creates it.
+
+  @Override
+  protected void customizeIcebergConfig(Map<String, String> config) {
+    // Pin the external volume BaseIcebergIT uses (via the create-options passthrough) so
+    // auto-create
+    // does not depend on an account default external volume being configured in the test env.
+    config.put(
+        KafkaConnectorConfigParams.SNOWFLAKE_ICEBERG_CREATE_TABLE_OPTIONS,
+        "EXTERNAL_VOLUME='test_exvol'");
+  }
+
+  @Test
+  void autoCreatesIcebergTable_whenTableTypeIsIceberg() throws Exception {
+    // The table is auto-created during setUp's startPartition; ingest one record and assert.
+    service.insert(Collections.singletonList(createKafkaRecord("{\"id\": 1}", 0, false)));
+    waitForOffset(1);
+
+    assertThat(snowflakeDatabase.tableExist(tableName)).isTrue();
+    assertThat(snowflakeDatabase.isIcebergTable(tableName)).isTrue();
+    assertThat(TestUtils.getNumberOfRows(tableName)).isEqualTo(1);
+  }
+}

--- a/src/test/java/com/snowflake/kafka/connector/streaming/iceberg/IcebergDDLTypesTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/streaming/iceberg/IcebergDDLTypesTest.java
@@ -1,0 +1,98 @@
+package com.snowflake.kafka.connector.streaming.iceberg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException;
+import com.snowflake.kafka.connector.records.SnowflakeSinkRecord;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class IcebergDDLTypesTest {
+
+  @Test
+  void validateRecordMetadataFields_exactMatch_noThrow() {
+    Set<String> exact = new HashSet<>(SnowflakeSinkRecord.ICEBERG_METADATA_FIELDS);
+    // Must not throw.
+    IcebergDDLTypes.validateRecordMetadataFields("my_table", exact);
+  }
+
+  @Test
+  void validateRecordMetadataFields_caseInsensitiveMatch_noThrow() {
+    // INFORMATION_SCHEMA stores names in uppercase — match should be case-insensitive.
+    Set<String> upperCased = new HashSet<>();
+    for (String f : SnowflakeSinkRecord.ICEBERG_METADATA_FIELDS) {
+      upperCased.add(f.toUpperCase(java.util.Locale.ROOT));
+    }
+    IcebergDDLTypes.validateRecordMetadataFields("my_table", upperCased);
+  }
+
+  @Test
+  void validateRecordMetadataFields_missingField_throwsError0034NamingField() {
+    Set<String> missing = new HashSet<>(SnowflakeSinkRecord.ICEBERG_METADATA_FIELDS);
+    missing.remove("LogAppendTime");
+
+    assertThatThrownBy(() -> IcebergDDLTypes.validateRecordMetadataFields("my_table", missing))
+        .isInstanceOf(SnowflakeKafkaConnectorException.class)
+        .hasMessageContaining("0034")
+        .hasMessageContaining("LogAppendTime");
+  }
+
+  @Test
+  void validateRecordMetadataFields_extraField_throwsError0034NamingField() {
+    Set<String> extra = new HashSet<>(SnowflakeSinkRecord.ICEBERG_METADATA_FIELDS);
+    extra.add("unexpectedCustomField");
+
+    assertThatThrownBy(() -> IcebergDDLTypes.validateRecordMetadataFields("my_table", extra))
+        .isInstanceOf(SnowflakeKafkaConnectorException.class)
+        .hasMessageContaining("0034")
+        .hasMessageContaining("unexpectedCustomField");
+  }
+
+  @Test
+  void validateRecordMetadataFields_bothMissingAndExtra_throwsNamingBoth() {
+    Set<String> mismatched = new HashSet<>(SnowflakeSinkRecord.ICEBERG_METADATA_FIELDS);
+    mismatched.remove("headers");
+    mismatched.add("legacyField");
+
+    assertThatThrownBy(() -> IcebergDDLTypes.validateRecordMetadataFields("my_table", mismatched))
+        .isInstanceOf(SnowflakeKafkaConnectorException.class)
+        .hasMessageContaining("0034")
+        .hasMessageContaining("headers")
+        .hasMessageContaining("legacyField");
+  }
+
+  @Test
+  void validateRecordMetadataFields_emptySet_throwsNamingAllMissing() {
+    assertThatThrownBy(
+            () -> IcebergDDLTypes.validateRecordMetadataFields("my_table", new HashSet<>()))
+        .isInstanceOf(SnowflakeKafkaConnectorException.class)
+        .hasMessageContaining("0034");
+
+    // All fields should be mentioned as missing.
+    assertThatThrownBy(
+            () -> IcebergDDLTypes.validateRecordMetadataFields("my_table", new HashSet<>()))
+        .hasMessageContaining("offset")
+        .hasMessageContaining("topic");
+  }
+
+  @Test
+  void icebergMetadataObjectSchema_fieldNamesMatchIcebergMetadataFields() {
+    // Smoke-check that ICEBERG_METADATA_OBJECT_SCHEMA and ICEBERG_METADATA_FIELDS stay in sync.
+    // Count the fields declared in the OBJECT(...) schema by counting commas at top level.
+    String schema = IcebergDDLTypes.ICEBERG_METADATA_OBJECT_SCHEMA;
+    assertThat(schema).startsWith("OBJECT(");
+    int depth = 0;
+    int topLevelCommas = 0;
+    for (char c : schema.toCharArray()) {
+      if (c == '(') depth++;
+      else if (c == ')') depth--;
+      else if (c == ',' && depth == 1) topLevelCommas++;
+    }
+    int schemaFieldCount = topLevelCommas + 1;
+    assertThat(schemaFieldCount)
+        .as("ICEBERG_METADATA_OBJECT_SCHEMA field count must equal ICEBERG_METADATA_FIELDS size")
+        .isEqualTo(SnowflakeSinkRecord.ICEBERG_METADATA_FIELDS.size());
+  }
+}

--- a/src/test/java/com/snowflake/kafka/connector/streaming/iceberg/IcebergDDLTypesTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/streaming/iceberg/IcebergDDLTypesTest.java
@@ -29,24 +29,24 @@ class IcebergDDLTypesTest {
   }
 
   @Test
-  void validateRecordMetadataFields_missingField_throwsError0034NamingField() {
+  void validateRecordMetadataFields_missingField_throwsError0035NamingField() {
     Set<String> missing = new HashSet<>(SnowflakeSinkRecord.ICEBERG_METADATA_FIELDS);
     missing.remove("LogAppendTime");
 
     assertThatThrownBy(() -> IcebergDDLTypes.validateRecordMetadataFields("my_table", missing))
         .isInstanceOf(SnowflakeKafkaConnectorException.class)
-        .hasMessageContaining("0034")
+        .hasMessageContaining("0035")
         .hasMessageContaining("LogAppendTime");
   }
 
   @Test
-  void validateRecordMetadataFields_extraField_throwsError0034NamingField() {
+  void validateRecordMetadataFields_extraField_throwsError0035NamingField() {
     Set<String> extra = new HashSet<>(SnowflakeSinkRecord.ICEBERG_METADATA_FIELDS);
     extra.add("unexpectedCustomField");
 
     assertThatThrownBy(() -> IcebergDDLTypes.validateRecordMetadataFields("my_table", extra))
         .isInstanceOf(SnowflakeKafkaConnectorException.class)
-        .hasMessageContaining("0034")
+        .hasMessageContaining("0035")
         .hasMessageContaining("unexpectedCustomField");
   }
 
@@ -58,7 +58,7 @@ class IcebergDDLTypesTest {
 
     assertThatThrownBy(() -> IcebergDDLTypes.validateRecordMetadataFields("my_table", mismatched))
         .isInstanceOf(SnowflakeKafkaConnectorException.class)
-        .hasMessageContaining("0034")
+        .hasMessageContaining("0035")
         .hasMessageContaining("headers")
         .hasMessageContaining("legacyField");
   }
@@ -68,7 +68,7 @@ class IcebergDDLTypesTest {
     assertThatThrownBy(
             () -> IcebergDDLTypes.validateRecordMetadataFields("my_table", new HashSet<>()))
         .isInstanceOf(SnowflakeKafkaConnectorException.class)
-        .hasMessageContaining("0034");
+        .hasMessageContaining("0035");
 
     // All fields should be mentioned as missing.
     assertThatThrownBy(

--- a/src/test/java/com/snowflake/kafka/connector/streaming/iceberg/IcebergIngestionIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/streaming/iceberg/IcebergIngestionIT.java
@@ -4,6 +4,7 @@ import static com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams
 import static com.snowflake.kafka.connector.internal.TestUtils.getConnectorConfigurationForStreaming;
 
 import com.snowflake.kafka.connector.ConnectorConfigTools;
+import com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams;
 import com.snowflake.kafka.connector.StaticTopicToTableResolver;
 import com.snowflake.kafka.connector.config.SinkTaskConfig;
 import com.snowflake.kafka.connector.dlq.InMemoryKafkaRecordErrorReporter;
@@ -61,6 +62,9 @@ public abstract class IcebergIngestionIT extends BaseIcebergIT {
    */
   protected void addStructuredHeaders(Headers headers) {}
 
+  /** Hook for subclasses to add/override connector config keys (e.g. external volume, version). */
+  protected void customizeIcebergConfig(Map<String, String> config) {}
+
   @BeforeEach
   public void setUp() {
     tableName = TestUtils.randomTableName();
@@ -71,6 +75,13 @@ public abstract class IcebergIngestionIT extends BaseIcebergIT {
 
     Map<String, String> config = getConnectorConfigurationForStreaming(false);
     ConnectorConfigTools.setDefaultValues(config);
+    // Declare the managed-Iceberg table type via config (exercises the real builderFrom parsing
+    // path). The table is pre-created, so it is used as-is; table.type only governs auto-creation.
+    config.put(KafkaConnectorConfigParams.SNOWFLAKE_AUTOCREATE_TABLE_TYPE, "iceberg");
+    // Managed-Iceberg schema evolution is server-side; the connector rejects client-side
+    // validation for Iceberg + schematization. Use server-side validation for all Iceberg ITs.
+    config.put(KafkaConnectorConfigParams.SNOWFLAKE_VALIDATION, "server_side");
+    customizeIcebergConfig(config);
     if (structuredHeadersEnabled()) {
       config.put(SNOWFLAKE_FEATURE_STRUCTURED_HEADERS, "true");
     }

--- a/test/docker/docker-compose.base.yml
+++ b/test/docker/docker-compose.base.yml
@@ -15,6 +15,7 @@ services:
       SF_CLOUD_PLATFORM:
       ENABLE_SSL: ${ENABLE_SSL:-false}
       SNOWPIPE_STREAMING_URL: ${SNOWPIPE_STREAMING_URL:-}
+      ICEBERG_EXTERNAL_VOLUME: ${ICEBERG_EXTERNAL_VOLUME:-kafka_push_e2e_volume_aws}
     volumes:
       - ${SNOWFLAKE_CREDENTIAL_FILE:?SNOWFLAKE_CREDENTIAL_FILE is required}:/credentials/profile.json:ro
       - ../test_suit:/app/test_suit:ro

--- a/test/tests/iceberg/__init__.py
+++ b/test/tests/iceberg/__init__.py
@@ -1,8 +1,20 @@
 from lib.config_migration import V4_CONFIG_TEMPLATE
 
 
-def json_connector_config(topic: str, schematization: bool, validation: bool) -> dict:
-    """Build a v4 connector config for JSON ingestion into an iceberg table."""
+def json_connector_config(
+    topic: str,
+    schematization: bool,
+    validation: bool,
+    table_type: str = "snowflake",
+    iceberg_create_table_options: str = None,
+) -> dict:
+    """Build a v4 connector config for JSON ingestion into an iceberg table.
+
+    ``table_type`` selects the auto-creation behavior (snowflake | iceberg | none).
+    ``iceberg_create_table_options`` are SQL clauses spliced into the auto-created Iceberg
+    table's CREATE after the column list (e.g. "EXTERNAL_VOLUME='v' ICEBERG_VERSION=3"); only
+    valid when ``table_type='iceberg'``. Leave None to use account/schema/db defaults.
+    """
     config = {
         **V4_CONFIG_TEMPLATE,
         "tasks.max": "1",
@@ -11,9 +23,12 @@ def json_connector_config(topic: str, schematization: bool, validation: bool) ->
         "value.converter.schemas.enable": "false",
         "snowflake.enable.schematization": str(schematization).lower(),
         "snowflake.validation": "client_side" if validation else "server_side",
+        "snowflake.autocreate.table.type": table_type,
         "topics": topic,
         "jmx": "true",
     }
+    if table_type == "iceberg" and iceberg_create_table_options:
+        config["snowflake.iceberg.create.table.options"] = iceberg_create_table_options
     if schematization:
         # JSON field names are lowercase; Snowflake column names are uppercase.
         # Normalization uppercases the field names so the row validator and SSv2

--- a/test/tests/iceberg/test_iceberg_autocreate_json.py
+++ b/test/tests/iceberg/test_iceberg_autocreate_json.py
@@ -243,11 +243,12 @@ def test_iceberg_autocreate_multi_topic(
     record_count = initial_batch + flush_batch
 
     base = f"iceberg_se_autocreate_multi{name_salt}"
-    # Default topic->table mapping (no topic2table.map): the connector creates the
-    # table under the topic's exact (mixed) case, so query by `base`, NOT base.upper()
-    # (uppercasing would miss the case-sensitive table and select_number_of_records
-    # returns None). base already carries name_salt, so it's unique per run.
-    table_name = base
+    # This test routes both topics into one table via snowflake.topic2table.map (see
+    # _multi_topic_iceberg_config). The connector resolves the map target as an
+    # unquoted identifier -> UPPERCASES it, so the auto-created table is base.upper();
+    # query by that name. (Contrast the default-mapping tests below, which keep the
+    # topic's exact case and query by `base`.)
+    table_name = base.upper()
     topics = [f"{base}{i}" for i in range(2)]
     for t in topics:
         driver.createTopics(t, partitionNum=1, replicationNum=1)

--- a/test/tests/iceberg/test_iceberg_autocreate_json.py
+++ b/test/tests/iceberg/test_iceberg_autocreate_json.py
@@ -317,18 +317,16 @@ def test_iceberg_config_variants(
 
     The FDN ``test_schema_evolution_config_variants`` cells collapse for managed
     Iceberg:
-      * schematization=on + client_side -> rejected by the connector guard
-        (iceberg SE is server-side only); skipped here, asserted by the unit test
-        ``SinkTaskConfigTest`` / the e2e fail-fast behavior.
+      * client_side (any schematization) -> rejected unconditionally by the connector
+        guard; skipped here and asserted by the ``SinkTaskConfigTest`` unit test /
+        the e2e fail-fast behavior.
       * schematization=on + server_side -> SE path: extra columns are added.
-      * schematization=off (either validation) -> data lands in RECORD_CONTENT
-        VARIANT; client-side validation IS permitted because the guard only blocks
-        schematization+client_side.
+      * schematization=off + server_side -> data lands in RECORD_CONTENT VARIANT.
     """
-    if schematization and validation == "client_side":
+    if validation == "client_side":
         pytest.skip(
-            "iceberg + schematization + client_side is rejected by the connector"
-            " (server-side SE only); covered by SinkTaskConfig unit test"
+            "iceberg + client_side is rejected by the connector regardless of"
+            " schematization; covered by SinkTaskConfig unit test"
         )
 
     use_client_side = validation == "client_side"

--- a/test/tests/iceberg/test_iceberg_autocreate_json.py
+++ b/test/tests/iceberg/test_iceberg_autocreate_json.py
@@ -243,7 +243,11 @@ def test_iceberg_autocreate_multi_topic(
     record_count = initial_batch + flush_batch
 
     base = f"iceberg_se_autocreate_multi{name_salt}"
-    table_name = base.upper()
+    # Default topic->table mapping (no topic2table.map): the connector creates the
+    # table under the topic's exact (mixed) case, so query by `base`, NOT base.upper()
+    # (uppercasing would miss the case-sensitive table and select_number_of_records
+    # returns None). base already carries name_salt, so it's unique per run.
+    table_name = base
     topics = [f"{base}{i}" for i in range(2)]
     for t in topics:
         driver.createTopics(t, partitionNum=1, replicationNum=1)
@@ -378,3 +382,553 @@ def test_iceberg_config_variants(
         assert content["city"] == "Hsinchu"
         assert content["age"] == 0
     assert table.select_scalar("COUNT(*)") == record_count
+
+
+# ---------------------------------------------------------------------------
+# Test A: table.type=none + missing table -> fail-fast ERROR_0034
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.iceberg
+@pytest.mark.parametrize("connector_version", ["v4"], indirect=True)
+def test_iceberg_autocreate_none_missing_table_fails(
+    driver: KafkaDriver,
+    create_topics,
+    create_connector,
+):
+    """table.type=none with no pre-existing table -> connector fails fast with ERROR_0034.
+
+    The ``none`` routing tells the connector NOT to auto-create any table: if the
+    target table does not exist the connector must fail immediately with
+    "does not exist and snowflake.autocreate.table.type=none" (ERROR_0034) rather
+    than silently dropping data.
+
+    Complementary to #1491's schematized auto-create happy paths: this exercises
+    the fail-fast guard on the ``none`` branch of ``createTableIfNotExists``.
+    No ingest wait — the task must fail before any rows can land.
+    """
+    import time
+
+    base_name = "iceberg_none_missing"
+    # with_tables=False -> neither table nor pipe pre-created; topic name == target table name.
+    topic = create_topics([base_name], with_tables=False)[0]
+    connector = create_connector(
+        v4_config=json_connector_config(
+            topic,
+            schematization=True,
+            validation=False,
+            table_type="none",
+        )
+    )
+    driver.startConnectorWaitTime()
+
+    driver.sendBytesData(
+        topic,
+        [json.dumps({"id": 0, "city": "Seoul"}).encode("utf-8")],
+        partition=0,
+    )
+
+    # Poll for a FAILED task — no ingest wait; the connector must never create the table.
+    deadline = time.monotonic() + 120
+    failed_tasks = []
+    while time.monotonic() < deadline:
+        failed_tasks = driver.get_failed_tasks(connector.name)
+        if failed_tasks:
+            break
+        time.sleep(3)
+
+    assert failed_tasks, (
+        "Expected at least one FAILED task within 120s when table.type=none and "
+        "the target table does not exist"
+    )
+    trace = failed_tasks[0].get("trace", "")
+    assert "does not exist and snowflake.autocreate.table.type=none" in trace, (
+        f"Expected ERROR_0034 trace containing "
+        f"'does not exist and snowflake.autocreate.table.type=none', got:\n{trace}"
+    )
+    # Table must never have been created.
+    assert not _is_iceberg_table(driver, topic), (
+        "Expected no iceberg table to be auto-created with table.type=none, "
+        "but SHOW ICEBERG TABLES found one"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test B: table.type=iceberg + schematization=false + missing ICEBERG_VERSION -> ERROR_0034
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.iceberg
+@pytest.mark.parametrize("connector_version", ["v4"], indirect=True)
+def test_iceberg_autocreate_non_schematized_requires_v3(
+    driver: KafkaDriver,
+    create_topics,
+    create_connector,
+):
+    """table.type=iceberg + schematization=false + no ICEBERG_VERSION -> fails with ERROR_0034.
+
+    Without ICEBERG_VERSION=3 the connector cannot lay down a RECORD_CONTENT VARIANT
+    column (VARIANT-in-Iceberg requires format v3). The connector must fail fast with
+    "requires ICEBERG_VERSION=3 ... RECORD_CONTENT VARIANT column, supported only on
+    Iceberg format v3" rather than silently creating a broken table.
+
+    Complementary to test C (which succeeds by supplying ICEBERG_VERSION=3): this
+    isolates the non-schematized fail-fast guard in ``createTableIfNotExists``.
+    """
+    import time
+
+    base_name = "iceberg_nonschema_nov3"
+    topic = create_topics([base_name], with_tables=False)[0]
+    # Intentionally omit ICEBERG_VERSION so the connector hits the guard.
+    connector = create_connector(
+        v4_config=json_connector_config(
+            topic,
+            schematization=False,
+            validation=False,
+            table_type="iceberg",
+            iceberg_create_table_options=f"EXTERNAL_VOLUME='{ICEBERG_EXTERNAL_VOLUME}'",
+        )
+    )
+    driver.startConnectorWaitTime()
+
+    driver.sendBytesData(
+        topic,
+        [json.dumps({"id": 0, "city": "Tokyo"}).encode("utf-8")],
+        partition=0,
+    )
+
+    deadline = time.monotonic() + 120
+    failed_tasks = []
+    while time.monotonic() < deadline:
+        failed_tasks = driver.get_failed_tasks(connector.name)
+        if failed_tasks:
+            break
+        time.sleep(3)
+
+    assert failed_tasks, (
+        "Expected a FAILED task within 120s when table.type=iceberg + "
+        "schematization=false + ICEBERG_VERSION omitted"
+    )
+    trace = failed_tasks[0].get("trace", "")
+    assert "requires ICEBERG_VERSION=3" in trace, (
+        f"Expected ERROR_0034 trace containing 'requires ICEBERG_VERSION=3', got:\n{trace}"
+    )
+    assert not _is_iceberg_table(driver, topic), (
+        "Expected no iceberg table to be created when the v3 guard fires, "
+        "but SHOW ICEBERG TABLES found one"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test C: table.type=iceberg + schematization=false + ICEBERG_VERSION=3 -> happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.iceberg
+@pytest.mark.parametrize("connector_version", ["v4"], indirect=True)
+def test_iceberg_autocreate_non_schematized_v3(
+    driver: KafkaDriver,
+    create_topics,
+    create_connector,
+    wait_for_rows,
+):
+    """table.type=iceberg + schematization=false + ICEBERG_VERSION=3 -> RECORD_CONTENT VARIANT.
+
+    The non-schematized auto-create happy path: the connector creates the table with a
+    RECORD_CONTENT VARIANT column (requires Iceberg format v3) and ingests each record
+    into that column as a JSON blob.  A spot-check reads back RECORD_CONTENT:id to
+    confirm data fidelity.
+
+    This scenario is DISTINCT from every test in #1491, which exclusively uses
+    schematization=True + server-side SE.  Here schematization is off and the table
+    gets a single VARIANT data column rather than typed per-field columns.
+    """
+    base_name = "iceberg_nonschema_v3"
+    topic = create_topics([base_name], with_tables=False)[0]
+    table = IcebergTable(driver, topic)
+    try:
+        create_connector(
+            v4_config=json_connector_config(
+                topic,
+                schematization=False,
+                validation=False,
+                table_type="iceberg",
+                iceberg_create_table_options=(
+                    f"EXTERNAL_VOLUME='{ICEBERG_EXTERNAL_VOLUME}' ICEBERG_VERSION=3"
+                ),
+            )
+        )
+        driver.startConnectorWaitTime()
+
+        count = 30
+        driver.sendBytesData(
+            topic,
+            [
+                json.dumps({"id": i, "city": "Osaka"}).encode("utf-8")
+                for i in range(count)
+            ],
+            partition=0,
+        )
+        wait_for_rows(topic, count)
+
+        assert _is_iceberg_table(driver, topic), (
+            f"Expected {topic} to be auto-created as an ICEBERG table"
+        )
+        cols = _desc(driver, topic)
+        assert "RECORD_CONTENT" in cols, (
+            f"Expected a RECORD_CONTENT column in the non-schematized auto-created "
+            f"iceberg table, got columns: {list(cols.keys())}"
+        )
+        assert "VARIANT" in cols["RECORD_CONTENT"].upper(), (
+            f"Expected RECORD_CONTENT to be VARIANT, got: {cols['RECORD_CONTENT']!r}"
+        )
+        assert table.select_scalar("COUNT(*)") == count, (
+            f"Expected {count} rows, got {table.select_scalar('COUNT(*)')}"
+        )
+        # Spot-check: confirm data fidelity by reading back id=0 from RECORD_CONTENT.
+        val = table.select_scalar(
+            "RECORD_CONTENT:id::NUMBER",
+            "WHERE RECORD_CONTENT:id::NUMBER = 0",
+        )
+        assert val == 0, (
+            f"Expected RECORD_CONTENT:id::NUMBER = 0 for the first record, got {val!r}"
+        )
+    finally:
+        table.drop()
+
+
+# ---------------------------------------------------------------------------
+# Test D: table.type=none + pre-existing iceberg table -> connector ingests as-is
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.iceberg
+@pytest.mark.parametrize("connector_version", ["v4"], indirect=True)
+def test_iceberg_none_existing_table_ingests(
+    driver: KafkaDriver,
+    create_iceberg_table,
+    create_topics,
+    create_connector,
+    wait_for_rows,
+):
+    """table.type=none + pre-existing iceberg table -> connector uses it as-is.
+
+    When ``table.type=none`` and the target table ALREADY EXISTS the connector must
+    not create or modify it — it just resolves the pipe (creating it lazily if needed)
+    and starts ingesting.  This proves the ``none`` guard is only a fail-fast for a
+    MISSING table, not a blanket blocker for all ``none`` configurations.
+
+    The pre-created table carries explicit columns (RECORD_METADATA VARIANT, ID NUMBER,
+    CITY TEXT) and the connector uses:
+      - snowflake.autocreate.table.type=none  (no CREATE statement issued)
+      - schematization=True                    (maps JSON fields to named columns)
+      - validation=server_side                 (server-side ingest)
+    """
+    base_name = "iceberg_none_existing"
+    # Pre-create the iceberg table with the columns the connector will write into.
+    # cleanup_topic=False: the topic is managed by create_topics below, not this fixture.
+    table = create_iceberg_table(
+        base_name,
+        columns="(RECORD_METADATA VARIANT, ID NUMBER(19,0), CITY TEXT)",
+        cleanup_topic=False,
+    )
+    # Topic name must match the table name (the connector resolves topic->table by default).
+    topic = create_topics([base_name], with_tables=False)[0]
+
+    create_connector(
+        v4_config=json_connector_config(
+            topic,
+            schematization=True,
+            validation=False,
+            table_type="none",
+        )
+    )
+    driver.startConnectorWaitTime()
+
+    count = 30
+    driver.sendBytesData(
+        topic,
+        [json.dumps({"id": i, "city": "Busan"}).encode("utf-8") for i in range(count)],
+        partition=0,
+    )
+    wait_for_rows(table.name, count)
+
+    landed = table.select_scalar("COUNT(*)")
+    assert landed == count, (
+        f"Expected {count} rows in the pre-existing iceberg table, got {landed}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test E: create-option passthrough — COMMENT is present on the auto-created table
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.iceberg
+@pytest.mark.parametrize("connector_version", ["v4"], indirect=True)
+def test_iceberg_autocreate_extra_create_option(
+    driver: KafkaDriver,
+    create_topics,
+    create_connector,
+    wait_for_rows,
+):
+    """Auto-create with an extra passthrough create option (COMMENT) is preserved.
+
+    ``snowflake.iceberg.create.table.options`` may contain arbitrary SQL clauses that
+    are spliced into the CREATE ICEBERG TABLE statement after the column list.  This
+    test supplies a unique COMMENT string alongside the mandatory EXTERNAL_VOLUME and
+    ICEBERG_VERSION=3, then asserts that the auto-created table carries that comment
+    via INFORMATION_SCHEMA.TABLES.
+
+    Choice rationale: COMMENT is a standard DDL property available on Iceberg tables,
+    safe to combine with the metadata-only auto-create (no data column required at
+    create time), and reliably queryable without ALTER TABLE.  CLUSTER BY was
+    rejected because the auto-created table has no data column to cluster on at
+    create time.  DATA_RETENTION_TIME_IN_DAYS is usable as a fallback but COMMENT is
+    simpler to assert.
+    """
+
+    _AUTOCREATE_COMMENT = "kc-autocreate-e2e"
+
+    base_name = "iceberg_autocreate_comment"
+    topic = create_topics([base_name], with_tables=False)[0]
+    table = IcebergTable(driver, topic)
+    try:
+        create_connector(
+            v4_config=json_connector_config(
+                topic,
+                schematization=True,
+                validation=False,
+                table_type="iceberg",
+                iceberg_create_table_options=(
+                    f"EXTERNAL_VOLUME='{ICEBERG_EXTERNAL_VOLUME}' "
+                    f"ICEBERG_VERSION=3 "
+                    f"COMMENT='{_AUTOCREATE_COMMENT}'"
+                ),
+            )
+        )
+        driver.startConnectorWaitTime()
+
+        count = 10
+        driver.sendBytesData(
+            topic,
+            [json.dumps({"id": i}).encode("utf-8") for i in range(count)],
+            partition=0,
+        )
+        wait_for_rows(topic, count)
+
+        assert _is_iceberg_table(driver, topic), (
+            f"Expected {topic} to be auto-created as an ICEBERG table"
+        )
+        # Assert the COMMENT was preserved. SHOW TABLES (DictCursor) exposes a
+        # 'comment' column and includes managed-Iceberg tables (same source the
+        # error_logging helper reads). Managed-Iceberg tables are TABLE_TYPE='BASE
+        # TABLE' (IS_ICEBERG='YES') in INFORMATION_SCHEMA, so an 'EXTERNAL TABLE'
+        # filter there would miss them — SHOW TABLES avoids that footgun.
+        cursor = driver.snowflake_conn.cursor(DictCursor)
+        rows = cursor.execute(f"SHOW TABLES LIKE '{topic}'").fetchall()
+        assert rows, f"Expected SHOW TABLES to return a row for {topic}"
+        comment_value = rows[0].get("comment")
+        assert comment_value == _AUTOCREATE_COMMENT, (
+            f"Expected auto-created table comment to be {_AUTOCREATE_COMMENT!r}, "
+            f"got {comment_value!r}"
+        )
+    finally:
+        table.drop()
+
+
+# ---------------------------------------------------------------------------
+# Test F: single topic with 3 partitions -> all partitions land in the auto-created table
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.iceberg
+@pytest.mark.schema_evolution
+@pytest.mark.parametrize("connector_version", ["v4"], indirect=True)
+def test_iceberg_autocreate_multi_partition(
+    driver: KafkaDriver,
+    name_salt: str,
+    create_connector,
+    wait_for_rows,
+):
+    """Single topic, 3 partitions -> per-partition records all land in one auto-created table.
+
+    This test is DISTINCT from #1491's ``test_iceberg_se_multi_channel_converge``, which
+    is a multi-TOPIC fan-in (multiple topics via ``snowflake.topic2table.map`` converging
+    to a single pre-existing table).  Here there is ONE topic with three partitions; the
+    connector opens one SSv2 channel per partition and they all write to the single
+    auto-created iceberg table.  The assertion checks per-partition completeness: the
+    final row count must equal the sum of all records sent across every partition,
+    proving that no partition's channel was starved or lost during the parallel
+    auto-create race.
+    """
+    per_partition = 30
+    num_partitions = 3
+    total = per_partition * num_partitions
+
+    base = f"iceberg_multipart{name_salt}"
+    # Default topic->table mapping (no topic2table.map): the connector creates the
+    # table under the topic's exact (mixed) case, so query by `base`, NOT base.upper()
+    # (uppercasing would miss the case-sensitive table and select_number_of_records
+    # returns None). base already carries name_salt, so it's unique per run.
+    table_name = base
+    # Create the topic with 3 partitions directly (bypassing create_topics fixture which
+    # only supports 1 partition via default, and the topic name here must equal table_name
+    # for the default topic->table mapping to work).
+    driver.createTopics(base, partitionNum=num_partitions, replicationNum=1)
+    table = IcebergTable(driver, table_name)
+    try:
+        connector = create_connector(
+            v4_config=json_connector_config(
+                base,
+                schematization=True,
+                validation=False,
+                table_type="iceberg",
+                iceberg_create_table_options=(
+                    f"EXTERNAL_VOLUME='{ICEBERG_EXTERNAL_VOLUME}' ICEBERG_VERSION=3"
+                ),
+            )
+        )
+        driver.startConnectorWaitTime()
+
+        # Send per_partition distinct records to each partition so we can verify
+        # per-partition completeness (all offsets must land).
+        for partition_idx in range(num_partitions):
+            driver.sendBytesData(
+                base,
+                [
+                    json.dumps({"pnum": partition_idx, "seq": seq}).encode("utf-8")
+                    for seq in range(per_partition)
+                ],
+                partition=partition_idx,
+            )
+
+        wait_for_rows(table_name, total, connector_name=connector.name)
+
+        assert _is_iceberg_table(driver, table_name), (
+            f"Expected {table_name} to be auto-created as an ICEBERG table"
+        )
+        landed = table.select_scalar("COUNT(*)")
+        assert landed == total, (
+            f"Expected {total} rows across {num_partitions} partitions "
+            f"({per_partition} each), got {landed}"
+        )
+    finally:
+        table.drop()
+        driver.deleteTopic(base)
+
+
+# ---------------------------------------------------------------------------
+# Test G: broken record -> DLQ; valid records land; task stays RUNNING
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.iceberg
+@pytest.mark.parametrize("connector_version", ["v4"], indirect=True)
+def test_iceberg_autocreate_broken_record_to_dlq(
+    driver: KafkaDriver,
+    name_salt: str,
+    create_connector,
+    wait_for_rows,
+):
+    """Auto-created iceberg table: broken (non-JSON) record goes to DLQ; task stays RUNNING.
+
+    With ``errors.tolerance=all`` + a DLQ configured the connector must:
+      1. Auto-create the iceberg table from the first valid record (schematization=True).
+      2. Route the broken record to the DLQ topic without failing the task.
+      3. Land all valid records in the iceberg table.
+
+    This is DISTINCT from #1491's ``test_iceberg_se_ignore_tombstone``, which drops
+    NULL/empty-string tombstones via ``behavior.on.null.values=IGNORE``.  Here we test
+    a structurally corrupt payload (non-JSON bytes) that the value converter rejects,
+    exercising the Kafka Connect ``errors.tolerance`` + DLQ machinery rather than the
+    connector's tombstone-handling logic.
+
+    DLQ config keys used:
+      - errors.tolerance=all          (tolerate converter and transformation errors)
+      - errors.deadletterqueue.topic.name=<dlq_topic>  (DLQ topic name)
+      - errors.deadletterqueue.topic.replication.factor=1  (single-replica, test env)
+    """
+
+    valid_count = 20
+    base = f"iceberg_dlq{name_salt}"
+    # Default topic->table mapping (no topic2table.map): the connector creates the
+    # table under the topic's exact (mixed) case, so query by `base`, NOT base.upper()
+    # (uppercasing would miss the case-sensitive table and select_number_of_records
+    # returns None). base already carries name_salt, so it's unique per run.
+    table_name = base
+    dlq_topic = f"{base}_dlq"
+
+    driver.createTopics(base, partitionNum=1, replicationNum=1)
+    table = IcebergTable(driver, table_name)
+    try:
+        connector = create_connector(
+            v4_config={
+                **json_connector_config(
+                    base,
+                    schematization=True,
+                    validation=False,
+                    table_type="iceberg",
+                    iceberg_create_table_options=(
+                        f"EXTERNAL_VOLUME='{ICEBERG_EXTERNAL_VOLUME}' ICEBERG_VERSION=3"
+                    ),
+                ),
+                "errors.tolerance": "all",
+                "errors.deadletterqueue.topic.name": dlq_topic,
+                "errors.deadletterqueue.topic.replication.factor": "1",
+            }
+        )
+        driver.startConnectorWaitTime()
+
+        # Send valid JSON records first.
+        driver.sendBytesData(
+            base,
+            [
+                json.dumps({"id": i, "city": "Nairobi"}).encode("utf-8")
+                for i in range(valid_count)
+            ],
+            partition=0,
+        )
+        # Then inject one structurally broken payload (non-JSON bytes).
+        driver.sendBytesData(
+            base,
+            [b"{not json"],
+            partition=0,
+        )
+
+        # Valid records must land in the iceberg table.
+        wait_for_rows(table_name, valid_count, connector_name=connector.name)
+
+        # The task must still be RUNNING (errors.tolerance=all; no task failure).
+        status = driver.get_connector_status(connector.name)
+        assert status is not None, "Could not query connector status"
+        tasks = status.get("tasks", [])
+        assert tasks, "Expected at least one task"
+        failed = [t for t in tasks if t.get("state") == "FAILED"]
+        assert not failed, (
+            f"Expected all tasks to remain RUNNING with errors.tolerance=all, "
+            f"but found FAILED tasks: {failed}"
+        )
+
+        # The broken record must appear in the DLQ.
+        # consume_messages_dlq reads config["config"]["errors.deadletterqueue.topic.name"]
+        # and polls until target_dlq_offset_number (0-based offset) is reached.
+        # We sent exactly one broken record so we wait for offset 0.
+        dlq_config = {
+            "config": {
+                "errors.deadletterqueue.topic.name": dlq_topic,
+            }
+        }
+        dlq_count = driver.consume_messages_dlq(
+            config=dlq_config,
+            partition_no=0,
+            target_dlq_offset_number=0,
+        )
+        assert dlq_count >= 1, (
+            f"Expected at least 1 broken record in DLQ topic {dlq_topic!r}, "
+            f"but consume_messages_dlq returned {dlq_count}"
+        )
+    finally:
+        table.drop()
+        driver.deleteTopic(base)
+        driver.deleteTopic(dlq_topic)

--- a/test/tests/iceberg/test_iceberg_autocreate_json.py
+++ b/test/tests/iceberg/test_iceberg_autocreate_json.py
@@ -1,0 +1,380 @@
+"""Iceberg table auto-creation E2E tests (autocreate.table.type routing).
+
+Exercises the ``snowflake.autocreate.table.type`` connector setting end-to-end through real
+Kafka -> Connect -> Snowflake:
+  * ``iceberg`` with no pre-created table -> connector auto-creates a managed Iceberg table.
+  * ``iceberg`` with a pre-existing (higher-version) table -> connector ingests into it as-is.
+
+v4-only.
+"""
+
+import json
+import logging
+
+import pytest
+from snowflake.connector import DictCursor
+
+from lib.driver import KafkaDriver, quote_name
+from lib.fixtures.table import ICEBERG_EXTERNAL_VOLUME, IcebergTable
+from tests.iceberg import json_connector_config
+
+logger = logging.getLogger(__name__)
+
+
+def _is_iceberg_table(driver: KafkaDriver, name: str) -> bool:
+    rows = (
+        driver.snowflake_conn.cursor()
+        .execute(f"SHOW ICEBERG TABLES LIKE '{name}'")
+        .fetchall()
+    )
+    return len(rows) > 0
+
+
+def _error_logging_enabled(driver: KafkaDriver, name: str) -> str:
+    """Return the ``error_logging`` flag SHOW TABLES reports for ``name``.
+
+    SHOW TABLES renders this column as 'ON'/'OFF' (not 'Y'/'N'). Raises if the
+    column is absent, which means the account lacks
+    ``ENABLE_ERROR_LOGGING_COLUMN_IN_SHOW_TABLES`` — a real environment problem we
+    want surfaced loudly, not silently skipped.
+    """
+    cursor = driver.snowflake_conn.cursor(DictCursor)
+    rows = cursor.execute(f"SHOW TABLES LIKE '{name}'").fetchall()
+    assert rows, f"Expected SHOW TABLES to return a row for {name}"
+    row = rows[0]
+    assert "error_logging" in row, (
+        f"SHOW TABLES has no error_logging column for {name}; account is missing "
+        f"ENABLE_ERROR_LOGGING_COLUMN_IN_SHOW_TABLES. Columns: {list(row.keys())}"
+    )
+    return row["error_logging"]
+
+
+def _desc(driver, table_name):
+    """Return {column_name: column_type} for a table via DESCRIBE.
+
+    Quotes the name: connector-auto-created tables and fixture tables can be
+    case-sensitive (lowercase) identifiers, which an unquoted DESCRIBE would
+    uppercase and fail to find.
+    """
+    return {
+        row[0]: row[1]
+        for row in driver.snowflake_conn.cursor()
+        .execute(f"DESCRIBE TABLE {quote_name(table_name)}")
+        .fetchall()
+    }
+
+
+def _multi_topic_iceberg_config(topics, table_name, *, create_options=None, extra=None):
+    """Build a server-side iceberg connector config fanning ``topics`` into one table.
+
+    Mirrors the FDN multi-topic pattern (``snowflake.topic2table.map``) but for
+    managed Iceberg: server-side validation only (the connector rejects iceberg +
+    schematization + client-side), ``table.type=iceberg``. Pass ``create_options``
+    to drive auto-creation of ``table_name``; omit when the table is pre-created.
+    """
+    cfg = {
+        **json_connector_config(
+            ",".join(topics),
+            schematization=True,
+            validation=False,
+            table_type="iceberg",
+            iceberg_create_table_options=create_options,
+        ),
+        "snowflake.topic2table.map": ",".join(f"{t}:{table_name}" for t in topics),
+    }
+    if extra:
+        cfg.update(extra)
+    return cfg
+
+
+# Datatype-coverage payloads for the multi-topic autocreate test: two records whose
+# union of fields exercises VARCHAR/NUMBER/BOOLEAN inference. PERF_GOLD_TYPES is the
+# expected DESCRIBE type prefix per column after server-side SE adds them.
+PERF_RECORDS = [
+    {"PERFORMANCE_STRING": "Excellent", "PERFORMANCE_CHAR": "A", "RATING_INT": 100},
+    {"PERFORMANCE_STRING": "Excellent", "RATING_DOUBLE": 0.99, "APPROVAL": True},
+]
+PERF_GOLD_TYPES = {
+    "PERFORMANCE_STRING": "VARCHAR",
+    "PERFORMANCE_CHAR": "VARCHAR",
+    "RATING_INT": "NUMBER",
+    # Iceberg server-side SE infers NUMBER(38,2) for a JSON float (e.g. 0.99),
+    # unlike FDN which infers FLOAT.
+    "RATING_DOUBLE": "NUMBER",
+    "APPROVAL": "BOOLEAN",
+}
+
+
+@pytest.mark.iceberg
+@pytest.mark.parametrize("connector_version", ["v4"], indirect=True)
+@pytest.mark.parametrize(
+    "iceberg_version",
+    [None, 3],
+    ids=["version-unset(v2)", "version-3"],
+)
+def test_iceberg_autocreate_json(
+    driver, create_topics, create_connector, wait_for_rows, iceberg_version
+):
+    """table.type=iceberg with NO pre-created table -> connector auto-creates it.
+
+    Parametrized over the Iceberg format version of the auto-created table:
+      * ``version-unset(v2)`` — no ICEBERG_VERSION clause, so the table is created
+        at the account-default format version (2). This is the case the structured
+        RECORD_METADATA OBJECT exists for: format v2 cannot use a VARIANT metadata
+        column (VARIANT-in-Iceberg requires v3), so ingestion *must* go through the
+        structured-OBJECT metadata that ``conformIcebergMetadata`` produces.
+      * ``version-3`` — explicit ICEBERG_VERSION=3.
+
+    Uses server-side SE (validation=false): the connector auto-creates the
+    metadata-only Iceberg table, then server-side schema evolution adds the ID/CITY
+    columns as records flow. Client-side validation is intentionally not used with
+    Iceberg + SE (the connector rejects that combination); server-side SE is the
+    supported mechanism.
+
+    Also asserts the auto-created table comes out with ERROR_LOGGING enabled (the
+    connector's CREATE includes ``error_logging = true``).
+    """
+    base_name = "iceberg_autocreate"
+    # with_tables=False -> neither table nor pipe pre-created; topic name == target table name.
+    topic = create_topics([base_name], with_tables=False)[0]
+    options = f"EXTERNAL_VOLUME='{ICEBERG_EXTERNAL_VOLUME}'"
+    if iceberg_version is not None:
+        options += f" ICEBERG_VERSION={iceberg_version}"
+    table = IcebergTable(driver, topic)
+    try:
+        create_connector(
+            v4_config=json_connector_config(
+                topic,
+                schematization=True,
+                validation=False,
+                table_type="iceberg",
+                iceberg_create_table_options=options,
+            )
+        )
+        driver.startConnectorWaitTime()
+
+        count = 50
+        driver.sendBytesData(
+            topic,
+            [
+                json.dumps({"id": i, "city": "Hsinchu"}).encode("utf-8")
+                for i in range(count)
+            ],
+            partition=0,
+        )
+        wait_for_rows(topic, count)
+
+        assert _is_iceberg_table(driver, topic), (
+            f"Expected {topic} to have been auto-created as an ICEBERG table"
+        )
+        assert _error_logging_enabled(driver, topic) == "ON", (
+            f"Expected auto-created iceberg table {topic} to have ERROR_LOGGING enabled"
+        )
+        cols = {row[0] for row in table.schema()}
+        assert "ID" in cols, f"Expected SE to add ID column, got: {cols}"
+        assert "CITY" in cols, f"Expected SE to add CITY column, got: {cols}"
+    finally:
+        table.drop()
+
+
+@pytest.mark.iceberg
+@pytest.mark.parametrize("connector_version", ["v4"], indirect=True)
+def test_iceberg_config_existing_higher_version_table_harmless(
+    driver, create_iceberg_table, create_topics, create_connector, wait_for_rows
+):
+    """config table.type=iceberg (version unset/2) + pre-existing v3 table -> harmless.
+
+    The version knob is create-time-only; an existing table is used as-is. The e2e
+    create_iceberg_table fixture creates a v3 table, so this proves the connector happily
+    ingests into a higher-version table than its (default v2) config would create. Plain
+    ingest into the pre-declared columns -- no SE, so independent of the server-side SE stack.
+    """
+    base_name = "iceberg_existing_v3"
+    table = create_iceberg_table(
+        base_name,
+        columns="(RECORD_METADATA VARIANT, ID NUMBER(19,0), CITY TEXT)",
+        cleanup_topic=False,
+    )
+    topic = create_topics([base_name], with_tables=False)[0]
+
+    create_connector(
+        v4_config=json_connector_config(
+            topic,
+            schematization=True,
+            validation=False,
+            table_type="iceberg",  # version unset -> default 2; existing table is v3
+            iceberg_create_table_options=f"EXTERNAL_VOLUME='{ICEBERG_EXTERNAL_VOLUME}'",
+        )
+    )
+    driver.startConnectorWaitTime()
+
+    count = 50
+    driver.sendBytesData(
+        topic,
+        [json.dumps({"id": i, "city": "Taipei"}).encode("utf-8") for i in range(count)],
+        partition=0,
+    )
+    wait_for_rows(table.name, count)
+
+    landed = table.select_scalar("COUNT(*)")
+    assert landed == count, (
+        f"Expected {count} rows in the pre-existing v3 table, got {landed}"
+    )
+
+
+@pytest.mark.iceberg
+@pytest.mark.schema_evolution
+@pytest.mark.parametrize("connector_version", ["v4"], indirect=True)
+def test_iceberg_autocreate_multi_topic(
+    driver: KafkaDriver,
+    name_salt: str,
+    create_connector,
+    wait_for_rows,
+):
+    """Two topics with different schemas auto-create + evolve one iceberg table.
+
+    Server-side mirror of FDN ``test_se_auto_table_creation_json``. The table does
+    not exist; the connector auto-creates the metadata-only iceberg table (no
+    ICEBERG_VERSION -> default format v2, exercising structured-OBJECT metadata),
+    then server-side SE adds every payload column from both topics.
+    """
+    initial_batch = 12
+    flush_batch = 300
+    record_count = initial_batch + flush_batch
+
+    base = f"iceberg_se_autocreate_multi{name_salt}"
+    table_name = base.upper()
+    topics = [f"{base}{i}" for i in range(2)]
+    for t in topics:
+        driver.createTopics(t, partitionNum=1, replicationNum=1)
+
+    connector = create_connector(
+        v4_config=_multi_topic_iceberg_config(
+            topics,
+            table_name,
+            create_options=f"EXTERNAL_VOLUME='{ICEBERG_EXTERNAL_VOLUME}'",
+        )
+    )
+    table = IcebergTable(driver, table_name)
+    try:
+        driver.startConnectorWaitTime()
+
+        for i, topic in enumerate(topics):
+            for batch_size in (initial_batch, flush_batch):
+                keys = [
+                    json.dumps({"number": str(e)}).encode("utf-8")
+                    for e in range(batch_size)
+                ]
+                values = [
+                    json.dumps(PERF_RECORDS[i]).encode("utf-8")
+                    for _ in range(batch_size)
+                ]
+                driver.sendBytesData(topic, values, keys)
+
+        wait_for_rows(
+            table_name, record_count * len(topics), connector_name=connector.name
+        )
+
+        assert _is_iceberg_table(driver, table_name), (
+            f"Expected {table_name} to be auto-created as ICEBERG"
+        )
+        cols = _desc(driver, table_name)
+        for col_name, prefix in PERF_GOLD_TYPES.items():
+            assert col_name in cols, (
+                f"Missing column {col_name}, got: {list(cols.keys())}"
+            )
+            assert cols[col_name].startswith(prefix), (
+                f"Column {col_name}: expected {prefix}, got {cols[col_name]}"
+            )
+    finally:
+        table.drop()
+
+
+@pytest.mark.iceberg
+@pytest.mark.schema_evolution
+@pytest.mark.parametrize("connector_version", ["v4"], indirect=True)
+@pytest.mark.parametrize(
+    "validation", ["server_side", "client_side"], ids=["valid=off", "valid=on"]
+)
+@pytest.mark.parametrize(
+    "schematization", [True, False], ids=["schema=on", "schema=off"]
+)
+def test_iceberg_config_variants(
+    driver: KafkaDriver,
+    create_iceberg_table,
+    create_topics,
+    create_connector,
+    wait_for_rows,
+    schematization,
+    validation,
+):
+    """Iceberg-applicable slice of the FDN config matrix (schematization x validation).
+
+    The FDN ``test_schema_evolution_config_variants`` cells collapse for managed
+    Iceberg:
+      * schematization=on + client_side -> rejected by the connector guard
+        (iceberg SE is server-side only); skipped here, asserted by the unit test
+        ``SinkTaskConfigTest`` / the e2e fail-fast behavior.
+      * schematization=on + server_side -> SE path: extra columns are added.
+      * schematization=off (either validation) -> data lands in RECORD_CONTENT
+        VARIANT; client-side validation IS permitted because the guard only blocks
+        schematization+client_side.
+    """
+    if schematization and validation == "client_side":
+        pytest.skip(
+            "iceberg + schematization + client_side is rejected by the connector"
+            " (server-side SE only); covered by SinkTaskConfig unit test"
+        )
+
+    use_client_side = validation == "client_side"
+    base_name = "iceberg_se_variant"
+
+    if schematization:
+        table = create_iceberg_table(
+            base_name,
+            columns="(RECORD_METADATA VARIANT) ENABLE_SCHEMA_EVOLUTION = TRUE",
+            cleanup_topic=False,
+        )
+    else:
+        # Non-schematized: data is wrapped into RECORD_CONTENT VARIANT (v3 table).
+        table = create_iceberg_table(
+            base_name,
+            columns="(RECORD_METADATA VARIANT, RECORD_CONTENT VARIANT)",
+            cleanup_topic=False,
+        )
+    topic = create_topics([base_name], with_tables=False)[0]
+
+    create_connector(
+        v4_config=json_connector_config(
+            topic,
+            schematization=schematization,
+            validation=use_client_side,
+            table_type="iceberg",
+        )
+    )
+    driver.startConnectorWaitTime()
+
+    record_count = 100
+    driver.sendBytesData(
+        topic,
+        [
+            json.dumps({"city": "Hsinchu", "age": i}).encode("utf-8")
+            for i in range(record_count)
+        ],
+        partition=0,
+    )
+    wait_for_rows(table.name, record_count)
+
+    if schematization:
+        cols = _desc(driver, table.name)
+        assert "CITY" in cols, f"Expected CITY column, got: {list(cols.keys())}"
+        assert "AGE" in cols, f"Expected AGE column, got: {list(cols.keys())}"
+    else:
+        rows = table.select(
+            "RECORD_CONTENT", 'WHERE RECORD_METADATA:"offset"::number = 0'
+        )
+        assert rows, "Expected row with offset 0"
+        content = json.loads(rows[0]["RECORD_CONTENT"])
+        assert content["city"] == "Hsinchu"
+        assert content["age"] == 0
+    assert table.select_scalar("COUNT(*)") == record_count

--- a/test/tests/iceberg/test_iceberg_se_json.py
+++ b/test/tests/iceberg/test_iceberg_se_json.py
@@ -1,7 +1,7 @@
 """Iceberg schema evolution E2E tests — JSON format.
 
 Tests client-side SE (RowValidator-driven ``ALTER ICEBERG TABLE ADD COLUMN``)
-and documents the server-side SE limitation (xfail).
+and server-side SE (``ENABLE_SCHEMA_EVOLUTION`` on the table, validation=false).
 
 v4-only: v3 iceberg support was removed in v4.
 """
@@ -186,21 +186,6 @@ def test_iceberg_se_multi_wave(
 
 @pytest.mark.iceberg
 @pytest.mark.schema_evolution
-@pytest.mark.xfail(
-    strict=False,
-    reason=(
-        "Server-side SE (ENABLE_SCHEMA_EVOLUTION on the table, validation=false) for "
-        "typed (non-VARIANT) column additions on iceberg tables is being rolled out "
-        "server-side. On deployments where it is not yet enabled the test xfails "
-        "(server-side SE silently discards the typed column additions); on deployments "
-        "where it is already enabled (e.g. the AWS CI account) it xpasses. Kept "
-        "non-strict so an xpass does not fail CI during the rollout. This test exercises "
-        "the HT path (validation=false) where server-side SE is the only mechanism; "
-        "client-side SE (validation=true) already works via ALTER ICEBERG TABLE ADD "
-        "COLUMN. Remove this marker once server-side SE for typed iceberg columns is "
-        "enabled on all deployments."
-    ),
-)
 @pytest.mark.parametrize("connector_version", ["v4"], indirect=True)
 def test_iceberg_se_json_server_side(
     driver: KafkaDriver,


### PR DESCRIPTION
## Summary

Adds managed-Iceberg **table auto-creation + ingestion** to KC v4, gated by a new connector-wide `snowflake.autocreate.table.type` (`snowflake` | `iceberg` | `none`). The setting governs **auto-creation only** — an existing table is always used as-is. Schema evolution for managed Iceberg is **server-side** (GS); the end-to-end SE test matrix is a follow-up PR stacked on top of this one.

- **`snowflake.autocreate.table.type`** (default `snowflake`) controls what to create when the table is **missing**:
  - `snowflake` → auto-create an FDN table (today's behavior, unchanged).
  - `iceberg` → auto-create a managed Iceberg table (`CATALOG='SNOWFLAKE'`, structured `RECORD_METADATA`, `ENABLE_SCHEMA_EVOLUTION`, `ERROR_LOGGING`).
  - `none` → create nothing; the table **and** its pipe must already exist (fail-fast otherwise).
  - **An existing table is used as-is regardless of this setting** — no cross-type guard. The setting only affects the missing-table path.
- **`snowflake.iceberg.create.table.options`** — SQL-clause passthrough spliced after the column list (e.g. `EXTERNAL_VOLUME='v' ICEBERG_VERSION=3 CLUSTER BY (id)`); valid only when `autocreate.table.type=iceberg`. Ignored if the table already exists.
- **`RECORD_METADATA` conforming** is keyed off the **actual target table type** (`isIcebergTable`), not the config — so it's correct even when `iceberg` config points at a pre-existing table, or `none` targets an existing Iceberg table. FDN's VARIANT metadata path is unchanged.
- **Non-schematized Iceberg autocreate requires `ICEBERG_VERSION=3`.** With `schematization=false` the raw record lands in a `RECORD_CONTENT` VARIANT column, and VARIANT-in-Iceberg needs v3; this is enforced **at autocreate time** (so pre-created tables are unaffected) with a clear fail-fast message.
- **Iceberg + `client_side` validation + schematization is rejected** at config time — managed-Iceberg SE is server-side; use `validation=server_side`.

## Also in this PR
- **Fix `hasErrorLoggingEnabled`**: `SHOW TABLES` renders `error_logging` as `ON`/`OFF`, not `Y`; the old `"Y"` check always returned false → spurious warnings for both FDN and Iceberg.
- Removed the now-dead FDN-create cross-type catch and the test-only `createTableIfNotExistsForTest` wrapper.
- `google-java-format` + `ruff format` applied.

## Test plan
- **Unit tests green** (config parse/rename, `use-existing-as-is` for both directions, autocreate-time v3 guard, `client_side` rejection, `ON`/`OFF` parsing, RECORD_METADATA conform incl. a drift test) + `IcebergAutoCreateIT`. Full `mvn package` suite passes.
- **Autocreate e2e validated green on a live SUT** (managed-Iceberg feature on): auto-create at Iceberg **v2 and v3**, `ERROR_LOGGING` present, existing-higher-version-table harmless, and server-side SE add-column / json-server-side on the auto-created/used table — all via the renamed config key.
- **Stress test run**: https://github.com/snowflakedb/snowflake-kafka-connector/actions/runs/29930045427/job/88957061569

## Scope / stack
- Depends on the pytest-8 collection compat fix (below in the stack).
- The full server-side SE e2e matrix is the follow-up PR stacked on top.

Related: SNOW-3552261 (server-side SE on managed Iceberg), SNOW-3053493 (primitive-column SE), SNOW-3161094 (KC for SSv2 Iceberg).
