### PR TITLE
ci(test): migrate connector_version to pytest_generate_tests for pytest 8

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -154,6 +154,34 @@ def pytest_collection_modifyitems(config, items):
             item.add_marker(skip)
 
 
+def _parametrize_argnames(marker) -> List[str]:
+    """Argument names targeted by a @pytest.mark.parametrize marker."""
+    argnames = marker.args[0] if marker.args else ""
+    if isinstance(argnames, str):
+        return [name.strip() for name in argnames.split(",")]
+    return list(argnames)
+
+
+def pytest_generate_tests(metafunc):
+    """Default the connector_version fixture to the v4/v3 cross-product.
+
+    connector_version is a plain fixture (no ``params=``), so we supply the
+    default matrix here for every test that consumes it (directly or
+    transitively) without already parametrizing it. Tests that pin a subset via
+    ``@pytest.mark.parametrize("connector_version", [...], indirect=True)`` keep
+    their own values. Doing the default here rather than on the fixture avoids
+    pytest>=8's "duplicate parametrization" error when a test overrides it.
+    """
+    if "connector_version" not in metafunc.fixturenames:
+        return
+    already_parametrized = any(
+        "connector_version" in _parametrize_argnames(marker)
+        for marker in metafunc.definition.iter_markers("parametrize")
+    )
+    if not already_parametrized:
+        metafunc.parametrize("connector_version", ["v4", "v3"], indirect=True)
+
+
 @pytest.fixture()
 def create_connector_from_file(
     driver: KafkaDriver,  # noqa: F811

--- a/test/lib/fixtures/function.py
+++ b/test/lib/fixtures/function.py
@@ -1,12 +1,16 @@
 import pytest
 
 
-@pytest.fixture(params=["v4", "v3"])
+@pytest.fixture
 def connector_version(request):
     """The Snowflake Kafka Connector version under test.
 
-    Every test that (transitively) depends on this fixture is automatically run twice:
-    once for v4 and once for v3.
+    Plain fixture (no ``params=``): the default v4/v3 cross-product is supplied
+    by the ``pytest_generate_tests`` hook in conftest.py. Keeping the params out
+    of the fixture lets individual tests pin a subset via
+    ``@pytest.mark.parametrize("connector_version", [...], indirect=True)``
+    without tripping pytest>=8's "duplicate parametrization" error (a
+    fixture-level ``params=`` combined with a test-level indirect override).
     """
     return request.param
 


### PR DESCRIPTION
## Context

All e2e functional jobs are red at collection — 0 tests run. CI run 27709869893 shows
`42 errors during collection, 206 deselected, in 0.68s` across every group (core,
compatibility, schema_and_correctness).

## Root cause

pytest 8.0 made it a hard error to apply a test-level
`@pytest.mark.parametrize("connector_version", [...], indirect=True)` override to a
fixture that itself declares `params=[...]` (`test/lib/fixtures/function.py`). In pytest
7.x the test-level value overrode the fixture's params; in >=8 it raises
`duplicate parametrization of 'connector_version'`. 42 test files use this pattern, so
collection aborts before any test runs. CI rebuilds the test-runner image every run
(fresh GitHub-hosted VM, no layer cache) and `pip install pytest` resolves to the latest
(now 9.x).

## Fix

Make `connector_version` a plain fixture (no `params=`) and supply the default v4/v3
cross-product from a `pytest_generate_tests` hook that backs off when a test parametrizes
the arg itself. Same test matrix/ids as before; tests keep the ability to pin a subset
via `@parametrize("connector_version", [...], indirect=True)`; no pytest version pin
(which would freeze the repo on 7.x while the latest is already 9.x).

## Validation

`pytest --collect-only` under pytest 9.1.0: **334 tests collected, 0 errors** (previously
42 collection errors). Matrix preserved — override tests stay single-version, non-override
tests run v4 + v3.
