### PR TITLE
SNOW-3664035: pass KC version to SSv2 SDK User-Agent

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProperties.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProperties.java
@@ -41,6 +41,12 @@ public class StreamingClientProperties {
   public static final String STREAMING_CLIENT_V2_PREFIX_NAME = "KC_CLIENT_V2_";
   public static final String DEFAULT_CLIENT_NAME = "DEFAULT_CLIENT";
 
+  /**
+   * Identifier sent to the SSv2 SDK via the {@code application} property. The SDK appends it to the
+   * outbound User-Agent as {@code (app=<value>)} for connector version attribution.
+   */
+  public static final String APPLICATION_NAME = "SnowflakeKafkaConnector/" + Utils.VERSION;
+
   private static final KCLogger LOGGER = new KCLogger(StreamingClientProperties.class.getName());
   public final Properties clientProperties;
   public final String clientNamePrefix;
@@ -76,6 +82,7 @@ public class StreamingClientProperties {
       clientProperties.put("role", config.getSnowflakeRole());
       clientProperties.put("account", url.getAccount());
       clientProperties.put("host", url.getUrlWithoutPort());
+      clientProperties.put("application", APPLICATION_NAME);
     }
 
     String clientNamePrefix =

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientPropertiesTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientPropertiesTest.java
@@ -67,7 +67,9 @@ public class StreamingClientPropertiesTest {
     assertThat(clientProps.getProperty("host"))
         .isEqualTo("testaccount.us-east-1.snowflakecomputing.com");
     assertThat(clientProps.getProperty("private_key")).isEqualTo(privateKeyPem);
-    assertThat(clientProps).hasSize(5);
+    assertThat(clientProps.getProperty("application"))
+        .isEqualTo("SnowflakeKafkaConnector/" + Utils.VERSION);
+    assertThat(clientProps).hasSize(6);
 
     // verify client name prefix and empty parameter overrides
     assertThat(result.clientNamePrefix).isEqualTo(STREAMING_CLIENT_V2_PREFIX_NAME + "testName");
@@ -141,6 +143,7 @@ public class StreamingClientPropertiesTest {
     expectedProps.put("role", "testRole");
     expectedProps.put("account", parsedUrl.getAccount());
     expectedProps.put("host", parsedUrl.getUrlWithoutPort());
+    expectedProps.put("application", "SnowflakeKafkaConnector/" + Utils.VERSION);
     String privateKeyStr = connectorConfig.get(KafkaConnectorConfigParams.SNOWFLAKE_PRIVATE_KEY);
     if (privateKeyStr != null) {
       String passphrase =


### PR DESCRIPTION
## Overview

SNOW-3664035

Sets the Snowpipe Streaming v2 (SSv2) SDK `application` property to
`SnowflakeKafkaConnector/<Utils.VERSION>` (e.g. `SnowflakeKafkaConnector/4.1.0`) when the
connector builds its SSv2 client. The SDK appends this to the outbound HTTP User-Agent as
`(app=SnowflakeKafkaConnector/4.1.0)`, giving Snowflake version attribution for SSv2 traffic
(fleet observability / incident triage).

## Change

- `StreamingClientProperties`: add `APPLICATION_NAME` constant (`"SnowflakeKafkaConnector/" + Utils.VERSION`)
  and set `clientProperties.put("application", APPLICATION_NAME)` alongside the existing
  connection properties (`user`/`role`/`account`/`host`/`private_key`) in `from(SinkTaskConfig)`.
- Updated `StreamingClientPropertiesTest` expectations.

No SDK changes — the `application` property already exists in `snowpipe-streaming` (added in
the SDK's #905) and is validated + appended to the User-Agent by the SDK. No new user-facing
config; this is automatic telemetry attribution only.

## Stacked on

Depends on #1481 (bump `snowpipe-streaming` 1.4.0 → 1.5.0); the `application` feature is only
present in 1.5.0. This PR's base is `skurella-bump-ssv2-sdk-to-1.5` and will retarget to
`master` automatically when #1481 merges.

## Testing

- **Unit:** full suite green (620 tests, 0 failures/errors), including the updated
  `StreamingClientPropertiesTest`.
- **Integration:** `SnowflakeSinkServiceV2IT` 12/12 green on a SUT against `snowpipe-streaming`
  1.5.0 — confirms the dependency level does not regress ingestion.

## Parameter protection

Not parameter-protected — this is a User-Agent attribution string with no change to ingestion
behavior.
