### PR TITLE
SNOW-3675649 fix client-side validation of decimals

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/validation/RowValidator.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/validation/RowValidator.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.snowflake.kafka.connector.Utils;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.ZoneId;
 import java.util.Collection;
 import java.util.Collections;
@@ -162,10 +163,21 @@ public class RowValidator {
             : Boolean.FALSE;
 
       case FIXED:
-        // Note: DataValidationUtil.validateAndParseBigDecimal doesn't check precision/scale
-        // It just parses the value. Precision/scale checking would need to be done separately
-        // if needed, but SSv1 didn't enforce it at validation time either.
-        DataValidationUtil.validateAndParseBigDecimal(col.getName(), value, insertRowIndex);
+        // DataValidationUtil.validateAndParseBigDecimal doesn't check precision/scale
+        // It just parses the value.
+        BigDecimal parsedNumber =
+            DataValidationUtil.validateAndParseBigDecimal(col.getName(), value, insertRowIndex);
+        // SSv1 enforced this during Parquet/SB16 serialization.
+        // We must range-check the value here.
+        int columnScale = col.getScale() != null ? col.getScale() : 0;
+        int columnPrecision = col.getPrecision() != null ? col.getPrecision() : 38;
+        // Round excess fractional digits to the column scale first, mirroring the server: it rounds
+        // the fraction and only errors when the *rounded* integer part exceeds (precision - scale)
+        // digits. The original value is still passed to the SDK unchanged; this scaled copy is used
+        // only for the range check.
+        BigDecimal scaledNumber = parsedNumber.setScale(columnScale, RoundingMode.HALF_UP);
+        DataValidationUtil.checkValueInRange(
+            col.getName(), scaledNumber, columnScale, columnPrecision, insertRowIndex);
         break;
 
       case REAL:

--- a/src/test/java/com/snowflake/kafka/connector/internal/validation/DataValidationUtilTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/validation/DataValidationUtilTest.java
@@ -481,6 +481,52 @@ public class DataValidationUtilTest {
         ErrorCode.INVALID_FORMAT_ROW, () -> validateAndParseBigDecimal("COL", new byte[4], 0));
   }
 
+  /**
+   * Range check for NUMBER(precision, scale): a value is rejected when its magnitude is >=
+   * 10^(precision - scale).
+   */
+  @Test
+  public void testCheckValueInRange() {
+    // NUMBER(3,0): comparand = 10^3 = 1000 (POWER_10 table branch).
+    DataValidationUtil.checkValueInRange("COL", new BigDecimal("999"), 0, 3, 0);
+    DataValidationUtil.checkValueInRange("COL", new BigDecimal("-999"), 0, 3, 0);
+    expectError(
+        ErrorCode.INVALID_FORMAT_ROW,
+        () -> DataValidationUtil.checkValueInRange("COL", new BigDecimal("1000"), 0, 3, 0));
+    expectError(
+        ErrorCode.INVALID_FORMAT_ROW,
+        () -> DataValidationUtil.checkValueInRange("COL", new BigDecimal("-1000"), 0, 3, 0));
+
+    // NUMBER(5,2): integer part limited to 10^(5-2)=10^3 (POWER_10 table branch).
+    DataValidationUtil.checkValueInRange("COL", new BigDecimal("999.99"), 2, 5, 0);
+    expectError(
+        ErrorCode.INVALID_FORMAT_ROW,
+        () -> DataValidationUtil.checkValueInRange("COL", new BigDecimal("1000.00"), 2, 5, 0));
+
+    // precision == scale: comparand = 10^0 = 1, so abs must be strictly < 1.
+    DataValidationUtil.checkValueInRange("COL", new BigDecimal("0.5"), 10, 10, 0);
+    expectError(
+        ErrorCode.INVALID_FORMAT_ROW,
+        () -> DataValidationUtil.checkValueInRange("COL", new BigDecimal("1"), 10, 10, 0));
+
+    // NUMBER(38,20): comparand = 10^18 (BigDecimal.TEN.pow fallback, beyond the cached table).
+    // 18 nines (10^18 - 1) is in range; 10^18 overflows.
+    DataValidationUtil.checkValueInRange("COL", new BigDecimal("999999999999999999"), 20, 38, 0);
+    expectError(
+        ErrorCode.INVALID_FORMAT_ROW,
+        () ->
+            DataValidationUtil.checkValueInRange(
+                "COL", new BigDecimal("1000000000000000000"), 20, 38, 0));
+
+    // NUMBER(38,0): the full 38-digit precision (38 nines) is in range — guards against
+    // over-rejection of legitimately large values.
+    DataValidationUtil.checkValueInRange(
+        "COL", new BigDecimal("99999999999999999999999999999999999999"), 0, 38, 0);
+    expectError(
+        ErrorCode.INVALID_FORMAT_ROW,
+        () -> DataValidationUtil.checkValueInRange("COL", BigDecimal.TEN.pow(38), 0, 38, 0));
+  }
+
   @Test
   public void testValidateAndParseString() {
     assertEquals("honk", validateAndParseString("COL", "honk", Optional.empty(), 0));

--- a/src/test/java/com/snowflake/kafka/connector/internal/validation/RowValidatorTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/validation/RowValidatorTest.java
@@ -260,6 +260,203 @@ public class RowValidatorTest {
   }
 
   @Test
+  public void testValidateRowNumberOverflowRejected() {
+    // SNOW-3675649: a value whose integer part exceeds the column's (precision - scale) digits must
+    // be rejected client-side. Previously it passed validation and failed server-side ("Failed to
+    // cast variant value", error 100071), silently dropping the record.
+    // NUMBER(38,20) allows 38 - 20 = 18 integer digits; this value has 30.
+    Map<String, ColumnSchema> schema = new HashMap<>();
+    schema.put("COL1", createColumnSchema("COL1", ColumnLogicalType.FIXED, true, 38, 20, null));
+
+    RowValidator validator = new RowValidator(schema);
+
+    Map<String, Object> row = new HashMap<>();
+    row.put("COL1", "999999999999999999999999999999.999999999");
+
+    ValidationResult result = validator.validateRow(row);
+    assertFalse(result.isValid());
+    assertTrue(result.hasTypeError());
+    assertEquals("COL1", result.getColumnName());
+    assertNotNull(result.getValueError());
+  }
+
+  @Test
+  public void testValidateRowNumberWithinRangeAccepted() {
+    // A value that fits within NUMBER(38,20) (18 integer digits, 9 fractional) must pass.
+    Map<String, ColumnSchema> schema = new HashMap<>();
+    schema.put("COL1", createColumnSchema("COL1", ColumnLogicalType.FIXED, true, 38, 20, null));
+
+    RowValidator validator = new RowValidator(schema);
+
+    Map<String, Object> row = new HashMap<>();
+    row.put("COL1", "123456789012345678.123456789");
+
+    ValidationResult result = validator.validateRow(row);
+    assertTrue(result.isValid());
+  }
+
+  @Test
+  public void testValidateRowNumberRoundsUpToOverflow() {
+    // Mirror the server: excess fractional digits are rounded to the column scale before the range
+    // check. NUMBER(2,1) allows 1 integer digit; 9.96 rounds (HALF_UP) to 10.0, which overflows.
+    Map<String, ColumnSchema> schema = new HashMap<>();
+    schema.put("COL1", createColumnSchema("COL1", ColumnLogicalType.FIXED, true, 2, 1, null));
+
+    RowValidator validator = new RowValidator(schema);
+
+    Map<String, Object> row = new HashMap<>();
+    row.put("COL1", "9.96");
+
+    ValidationResult result = validator.validateRow(row);
+    assertFalse(result.isValid());
+    assertTrue(result.hasTypeError());
+    assertEquals("COL1", result.getColumnName());
+  }
+
+  @Test
+  public void testValidateRowNumberExcessFractionalDigitsAccepted() {
+    // Excess fractional digits alone (without integer overflow) are rounded by the server, not
+    // rejected. NUMBER(38,2) with extra fractional precision must pass client-side validation.
+    Map<String, ColumnSchema> schema = new HashMap<>();
+    schema.put("COL1", createColumnSchema("COL1", ColumnLogicalType.FIXED, true, 38, 2, null));
+
+    RowValidator validator = new RowValidator(schema);
+
+    Map<String, Object> row = new HashMap<>();
+    row.put("COL1", "123.456789");
+
+    ValidationResult result = validator.validateRow(row);
+    assertTrue(result.isValid());
+  }
+
+  @Test
+  public void testValidateRowNumberNegativeOverflowRejected() {
+    // Sign must not matter: a large-magnitude negative value also overflows.
+    Map<String, ColumnSchema> schema = new HashMap<>();
+    schema.put("COL1", createColumnSchema("COL1", ColumnLogicalType.FIXED, true, 38, 20, null));
+
+    RowValidator validator = new RowValidator(schema);
+
+    Map<String, Object> row = new HashMap<>();
+    row.put("COL1", "-999999999999999999999999999999.999999999");
+
+    ValidationResult result = validator.validateRow(row);
+    assertFalse(result.isValid());
+    assertTrue(result.hasTypeError());
+  }
+
+  @Test
+  public void testValidateRowNumberScientificNotationOverflowRejected() {
+    // Scientific notation must be range-checked after parsing: 1E30 overflows NUMBER(38,20).
+    Map<String, ColumnSchema> schema = new HashMap<>();
+    schema.put("COL1", createColumnSchema("COL1", ColumnLogicalType.FIXED, true, 38, 20, null));
+
+    RowValidator validator = new RowValidator(schema);
+
+    Map<String, Object> row = new HashMap<>();
+    row.put("COL1", "1E30");
+
+    ValidationResult result = validator.validateRow(row);
+    assertFalse(result.isValid());
+    assertTrue(result.hasTypeError());
+  }
+
+  @Test
+  public void testValidateRowNumberNativeLongOverflowRejected() {
+    // The range check must apply to native numeric inputs too, not just strings. Long.MAX_VALUE
+    // (19 digits) overflows NUMBER(38,20), which permits 18 integer digits.
+    Map<String, ColumnSchema> schema = new HashMap<>();
+    schema.put("COL1", createColumnSchema("COL1", ColumnLogicalType.FIXED, true, 38, 20, null));
+
+    RowValidator validator = new RowValidator(schema);
+
+    Map<String, Object> row = new HashMap<>();
+    row.put("COL1", Long.MAX_VALUE); // 9223372036854775807 — 19 digits
+
+    ValidationResult result = validator.validateRow(row);
+    assertFalse(result.isValid());
+    assertTrue(result.hasTypeError());
+  }
+
+  @Test
+  public void testValidateRowNumberBoundaryMaxAccepted() {
+    // NUMBER(5,0) permits magnitudes < 10^5. 99999 is the largest in-range value.
+    Map<String, ColumnSchema> schema = new HashMap<>();
+    schema.put("COL1", createColumnSchema("COL1", ColumnLogicalType.FIXED, true, 5, 0, null));
+
+    RowValidator validator = new RowValidator(schema);
+
+    Map<String, Object> row = new HashMap<>();
+    row.put("COL1", "99999");
+
+    ValidationResult result = validator.validateRow(row);
+    assertTrue(result.isValid());
+  }
+
+  @Test
+  public void testValidateRowNumberBoundaryOverflowRejected() {
+    // NUMBER(5,0): 100000 (= 10^5) is the smallest value that overflows.
+    Map<String, ColumnSchema> schema = new HashMap<>();
+    schema.put("COL1", createColumnSchema("COL1", ColumnLogicalType.FIXED, true, 5, 0, null));
+
+    RowValidator validator = new RowValidator(schema);
+
+    Map<String, Object> row = new HashMap<>();
+    row.put("COL1", "100000");
+
+    ValidationResult result = validator.validateRow(row);
+    assertFalse(result.isValid());
+    assertTrue(result.hasTypeError());
+  }
+
+  @Test
+  public void testValidateRowNumberFullPrecisionAccepted() {
+    // Guard against over-rejection: the full 38-digit precision (38 nines) fits NUMBER(38,0).
+    Map<String, ColumnSchema> schema = new HashMap<>();
+    schema.put("COL1", createColumnSchema("COL1", ColumnLogicalType.FIXED, true, 38, 0, null));
+
+    RowValidator validator = new RowValidator(schema);
+
+    Map<String, Object> row = new HashMap<>();
+    row.put("COL1", "99999999999999999999999999999999999999"); // 38 nines
+
+    ValidationResult result = validator.validateRow(row);
+    assertTrue(result.isValid());
+  }
+
+  @Test
+  public void testValidateRowVarcharExceedsLengthRejected() {
+    // Parallel server-constraint check: a plain string longer than VARCHAR(N) must be rejected
+    // client-side, not silently truncated/dropped server-side.
+    Map<String, ColumnSchema> schema = new HashMap<>();
+    schema.put("COL1", createColumnSchema("COL1", ColumnLogicalType.TEXT, true, null, null, 5));
+
+    RowValidator validator = new RowValidator(schema);
+
+    Map<String, Object> row = new HashMap<>();
+    row.put("COL1", "abcdef"); // 6 characters, exceeds VARCHAR(5)
+
+    ValidationResult result = validator.validateRow(row);
+    assertFalse(result.isValid());
+    assertTrue(result.hasTypeError());
+  }
+
+  @Test
+  public void testValidateRowVarcharExactLengthAccepted() {
+    // A string exactly at the VARCHAR(N) limit must be accepted (boundary guard).
+    Map<String, ColumnSchema> schema = new HashMap<>();
+    schema.put("COL1", createColumnSchema("COL1", ColumnLogicalType.TEXT, true, null, null, 5));
+
+    RowValidator validator = new RowValidator(schema);
+
+    Map<String, Object> row = new HashMap<>();
+    row.put("COL1", "abcde"); // exactly 5 characters
+
+    ValidationResult result = validator.validateRow(row);
+    assertTrue(result.isValid());
+  }
+
+  @Test
   public void testValidateRowMatchingColumnName() {
     // Column names are expected to be already normalized by the caller (SnowflakeSinkRecord).
     // RowValidator just does direct comparison against raw column names.

--- a/test/tests/compatibility/test_type_compatibility.py
+++ b/test/tests/compatibility/test_type_compatibility.py
@@ -24,6 +24,7 @@ Reference: https://docs.snowflake.com/en/sql-reference/intro-summary-data-types
 import datetime
 import json
 import logging
+from decimal import Decimal
 from enum import Enum
 
 import pytest
@@ -57,6 +58,7 @@ COLUMNS = {
     "TEST_CASE": "VARCHAR",
     "COL_NUMBER": "NUMBER",
     "COL_NUMSCALE": "NUMBER(10,2)",
+    "COL_NUM3820": "NUMBER(38,20)",
     "COL_FLOAT": "FLOAT",
     "COL_VARCHAR": "VARCHAR",
     "COL_VARCHAR10": "VARCHAR(10)",
@@ -104,6 +106,36 @@ CASES = [
     Case("nsc_zero", "COL_NUMSCALE", 0.0, OK, approx=0.01),
     Case("nsc_max", "COL_NUMSCALE", 99999.99, OK, approx=0.01),
     Case("nsc_bad_text", "COL_NUMSCALE", "text", ERR),
+    # NUMBER(10,2) permits 10 - 2 = 8 integer digits; 11 integer digits overflows.
+    Case("nsc_overflow", "COL_NUMSCALE", "12345678901", ERR),
+    # ---- NUMBER(38,20) — precision/scale overflow (SNOW-3675649) ----
+    # Values are sent as strings to mirror Debezium decimal.handling.mode=string.
+    # NUMBER(38,20) permits 38 - 20 = 18 integer digits.
+    # In range: 17 integer digits + 2 fractional → ingested on all modes.
+    Case(
+        "num3820_inrange",
+        "COL_NUM3820",
+        "99999999999999999.99",
+        OK,
+        expected_value=Decimal("99999999999999999.99"),
+    ),
+    # Overflow: 30 integer digits (the exact value from the ticket) cannot fit
+    # 18 integer digits → rejected. v3 (SSv1) rejects during client-side
+    # serialization; v4-compat must match via RowValidator's range check;
+    # v4-ht relies on the server, which rejects with error 100071.
+    Case(
+        "num3820_overflow",
+        "COL_NUM3820",
+        "999999999999999999999999999999.999999999",
+        ERR,
+    ),
+    # Sign must not matter — a large negative value overflows identically.
+    Case(
+        "num3820_neg_overflow",
+        "COL_NUM3820",
+        "-999999999999999999999999999999.999999999",
+        ERR,
+    ),
     # ---- FLOAT ----
     Case("flt_pi", "COL_FLOAT", 3.14, OK),
     Case("flt_neg", "COL_FLOAT", -1.5, OK),
@@ -480,6 +512,20 @@ def test_number_with_scale(results):
     _assert_all(
         results, cases_where(col="COL_NUMSCALE", exclude_groups=_SPECIAL_GROUPS)
     )
+
+
+def test_number_high_precision_overflow(results):
+    """NUMBER(38,20): integer part exceeding (precision - scale)=18 digits → DLQ/dropped.
+
+    SNOW-3675649: a Debezium decimal.handling.mode=string value with 30 integer
+    digits overflows NUMBER(38,20).  v3 (SSv1) rejects it during client-side
+    serialization and routes it to the DLQ.  v4-compat must match — previously
+    it passed client-side validation and was rejected only server-side ("Failed
+    to cast variant value", error 100071), silently dropping the record.  v4-ht
+    has no client-side range check and relies on the server, which also rejects.
+    An in-range value (≤18 integer digits) ingests on all modes.
+    """
+    _assert_all(results, cases_where(col="COL_NUM3820", exclude_groups=_SPECIAL_GROUPS))
 
 
 def test_float(results):


### PR DESCRIPTION
SNOW-3675649

We were not verifying precision and scale of NUMBER columns when using client-side validation. This accidentally wasn't ported from the SSv1 SDK because it was done within the Parquet serializer.