### PR TITLE
SNOW-3655748: add offset-gap and recovery-skip telemetry for data-loss detection

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -351,6 +351,14 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
     if (!pendingResets.isEmpty()) {
       LOGGER.info("Draining {} pending offset resets: {}", pendingResets.size(), pendingResets);
       offsetsToRewindTo.putAll(pendingResets);
+
+      // Count channels recovering while this batch carries records past their resume offset -- the
+      // PROD-538073 data-loss interleaving. Benign post-fix; tracked for cross-version trending.
+      for (TopicPartition tp : detectRecoverySkipConflicts(pendingResets, records)) {
+        channelManager
+            .getChannel(tp)
+            .ifPresent(TopicPartitionChannel::incRecoverySkipConflictCount);
+      }
     }
 
     // If still in cooldown from a recent backpressure event, treat all partitions as
@@ -424,6 +432,48 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
       LOGGER.info("Rewinding offsets for skipped partitions: {}", offsetsToRewindTo);
       sinkTaskContext.offset(offsetsToRewindTo);
     }
+  }
+
+  /**
+   * Returns the set of channels for which:
+   *
+   * <ol>
+   *   <li>we enqueued an offset rewind (a pending reset in {@code pendingResets}), and
+   *   <li>the current batch contains only records with higher offsets than that rewind offset.
+   * </ol>
+   *
+   * <p>For such channels we must take care NOT to rewind to the beginning of the current batch, or
+   * we would skip the records between the rewind offset and the batch — exactly the PROD-538073
+   * data-loss interleaving (the pre-SNOW-3574225 code rewound to a skipped record's offset instead
+   * of the recovery offset). A batch that includes a record at or below the rewind offset (e.g.
+   * {@code [51, 52, 53]} after a reset to 51, which also covers ordinary channel init) is NOT a
+   * conflict — nothing is dropped.
+   *
+   * <p>The fix preserves the recovery offset, so any conflict counted here is benign today; a
+   * rising cross-version trend means the risky interleaving is more frequent or a regression has
+   * returned.
+   */
+  static Set<TopicPartition> detectRecoverySkipConflicts(
+      Map<TopicPartition, Long> pendingResets, Collection<SinkRecord> records) {
+    if (pendingResets.isEmpty()) {
+      return Collections.emptySet();
+    }
+    Set<TopicPartition> partitionsWithRecordsAfterRewindOffset = new HashSet<>();
+    Set<TopicPartition> partitionsWithRecordsBeforeOrOnRewindOffset = new HashSet<>();
+    for (SinkRecord record : records) {
+      TopicPartition tp = new TopicPartition(record.topic(), record.kafkaPartition());
+      Long rewindOffset = pendingResets.get(tp);
+      if (rewindOffset == null) {
+        continue;
+      }
+      if (record.kafkaOffset() <= rewindOffset) {
+        partitionsWithRecordsBeforeOrOnRewindOffset.add(tp);
+      } else {
+        partitionsWithRecordsAfterRewindOffset.add(tp);
+      }
+    }
+    partitionsWithRecordsAfterRewindOffset.removeAll(partitionsWithRecordsBeforeOrOnRewindOffset);
+    return partitionsWithRecordsAfterRewindOffset;
   }
 
   /**

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/channel/TopicPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/channel/TopicPartitionChannel.java
@@ -91,6 +91,13 @@ public interface TopicPartitionChannel {
     return CompletableFuture.completedFuture(null);
   }
 
+  /**
+   * Records that this channel finished recovering while the current batch contained only records
+   * past its resume offset for this channel (the PROD-538073 data-loss interleaving). Default is a
+   * no-op for channel implementations that do not track it.
+   */
+  default void incRecoverySkipConflictCount() {}
+
   @VisibleForTesting
   SnowflakeTelemetryChannelStatus getSnowflakeTelemetryChannelStatus();
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/telemetry/SnowflakeTelemetryChannelStatus.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/telemetry/SnowflakeTelemetryChannelStatus.java
@@ -40,9 +40,12 @@ import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.node.Object
  * <p>Most of the data sent to Snowflake is aggregated data.
  */
 public class SnowflakeTelemetryChannelStatus extends SnowflakeTelemetryBasicInfo {
-  public static final long NUM_METRICS = 4; // update when new metrics are added
+  public static final long NUM_METRICS = 7; // update when new metrics are added
 
   static final String CHANNEL_RECOVERY_COUNT = "channel-recovery-count";
+  static final String OFFSET_GAP_COUNT = "offset-gap-count";
+  static final String OFFSET_GAP_MISSING_RECORD_COUNT = "offset-gap-missing-record-count";
+  static final String RECOVERY_SKIP_CONFLICT_COUNT = "recovery-skip-conflict-count";
 
   // channel properties
   private final String connectorName;
@@ -55,8 +58,20 @@ public class SnowflakeTelemetryChannelStatus extends SnowflakeTelemetryBasicInfo
   private final AtomicLong processedOffset;
   private final AtomicLong latestConsumerOffset;
 
+  // Offset-gap counters, owned by PartitionOffsetTracker and read here by reference for telemetry
+  // and JMX. Recorded in shouldProcess (from insertRecord): the number of forward discontinuities
+  // in the processed offsets, and the total offset positions skipped across them (an upper bound on
+  // records actually lost). See SNOW-3655748 / PROD-538073.
+  private final AtomicLong offsetGapCount;
+  private final AtomicLong offsetGapMissingRecordCount;
+
   // channel recovery counter (always tracked; also registered as JMX gauge if enabled)
   private final AtomicLong recoveryCount = new AtomicLong(0);
+
+  // Count of batches where this channel was recovering while the same batch carried records past
+  // its resume offset -- the PROD-538073 data-loss interleaving. Benign post-SNOW-3574225; tracked
+  // for cross-version trending.
+  private final AtomicLong recoverySkipConflictCount = new AtomicLong(0);
 
   // Client recreation counters — incremented from openChannelWithClientRecovery when a
   // client-invalid SDK error (HTTP 410 / pipe failover) triggers a swap of the streaming client.
@@ -116,7 +131,9 @@ public class SnowflakeTelemetryChannelStatus extends SnowflakeTelemetryBasicInfo
       final Optional<MetricsJmxReporter> metricsJmxReporter,
       final AtomicLong offsetPersistedInSnowflake,
       final AtomicLong processedOffset,
-      final AtomicLong latestConsumerOffset) {
+      final AtomicLong latestConsumerOffset,
+      final AtomicLong offsetGapCount,
+      final AtomicLong offsetGapMissingRecordCount) {
     super(tableName, SnowflakeTelemetryService.TelemetryType.KAFKA_CHANNEL_USAGE);
 
     this.channelCreationTime = startTime;
@@ -127,6 +144,8 @@ public class SnowflakeTelemetryChannelStatus extends SnowflakeTelemetryBasicInfo
     this.offsetPersistedInSnowflake = offsetPersistedInSnowflake;
     this.processedOffset = processedOffset;
     this.latestConsumerOffset = latestConsumerOffset;
+    this.offsetGapCount = offsetGapCount;
+    this.offsetGapMissingRecordCount = offsetGapMissingRecordCount;
 
     metricsJmxReporter.ifPresent(reporter -> registerChannelJMXMetrics(reporter));
   }
@@ -155,6 +174,10 @@ public class SnowflakeTelemetryChannelStatus extends SnowflakeTelemetryBasicInfo
     msg.put(TelemetryConstants.VALIDATION_FAILURE_COUNT, this.validationFailureCount.get());
     msg.put(TelemetryConstants.ERROR_TOLERATED_COUNT, this.errorToleratedCount.get());
     msg.put(TelemetryConstants.CHANNEL_RECOVERY_COUNT, this.recoveryCount.get());
+    msg.put(TelemetryConstants.OFFSET_GAP_COUNT, this.offsetGapCount.get());
+    msg.put(
+        TelemetryConstants.OFFSET_GAP_MISSING_RECORD_COUNT, this.offsetGapMissingRecordCount.get());
+    msg.put(TelemetryConstants.RECOVERY_SKIP_CONFLICT_COUNT, this.recoverySkipConflictCount.get());
     msg.put(
         TelemetryConstants.CLIENT_RECREATION_ATTEMPT_COUNT,
         this.clientRecreationAttemptCount.get());
@@ -200,6 +223,11 @@ public class SnowflakeTelemetryChannelStatus extends SnowflakeTelemetryBasicInfo
               this.channelName, MetricsUtil.OFFSET_SUB_DOMAIN, MetricsUtil.LATEST_CONSUMER_OFFSET),
           channelMetricName(
               this.channelName, MetricsUtil.OFFSET_SUB_DOMAIN, CHANNEL_RECOVERY_COUNT),
+          channelMetricName(this.channelName, MetricsUtil.OFFSET_SUB_DOMAIN, OFFSET_GAP_COUNT),
+          channelMetricName(
+              this.channelName, MetricsUtil.OFFSET_SUB_DOMAIN, OFFSET_GAP_MISSING_RECORD_COUNT),
+          channelMetricName(
+              this.channelName, MetricsUtil.OFFSET_SUB_DOMAIN, RECOVERY_SKIP_CONFLICT_COUNT),
         };
 
     @SuppressWarnings("unchecked")
@@ -209,6 +237,9 @@ public class SnowflakeTelemetryChannelStatus extends SnowflakeTelemetryBasicInfo
           (Gauge<Long>) this.processedOffset::get,
           (Gauge<Long>) this.latestConsumerOffset::get,
           (Gauge<Long>) this.recoveryCount::get,
+          (Gauge<Long>) this.offsetGapCount::get,
+          (Gauge<Long>) this.offsetGapMissingRecordCount::get,
+          (Gauge<Long>) this.recoverySkipConflictCount::get,
         };
 
     for (int i = 0; i < registeredMetricNames.length; i++) {
@@ -245,6 +276,11 @@ public class SnowflakeTelemetryChannelStatus extends SnowflakeTelemetryBasicInfo
   /** Increments the channel recovery counter. Thread-safe. */
   public void incRecoveryCount() {
     this.recoveryCount.incrementAndGet();
+  }
+
+  /** Increments the recovery-skip conflict counter. Thread-safe. */
+  public void incRecoverySkipConflictCount() {
+    this.recoverySkipConflictCount.incrementAndGet();
   }
 
   /** Increments the client recreation attempt counter. Thread-safe. */
@@ -344,5 +380,20 @@ public class SnowflakeTelemetryChannelStatus extends SnowflakeTelemetryBasicInfo
   @VisibleForTesting
   public long getLatestConsumerOffset() {
     return this.latestConsumerOffset.get();
+  }
+
+  @VisibleForTesting
+  public long getOffsetGapCount() {
+    return this.offsetGapCount.get();
+  }
+
+  @VisibleForTesting
+  public long getOffsetGapMissingRecordCount() {
+    return this.offsetGapMissingRecordCount.get();
+  }
+
+  @VisibleForTesting
+  public long getRecoverySkipConflictCount() {
+    return this.recoverySkipConflictCount.get();
   }
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannel.java
@@ -943,6 +943,11 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
   }
 
   @Override
+  public void incRecoverySkipConflictCount() {
+    this.snowflakeTelemetryChannelStatus.incRecoverySkipConflictCount();
+  }
+
+  @Override
   public void setLatestConsumerGroupOffset(long consumerOffset) {
     offsetTracker.setLatestConsumerGroupOffset(consumerOffset);
   }

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/channel/PartitionOffsetTracker.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/channel/PartitionOffsetTracker.java
@@ -57,6 +57,19 @@ public class PartitionOffsetTracker {
   // Last offset passed to appendRow -- used by flush to know when all data is committed.
   private long lastAppendRowsOffset = NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE;
 
+  // Offset-gap data-loss detection (SNOW-3655748 / PROD-538073). Observed in shouldProcess (called
+  // from insertRecord), when the connector decides to process a record whose offset is past the
+  // next expected one:
+  //   offsetGapCount      - number of such forward discontinuities.
+  //   offsetGapMissingRecordCount - total count of offset positions skipped over across those gaps.
+  // These are observation-time, cumulative counts: a gap seen here that is later closed by recovery
+  // + redelivery is still counted, and legitimate gaps (compaction, SMT filters,
+  // errors.tolerance=all) are counted too. So the missing count is an upper bound on records
+  // actually lost, NOT a count of permanently lost rows -- the cross-version trend, not the
+  // absolute value, is the data-loss signal.
+  private final AtomicLong offsetGapCount = new AtomicLong(0);
+  private final AtomicLong offsetGapMissingRecordCount = new AtomicLong(0);
+
   public PartitionOffsetTracker(String channelName, Consumer<Long> onOffsetReset) {
     this.channelName = channelName;
     this.onOffsetReset = onOffsetReset;
@@ -97,19 +110,37 @@ public class PartitionOffsetTracker {
     }
 
     long currentProcessedOffset = this.processedOffset.get();
-    if (currentProcessedOffset == NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE
-        || kafkaOffset >= currentProcessedOffset + 1) {
-      return true;
+
+    // Already-committed / duplicate record (offset at or below what we've processed): skip it.
+    if (currentProcessedOffset != NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE
+        && kafkaOffset < currentProcessedOffset + 1) {
+      LOGGER.warn(
+          "Channel {} - skipping current record - expected offset {} but received {}. The"
+              + " current offset stored in Snowflake: {}",
+          channelName,
+          currentProcessedOffset,
+          kafkaOffset,
+          offsetPersistedInSnowflake.get());
+      return false;
     }
 
-    LOGGER.warn(
-        "Channel {} - skipping current record - expected offset {} but received {}. The"
-            + " current offset stored in Snowflake: {}",
-        channelName,
-        currentProcessedOffset,
-        kafkaOffset,
-        offsetPersistedInSnowflake.get());
-    return false;
+    // The record will be processed. If its offset is past the next expected one, the connector
+    // observed a gap (offsets it expected but never received); record it for data-loss detection.
+    if (currentProcessedOffset != NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE
+        && kafkaOffset > currentProcessedOffset + 1) {
+      long missing = kafkaOffset - (currentProcessedOffset + 1);
+      offsetGapCount.incrementAndGet();
+      offsetGapMissingRecordCount.addAndGet(missing);
+      LOGGER.debug(
+          "Channel {} - offset gap detected: expected {} but received {} ({} offset(s) missing)."
+              + " Persisted offset in Snowflake: {}",
+          channelName,
+          currentProcessedOffset + 1,
+          kafkaOffset,
+          missing,
+          offsetPersistedInSnowflake.get());
+    }
+    return true;
   }
 
   /** Called after a record has been fully processed (inserted or reported as broken). */
@@ -186,6 +217,14 @@ public class PartitionOffsetTracker {
     return lastAppendRowsOffset;
   }
 
+  public long getOffsetGapCount() {
+    return offsetGapCount.get();
+  }
+
+  public long getOffsetGapMissingRecordCount() {
+    return offsetGapMissingRecordCount.get();
+  }
+
   // Expose AtomicLong refs for telemetry binding
   public AtomicLong persistedOffsetRef() {
     return offsetPersistedInSnowflake;
@@ -197,5 +236,13 @@ public class PartitionOffsetTracker {
 
   public AtomicLong consumerGroupOffsetRef() {
     return currentConsumerGroupOffset;
+  }
+
+  public AtomicLong offsetGapCountRef() {
+    return offsetGapCount;
+  }
+
+  public AtomicLong offsetGapMissingRecordCountRef() {
+    return offsetGapMissingRecordCount;
   }
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/service/PartitionChannelManager.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/service/PartitionChannelManager.java
@@ -198,7 +198,9 @@ public class PartitionChannelManager {
             this.metricsJmxReporter,
             offsetTracker.persistedOffsetRef(),
             offsetTracker.processedOffsetRef(),
-            offsetTracker.consumerGroupOffsetRef());
+            offsetTracker.consumerGroupOffsetRef(),
+            offsetTracker.offsetGapCountRef(),
+            offsetTracker.offsetGapMissingRecordCountRef());
 
     final ExecutorService openChannelIoExecutor =
         ThreadPools.getOpenChannelIoExecutor(taskConfig.getConnectorName());

--- a/src/main/java/com/snowflake/kafka/connector/internal/telemetry/TelemetryConstants.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/telemetry/TelemetryConstants.java
@@ -26,6 +26,16 @@ public final class TelemetryConstants {
   public static final String VALIDATION_FAILURE_COUNT = "validation_failure_count";
   public static final String ERROR_TOLERATED_COUNT = "error_tolerated_count";
   public static final String CHANNEL_RECOVERY_COUNT = "channel_recovery_count";
+  // Offset-gap / data-loss detection telemetry (SNOW-3655748 / PROD-538073):
+  //   offset_gap_count                - forward discontinuities in the processed offsets
+  //                                     (recorded in insertRecord)
+  //   offset_gap_missing_record_count - offset positions skipped across those gaps
+  //                                     (upper bound on records actually lost)
+  //   recovery_skip_conflict_count    - batches delivered entirely past a recovering channel's
+  //                                     rewind offset
+  public static final String OFFSET_GAP_COUNT = "offset_gap_count";
+  public static final String OFFSET_GAP_MISSING_RECORD_COUNT = "offset_gap_missing_record_count";
+  public static final String RECOVERY_SKIP_CONFLICT_COUNT = "recovery_skip_conflict_count";
   // Client recreation telemetry: attempts is the number of times openChannelWithClientRecovery
   // tried to swap the SDK client; success/failure split records whether the underlying pool retry
   // budget held. attempts == success + failure.

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2RecoveryOffsetTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2RecoveryOffsetTest.java
@@ -185,7 +185,9 @@ class SnowflakeSinkServiceV2RecoveryOffsetTest {
             Optional.empty(),
             offsetTracker.persistedOffsetRef(),
             offsetTracker.processedOffsetRef(),
-            offsetTracker.consumerGroupOffsetRef());
+            offsetTracker.consumerGroupOffsetRef(),
+            offsetTracker.offsetGapCountRef(),
+            offsetTracker.offsetGapMissingRecordCountRef());
 
     SnowpipeStreamingPartitionChannel realChannel =
         new SnowpipeStreamingPartitionChannel(
@@ -303,6 +305,14 @@ class SnowflakeSinkServiceV2RecoveryOffsetTest {
             + (failingOffset - 1)
             + " are permanently lost because resetAfterRecovery's offset was overwritten by"
             + " offsetsOfFirstSkippedRecord.");
+
+    // Batch 2 drained the pending recovery reset (51) while carrying records 80-85 (all past 51) --
+    // exactly the PROD-538073 interleaving -- so one recovery-skip conflict must be recorded.
+    assertEquals(
+        1,
+        realChannel.getSnowflakeTelemetryChannelStatus().getRecoverySkipConflictCount(),
+        "Recovery-skip conflict should be counted when a recovering channel's batch carries"
+            + " records past the recovery offset.");
   }
 
   private List<SinkRecord> buildRecordBatch(long fromOffset, long toOffset) {

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2RecoverySkipConflictTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2RecoverySkipConflictTest.java
@@ -1,0 +1,107 @@
+package com.snowflake.kafka.connector.internal.streaming;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for the recovery-skip conflict detection used by {@link SnowflakeSinkServiceV2}. */
+class SnowflakeSinkServiceV2RecoverySkipConflictTest {
+
+  private static final String TOPIC = "t";
+
+  @Test
+  void batchEntirelyPastResumeOffsetIsAConflict() {
+    TopicPartition tp = new TopicPartition(TOPIC, 0);
+    Map<TopicPartition, Long> pendingResets = Map.of(tp, 51L);
+    // Resume point is 51 but the batch starts at 80 -- records 51-79 are unreachable (data loss).
+    Collection<SinkRecord> records = batch(tp, 80, 85);
+
+    Set<TopicPartition> conflicts =
+        SnowflakeSinkServiceV2.detectRecoverySkipConflicts(pendingResets, records);
+
+    assertEquals(Set.of(tp), conflicts);
+  }
+
+  @Test
+  void contiguousBatchIncludingResumeOffsetIsNotAConflict() {
+    TopicPartition tp = new TopicPartition(TOPIC, 0);
+    Map<TopicPartition, Long> pendingResets = Map.of(tp, 51L);
+    // Normal post-reset / channel-init delivery: batch includes the resume record 51, so nothing
+    // between the committed offset and the batch is dropped. Must NOT be flagged (false positive).
+    Collection<SinkRecord> records = batch(tp, 51, 53);
+
+    Set<TopicPartition> conflicts =
+        SnowflakeSinkServiceV2.detectRecoverySkipConflicts(pendingResets, records);
+
+    assertTrue(conflicts.isEmpty());
+  }
+
+  @Test
+  void recordAtExactlyResetOffsetIsNotAConflict() {
+    TopicPartition tp = new TopicPartition(TOPIC, 0);
+    Map<TopicPartition, Long> pendingResets = Map.of(tp, 51L);
+    // Resume point is 51; a record at 51 is the next record to re-deliver, not lost data.
+    Collection<SinkRecord> records = batch(tp, 51, 51);
+
+    Set<TopicPartition> conflicts =
+        SnowflakeSinkServiceV2.detectRecoverySkipConflicts(pendingResets, records);
+
+    assertTrue(conflicts.isEmpty());
+  }
+
+  @Test
+  void noPendingResetMeansNoConflict() {
+    TopicPartition tp = new TopicPartition(TOPIC, 0);
+    Collection<SinkRecord> records = batch(tp, 80, 85);
+
+    Set<TopicPartition> conflicts =
+        SnowflakeSinkServiceV2.detectRecoverySkipConflicts(Map.of(), records);
+
+    assertTrue(conflicts.isEmpty());
+  }
+
+  @Test
+  void pendingResetWithNoRecordsForThatPartitionIsNoConflict() {
+    TopicPartition recovering = new TopicPartition(TOPIC, 0);
+    TopicPartition other = new TopicPartition(TOPIC, 1);
+    Map<TopicPartition, Long> pendingResets = Map.of(recovering, 51L);
+    Collection<SinkRecord> records = batch(other, 80, 85);
+
+    Set<TopicPartition> conflicts =
+        SnowflakeSinkServiceV2.detectRecoverySkipConflicts(pendingResets, records);
+
+    assertTrue(conflicts.isEmpty());
+  }
+
+  @Test
+  void onlyPartitionsDeliveredEntirelyPastResetAreFlagged() {
+    TopicPartition tp1 = new TopicPartition(TOPIC, 0);
+    TopicPartition tp2 = new TopicPartition(TOPIC, 1);
+    Map<TopicPartition, Long> pendingResets = Map.of(tp1, 51L, tp2, 10L);
+    // tp1's batch is entirely past 51; tp2's batch includes its resume record at 10.
+    List<SinkRecord> records = new ArrayList<>();
+    records.addAll(batch(tp1, 80, 81));
+    records.addAll(batch(tp2, 10, 12));
+
+    Set<TopicPartition> conflicts =
+        SnowflakeSinkServiceV2.detectRecoverySkipConflicts(pendingResets, records);
+
+    assertEquals(Set.of(tp1), conflicts);
+  }
+
+  private static List<SinkRecord> batch(TopicPartition tp, long from, long to) {
+    List<SinkRecord> records = new ArrayList<>();
+    for (long o = from; o <= to; o++) {
+      records.add(new SinkRecord(tp.topic(), tp.partition(), null, null, null, null, o));
+    }
+    return records;
+  }
+}

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingErrorHandlerIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingErrorHandlerIT.java
@@ -286,7 +286,9 @@ class StreamingErrorHandlerIT {
             Optional.empty(),
             offsetTracker.persistedOffsetRef(),
             offsetTracker.processedOffsetRef(),
-            offsetTracker.consumerGroupOffsetRef());
+            offsetTracker.consumerGroupOffsetRef(),
+            offsetTracker.offsetGapCountRef(),
+            offsetTracker.offsetGapMissingRecordCountRef());
 
     return new SnowpipeStreamingPartitionChannel(
         "test_table",

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/telemetry/PeriodicTelemetryReporterTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/telemetry/PeriodicTelemetryReporterTest.java
@@ -333,7 +333,9 @@ class PeriodicTelemetryReporterTest {
             Optional.empty(),
             new AtomicLong(10L),
             new AtomicLong(5L),
-            new AtomicLong(15L));
+            new AtomicLong(15L),
+            new AtomicLong(0),
+            new AtomicLong(0));
     when(mockChannel.getSnowflakeTelemetryChannelStatus()).thenReturn(mockStatus);
     return mockChannel;
   }
@@ -349,7 +351,9 @@ class PeriodicTelemetryReporterTest {
             Optional.empty(),
             new AtomicLong(-1L),
             new AtomicLong(-1L),
-            new AtomicLong(-1L));
+            new AtomicLong(-1L),
+            new AtomicLong(0),
+            new AtomicLong(0));
     when(mockChannel.getSnowflakeTelemetryChannelStatus()).thenReturn(emptyStatus);
     return mockChannel;
   }

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannelTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannelTest.java
@@ -241,7 +241,9 @@ class SnowpipeStreamingPartitionChannelTest {
             Optional.empty(),
             offsetTracker.persistedOffsetRef(),
             offsetTracker.processedOffsetRef(),
-            offsetTracker.consumerGroupOffsetRef());
+            offsetTracker.consumerGroupOffsetRef(),
+            offsetTracker.offsetGapCountRef(),
+            offsetTracker.offsetGapMissingRecordCountRef());
     final SinkTaskConfig taskConfig =
         SinkTaskConfigTestBuilder.builder()
             .connectorName(CONNECTOR_NAME)
@@ -660,7 +662,9 @@ class SnowpipeStreamingPartitionChannelTest {
             Optional.empty(),
             offsetTracker.persistedOffsetRef(),
             offsetTracker.processedOffsetRef(),
-            offsetTracker.consumerGroupOffsetRef());
+            offsetTracker.consumerGroupOffsetRef(),
+            offsetTracker.offsetGapCountRef(),
+            offsetTracker.offsetGapMissingRecordCountRef());
 
     SinkTaskConfig taskConfig =
         SinkTaskConfigTestBuilder.builder()
@@ -741,7 +745,9 @@ class SnowpipeStreamingPartitionChannelTest {
             Optional.empty(),
             offsetTracker.persistedOffsetRef(),
             offsetTracker.processedOffsetRef(),
-            offsetTracker.consumerGroupOffsetRef());
+            offsetTracker.consumerGroupOffsetRef(),
+            offsetTracker.offsetGapCountRef(),
+            offsetTracker.offsetGapMissingRecordCountRef());
 
     SinkTaskConfig taskConfig =
         SinkTaskConfigTestBuilder.builder()
@@ -836,7 +842,9 @@ class SnowpipeStreamingPartitionChannelTest {
             Optional.empty(),
             offsetTracker.persistedOffsetRef(),
             offsetTracker.processedOffsetRef(),
-            offsetTracker.consumerGroupOffsetRef());
+            offsetTracker.consumerGroupOffsetRef(),
+            offsetTracker.offsetGapCountRef(),
+            offsetTracker.offsetGapMissingRecordCountRef());
 
     SinkTaskConfig taskConfig =
         SinkTaskConfigTestBuilder.builder()
@@ -978,7 +986,9 @@ class SnowpipeStreamingPartitionChannelTest {
             Optional.empty(),
             offsetTracker.persistedOffsetRef(),
             offsetTracker.processedOffsetRef(),
-            offsetTracker.consumerGroupOffsetRef());
+            offsetTracker.consumerGroupOffsetRef(),
+            offsetTracker.offsetGapCountRef(),
+            offsetTracker.offsetGapMissingRecordCountRef());
 
     SinkTaskConfig migrationTaskConfig =
         SinkTaskConfigTestBuilder.builder()

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/channel/PartitionOffsetTrackerTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/channel/PartitionOffsetTrackerTest.java
@@ -1,0 +1,92 @@
+package com.snowflake.kafka.connector.internal.streaming.v2.channel;
+
+import static com.snowflake.kafka.connector.internal.streaming.channel.TopicPartitionChannel.NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class PartitionOffsetTrackerTest {
+
+  private PartitionOffsetTracker newTracker() {
+    return new PartitionOffsetTracker("test-channel", offset -> {});
+  }
+
+  @Test
+  void contiguousOffsetsProduceNoGap() {
+    PartitionOffsetTracker tracker = newTracker();
+    tracker.initializeFromSnowflake(9);
+
+    process(tracker, 10);
+    process(tracker, 11);
+    process(tracker, 12);
+
+    assertEquals(0, tracker.getOffsetGapCount());
+    assertEquals(0, tracker.getOffsetGapMissingRecordCount());
+  }
+
+  @Test
+  void forwardJumpIsCountedAsOneGapWithMissingRows() {
+    PartitionOffsetTracker tracker = newTracker();
+    tracker.initializeFromSnowflake(9);
+
+    process(tracker, 10); // contiguous
+    process(tracker, 15); // gap: missing 11,12,13,14 -> 4 rows
+
+    assertEquals(1, tracker.getOffsetGapCount());
+    assertEquals(4, tracker.getOffsetGapMissingRecordCount());
+  }
+
+  @Test
+  void multipleGapsAccumulate() {
+    PartitionOffsetTracker tracker = newTracker();
+    tracker.initializeFromSnowflake(0);
+
+    process(tracker, 1); // contiguous
+    process(tracker, 5); // gap of 3 (2,3,4)
+    process(tracker, 6); // contiguous
+    process(tracker, 10); // gap of 3 (7,8,9)
+
+    assertEquals(2, tracker.getOffsetGapCount());
+    assertEquals(6, tracker.getOffsetGapMissingRecordCount());
+  }
+
+  @Test
+  void firstRecordOnUninitializedChannelIsNotAGap() {
+    PartitionOffsetTracker tracker = newTracker();
+    // processedOffset starts at NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE: a topic that does not
+    // start at offset 0 must not be flagged as a gap.
+    process(tracker, 100);
+
+    assertEquals(0, tracker.getOffsetGapCount());
+    assertEquals(0, tracker.getOffsetGapMissingRecordCount());
+  }
+
+  @Test
+  void redeliveryAfterRecoveryFromCommittedPlusOneIsNotAGap() {
+    PartitionOffsetTracker tracker = newTracker();
+    tracker.initializeFromSnowflake(49);
+    process(tracker, 50); // contiguous
+
+    // Channel invalidated and reopened at committed=49; Kafka redelivers from 50.
+    tracker.resetAfterRecovery(49);
+    process(tracker, 50); // first redelivered record, contiguous with committed+1
+
+    assertEquals(0, tracker.getOffsetGapCount());
+    assertEquals(0, tracker.getOffsetGapMissingRecordCount());
+  }
+
+  @Test
+  void uninitializedTrackerStartsAtZeroGaps() {
+    PartitionOffsetTracker tracker = newTracker();
+    assertEquals(0, tracker.getOffsetGapCount());
+    assertEquals(0, tracker.getOffsetGapMissingRecordCount());
+    assertEquals(NO_OFFSET_TOKEN_REGISTERED_IN_SNOWFLAKE, tracker.getProcessedOffset());
+  }
+
+  /** Mirrors the connector's gate-then-advance flow: shouldProcess, then recordProcessed. */
+  private void process(PartitionOffsetTracker tracker, long offset) {
+    if (tracker.shouldProcess(offset)) {
+      tracker.recordProcessed(offset);
+    }
+  }
+}

--- a/src/test/java/com/snowflake/kafka/connector/internal/telemetry/SnowflakeTelemetryChannelStatusTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/telemetry/SnowflakeTelemetryChannelStatusTest.java
@@ -36,9 +36,11 @@ public class SnowflakeTelemetryChannelStatusTest {
             Optional.of(metricsJmxReporter),
             new AtomicLong(-1),
             new AtomicLong(-1),
-            new AtomicLong(-1));
+            new AtomicLong(-1),
+            new AtomicLong(0),
+            new AtomicLong(0));
 
-    // Registration: 4 metrics registered, start() NOT called (handled at task level)
+    // Registration: NUM_METRICS gauges registered, start() NOT called (handled at task level)
     verify(metricsJmxReporter, times(0)).start();
     verify(metricRegistry, times((int) SnowflakeTelemetryChannelStatus.NUM_METRICS))
         .register(Mockito.anyString(), Mockito.any());
@@ -67,7 +69,9 @@ public class SnowflakeTelemetryChannelStatusTest {
             Optional.empty(),
             new AtomicLong(-1),
             new AtomicLong(-1),
-            new AtomicLong(-1));
+            new AtomicLong(-1),
+            new AtomicLong(0),
+            new AtomicLong(0));
     verify(metricsJmxReporter, times(0)).start();
     verify(metricRegistry, times(0)).register(Mockito.anyString(), Mockito.any());
     verify(metricsJmxReporter, times(0))
@@ -89,7 +93,9 @@ public class SnowflakeTelemetryChannelStatusTest {
             Optional.empty(),
             new AtomicLong(-1),
             new AtomicLong(-1),
-            new AtomicLong(-1));
+            new AtomicLong(-1),
+            new AtomicLong(0),
+            new AtomicLong(0));
 
     // Initially zero
     ObjectNode msg = new ObjectMapper().createObjectNode();
@@ -104,5 +110,42 @@ public class SnowflakeTelemetryChannelStatusTest {
     msg = new ObjectMapper().createObjectNode();
     status.dumpTo(msg);
     assertEquals(3, msg.get(TelemetryConstants.VALIDATION_FAILURE_COUNT).asLong());
+  }
+
+  @Test
+  public void testOffsetGapAndConflictCountsInDumpTo() {
+    AtomicLong offsetGapCount = new AtomicLong(0);
+    AtomicLong offsetGapMissingRecordCount = new AtomicLong(0);
+    SnowflakeTelemetryChannelStatus status =
+        new SnowflakeTelemetryChannelStatus(
+            tableName,
+            connectorName,
+            channelName,
+            1234,
+            Optional.empty(),
+            new AtomicLong(-1),
+            new AtomicLong(-1),
+            new AtomicLong(-1),
+            offsetGapCount,
+            offsetGapMissingRecordCount);
+
+    // Initially zero
+    ObjectNode msg = new ObjectMapper().createObjectNode();
+    status.dumpTo(msg);
+    assertEquals(0, msg.get(TelemetryConstants.OFFSET_GAP_COUNT).asLong());
+    assertEquals(0, msg.get(TelemetryConstants.OFFSET_GAP_MISSING_RECORD_COUNT).asLong());
+    assertEquals(0, msg.get(TelemetryConstants.RECOVERY_SKIP_CONFLICT_COUNT).asLong());
+
+    // The gap counters are owned by the offset tracker; simulate it observing two gaps totalling
+    // seven missing offsets, and the service recording one recovery-skip conflict.
+    offsetGapCount.set(2);
+    offsetGapMissingRecordCount.set(7);
+    status.incRecoverySkipConflictCount();
+
+    msg = new ObjectMapper().createObjectNode();
+    status.dumpTo(msg);
+    assertEquals(2, msg.get(TelemetryConstants.OFFSET_GAP_COUNT).asLong());
+    assertEquals(7, msg.get(TelemetryConstants.OFFSET_GAP_MISSING_RECORD_COUNT).asLong());
+    assertEquals(1, msg.get(TelemetryConstants.RECOVERY_SKIP_CONFLICT_COUNT).asLong());
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/internal/telemetry/SnowflakeTelemetryServiceTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/telemetry/SnowflakeTelemetryServiceTest.java
@@ -226,7 +226,9 @@ public class SnowflakeTelemetryServiceTest {
             Optional.empty(),
             new AtomicLong(expectedOffsetPersistedInSnowflake),
             new AtomicLong(expectedProcessedOffset),
-            new AtomicLong(expectedLatestConsumerOffset));
+            new AtomicLong(expectedLatestConsumerOffset),
+            new AtomicLong(0),
+            new AtomicLong(0));
 
     channelStatus.incErrorToleratedCount();
     channelStatus.incErrorToleratedCount();


### PR DESCRIPTION
PM action item from PROD-538073 (KC 4.0.0 silent offset-rewind data loss).
Adds two additive, per-channel signals (JMX + `kafka_channel_usage` telemetry, already version-stamped) so offset-gap abnormalities can be trended across connector releases:

- **`offset_gap_count` / `offset_gap_missing_record_count`**: forward discontinuities observed when the connector decides to process a record (`PartitionOffsetTracker.shouldProcess`, from `insertRecord`), and the total offset positions skipped across them — an upper bound on records actually lost, since legitimate filtering/compaction gaps count too. Noisy in absolute terms; the cross-version trend is the signal.
- **`recovery_skip_conflict_count`**: batches delivered entirely past a recovering channel's rewind offset — the exact PROD-538073 interleaving (`SnowflakeSinkServiceV2.detectRecoverySkipConflicts`). Low-noise; should sit at zero in healthy operation.

Observation-only; no change to offset/recovery control flow. Baselining and alerting on these signals are owned by sibling action items.

## Testing
- Unit/integration: new `PartitionOffsetTrackerTest`, `SnowflakeSinkServiceV2RecoverySkipConflictTest`; extended `SnowflakeSinkServiceV2RecoveryOffsetTest` (asserts the conflict count in the real PROD-538073 scenario) and a `dumpTo` test for the new fields. All affected unit tests green; google-java-format (v1.24.0) clean.
- Live e2e on a SUT (apache 3.7.0, via the Snowfort KC proxy holder, SDK pinned 1.4.0 per #1481): `test_string_json[v4]` and `test_channel_invalidation_recovery[v4]` both PASS.

JIRA: SNOW-3655748