### PR TITLE
SNOW-3647384 don't rewind unassigned partitions

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/Constants.java
+++ b/src/main/java/com/snowflake/kafka/connector/Constants.java
@@ -52,6 +52,11 @@ public final class Constants {
     public static final boolean SNOWFLAKE_SSV1_OFFSET_MIGRATION_INCLUDE_CONNECTOR_NAME_DEFAULT =
         false;
 
+    // Feature flags
+    public static final String SNOWFLAKE_FEATURE_ASSERT_PARTITION_ASSIGNMENT =
+        "snowflake.feature.assert.partition.assignment";
+    public static final boolean SNOWFLAKE_FEATURE_ASSERT_PARTITION_ASSIGNMENT_DEFAULT = true;
+
     // Caching
     public static final String CACHE_TABLE_EXISTS = "snowflake.cache.table.exists";
     public static final boolean CACHE_TABLE_EXISTS_DEFAULT = true;

--- a/src/main/java/com/snowflake/kafka/connector/config/SinkTaskConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/config/SinkTaskConfig.java
@@ -117,6 +117,13 @@ public abstract class SinkTaskConfig {
 
   public abstract boolean isSsv1MigrationIncludeConnectorName();
 
+  /**
+   * Whether the partition-assignment invariant assertions in {@code
+   * SnowflakeSinkServiceV2.insert(Collection)} are enabled. See {@link
+   * KafkaConnectorConfigParams#SNOWFLAKE_FEATURE_ASSERT_PARTITION_ASSIGNMENT}.
+   */
+  public abstract boolean isAssertPartitionAssignmentEnabled();
+
   /** Convenience overload that calls {@link #from(Map, boolean)} with {@code false}. */
   public static SinkTaskConfig from(Map<String, String> raw) {
     return from(raw, false);
@@ -297,6 +304,14 @@ public abstract class SinkTaskConfig {
     String proxyPassword = config.get(KafkaConnectorConfigParams.JVM_PROXY_PASSWORD);
     String jdbcMap = config.get(KafkaConnectorConfigParams.SNOWFLAKE_JDBC_MAP);
 
+    boolean assertPartitionAssignmentEnabled =
+        Optional.ofNullable(
+                config.get(
+                    KafkaConnectorConfigParams.SNOWFLAKE_FEATURE_ASSERT_PARTITION_ASSIGNMENT))
+            .map(Boolean::parseBoolean)
+            .orElse(
+                KafkaConnectorConfigParams.SNOWFLAKE_FEATURE_ASSERT_PARTITION_ASSIGNMENT_DEFAULT);
+
     return builder()
         .connectorName(connectorName)
         .taskId(taskId)
@@ -333,7 +348,8 @@ public abstract class SinkTaskConfig {
         .proxyPassword(proxyPassword)
         .jdbcMap(jdbcMap)
         .ssv1MigrationMode(ssv1MigrationMode)
-        .ssv1MigrationIncludeConnectorName(ssv1MigrationIncludeConnectorName);
+        .ssv1MigrationIncludeConnectorName(ssv1MigrationIncludeConnectorName)
+        .assertPartitionAssignmentEnabled(assertPartitionAssignmentEnabled);
   }
 
   private static Password passwordOrNull(String value) {
@@ -425,6 +441,9 @@ public abstract class SinkTaskConfig {
 
     public abstract Builder ssv1MigrationIncludeConnectorName(
         boolean ssv1MigrationIncludeConnectorName);
+
+    public abstract Builder assertPartitionAssignmentEnabled(
+        boolean assertPartitionAssignmentEnabled);
 
     public abstract SinkTaskConfig build();
   }

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2.java
@@ -306,11 +306,29 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
    */
   @Override
   public void insert(final Collection<SinkRecord> records) {
+    // Materialize the current assignment once. The connector must never ingest into or rewind a
+    // partition it no longer owns: a rebalance can revoke a partition, and seeking it would make
+    // WorkerSinkTask.rewind() throw "IllegalStateException: No current assignment for partition"
+    // and kill the task (SNOW-3647384).
+    Set<TopicPartition> assignment = sinkTaskContext.assignment();
+
     // Skip partitions for which the partition-channel bridge is currently being initialized.
     Set<TopicPartition> partitions =
         records.stream()
             .map(record -> new TopicPartition(record.topic(), record.kafkaPartition()))
             .collect(Collectors.toSet());
+    // Kafka Connect only delivers records for partitions currently assigned to this task. If this
+    // did not hold we would ingest data for a partition we don't own without ever rewinding it.
+    if (taskConfig.isAssertPartitionAssignmentEnabled() && !assignment.containsAll(partitions)) {
+      throw new IllegalStateException(
+          "Received records for partitions not in the current assignment: "
+              + partitions.stream()
+                  .filter(partition -> !assignment.contains(partition))
+                  .collect(Collectors.toSet())
+              + " (assignment="
+              + assignment
+              + ")");
+    }
 
     Set<TopicPartition> initializingPartitions = currentlyInitializing(partitions);
     if (!initializingPartitions.isEmpty()) {
@@ -327,7 +345,9 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
     // These partitions are skipped in this batch and rewound at the end.
     // They will be processed normally in the next batch.
     // This is so that sinkTaskContext.offset() is only ever called from this (task) thread.
-    Map<TopicPartition, Long> pendingResets = channelManager.drainPendingOffsetResets();
+    // Pass the current assignment so resets for partitions revoked by a rebalance are dropped
+    // rather than rewound (SNOW-3647384).
+    Map<TopicPartition, Long> pendingResets = channelManager.drainPendingOffsetResets(assignment);
     if (!pendingResets.isEmpty()) {
       LOGGER.info("Draining {} pending offset resets: {}", pendingResets.size(), pendingResets);
       offsetsToRewindTo.putAll(pendingResets);
@@ -386,6 +406,21 @@ public class SnowflakeSinkServiceV2 implements SnowflakeSinkService {
     }
 
     if (!offsetsToRewindTo.isEmpty()) {
+      // Defense-in-depth against SNOW-3647384: drainPendingOffsetResets already dropped revoked
+      // partitions and the skipped-record offsets come from `partitions` (asserted assigned above),
+      // so every rewind must target a currently-assigned partition. Guards any future path that
+      // could add an unassigned partition to offsetsToRewindTo before the seek.
+      if (taskConfig.isAssertPartitionAssignmentEnabled()
+          && !assignment.containsAll(offsetsToRewindTo.keySet())) {
+        throw new IllegalStateException(
+            "Attempting to rewind partitions not in the current assignment: "
+                + offsetsToRewindTo.keySet().stream()
+                    .filter(partition -> !assignment.contains(partition))
+                    .collect(Collectors.toSet())
+                + " (assignment="
+                + assignment
+                + ")");
+      }
       LOGGER.info("Rewinding offsets for skipped partitions: {}", offsetsToRewindTo);
       sinkTaskContext.offset(offsetsToRewindTo);
     }

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannel.java
@@ -150,7 +150,20 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
             () -> {
               OpenChannelResult openChannelResult = openChannelWithClientRecovery(channelName);
               long offsetRecoveredFromSnowflake = parseOrMigrateOffsetToken(openChannelResult);
-              offsetTracker.initializeFromSnowflake(offsetRecoveredFromSnowflake);
+              // If this channel was cancelled (e.g. the partition was revoked during a rebalance)
+              // while the open was in-flight, skip the offset reset. Otherwise
+              // initializeFromSnowflake fires onOffsetReset, which re-enqueues a pending offset
+              // reset for a partition the task no longer owns; that reset is later applied via
+              // sinkTaskContext.offset() and seeks a revoked partition (SNOW-3647384). The channel
+              // is still returned so closeChannelAsync can close it.
+              if (cancelled.get()) {
+                LOGGER.info(
+                    "Channel {} was cancelled during open; skipping offset reset to avoid rewinding"
+                        + " a revoked partition",
+                    channelName);
+              } else {
+                offsetTracker.initializeFromSnowflake(offsetRecoveredFromSnowflake);
+              }
               return openChannelResult.getChannel();
             },
             openChannelIoExecutor);
@@ -413,7 +426,18 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
                         offsetTracker.consumerGroupOffsetRef().get());
                   }
 
-                  offsetTracker.resetAfterRecovery(offsetRecoveredFromSnowflake);
+                  // Symmetric to the constructor open path: if the partition was revoked (channel
+                  // cancelled) while this recovery open was in-flight, skip the offset reset.
+                  // The channel is still returned so it can be closed.
+                  if (cancelled.get()) {
+                    LOGGER.info(
+                        "{} Channel {} was cancelled during recovery; skipping offset reset to"
+                            + " avoid rewinding a revoked partition",
+                        reason,
+                        this.channelName);
+                  } else {
+                    offsetTracker.resetAfterRecovery(offsetRecoveredFromSnowflake);
+                  }
 
                   LOGGER.info(
                       "{} Channel {} recovery complete, offsetRecoveredFromSnowflake={}",

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/service/PartitionChannelManager.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/service/PartitionChannelManager.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
@@ -363,8 +364,17 @@ public class PartitionChannelManager {
   /**
    * Atomically drains all pending offset resets submitted by channel init / recovery. Called from
    * the task thread at the beginning of {@code SSV2.insert(Collection)}.
+   *
+   * <p>Resets for partitions not in {@code assignment} are dropped (with a warning) rather than
+   * returned. A rebalance can revoke a partition after a reset was enqueued for it (e.g. an
+   * in-flight channel open completing after close re-adds the reset). Rewinding an unassigned
+   * partition makes {@code WorkerSinkTask.rewind()} seek a partition the consumer no longer owns
+   * and throws "IllegalStateException: No current assignment for partition", killing the task
+   * (SNOW-3647384). The partition's new owner re-initializes its own offset on open.
+   *
+   * @param assignment the partitions currently assigned to this task
    */
-  public Map<TopicPartition, Long> drainPendingOffsetResets() {
+  public Map<TopicPartition, Long> drainPendingOffsetResets(Set<TopicPartition> assignment) {
     if (pendingOffsetResets.isEmpty()) {
       return Map.of();
     }
@@ -372,10 +382,19 @@ public class PartitionChannelManager {
     pendingOffsetResets
         .keySet()
         .forEach(
-            tp -> {
-              Long offset = pendingOffsetResets.remove(tp);
-              if (offset != null) {
-                drained.put(tp, offset);
+            topicPartition -> {
+              Long offset = pendingOffsetResets.remove(topicPartition);
+              if (offset == null) {
+                return;
+              }
+              if (assignment.contains(topicPartition)) {
+                drained.put(topicPartition, offset);
+              } else {
+                LOGGER.warn(
+                    "Dropping pending offset reset for partition {} (offset {}) that is no longer"
+                        + " assigned to this task",
+                    topicPartition,
+                    offset);
               }
             });
     return drained;

--- a/src/test/java/com/snowflake/kafka/connector/SnowflakeSinkTaskForStreamingIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/SnowflakeSinkTaskForStreamingIT.java
@@ -99,8 +99,12 @@ public class SnowflakeSinkTaskForStreamingIT {
     ConnectorConfigTools.setDefaultValues(config);
 
     SnowflakeSinkTask sinkTask = new SnowflakeSinkTask();
-    // Inits the sinktaskcontext
-    sinkTask.initialize(new InMemorySinkTaskContext(Collections.singleton(topicPartition)));
+    // Inits the sinktaskcontext. The task opens a second partition later in this test, so the
+    // assignment must include both partitions (Kafka Connect updates assignment() on open()).
+    sinkTask.initialize(
+        new InMemorySinkTaskContext(
+            new HashSet<>(
+                Arrays.asList(topicPartition, new TopicPartition(topicName, partition + 1)))));
 
     sinkTask.start(config);
     ArrayList<TopicPartition> topicPartitions = new ArrayList<>();

--- a/src/test/java/com/snowflake/kafka/connector/config/SinkTaskConfigTestBuilder.java
+++ b/src/test/java/com/snowflake/kafka/connector/config/SinkTaskConfigTestBuilder.java
@@ -53,6 +53,7 @@ public final class SinkTaskConfigTestBuilder {
         .snowflakeDatabase("")
         .snowflakeSchema("")
         .ssv1MigrationMode(Ssv1MigrationMode.SKIP)
-        .ssv1MigrationIncludeConnectorName(false);
+        .ssv1MigrationIncludeConnectorName(false)
+        .assertPartitionAssignmentEnabled(true);
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2IT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2IT.java
@@ -24,8 +24,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
@@ -223,7 +225,8 @@ public class SnowflakeSinkServiceV2IT extends SnowflakeSinkServiceV2BaseIT {
     // opens a channel for partition 0, table and topic
     SnowflakeSinkService service =
         StreamingSinkServiceBuilder.builder(connectionService, configBuilder.build())
-            .withSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(topicPartition)))
+            .withSinkTaskContext(
+                new InMemorySinkTaskContext(Set.of(topicPartition, topicPartition2)))
             .withMetricsJmxReporter(
                 new com.snowflake.kafka.connector.internal.metrics.MetricsJmxReporter(
                     new com.codahale.metrics.MetricRegistry(), TEST_CONNECTOR_NAME))
@@ -346,9 +349,16 @@ public class SnowflakeSinkServiceV2IT extends SnowflakeSinkServiceV2BaseIT {
     }
     configBuilder.topicToTableMap(topic2Table);
 
+    Set<TopicPartition> assignment = new HashSet<>();
+    for (String assignedTopic : topics) {
+      for (int assignedPartition = 0; assignedPartition < partitionCount; assignedPartition++) {
+        assignment.add(new TopicPartition(assignedTopic, assignedPartition));
+      }
+    }
+
     SnowflakeSinkService service =
         StreamingSinkServiceBuilder.builder(conn, configBuilder.build())
-            .withSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(topicPartition)))
+            .withSinkTaskContext(new InMemorySinkTaskContext(assignment))
             .build();
 
     for (int topic = 0; topic < topicCount; topic++) {
@@ -402,7 +412,7 @@ public class SnowflakeSinkServiceV2IT extends SnowflakeSinkServiceV2BaseIT {
 
     SnowflakeSinkService service =
         StreamingSinkServiceBuilder.builder(conn, configBuilder.build())
-            .withSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(topicPartition)))
+            .withSinkTaskContext(new InMemorySinkTaskContext(new HashSet<>(topicPartitions)))
             .build();
 
     service.startPartitions(topicPartitions);

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2RebalanceRewindTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2RebalanceRewindTest.java
@@ -1,0 +1,90 @@
+package com.snowflake.kafka.connector.internal.streaming;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.snowflake.kafka.connector.config.SinkTaskConfig;
+import com.snowflake.kafka.connector.config.SinkTaskConfigTestBuilder;
+import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
+import com.snowflake.kafka.connector.internal.metrics.TaskMetrics;
+import com.snowflake.kafka.connector.internal.streaming.v2.service.BatchOffsetFetcher;
+import com.snowflake.kafka.connector.internal.streaming.v2.service.PartitionChannelManager;
+import com.snowflake.kafka.connector.internal.streaming.v2.service.ThreadPools;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+/**
+ * Reproduces the SSV2-side contribution to the SNOW-3647384 fix.
+ *
+ * <p>When an in-flight channel open completes after a partition has been revoked, it re-enqueues a
+ * pending offset reset for that revoked partition. If {@link
+ * SnowflakeSinkServiceV2#insert(java.util.Collection)} then applied that reset via {@code
+ * sinkTaskContext.offset(...)}, {@code WorkerSinkTask.rewind()} would seek a partition the consumer
+ * no longer owns and throw {@code IllegalStateException: No current assignment for partition},
+ * killing the task.
+ *
+ * <p>The fix drops resets for revoked partitions inside {@link
+ * PartitionChannelManager#drainPendingOffsetResets(Set)} (see {@code
+ * PartitionChannelManagerTest#drainPendingOffsetResetsDropsResetsForUnassignedPartitions}). This
+ * test pins {@code insert()}'s half of the contract: it must forward the task's <b>current</b>
+ * assignment to the drain so the manager can do that filtering.
+ */
+class SnowflakeSinkServiceV2RebalanceRewindTest {
+
+  private static final String TOPIC = "test_topic";
+  private static final String CONNECTOR_NAME = "test_connector";
+
+  @AfterEach
+  void tearDown() {
+    ThreadPools.closeForTask(CONNECTOR_NAME);
+  }
+
+  @Test
+  void insertForwardsCurrentAssignmentToDrain() {
+    TopicPartition assignedTp = new TopicPartition(TOPIC, 28);
+    Set<TopicPartition> assignment = Set.of(assignedTp);
+
+    InMemorySinkTaskContext sinkTaskContext = new InMemorySinkTaskContext(assignment);
+
+    SinkTaskConfig taskConfig =
+        SinkTaskConfigTestBuilder.builder().connectorName(CONNECTOR_NAME).taskId("0").build();
+
+    PartitionChannelManager mockChannelManager = mock(PartitionChannelManager.class);
+    when(mockChannelManager.drainPendingOffsetResets(any())).thenReturn(Map.of());
+
+    SnowflakeConnectionService mockConn = mock(SnowflakeConnectionService.class);
+    when(mockConn.isClosed()).thenReturn(false);
+
+    SnowflakeSinkServiceV2 service =
+        new SnowflakeSinkServiceV2(
+            mockConn,
+            taskConfig,
+            sinkTaskContext,
+            Optional.empty(),
+            () -> mock(BatchOffsetFetcher.class),
+            () -> mockChannelManager,
+            TaskMetrics.noop());
+
+    service.insert(Collections.emptyList());
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Set<TopicPartition>> assignmentCaptor = ArgumentCaptor.forClass(Set.class);
+    verify(mockChannelManager).drainPendingOffsetResets(assignmentCaptor.capture());
+    assertEquals(
+        assignment,
+        assignmentCaptor.getValue(),
+        "insert() must forward the task's current assignment so PartitionChannelManager drops"
+            + " pending offset resets for partitions revoked by a rebalance, rather than rewinding"
+            + " them and triggering IllegalStateException: No current assignment for partition"
+            + " (SNOW-3647384).");
+  }
+}

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2RecoveryOffsetTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2RecoveryOffsetTest.java
@@ -224,10 +224,12 @@ class SnowflakeSinkServiceV2RecoveryOffsetTest {
     Map<String, TopicPartitionChannel> channelMap = new ConcurrentHashMap<>();
     channelMap.put(channelName, realChannel);
     when(mockChannelManager.getPartitionChannels()).thenReturn(channelMap);
-    // Wire drainPendingOffsetResets to drain the real map (mirrors PartitionChannelManager)
-    when(mockChannelManager.drainPendingOffsetResets())
+    // Wire drainPendingOffsetResets to drain the real map (mirrors PartitionChannelManager):
+    // returns resets for assigned partitions and drops the rest.
+    when(mockChannelManager.drainPendingOffsetResets(any()))
         .thenAnswer(
             invocation -> {
+              Set<TopicPartition> assignment = invocation.getArgument(0);
               if (pendingOffsetResets.isEmpty()) {
                 return Map.of();
               }
@@ -237,7 +239,7 @@ class SnowflakeSinkServiceV2RecoveryOffsetTest {
                   .forEach(
                       key -> {
                         Long offset = pendingOffsetResets.remove(key);
-                        if (offset != null) {
+                        if (offset != null && assignment.contains(key)) {
                           drained.put(key, offset);
                         }
                       });

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2Test.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/SnowflakeSinkServiceV2Test.java
@@ -54,9 +54,13 @@ class SnowflakeSinkServiceV2Test {
   @BeforeEach
   void setUp() {
     mockChannelManager = mock(PartitionChannelManager.class);
-    when(mockChannelManager.drainPendingOffsetResets()).thenReturn(Map.of());
+    when(mockChannelManager.drainPendingOffsetResets(any())).thenReturn(Map.of());
     mockBatchOffsetFetcher = mock(BatchOffsetFetcher.class);
     mockSinkTaskContext = mock(SinkTaskContext.class);
+    // insert() asserts that record partitions and rewinds are within the current assignment; the
+    // insert() tests below use partitions 0 and 1 of TOPIC.
+    when(mockSinkTaskContext.assignment())
+        .thenReturn(Set.of(new TopicPartition(TOPIC, 0), new TopicPartition(TOPIC, 1)));
 
     SnowflakeConnectionService mockConn = mock(SnowflakeConnectionService.class);
     when(mockConn.isClosed()).thenReturn(false);

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannelTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannelTest.java
@@ -164,6 +164,136 @@ class SnowpipeStreamingPartitionChannelTest {
     assertEquals(0, trackingClientSupplier.getCloseCallCount());
   }
 
+  /**
+   * Reproduces SNOW-3647384: an {@code openChannel} that is still in-flight when the partition is
+   * revoked completes <b>after</b> {@code PartitionChannelManager.close()} has already removed the
+   * partition's pending offset reset, and re-enqueues it.
+   *
+   * <p>Production ordering ({@code PartitionChannelManager.close}):
+   *
+   * <ol>
+   *   <li>{@code pendingOffsetResets.remove(tp)}
+   *   <li>{@code channel.closeChannelAsync().join()} — chains onto the still-pending open future
+   * </ol>
+   *
+   * <p>The open future's body unconditionally calls {@code offsetTracker.initializeFromSnowflake},
+   * which fires {@code onOffsetReset} → {@code pendingOffsetResets.put(tp, committedOffset + 1)} —
+   * re-adding the entry that {@code close()} just removed. That stale reset is later drained on the
+   * task thread and applied via {@code sinkTaskContext.offset()}, so {@code
+   * WorkerSinkTask.rewind()} seeks a partition the consumer no longer owns:
+   *
+   * <pre>java.lang.IllegalStateException: No current assignment for partition ...</pre>
+   *
+   * which Kafka Connect treats as unrecoverable and kills the task.
+   *
+   * <p>This test should <b>FAIL</b> on current code and <b>PASS</b> once the async open skips the
+   * offset reset for a cancelled/closed channel.
+   */
+  @Test
+  void inFlightOpenCompletingAfterCloseDoesNotReAddOffsetReset() throws Exception {
+    final TopicPartition tp = new TopicPartition(TOPIC_NAME, PARTITION);
+    final long committedOffset = 50L;
+
+    // Mirror PartitionChannelManager.pendingOffsetResets and the onOffsetReset wiring that
+    // PartitionChannelManager.buildChannel installs on each channel's PartitionOffsetTracker.
+    final ConcurrentHashMap<TopicPartition, Long> pendingOffsetResets = new ConcurrentHashMap<>();
+
+    // Hold the openChannel call so the channel stays "initializing" while we run close().
+    final CountDownLatch openGate = new CountDownLatch(1);
+    trackingClientSupplier.setBlockOnOpenChannel(openGate);
+
+    // openChannel reports a committed offset of 50 so init fires onOffsetReset(51).
+    final TrackingStreamingIngestClient committedOffsetClient =
+        new TrackingStreamingIngestClient(pipeName, trackingClientSupplier) {
+          @Override
+          public OpenChannelResult openChannel(String channelNameArg, String offsetToken) {
+            OpenChannelResult result =
+                super.openChannel(channelNameArg, offsetToken); // awaits gate
+            ChannelStatus status =
+                new ChannelStatus(
+                    "db",
+                    "schema",
+                    pipeName,
+                    channelNameArg,
+                    "SUCCESS",
+                    String.valueOf(committedOffset),
+                    Instant.now(),
+                    0,
+                    0,
+                    0,
+                    null,
+                    null,
+                    null,
+                    null,
+                    Instant.now());
+            return new OpenChannelResult(result.getChannel(), status);
+          }
+        };
+
+    final PartitionOffsetTracker offsetTracker =
+        new PartitionOffsetTracker(channelName, offset -> pendingOffsetResets.put(tp, offset));
+    final SnowflakeTelemetryChannelStatus telemetryChannelStatus =
+        new SnowflakeTelemetryChannelStatus(
+            TABLE_NAME,
+            CONNECTOR_NAME,
+            channelName,
+            System.currentTimeMillis(),
+            Optional.empty(),
+            offsetTracker.persistedOffsetRef(),
+            offsetTracker.processedOffsetRef(),
+            offsetTracker.consumerGroupOffsetRef());
+    final SinkTaskConfig taskConfig =
+        SinkTaskConfigTestBuilder.builder()
+            .connectorName(CONNECTOR_NAME)
+            .taskId("0")
+            .enableSchematization(false)
+            .enableColumnIdentifierNormalization(true)
+            .validation(SnowflakeValidation.SERVER_SIDE)
+            .build();
+
+    final SnowpipeStreamingPartitionChannel partitionChannel =
+        new SnowpipeStreamingPartitionChannel(
+            TABLE_NAME,
+            channelName,
+            pipeName,
+            committedOffsetClient,
+            invalidClient -> {
+              throw new UnsupportedOperationException("ClientRecreator not wired in this test");
+            },
+            openChannelIoExecutor,
+            mockTelemetryService,
+            telemetryChannelStatus,
+            offsetTracker,
+            taskConfig,
+            mockErrorHandler,
+            TaskMetrics.noop(),
+            false,
+            null,
+            Optional.empty());
+
+    assertTrue(
+        partitionChannel.isInitializing(), "Open should still be in-flight (blocked on gate)");
+
+    // Simulate PartitionChannelManager.close([tp]) for the just-revoked partition:
+    // (1) remove any pending reset for the revoked partition, then
+    // (2) close the channel (chains onto the still-in-flight open future).
+    pendingOffsetResets.remove(tp);
+    final CompletableFuture<Void> closeFuture = partitionChannel.closeChannelAsync();
+
+    // The in-flight open now completes -- AFTER close() already removed the pending reset.
+    openGate.countDown();
+    closeFuture.get(5, TimeUnit.SECONDS);
+
+    assertTrue(
+        pendingOffsetResets.isEmpty(),
+        "An openChannel that completes after the partition was revoked/closed must not re-enqueue"
+            + " an offset reset. A stale reset here is later drained on the task thread and applied"
+            + " via sinkTaskContext.offset(), causing WorkerSinkTask.rewind() to seek a partition"
+            + " the consumer no longer owns -> IllegalStateException: No current assignment for"
+            + " partition (task killed). Found stale reset: "
+            + pendingOffsetResets);
+  }
+
   @Test
   void reopenChannelRecoversAfterFailedAsyncInitialization() {
     // Make the first openChannel call (during async init) throw

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/service/PartitionChannelManagerTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/v2/service/PartitionChannelManagerTest.java
@@ -17,6 +17,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import org.apache.kafka.common.TopicPartition;
 import org.junit.jupiter.api.BeforeEach;
@@ -264,7 +265,7 @@ class PartitionChannelManagerTest {
 
   @Test
   void drainPendingOffsetResetsReturnsEmptyMapWhenNothingPending() {
-    assertTrue(manager.drainPendingOffsetResets().isEmpty());
+    assertTrue(manager.drainPendingOffsetResets(Set.of()).isEmpty());
   }
 
   @Test
@@ -275,10 +276,12 @@ class PartitionChannelManagerTest {
     manager.submitPendingOffsetReset(tp0, 51L);
     manager.submitPendingOffsetReset(tp1, 101L);
 
-    Map<TopicPartition, Long> drained = manager.drainPendingOffsetResets();
+    Map<TopicPartition, Long> drained = manager.drainPendingOffsetResets(Set.of(tp0, tp1));
 
     assertEquals(Map.of(tp0, 51L, tp1, 101L), drained);
-    assertTrue(manager.drainPendingOffsetResets().isEmpty(), "Second drain should be empty");
+    assertTrue(
+        manager.drainPendingOffsetResets(Set.of(tp0, tp1)).isEmpty(),
+        "Second drain should be empty");
   }
 
   @Test
@@ -288,10 +291,30 @@ class PartitionChannelManagerTest {
     manager.submitPendingOffsetReset(tp, 51L);
     manager.submitPendingOffsetReset(tp, 71L);
 
-    Map<TopicPartition, Long> drained = manager.drainPendingOffsetResets();
+    Map<TopicPartition, Long> drained = manager.drainPendingOffsetResets(Set.of(tp));
 
     assertEquals(71L, drained.get(tp), "Later recovery offset should win");
     assertEquals(1, drained.size());
+  }
+
+  @Test
+  void drainPendingOffsetResetsDropsResetsForUnassignedPartitions() {
+    TopicPartition assigned = new TopicPartition(TOPIC, 0);
+    TopicPartition revoked = new TopicPartition(TOPIC, 1);
+
+    manager.submitPendingOffsetReset(assigned, 51L);
+    manager.submitPendingOffsetReset(revoked, 101L);
+
+    // The revoked partition is no longer in the task's assignment (a rebalance revoked it after the
+    // reset was enqueued). Its stale reset must be dropped, not returned -- rewinding it would seek
+    // a partition the consumer no longer owns -> IllegalStateException: No current assignment for
+    // partition (SNOW-3647384).
+    Map<TopicPartition, Long> drained = manager.drainPendingOffsetResets(Set.of(assigned));
+
+    assertEquals(Map.of(assigned, 51L), drained);
+    assertTrue(
+        manager.drainPendingOffsetResets(Set.of(assigned, revoked)).isEmpty(),
+        "Dropped reset must be removed from the pending map, not left for a later drain");
   }
 
   @Test
@@ -305,7 +328,7 @@ class PartitionChannelManagerTest {
 
     manager.close(Collections.singletonList(tp0));
 
-    Map<TopicPartition, Long> drained = manager.drainPendingOffsetResets();
+    Map<TopicPartition, Long> drained = manager.drainPendingOffsetResets(Set.of(tp0, tp1));
     assertFalse(drained.containsKey(tp0), "Closed partition should not appear in drain");
     assertEquals(101L, drained.get(tp1));
   }


### PR DESCRIPTION
SNOW-3647384

This PR is a reopen of https://github.com/snowflakedb/snowflake-kafka-connector/pull/1495.

## Summary

During a consumer rebalance a partition can be revoked while its `openChannel` is still in-flight. When that open completes — after `PartitionChannelManager.close()` has already removed the partition's pending offset reset — `initializeFromSnowflake` fires `onOffsetReset` and re-enqueues a reset for the now-unowned partition. That stale reset is later drained on the task thread and applied via `sinkTaskContext.offset()`, so `WorkerSinkTask.rewind()` seeks a partition the consumer no longer owns and throws `IllegalStateException: No current assignment for partition`. Kafka Connect treats this as fatal and kills the task.

The fix stops unassigned partitions from ever being rewound, in three places:

- The in-flight open skips the offset reset when its channel has been cancelled (partition revoked), so it no longer re-enqueues a stale reset.
- `PartitionChannelManager.drainPendingOffsetResets` now takes the task's current assignment and drops resets for partitions no longer assigned, instead of returning them.
- `insert()` forwards the current assignment to the drain and guards the seek with an invariant check that it never rewinds an unassigned partition. The check can be disabled via `snowflake.feature.assert.partition.assignment` (default true) if it ever misfires.

## Testing

Apart from the unit tests, I confirmed with an in-progress soak test with chaos (which now includes changing the task count) that the fix works (see [successful run](https://github.com/snowflakedb/snowflake-kafka-connector/actions/runs/27969081410/job/82770400739)) while the same test failed on `master` locally in an 8-minute run.