### PR TITLE
implement `topic2table` regex replacement

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/Constants.java
+++ b/src/main/java/com/snowflake/kafka/connector/Constants.java
@@ -9,6 +9,9 @@ public final class Constants {
     public static final String NAME = "name";
     public static final String TOPICS = "topics";
     public static final String SNOWFLAKE_TOPICS2TABLE_MAP = "snowflake.topic2table.map";
+    public static final String SNOWFLAKE_TOPIC2TABLE_MAP_REGEX_REPLACEMENT =
+        "snowflake.topic2table.map.regex.replacement";
+    public static final boolean SNOWFLAKE_TOPIC2TABLE_MAP_REGEX_REPLACEMENT_DEFAULT = false;
     public static final String SNOWFLAKE_URL_NAME = "snowflake.url.name";
     public static final String SNOWFLAKE_USER_NAME = "snowflake.user.name";
     public static final String SNOWFLAKE_PRIVATE_KEY = "snowflake.private.key";

--- a/src/main/java/com/snowflake/kafka/connector/RegexTopicToTableResolver.java
+++ b/src/main/java/com/snowflake/kafka/connector/RegexTopicToTableResolver.java
@@ -1,0 +1,95 @@
+package com.snowflake.kafka.connector;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.annotation.Nullable;
+
+/**
+ * Resolves topic names to table names using compiled regex patterns with group substitution.
+ * Patterns are compiled once at construction time and matched in declaration order. The replacement
+ * template may contain group references ($1, $2, etc.). Unquoted table templates are uppercased
+ * after substitution; quoted templates preserve the case of both the template and the substituted
+ * groups.
+ */
+public class RegexTopicToTableResolver implements TopicToTableResolver {
+
+  private final List<ResolverEntry> entries;
+
+  private RegexTopicToTableResolver(List<TopicToTableParser.Entry> parsedEntries) {
+    List<ResolverEntry> built = new ArrayList<>(parsedEntries.size());
+    for (TopicToTableParser.Entry entry : parsedEntries) {
+      built.add(
+          new ResolverEntry(
+              Pattern.compile(entry.getTopic()), entry.getTable(), entry.shouldUppercase()));
+    }
+    this.entries = Collections.unmodifiableList(built);
+  }
+
+  /** Build a regex resolver with group substitution support from parsed entries. */
+  public static RegexTopicToTableResolver from(List<TopicToTableParser.Entry> entries) {
+    return new RegexTopicToTableResolver(entries);
+  }
+
+  @Override
+  @Nullable
+  public String resolve(String topic) {
+    for (ResolverEntry entry : entries) {
+      Matcher matcher = entry.pattern.matcher(topic);
+      if (matcher.matches()) {
+        String result = matcher.replaceFirst(entry.template);
+        if (entry.shouldUppercase) {
+          result = result.toUpperCase(Locale.ROOT);
+        }
+        return result;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Returns table names that can be statically determined. Templates containing group references
+   * (numbered $0-$9 or named ${name}) are excluded since their resolved names depend on the matched
+   * topic.
+   */
+  @Override
+  public Collection<String> tableNames() {
+    List<String> names = new ArrayList<>();
+    for (ResolverEntry entry : entries) {
+      if (!containsGroupReference(entry.template)) {
+        String table =
+            entry.shouldUppercase ? entry.template.toUpperCase(Locale.ROOT) : entry.template;
+        names.add(table);
+      }
+    }
+    return Collections.unmodifiableList(names);
+  }
+
+  private static boolean containsGroupReference(String template) {
+    for (int i = 0; i < template.length() - 1; i++) {
+      // Numbered ($1) and named (${name}) group references both make the resolved name depend on
+      // the matched topic, so neither can be enumerated statically.
+      char next = template.charAt(i + 1);
+      if (template.charAt(i) == '$' && (Character.isDigit(next) || next == '{')) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static final class ResolverEntry {
+    final Pattern pattern;
+    final String template;
+    final boolean shouldUppercase;
+
+    ResolverEntry(Pattern pattern, String template, boolean shouldUppercase) {
+      this.pattern = pattern;
+      this.template = template;
+      this.shouldUppercase = shouldUppercase;
+    }
+  }
+}

--- a/src/main/java/com/snowflake/kafka/connector/config/ConnectorConfigDefinition.java
+++ b/src/main/java/com/snowflake/kafka/connector/config/ConnectorConfigDefinition.java
@@ -529,6 +529,18 @@ public class ConnectorConfigDefinition {
             CONNECTOR_CONFIG_DOC,
             14,
             Width.NONE,
-            KafkaConnectorConfigParams.CACHE_PIPE_EXISTS_EXPIRE_MS);
+            KafkaConnectorConfigParams.CACHE_PIPE_EXISTS_EXPIRE_MS)
+        .define(
+            KafkaConnectorConfigParams.SNOWFLAKE_TOPIC2TABLE_MAP_REGEX_REPLACEMENT,
+            BOOLEAN,
+            KafkaConnectorConfigParams.SNOWFLAKE_TOPIC2TABLE_MAP_REGEX_REPLACEMENT_DEFAULT,
+            LOW,
+            "When true, table names in snowflake.topic2table.map support regex group replacement"
+                + " (e.g. topic(.*):table$1). Default false preserves legacy behavior (no group"
+                + " substitution), which is required for table names that contain a literal '$'.",
+            CONNECTOR_CONFIG_DOC,
+            15,
+            Width.NONE,
+            KafkaConnectorConfigParams.SNOWFLAKE_TOPIC2TABLE_MAP_REGEX_REPLACEMENT);
   }
 }

--- a/src/main/java/com/snowflake/kafka/connector/config/SinkTaskConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/config/SinkTaskConfig.java
@@ -4,6 +4,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.annotations.VisibleForTesting;
 import com.snowflake.kafka.connector.ConnectorConfigTools;
 import com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams;
+import com.snowflake.kafka.connector.RegexTopicToTableResolver;
 import com.snowflake.kafka.connector.StaticTopicToTableResolver;
 import com.snowflake.kafka.connector.TopicToTableParser;
 import com.snowflake.kafka.connector.TopicToTableResolver;
@@ -185,6 +186,14 @@ public abstract class SinkTaskConfig {
       }
     }
 
+    boolean regexReplacement =
+        Boolean.parseBoolean(
+            config.getOrDefault(
+                KafkaConnectorConfigParams.SNOWFLAKE_TOPIC2TABLE_MAP_REGEX_REPLACEMENT,
+                String.valueOf(
+                    KafkaConnectorConfigParams
+                        .SNOWFLAKE_TOPIC2TABLE_MAP_REGEX_REPLACEMENT_DEFAULT)));
+
     TopicToTableResolver topicToTableResolver =
         Optional.ofNullable(config.get(KafkaConnectorConfigParams.SNOWFLAKE_TOPICS2TABLE_MAP))
             .map(
@@ -192,7 +201,9 @@ public abstract class SinkTaskConfig {
                   try {
                     List<TopicToTableParser.Entry> entries =
                         TopicToTableParser.parseAndValidate(value);
-                    return StaticTopicToTableResolver.from(entries);
+                    return regexReplacement
+                        ? RegexTopicToTableResolver.from(entries)
+                        : StaticTopicToTableResolver.from(entries);
                   } catch (IllegalArgumentException e) {
                     throw SnowflakeErrors.ERROR_0021.getException(e.getMessage());
                   }

--- a/src/test/java/com/snowflake/kafka/connector/RegexTopicToTableResolverTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/RegexTopicToTableResolverTest.java
@@ -1,0 +1,111 @@
+package com.snowflake.kafka.connector;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collection;
+import java.util.List;
+import org.junit.Test;
+
+public class RegexTopicToTableResolverTest {
+
+  private static RegexTopicToTableResolver resolverFrom(String input) {
+    List<TopicToTableParser.Entry> entries = TopicToTableParser.parseAndValidate(input);
+    return RegexTopicToTableResolver.from(entries);
+  }
+
+  @Test
+  public void testExactMatchUnquotedIsUppercased() {
+    TopicToTableResolver resolver = resolverFrom("my_topic:my_table");
+
+    assertEquals("MY_TABLE", resolver.resolve("my_topic"));
+  }
+
+  @Test
+  public void testExactMatchQuotedPreservesCase() {
+    TopicToTableResolver resolver = resolverFrom("my_topic:\"My_Table\"");
+
+    assertEquals("My_Table", resolver.resolve("my_topic"));
+  }
+
+  @Test
+  public void testGroupSubstitutionUnquotedIsUppercased() {
+    TopicToTableResolver resolver = resolverFrom("src_(.*):dest_$1");
+
+    assertEquals("DEST_ORDERS", resolver.resolve("src_orders"));
+    assertEquals("DEST_USERS", resolver.resolve("src_users"));
+  }
+
+  @Test
+  public void testGroupSubstitutionQuotedPreservesCase() {
+    TopicToTableResolver resolver = resolverFrom("src_(.*):\"Dest_$1\"");
+
+    assertEquals("Dest_Orders", resolver.resolve("src_Orders"));
+  }
+
+  @Test
+  public void testMultipleGroups() {
+    TopicToTableResolver resolver = resolverFrom("(.*)\\.(.*):\"$1_$2\"");
+
+    assertEquals("db_events", resolver.resolve("db.events"));
+    assertEquals("app_logs", resolver.resolve("app.logs"));
+  }
+
+  @Test
+  public void testNoMatchReturnsNull() {
+    TopicToTableResolver resolver = resolverFrom("prefix_.*:table");
+
+    assertNull(resolver.resolve("other_topic"));
+  }
+
+  @Test
+  public void testMultiplePatterns() {
+    TopicToTableResolver resolver = resolverFrom("alpha_(.*):a_$1, beta_(.*):b_$1");
+
+    assertEquals("A_X", resolver.resolve("alpha_x"));
+    assertEquals("B_Y", resolver.resolve("beta_y"));
+    assertNull(resolver.resolve("gamma_z"));
+  }
+
+  @Test
+  public void testTableNamesExcludesDynamicTemplates() {
+    TopicToTableResolver resolver = resolverFrom("a:static_table, b_(.*):dynamic_$1");
+
+    Collection<String> names = resolver.tableNames();
+    assertEquals(1, names.size());
+    assertTrue(names.contains("STATIC_TABLE"));
+  }
+
+  @Test
+  public void testTableNamesExcludesNamedGroupTemplates() {
+    TopicToTableResolver resolver =
+        resolverFrom("(?<env>.*)_topic:${env}_sink, plain:static_table");
+
+    // Named-group templates resolve correctly at runtime...
+    assertEquals("PROD_SINK", resolver.resolve("prod_topic"));
+
+    // ...but must not be enumerated as a static table name (would cause spurious startup table
+    // checks against a literal "${ENV}_SINK").
+    Collection<String> names = resolver.tableNames();
+    assertEquals(1, names.size());
+    assertTrue(names.contains("STATIC_TABLE"));
+  }
+
+  @Test
+  public void testTableNamesQuotedStaticPreservesCase() {
+    TopicToTableResolver resolver = resolverFrom("a:\"Mixed_Case\"");
+
+    Collection<String> names = resolver.tableNames();
+    assertEquals(1, names.size());
+    assertTrue(names.contains("Mixed_Case"));
+  }
+
+  @Test
+  public void testFullMatchRequired() {
+    TopicToTableResolver resolver = resolverFrom("abc:table");
+
+    assertNull(resolver.resolve("xabcx"));
+    assertEquals("TABLE", resolver.resolve("abc"));
+  }
+}

--- a/src/test/java/com/snowflake/kafka/connector/TopicToTableParserTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/TopicToTableParserTest.java
@@ -16,6 +16,11 @@ public class TopicToTableParserTest {
     return StaticTopicToTableResolver.from(entries);
   }
 
+  private static TopicToTableResolver regexResolverFrom(String input) {
+    List<TopicToTableParser.Entry> entries = TopicToTableParser.parseAndValidate(input);
+    return RegexTopicToTableResolver.from(entries);
+  }
+
   @Test
   public void testParseEmptyInput() {
     assertNull(staticResolverFrom("").resolve("anything"));
@@ -104,6 +109,23 @@ public class TopicToTableParserTest {
   public void testParseRejectsMissingColon() {
     IllegalArgumentException error = assertParseError("topic table");
     assertTrue(error.getMessage().contains("Expected ':'"));
+  }
+
+  @Test
+  public void testParseRegexGroupSubstitution() {
+    TopicToTableResolver resolver = regexResolverFrom("topic_(.*):table_$1");
+
+    assertEquals("TABLE_EVENTS", resolver.resolve("topic_events"));
+    assertEquals("TABLE_LOGS", resolver.resolve("topic_logs"));
+    assertNull(resolver.resolve("other"));
+  }
+
+  @Test
+  public void testParseRegexQuotedPreservesCase() {
+    TopicToTableResolver resolver = regexResolverFrom("topic_(.*):\"Table_$1\"");
+
+    assertEquals("Table_Events", resolver.resolve("topic_Events"));
+    assertNull(resolver.resolve("other"));
   }
 
   private static IllegalArgumentException assertParseError(String input) {


### PR DESCRIPTION
[SNOW-3417175](https://snowflakecomputing.atlassian.net/browse/SNOW-3417175)

Adds optional regex **group substitution** to `snowflake.topic2table.map`, so a capturing topic pattern can project matched groups into the resolved table name (e.g. `topic_(.*):"tbl_$1"` sends `topic_events` to `tbl_events`).

## Setting

`snowflake.topic2table.map.regex.replacement` — **defaults to `false`** (opt-in). It selects which resolver backs `topic2table.map`; the mapping syntax itself is unchanged.

## Behavior: old vs new

- **`false` (default, unchanged):** a topic that matches an entry resolves to that entry's table value **verbatim**. `$1` and other `$`/`\` characters are literal. Unquoted tables are uppercased, quoted tables preserve case.
- **`true`:** the table value is treated as a Java regex **replacement template** evaluated against the topic match. `$1`, `$2`, … expand to the topic's capture groups. Unquoted templates are uppercased **after** substitution (so captured text is uppercased too); quoted templates preserve case of both the literal text and the substituted groups.

## Pitfalls

- **Literal `$` / `\` break under `true`.** With replacement enabled, these become replacement syntax, so an existing table name like `MLOG$_TBL` (Oracle CDC style) throws at **resolution time** — config validation does not catch it because it doesn't simulate substitution. Quoting the table does **not** make `$` literal. This regression risk is the reason the setting is opt-in and defaults to `false`; existing users are unaffected unless they enable it.
- **Uppercasing applies to substituted groups.** Under `true`, an unquoted template uppercases the whole result, including captured topic text. Quote the table to preserve case.
- **Known-table listing is partial.** Templates containing a group reference (`$0`–`$9`) can't be enumerated ahead of time, so they're omitted from the statically-known table names; only fixed templates are reported.
- Topic patterns still must not overlap (rejected at config time).

[SNOW-3417175]: https://snowflakecomputing.atlassian.net/browse/SNOW-3417175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ