### PR TITLE
Reduce config logging in Python integration tests

### DIFF
--- a/test/lib/driver.py
+++ b/test/lib/driver.py
@@ -670,9 +670,6 @@ class KafkaDriver:
 
         snowflake_connector_name = unsalted_name + name_salt
         logger.info(f"=== Creating connector: {snowflake_connector_name} ===")
-        logger.info(
-            f"Config template: {json.dumps(rest_request_template['config'], indent=4)}"
-        )
 
         snowflake_topic_name = snowflake_connector_name
 


### PR DESCRIPTION
## Summary
Removes a verbose `Config template` debug dump from the connector-creation path in the Python integration test driver (`test/lib/driver.py`). This trims unnecessary log output during test runs.

## Details
- Drops the `logger.info("Config template: ...")` call in `KafkaDriver.createConnector`.
- No change to test behavior; the connector is still created and validated exactly as before.

## Test plan
- [x] Existing integration test suite runs unchanged (the removed line was log-only).