### PR TITLE
end-to-end: de-flake by fixing result order

### DIFF
--- a/test/tests/test_avrosr_avrosr.py
+++ b/test/tests/test_avrosr_avrosr.py
@@ -88,7 +88,9 @@ def test_avrosr_avrosr(
     wait_for_rows(table.name, RECORD_COUNT)
 
     # -- Verify first row content --
-    row = table.select("*")[0]
+    # Snowflake does not guarantee row ordering without ORDER BY, so we must
+    # select the specific record at offset 0 rather than relying on insertion order.
+    row = table.select("*", "WHERE record_metadata:offset::int = 0")[0]
 
     assert row["ID"] == 0
     assert row["FIRSTNAME"] == "abc0"

--- a/test/tests/test_native_complex_smt.py
+++ b/test/tests/test_native_complex_smt.py
@@ -41,7 +41,9 @@ def test_native_complex_smt(
     wait_for_rows(table.name, RECORD_COUNT)
 
     # -- Verify first row: key extracted, c2 dropped --
-    row = table.select("*")[0]
+    # Snowflake does not guarantee row ordering without ORDER BY, so we must
+    # select the specific record at offset 0 rather than relying on insertion order.
+    row = table.select("*", "WHERE record_metadata:offset::int = 0")[0]
 
     assert json.loads(row["RECORD_METADATA"]) == {
         "CreateTime": ANY_INT,

--- a/test/tests/test_native_string_json_without_schema.py
+++ b/test/tests/test_native_string_json_without_schema.py
@@ -36,7 +36,9 @@ def test_native_string_json_without_schema(
     wait_for_rows(table.name, RECORD_COUNT)
 
     # -- Verify first row: only 'val' survives the SMT --
-    row = table.select("*")[0]
+    # Snowflake does not guarantee row ordering without ORDER BY, so we must
+    # select the specific record at offset 0 rather than relying on insertion order.
+    row = table.select("*", "WHERE record_metadata:offset::int = 0")[0]
 
     assert json.loads(row["RECORD_METADATA"]) == {
         "CreateTime": ANY_INT,

--- a/test/tests/test_native_string_protobuf.py
+++ b/test/tests/test_native_string_protobuf.py
@@ -50,7 +50,11 @@ def test_native_string_protobuf(
     wait_for_rows(table.name, RECORD_COUNT)
 
     # -- Verify first row content --
-    row = table.select("record_metadata, record_content", "LIMIT 1")[0]
+    # Snowflake does not guarantee row ordering without ORDER BY, so we must
+    # select the specific record at offset 0 rather than relying on insertion order.
+    row = table.select(
+        "record_metadata, record_content", "WHERE record_metadata:offset::int = 0"
+    )[0]
 
     record_metadata = json.loads(row["RECORD_METADATA"])
     assert record_metadata == {

--- a/test/tests/test_string_avrosr.py
+++ b/test/tests/test_string_avrosr.py
@@ -50,7 +50,9 @@ def test_string_avrosr(
     wait_for_rows(table.name, RECORD_COUNT)
 
     # -- Verify first row content --
-    row = table.select("*")[0]
+    # Snowflake does not guarantee row ordering without ORDER BY, so we must
+    # select the specific record at offset 0 rather than relying on insertion order.
+    row = table.select("*", "WHERE record_metadata:offset::int = 0")[0]
 
     assert row["ID"] == 0
     assert row["FIRSTNAME"] == "abc0"


### PR DESCRIPTION
## Summary

`test_native_complex_smt[v3]` flaked in CI (release-4.0): it asserted the first row's `offset == 0` but got `13`. Root cause is in the test, not the connector — all 100 rows ingested fine.

`Table.select` issues `SELECT * FROM <table>` with no `ORDER BY`, so `select(...)[0]` returns an arbitrary row. Several e2e tests send N distinct records and then assert that the "first" row is the offset-0 record (its offset, key, or value). Snowflake does not guarantee row order without `ORDER BY`, so this is inherently flaky — it only passes when the engine happens to return offset 0 first.

This selects the offset-0 row explicitly via `WHERE record_metadata:offset::int = 0`, mirroring the existing fix already in `test_string_json.py` / `test_json_json.py`.

Tests fixed (the rest of the `select(...)[0]` call sites are safe — identical payloads, `WHERE`/`COUNT` filters, single-record sends, or already ordered):

- `test_native_complex_smt.py`
- `test_avrosr_avrosr.py`
- `test_string_avrosr.py`
- `test_native_string_json_without_schema.py`
- `test_native_string_protobuf.py` (also drops a misleading `LIMIT 1`, which was equally unordered)