### PR TITLE
fix hasErrorLoggingEnabled to check SHOW TABLES error_logging value ON

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionService.java
@@ -136,7 +136,7 @@ public interface SnowflakeConnectionService {
    * Check whether the given table has ERROR_LOGGING enabled via SHOW TABLES.
    *
    * @param tableName table name
-   * @return true if error_logging is "Y", false otherwise or if the column is not present
+   * @return true if error_logging is "ON", false otherwise or if the column is not present
    */
   boolean hasErrorLoggingEnabled(String tableName);
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/StandardSnowflakeConnectionService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/StandardSnowflakeConnectionService.java
@@ -424,7 +424,7 @@ public class StandardSnowflakeConnectionService implements SnowflakeConnectionSe
       try (ResultSet result = stmt.executeQuery()) {
         if (result.next()) {
           try {
-            if ("Y".equals(result.getString("error_logging"))) {
+            if ("ON".equals(result.getString("error_logging"))) {
               LOGGER.debug("Table {} has ERROR_LOGGING enabled", tableName);
               return true;
             }


### PR DESCRIPTION
Snowflake returns "ON" (not "Y") for enabled ERROR_LOGGING in SHOW TABLES output, so tables with error logging were incorrectly flagged as disabled.