### PR TITLE
Reduce noisy integration-test logging

### DIFF
--- a/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/TestUtils.java
@@ -265,11 +265,6 @@ public class TestUtils {
       configuration.put(KafkaConnectorConfigParams.SNOWFLAKE_PRIVATE_KEY, p.privateKey);
     }
 
-    // password only appears in test profile
-    if (p.password != null) {
-      configuration.put("password", p.password);
-    }
-
     configuration.put(KafkaConnectorConfigParams.NAME, TEST_CONNECTOR_NAME);
 
     // enable test query mark

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -14,3 +14,5 @@ log4j.logger.com.snowflake.kafka.connector=TRACE
 # Avoid httpClient flooding the log
 log4j.logger.net.snowflake.client.jdbc.internal.apache.http.wire=WARN
 log4j.logger.net.snowflake.client.jdbc.internal.apache.http.headers=WARN
+# EmbeddedConnectCluster echoes the full connector REST request/response at INFO; keep tests quiet
+log4j.logger.org.apache.kafka.connect.util.clusters=WARN


### PR DESCRIPTION
EmbeddedConnectCluster echoes the full connector REST request/response at INFO on every `configureConnector` call, which is very verbose. Lower that logger to WARN in the test log config. Also drop an unused `password` key that TestUtils injected into the test connector configuration (not read anywhere).