### PR TITLE
end-to-end: de-flake v3 Snowpipe migration test by increasing warmup timeout

### DIFF
--- a/test/tests/compatibility/test_migration.py
+++ b/test/tests/compatibility/test_migration.py
@@ -402,8 +402,15 @@ def test_migration_from_snowpipe(
 
     try:
         logging.info("Waiting for v3 to ingest beyond the warmup batch")
-        assert wait_for(lambda: table.select_scalar("count(*)") > warmup_records), (
-            f"v3 never ingested beyond {warmup_records} warmup records"
+        # File-based Snowpipe loads staged files asynchronously with highly
+        # variable server-side latency (the warmup batch alone can take ~45s+).
+        # Use wait_for_rows for its longer default budget and task-health check
+        # rather than the 60s wait_for, which flakes when Snowpipe is slow.
+        wait_for_rows(
+            table_name=table.name,
+            expected=warmup_records + 1,
+            at_least=True,
+            connector_name=v3_connector.name,
         )
         logging.info(f"v3 ingested {table.select_scalar('count(*)')} rows so far")
 


### PR DESCRIPTION
## Summary

`test_migration_from_snowpipe` intermittently fails with `AssertionError: v3 never ingested beyond 10 warmup records`. The warmup check waited via `wait_for(..., timeout=60)`, but the v3 connector ingests through classic file-based Snowpipe, whose async file loading routinely exceeds 60s. When that fixed 60s window expires before the first post-warmup rows land, the assertion fails even though ingestion is healthy and eventually completes.

Fix: use the `wait_for_rows` fixture (300s `E2E_WAIT_TIMEOUT` budget, plus fail-fast if a task enters FAILED) instead of the bare 60s `wait_for`, matching the other v3 waits in this test. The identical check in `test_migration_with_ingestion` is intentionally left unchanged — that path uses fast SSv1 streaming rather than file-based Snowpipe, so 60s is sufficient there.

## Verification

Ran the test locally (apache 4.1.1 / Java 17 / AWS). The run reproduced the exact failure window: after the warmup reached 10 rows, the count stayed at 10 for ~2m14s before the next file-based Snowpipe batch loaded — which the old 60s wait would have failed on. With the wider budget it passed cleanly, no gaps and no duplicates (25950 expected / distinct / total).