### PR TITLE
Bump version to 4.1.0-rc1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.snowflake</groupId>
     <artifactId>snowflake-kafka-connector</artifactId>
-    <version>4.1.0</version>
+    <version>4.1.0-rc1</version>
     <packaging>jar</packaging>
     <name>Snowflake Kafka Connector</name>
     <description>Snowflake Kafka Connect Sink Connector</description>

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.snowflake</groupId>
     <artifactId>snowflake-kafka-connector</artifactId>
-    <version>4.1.0</version>
+    <version>4.1.0-rc1</version>
     <packaging>jar</packaging>
     <name>Snowflake Kafka Connector</name>
     <description>Snowflake Kafka Connect Sink Connector</description>

--- a/src/main/java/com/snowflake/kafka/connector/Utils.java
+++ b/src/main/java/com/snowflake/kafka/connector/Utils.java
@@ -42,7 +42,7 @@ import org.apache.kafka.common.config.ConfigValue;
 public class Utils {
 
   // Connector version, change every release
-  public static final String VERSION = "4.1.0";
+  public static final String VERSION = "4.1.0-rc1";
 
   // task id
   public static final String TASK_ID = "task_id";


### PR DESCRIPTION
Bumps the connector version to `4.1.0-rc1` (release candidate) across the three version sources: `pom.xml`, `pom_confluent.xml`, and the `VERSION` constant in `Utils.java`.