### PR TITLE
Sync dependency versions across pom.xml and pom_confluent.xml + safe bumps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,11 +61,11 @@
         <protobuf.version>3.25.5</protobuf.version>
         <guava.version>33.6.0-jre</guava.version>
 
-        <jackson.version>2.21.2</jackson.version>
+        <jackson.version>2.22.0</jackson.version>
         <commons-compress.version>1.28.0</commons-compress.version>
         <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
-        <snowflake-jdbc.version>4.2.0</snowflake-jdbc.version>
-        <slf4j-api.version>2.0.17</slf4j-api.version>
+        <snowflake-jdbc.version>4.3.1</snowflake-jdbc.version>
+        <slf4j-api.version>2.0.18</slf4j-api.version>
         <commons-lang3.version>3.20.0</commons-lang3.version>
         <auto-value.version>1.11.1</auto-value.version>
 
@@ -77,7 +77,7 @@
             http://mitmproxy:8080 destination at the request-builder layer.
             Tracking ticket: SNOW-3683451.
         -->
-        <snowpipe-streaming.version>1.6.0</snowpipe-streaming.version>
+        <snowpipe-streaming.version>1.6.1</snowpipe-streaming.version>
 
     </properties>
 
@@ -446,13 +446,13 @@
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
-            <version>4.2.33</version>
+            <version>4.2.39</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/io.dropwizard.metrics/metrics-jmx -->
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-jmx</artifactId>
-            <version>4.2.33</version>
+            <version>4.2.39</version>
         </dependency>
 
         <dependency>
@@ -510,7 +510,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
 
@@ -536,7 +536,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.25.4</version>
+            <version>2.26.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -63,19 +63,19 @@
         -->
         <license.processing.targetDir>${project.build.directory}/../licenses</license.processing.targetDir>
 
-        <kafka.version>3.9.1</kafka.version>
+        <kafka.version>3.9.2</kafka.version>
         <awaitility.version>4.3.0</awaitility.version>
-        <assertj-core.version>3.26.3</assertj-core.version>
+        <assertj-core.version>3.27.7</assertj-core.version>
         <confluent.version>7.9.2</confluent.version>
         <!--Compatible protobuf version https://github.com/confluentinc/common/blob/v7.7.0/pom.xml#L91 -->
         <protobuf.version>3.25.5</protobuf.version>
         <guava.version>33.6.0-jre</guava.version>
 
-        <jackson.version>2.21.2</jackson.version>
+        <jackson.version>2.22.0</jackson.version>
         <commons-compress.version>1.28.0</commons-compress.version>
         <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
-        <snowflake-jdbc.version>4.2.0</snowflake-jdbc.version>
-        <slf4j-api.version>2.0.17</slf4j-api.version>
+        <snowflake-jdbc.version>4.3.1</snowflake-jdbc.version>
+        <slf4j-api.version>2.0.18</slf4j-api.version>
         <parquet.version>1.14.4</parquet.version>
         <commons-lang3.version>3.20.0</commons-lang3.version>
         <auto-value.version>1.11.1</auto-value.version>
@@ -88,7 +88,7 @@
             http://mitmproxy:8080 destination at the request-builder layer.
             Tracking ticket: SNOW-3683451.
         -->
-        <snowpipe-streaming.version>1.6.0</snowpipe-streaming.version>
+        <snowpipe-streaming.version>1.6.1</snowpipe-streaming.version>
 
     </properties>
 
@@ -276,7 +276,7 @@
             <plugin>
                 <groupId>org.sonatype.central</groupId>
                 <artifactId>central-publishing-maven-plugin</artifactId>
-                <version>0.8.0</version>
+                <version>0.10.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <autoPublish>true</autoPublish>
@@ -360,7 +360,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.3.1</version>
+                <version>3.4.0</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -587,13 +587,13 @@
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
-            <version>4.2.33</version>
+            <version>4.2.39</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/io.dropwizard.metrics/metrics-jmx -->
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-jmx</artifactId>
-            <version>4.2.33</version>
+            <version>4.2.39</version>
         </dependency>
 
         <dependency>
@@ -657,7 +657,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
 
@@ -683,7 +683,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.17.1</version>
+            <version>2.26.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -705,7 +705,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-dbcp2</artifactId>
-            <version>2.12.0</version>
+            <version>2.14.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/scripts/process_licenses.py
+++ b/scripts/process_licenses.py
@@ -39,6 +39,7 @@ IGNORED_DEPENDENCIES = {"net.snowflake:snowflake-jdbc", "org.slf4j:slf4j-api"}
 # List of dependencies, which don't ship with a license file.
 # Only add a new record here after verifying that the dependency JAR does not contain a license!
 ADDITIONAL_LICENSES_MAP = {
+    "at.yawk.lz4:lz4-java": APACHE_LICENSE,
     "com.eclipsesource.minimal-json:minimal-json": MIT_LICENSE,
     "com.fasterxml.jackson.dataformat:jackson-dataformat-protobuf": APACHE_LICENSE,
     "com.github.ben-manes.caffeine:caffeine": APACHE_LICENSE,


### PR DESCRIPTION
## Summary

The two build POMs had drifted out of sync (kafka, assertj, log4j, commons-dbcp2, and two Maven plugins differed between `pom.xml` and `pom_confluent.xml`). This aligns them and bumps the safe/stable shared dependencies to their latest stable releases, so every shared version is now identical across both files.

- **Synced** (confluent POM was behind → matched to `pom.xml`): `kafka` 3.9.1→3.9.2, `assertj` 3.26.3→3.27.7, `commons-dbcp2` 2.12.0→2.14.0, `central-publishing-maven-plugin` 0.8.0→0.10.0, `maven-source-plugin` 3.3.1→3.4.0.
- **Bumped in both**: `jackson` 2.21.2→2.22.0, `slf4j` 2.0.17→2.0.18, `dropwizard-metrics` 4.2.33→4.2.39, `snowflake-jdbc` 4.2.0→4.3.1, `junit` (JUnit4/vintage) 4.13.1→4.13.2, `log4j-core` (test) →2.26.1, `snowpipe-streaming` 1.6.0→1.6.1.
- **Deliberately excluded**: `confluent` 8.x (major, coupled to Kafka client — separate PR), `junit-bom` 6.x (requires Java 17; project is Java 11), `protobuf` 4.x (pinned to Confluent `common` compatibility), and pre-release-only jumps the version plugin surfaced (assertj 4.0.0-M1, log4j 3.x-beta, slf4j 2.1.0-alpha). `parquet` stays at 1.14.4 — 1.17.1 drags in a new `org.locationtech.jts:jts-core` geospatial transitive dependency the connector doesn't need.

### snowpipe-streaming 1.6.1

Patch release that pulls native-library CVE fixes (rustls-webpki, quinn-proto, time, rand, lru via aws-sdk). The only functional change is additive OAuth-scope config — no changes to channel behavior, offset tokens, or `https_only` enforcement. Uses the plain `1.6.1` coordinate (not the `-unshaded` classifier variant surfaced by the Maven versions plugin, which is a different artifact).

### License map (`scripts/process_licenses.py`)

Kafka 3.9.2 switched its lz4 dependency from `org.lz4:lz4-java` (which the POMs exclude) to the `at.yawk.lz4:lz4-java` fork, which nothing excludes. Since the Confluent jar already bundles the other codecs (zstd, snappy) and declares them in the license map, `at.yawk.lz4:lz4-java` (Apache-2.0) is added there so the Confluent build's license-processing step passes. This was previously masked only because the Confluent POM lagged at kafka 3.9.1.

### Closable Dependabot PRs once this lands

- #1470 (jackson → 2.21.3) — superseded by 2.22.0
- #1469 (slf4j → 2.0.18) — included as-is
- #1466 (dropwizard-metrics → 4.2.38) — superseded by 4.2.39