### PR TITLE
Include target table name in structural validation error messages

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/Constants.java
+++ b/src/main/java/com/snowflake/kafka/connector/Constants.java
@@ -65,6 +65,13 @@ public final class Constants {
         "snowflake.feature.precommit.client.recovery";
     public static final boolean SNOWFLAKE_FEATURE_PRECOMMIT_CLIENT_RECOVERY_DEFAULT = true;
 
+    // Kill-switch (unregistered, default on) for including the target table name in client-side
+    // structural validation error messages routed to the DLQ. Set to false to revert to the
+    // legacy message format that omits the table name.
+    public static final String SNOWFLAKE_FEATURE_VALIDATION_ERROR_TABLE_NAME =
+        "snowflake.feature.validation.error.table.name";
+    public static final boolean SNOWFLAKE_FEATURE_VALIDATION_ERROR_TABLE_NAME_DEFAULT = true;
+
     // Caching
     public static final String CACHE_TABLE_EXISTS = "snowflake.cache.table.exists";
     public static final boolean CACHE_TABLE_EXISTS_DEFAULT = true;

--- a/src/main/java/com/snowflake/kafka/connector/config/SinkTaskConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/config/SinkTaskConfig.java
@@ -125,6 +125,13 @@ public abstract class SinkTaskConfig {
    */
   public abstract boolean isPrecommitClientRecoveryEnabled();
 
+  /**
+   * Whether client-side structural validation error messages routed to the DLQ include the target
+   * table name. See {@link
+   * KafkaConnectorConfigParams#SNOWFLAKE_FEATURE_VALIDATION_ERROR_TABLE_NAME}.
+   */
+  public abstract boolean isValidationErrorTableNameEnabled();
+
   /** Convenience overload that calls {@link #from(Map, boolean)} with {@code false}. */
   public static SinkTaskConfig from(Map<String, String> raw) {
     return from(raw, false);
@@ -324,6 +331,14 @@ public abstract class SinkTaskConfig {
             .orElse(
                 KafkaConnectorConfigParams.SNOWFLAKE_FEATURE_ASSERT_PARTITION_ASSIGNMENT_DEFAULT);
 
+    boolean validationErrorTableNameEnabled =
+        Optional.ofNullable(
+                config.get(
+                    KafkaConnectorConfigParams.SNOWFLAKE_FEATURE_VALIDATION_ERROR_TABLE_NAME))
+            .map(Boolean::parseBoolean)
+            .orElse(
+                KafkaConnectorConfigParams.SNOWFLAKE_FEATURE_VALIDATION_ERROR_TABLE_NAME_DEFAULT);
+
     Builder b = builder();
     b.connectorName(connectorName)
         .taskId(taskId)
@@ -356,7 +371,8 @@ public abstract class SinkTaskConfig {
         .ssv1MigrationMode(ssv1MigrationMode)
         .ssv1MigrationIncludeConnectorName(ssv1MigrationIncludeConnectorName)
         .assertPartitionAssignmentEnabled(assertPartitionAssignmentEnabled)
-        .precommitClientRecoveryEnabled(precommitClientRecoveryEnabled);
+        .precommitClientRecoveryEnabled(precommitClientRecoveryEnabled)
+        .validationErrorTableNameEnabled(validationErrorTableNameEnabled);
 
     snowflakePrivateKey.ifPresent(b::snowflakePrivateKey);
     snowflakePrivateKeyPassphrase.ifPresent(b::snowflakePrivateKeyPassphrase);
@@ -466,6 +482,9 @@ public abstract class SinkTaskConfig {
         boolean assertPartitionAssignmentEnabled);
 
     public abstract Builder precommitClientRecoveryEnabled(boolean precommitClientRecoveryEnabled);
+
+    public abstract Builder validationErrorTableNameEnabled(
+        boolean validationErrorTableNameEnabled);
 
     public abstract SinkTaskConfig build();
   }

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannel.java
@@ -663,9 +663,9 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
 
       String errorMsg =
           String.format(
-              "Structural validation error (schema evolution disabled): extraCols=%s,"
+              "Structural validation error for table %s (schema evolution disabled): extraCols=%s,"
                   + " missingNotNull=%s",
-              result.getExtraColNames(), result.getMissingNotNullColNames());
+              tableName, result.getExtraColNames(), result.getMissingNotNullColNames());
       LOGGER.info("Routing to DLQ for channel {}: {}", channelName, errorMsg);
       streamingErrorHandler.handleError(new DataException(errorMsg), originalRecordForReporting);
       snowflakeTelemetryChannelStatus.incErrorToleratedCount();
@@ -694,8 +694,9 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
 
       String errorMsg =
           String.format(
-              "Schema mismatch after evolution attempt: extraCols=%s, missingNotNull=%s",
-              retryResult.getExtraColNames(), retryResult.getMissingNotNullColNames());
+              "Schema mismatch after evolution attempt for table %s: extraCols=%s,"
+                  + " missingNotNull=%s",
+              tableName, retryResult.getExtraColNames(), retryResult.getMissingNotNullColNames());
       streamingErrorHandler.handleError(new DataException(errorMsg), originalRecordForReporting);
       snowflakeTelemetryChannelStatus.incErrorToleratedCount();
     } catch (SnowflakeKafkaConnectorException e) {

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/v2/SnowpipeStreamingPartitionChannel.java
@@ -662,10 +662,15 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
       snowflakeTelemetryChannelStatus.incValidationFailureCount();
 
       String errorMsg =
-          String.format(
-              "Structural validation error for table %s (schema evolution disabled): extraCols=%s,"
-                  + " missingNotNull=%s",
-              tableName, result.getExtraColNames(), result.getMissingNotNullColNames());
+          taskConfig.isValidationErrorTableNameEnabled()
+              ? String.format(
+                  "Structural validation error for table %s (schema evolution disabled):"
+                      + " extraCols=%s, missingNotNull=%s",
+                  tableName, result.getExtraColNames(), result.getMissingNotNullColNames())
+              : String.format(
+                  "Structural validation error (schema evolution disabled): extraCols=%s,"
+                      + " missingNotNull=%s",
+                  result.getExtraColNames(), result.getMissingNotNullColNames());
       LOGGER.info("Routing to DLQ for channel {}: {}", channelName, errorMsg);
       streamingErrorHandler.handleError(new DataException(errorMsg), originalRecordForReporting);
       snowflakeTelemetryChannelStatus.incErrorToleratedCount();
@@ -693,10 +698,16 @@ public class SnowpipeStreamingPartitionChannel implements TopicPartitionChannel 
       snowflakeTelemetryChannelStatus.incSchemaEvolutionFailureCount();
 
       String errorMsg =
-          String.format(
-              "Schema mismatch after evolution attempt for table %s: extraCols=%s,"
-                  + " missingNotNull=%s",
-              tableName, retryResult.getExtraColNames(), retryResult.getMissingNotNullColNames());
+          taskConfig.isValidationErrorTableNameEnabled()
+              ? String.format(
+                  "Schema mismatch after evolution attempt for table %s: extraCols=%s,"
+                      + " missingNotNull=%s",
+                  tableName,
+                  retryResult.getExtraColNames(),
+                  retryResult.getMissingNotNullColNames())
+              : String.format(
+                  "Schema mismatch after evolution attempt: extraCols=%s, missingNotNull=%s",
+                  retryResult.getExtraColNames(), retryResult.getMissingNotNullColNames());
       streamingErrorHandler.handleError(new DataException(errorMsg), originalRecordForReporting);
       snowflakeTelemetryChannelStatus.incErrorToleratedCount();
     } catch (SnowflakeKafkaConnectorException e) {

--- a/src/test/java/com/snowflake/kafka/connector/config/SinkTaskConfigTestBuilder.java
+++ b/src/test/java/com/snowflake/kafka/connector/config/SinkTaskConfigTestBuilder.java
@@ -53,6 +53,8 @@ public final class SinkTaskConfigTestBuilder {
         .ssv1MigrationMode(Ssv1MigrationMode.SKIP)
         .ssv1MigrationIncludeConnectorName(false)
         .assertPartitionAssignmentEnabled(true)
-        .precommitClientRecoveryEnabled(true);
+        .precommitClientRecoveryEnabled(true)
+        .validationErrorTableNameEnabled(
+            KafkaConnectorConfigParams.SNOWFLAKE_FEATURE_VALIDATION_ERROR_TABLE_NAME_DEFAULT);
   }
 }


### PR DESCRIPTION
## Summary

When client-side structural validation fails (extra columns or missing NOT NULL columns) and schema evolution is disabled, the resulting `DataException` routed to the DLQ did not identify which table triggered the failure. With many tables in flight this made the error hard to act on — the message only listed the column names.

This adds the target table name to both structural-error `DataException` messages in `SnowpipeStreamingPartitionChannel.handleStructuralError` (the "schema evolution disabled" case and the "schema mismatch after evolution attempt" case).

The new message format is gated behind an unregistered kill-switch feature flag `snowflake.feature.validation.error.table.name` (default `true`), matching the existing `snowflake.feature.*` flags. Set it to `false` to revert to the legacy message format that omits the table name.