### PR TITLE
Expose snowflake.oauth.include.scope to control OAuth scope (default false)

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/Constants.java
+++ b/src/main/java/com/snowflake/kafka/connector/Constants.java
@@ -22,6 +22,14 @@ public final class Constants {
     public static final String SNOWFLAKE_OAUTH_CLIENT_SECRET = "snowflake.oauth.client.secret";
     public static final String SNOWFLAKE_OAUTH_REFRESH_TOKEN = "snowflake.oauth.refresh.token";
     public static final String SNOWFLAKE_OAUTH_TOKEN_ENDPOINT = "snowflake.oauth.token.endpoint";
+    // Whether OAuth token requests include a "scope" parameter. Defaults to false so that a refresh
+    // token whose original authorize grant did not include a role scope (e.g. external OAuth / IdP
+    // tokens) is not rejected. When true, the scope is the explicit SNOWFLAKE_OAUTH_SCOPE or, when
+    // that is unset, "session:role:{role}" derived from SNOWFLAKE_ROLE_NAME.
+    public static final String SNOWFLAKE_OAUTH_INCLUDE_SCOPE = "snowflake.oauth.include.scope";
+    public static final boolean SNOWFLAKE_OAUTH_INCLUDE_SCOPE_DEFAULT = false;
+    // Explicit OAuth scope to request. Only used when SNOWFLAKE_OAUTH_INCLUDE_SCOPE is true.
+    public static final String SNOWFLAKE_OAUTH_SCOPE = "snowflake.oauth.scope";
 
     public static final String SNOWFLAKE_JDBC_MAP = "snowflake.jdbc.map";
     public static final String SNOWFLAKE_METADATA_CREATETIME = "snowflake.metadata.createtime";

--- a/src/main/java/com/snowflake/kafka/connector/DefaultConnectorConfigValidator.java
+++ b/src/main/java/com/snowflake/kafka/connector/DefaultConnectorConfigValidator.java
@@ -178,6 +178,21 @@ public class DefaultConnectorConfigValidator implements ConnectorConfigValidator
               "{} must be non-empty when using oauth authenticator",
               KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_CLIENT_SECRET));
     }
+
+    boolean includeScope =
+        Boolean.parseBoolean(
+            config.getOrDefault(
+                KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_INCLUDE_SCOPE,
+                String.valueOf(KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_INCLUDE_SCOPE_DEFAULT)));
+    String scope = config.getOrDefault(KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_SCOPE, "");
+    if (!scope.isBlank() && !includeScope) {
+      invalidConfigParams.put(
+          KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_SCOPE,
+          Utils.formatString(
+              "{} is only used when {} is true",
+              KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_SCOPE,
+              KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_INCLUDE_SCOPE));
+    }
   }
 
   private void validateCompatibilitySettings(

--- a/src/main/java/com/snowflake/kafka/connector/config/ConnectorConfigDefinition.java
+++ b/src/main/java/com/snowflake/kafka/connector/config/ConnectorConfigDefinition.java
@@ -159,8 +159,12 @@ public class ConnectorConfigDefinition {
             BOOLEAN,
             KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_INCLUDE_SCOPE_DEFAULT,
             LOW,
-            "Whether OAuth token requests include a scope parameter. Defaults to false; enable only"
-                + " when the OAuth grant requires a role scope.",
+            "Whether OAuth token requests include a scope parameter. Defaults to false, which sends"
+                + " no scope (matching KC v3). Set to true to send a scope: either the explicit "
+                + KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_SCOPE
+                + " or, if that is unset, session:role:{role} derived from "
+                + KafkaConnectorConfigParams.SNOWFLAKE_ROLE_NAME
+                + ".",
             SNOWFLAKE_LOGIN_INFO_DOC,
             12,
             Width.NONE,
@@ -172,7 +176,10 @@ public class ConnectorConfigDefinition {
             LOW,
             "Explicit OAuth scope to request. Only used when "
                 + KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_INCLUDE_SCOPE
-                + " is true; otherwise the scope defaults to session:role:{role}.",
+                + " is true; when it is true and this is unset, the scope defaults to"
+                + " session:role:{role}. Has no effect while "
+                + KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_INCLUDE_SCOPE
+                + " is false (no scope is sent).",
             SNOWFLAKE_LOGIN_INFO_DOC,
             13,
             Width.NONE,

--- a/src/main/java/com/snowflake/kafka/connector/config/ConnectorConfigDefinition.java
+++ b/src/main/java/com/snowflake/kafka/connector/config/ConnectorConfigDefinition.java
@@ -154,6 +154,29 @@ public class ConnectorConfigDefinition {
             11,
             Width.NONE,
             KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_TOKEN_ENDPOINT)
+        .define(
+            KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_INCLUDE_SCOPE,
+            BOOLEAN,
+            KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_INCLUDE_SCOPE_DEFAULT,
+            LOW,
+            "Whether OAuth token requests include a scope parameter. Defaults to false; enable only"
+                + " when the OAuth grant requires a role scope.",
+            SNOWFLAKE_LOGIN_INFO_DOC,
+            12,
+            Width.NONE,
+            KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_INCLUDE_SCOPE)
+        .define(
+            KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_SCOPE,
+            STRING,
+            "",
+            LOW,
+            "Explicit OAuth scope to request. Only used when "
+                + KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_INCLUDE_SCOPE
+                + " is true; otherwise the scope defaults to session:role:{role}.",
+            SNOWFLAKE_LOGIN_INFO_DOC,
+            13,
+            Width.NONE,
+            KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_SCOPE)
         // proxy
         .define(
             KafkaConnectorConfigParams.JVM_PROXY_HOST,

--- a/src/main/java/com/snowflake/kafka/connector/config/SinkTaskConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/config/SinkTaskConfig.java
@@ -83,6 +83,10 @@ public abstract class SinkTaskConfig {
 
   public abstract Optional<String> getOauthTokenEndpoint();
 
+  public abstract boolean getOauthIncludeScope();
+
+  public abstract Optional<String> getOauthScope();
+
   @Nullable
   public abstract String getSnowflakeDatabase();
 
@@ -308,6 +312,12 @@ public abstract class SinkTaskConfig {
         optionalPassword(config.get(KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_REFRESH_TOKEN));
     Optional<String> oauthTokenEndpoint =
         optionalString(config.get(KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_TOKEN_ENDPOINT));
+    boolean oauthIncludeScope =
+        Optional.ofNullable(config.get(KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_INCLUDE_SCOPE))
+            .map(Boolean::parseBoolean)
+            .orElse(KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_INCLUDE_SCOPE_DEFAULT);
+    Optional<String> oauthScope =
+        optionalString(config.get(KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_SCOPE));
 
     String proxyHost = config.get(KafkaConnectorConfigParams.JVM_PROXY_HOST);
     String proxyPort = config.get(KafkaConnectorConfigParams.JVM_PROXY_PORT);
@@ -345,6 +355,7 @@ public abstract class SinkTaskConfig {
         .snowflakeUser(snowflakeUser)
         .snowflakeRole(snowflakeRole)
         .authenticator(authenticator)
+        .oauthIncludeScope(oauthIncludeScope)
         .snowflakeDatabase(snowflakeDatabase)
         .snowflakeSchema(snowflakeSchema)
         .proxyHost(proxyHost)
@@ -365,6 +376,7 @@ public abstract class SinkTaskConfig {
     oauthClientSecret.ifPresent(b::oauthClientSecret);
     oauthRefreshToken.ifPresent(b::oauthRefreshToken);
     oauthTokenEndpoint.ifPresent(b::oauthTokenEndpoint);
+    oauthScope.ifPresent(b::oauthScope);
     return b;
   }
 
@@ -440,6 +452,10 @@ public abstract class SinkTaskConfig {
     public abstract Builder oauthRefreshToken(Password oauthRefreshToken);
 
     public abstract Builder oauthTokenEndpoint(String oauthTokenEndpoint);
+
+    public abstract Builder oauthIncludeScope(boolean oauthIncludeScope);
+
+    public abstract Builder oauthScope(String oauthScope);
 
     public abstract Builder snowflakeDatabase(String snowflakeDatabase);
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
@@ -12,6 +12,7 @@ import java.sql.SQLException;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.util.Optional;
 import java.util.Properties;
 import org.apache.kafka.common.config.types.Password;
 
@@ -106,7 +107,11 @@ public class InternalUtils {
         properties.put(
             JDBC_TOKEN,
             OAuthAccessTokenFetcher.fetchAccessToken(
-                oauthUrl, oauthClientId, oauthClientSecret, config.getOauthRefreshToken()));
+                oauthUrl,
+                oauthClientId,
+                oauthClientSecret,
+                config.getOauthRefreshToken(),
+                resolveOauthScope(config)));
         break;
       case SNOWFLAKE_JWT:
         properties.put(JdbcPropertyKeys.AUTHENTICATOR, SNOWFLAKE_JWT);
@@ -146,6 +151,25 @@ public class InternalUtils {
     if (!isBlank(value)) {
       properties.put(key, value);
     }
+  }
+
+  /**
+   * Resolves the OAuth scope to send on the JDBC token request, mirroring the streaming SDK's
+   * resolution: no scope unless {@code snowflake.oauth.include.scope} is enabled, then the explicit
+   * {@code snowflake.oauth.scope} if set, otherwise {@code session:role:{role}} derived from the
+   * configured role. Returns empty when scopes are disabled or no scope can be derived, preserving
+   * KC v3 behavior (no scope) by default.
+   */
+  private static Optional<String> resolveOauthScope(SinkTaskConfig config) {
+    if (!config.getOauthIncludeScope()) {
+      return Optional.empty();
+    }
+    if (config.getOauthScope().isPresent()) {
+      return config.getOauthScope();
+    }
+    return Optional.ofNullable(config.getSnowflakeRole())
+        .filter(role -> !isBlank(role))
+        .map(role -> "session:role:" + role);
   }
 
   /**

--- a/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
@@ -7,6 +7,8 @@ import com.snowflake.kafka.connector.config.AuthenticatorType;
 import com.snowflake.kafka.connector.config.SinkTaskConfig;
 import com.snowflake.kafka.connector.internal.oauth.OAuthAccessTokenFetcher;
 import com.snowflake.kafka.connector.internal.oauth.OAuthURL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Instant;
@@ -159,8 +161,13 @@ public class InternalUtils {
    * {@code snowflake.oauth.scope} if set, otherwise {@code session:role:{role}} derived from the
    * configured role. Returns empty when scopes are disabled or no scope can be derived, preserving
    * KC v3 behavior (no scope) by default.
+   *
+   * <p>The derived role is URL-encoded so that reserved characters (e.g. spaces) don't split the
+   * scope value, matching the SDK (OAuth scopes are space-delimited per RFC 6749 §3.3). The token
+   * fetcher form-encodes the whole value again, so the server form-decodes once to recover {@code
+   * session:role:<encoded-role>} as a single token and then URL-decodes the role.
    */
-  private static Optional<String> resolveOauthScope(SinkTaskConfig config) {
+  static Optional<String> resolveOauthScope(SinkTaskConfig config) {
     if (!config.getOauthIncludeScope()) {
       return Optional.empty();
     }
@@ -169,7 +176,17 @@ public class InternalUtils {
     }
     return Optional.ofNullable(config.getSnowflakeRole())
         .filter(role -> !isBlank(role))
-        .map(role -> "session:role:" + role);
+        .map(role -> "session:role:" + percentEncode(role));
+  }
+
+  /**
+   * Percent-encodes a value for use inside a scope token. {@link URLEncoder} follows {@code
+   * application/x-www-form-urlencoded} rules (space -> {@code +}); we convert those to {@code %20}
+   * so the encoding matches the streaming SDK and is unambiguous once the token fetcher
+   * form-encodes the whole scope value a second time.
+   */
+  private static String percentEncode(String value) {
+    return URLEncoder.encode(value, StandardCharsets.UTF_8).replace("+", "%20");
   }
 
   /**

--- a/src/main/java/com/snowflake/kafka/connector/internal/oauth/OAuthAccessTokenFetcher.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/oauth/OAuthAccessTokenFetcher.java
@@ -51,6 +51,7 @@ public class OAuthAccessTokenFetcher {
   private static final String GRANT_TYPE_CLIENT_CREDENTIALS = "client_credentials";
   private static final String REFRESH_TOKEN = "refresh_token";
   private static final String ACCESS_TOKEN = "access_token";
+  private static final String SCOPE = "scope";
   private static final String REDIRECT_URI = "redirect_uri";
   private static final String DEFAULT_REDIRECT_URI = "https://localhost.com/oauth";
 
@@ -69,13 +70,18 @@ public class OAuthAccessTokenFetcher {
    * @param clientId OAuth client ID
    * @param clientSecret OAuth client secret
    * @param refreshToken OAuth refresh token; empty selects client_credentials grant
+   * @param scope explicit OAuth scope to request; empty sends no scope (KC v3 behavior)
    * @return the access token string
    * @throws SnowflakeKafkaConnectorException if the token fetch fails after all retries
    */
   public static String fetchAccessToken(
-      URL url, String clientId, Password clientSecret, Optional<Password> refreshToken) {
+      URL url,
+      String clientId,
+      Password clientSecret,
+      Optional<Password> refreshToken,
+      Optional<String> scope) {
     HttpClient httpClient = HttpClient.newBuilder().proxy(ProxySelector.getDefault()).build();
-    return fetchAccessToken(url, clientId, clientSecret, refreshToken, httpClient);
+    return fetchAccessToken(url, clientId, clientSecret, refreshToken, scope, httpClient);
   }
 
   static String fetchAccessToken(
@@ -83,6 +89,7 @@ public class OAuthAccessTokenFetcher {
       String clientId,
       Password clientSecret,
       Optional<Password> refreshToken,
+      Optional<String> scope,
       HttpClient httpClient) {
     String basicAuth =
         BASIC_AUTH_HEADER_PREFIX
@@ -100,6 +107,7 @@ public class OAuthAccessTokenFetcher {
               formParams.put(REDIRECT_URI, DEFAULT_REDIRECT_URI);
             },
             () -> formParams.put(GRANT_TYPE_PARAM, GRANT_TYPE_CLIENT_CREDENTIALS));
+    scope.ifPresent(value -> formParams.put(SCOPE, value));
 
     String formBody =
         formParams.entrySet().stream()

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProperties.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProperties.java
@@ -80,6 +80,15 @@ public class StreamingClientProperties {
           config
               .getOauthTokenEndpoint()
               .ifPresent(v -> clientProperties.put("oauth_token_endpoint", v));
+          // The SDK defaults oauth_include_scope to true, which makes it derive
+          // "session:role:{role}" and send it as the scope on refresh. That breaks external OAuth /
+          // IdP refresh tokens minted without a role scope, so forward the connector's value
+          // explicitly (default false). Only send an explicit scope when scopes are enabled.
+          clientProperties.put(
+              "oauth_include_scope", String.valueOf(config.getOauthIncludeScope()));
+          if (config.getOauthIncludeScope()) {
+            config.getOauthScope().ifPresent(v -> clientProperties.put("oauth_scope", v));
+          }
           break;
         case SNOWFLAKE_JWT:
           final PrivateKey privateKey =

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigValidatorTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigValidatorTest.java
@@ -798,6 +798,38 @@ public class ConnectorConfigValidatorTest {
         .doesNotThrowAnyException();
   }
 
+  @Test
+  public void testOAuthScopeWithoutIncludeScopeIsInvalid() {
+    Map<String, String> config =
+        SnowflakeSinkConnectorConfigBuilder.streamingConfig()
+            .withAuthenticator(AuthenticatorType.OAUTH.toConfigValue())
+            .withOauthClientId("client_id")
+            .withOauthClientSecret("client_secret")
+            .withOauthRefreshToken("refresh_token")
+            .withOauthScope("session:role:MY_ROLE")
+            .withoutPrivateKey()
+            .build();
+    assertThatThrownBy(() -> connectorConfigValidator.validateConfig(config))
+        .isInstanceOf(SnowflakeKafkaConnectorException.class)
+        .hasMessageContaining(KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_SCOPE);
+  }
+
+  @Test
+  public void testOAuthScopeWithIncludeScopeIsValid() {
+    Map<String, String> config =
+        SnowflakeSinkConnectorConfigBuilder.streamingConfig()
+            .withAuthenticator(AuthenticatorType.OAUTH.toConfigValue())
+            .withOauthClientId("client_id")
+            .withOauthClientSecret("client_secret")
+            .withOauthRefreshToken("refresh_token")
+            .withOauthIncludeScope(true)
+            .withOauthScope("session:role:MY_ROLE")
+            .withoutPrivateKey()
+            .build();
+    assertThatCode(() -> connectorConfigValidator.validateConfig(config))
+        .doesNotThrowAnyException();
+  }
+
   private void invalidConfigRunner(List<String> paramsToRemove) {
     Map<String, String> config = getConfig();
     for (String configParam : paramsToRemove) {

--- a/src/test/java/com/snowflake/kafka/connector/config/SinkTaskConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/config/SinkTaskConfigTest.java
@@ -188,6 +188,23 @@ public class SinkTaskConfigTest {
     assertEquals(
         "my_refresh_token", config.getOauthRefreshToken().map(Password::value).orElse(null));
     assertEquals("https://oauth.example.com/token", config.getOauthTokenEndpoint().orElse(null));
+    assertFalse(config.getOauthIncludeScope());
+    assertTrue(config.getOauthScope().isEmpty());
+  }
+
+  @Test
+  public void from_oauthScopeFields_areParsed() {
+    Map<String, String> raw = minimalConfig();
+    raw.put(SNOWFLAKE_AUTHENTICATOR, AuthenticatorType.OAUTH.toConfigValue());
+    raw.put(SNOWFLAKE_OAUTH_CLIENT_ID, "my_client_id");
+    raw.put(SNOWFLAKE_OAUTH_CLIENT_SECRET, "my_client_secret");
+    raw.put(SNOWFLAKE_OAUTH_INCLUDE_SCOPE, "true");
+    raw.put(SNOWFLAKE_OAUTH_SCOPE, "session:role:MY_ROLE");
+
+    SinkTaskConfig config = SinkTaskConfig.from(raw);
+
+    assertTrue(config.getOauthIncludeScope());
+    assertEquals("session:role:MY_ROLE", config.getOauthScope().orElse(null));
   }
 
   @Test
@@ -230,6 +247,8 @@ public class SinkTaskConfigTest {
     assertEquals(AuthenticatorType.OAUTH, config.getAuthenticator());
     assertTrue(config.getOauthRefreshToken().isEmpty());
     assertTrue(config.getOauthTokenEndpoint().isEmpty());
+    assertFalse(config.getOauthIncludeScope());
+    assertTrue(config.getOauthScope().isEmpty());
   }
 
   @Test

--- a/src/test/java/com/snowflake/kafka/connector/config/SinkTaskConfigTestBuilder.java
+++ b/src/test/java/com/snowflake/kafka/connector/config/SinkTaskConfigTestBuilder.java
@@ -48,6 +48,7 @@ public final class SinkTaskConfigTestBuilder {
         .snowflakeUser("")
         .snowflakeRole("")
         .authenticator(AuthenticatorType.SNOWFLAKE_JWT)
+        .oauthIncludeScope(KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_INCLUDE_SCOPE_DEFAULT)
         .snowflakeDatabase("")
         .snowflakeSchema("")
         .ssv1MigrationMode(Ssv1MigrationMode.SKIP)

--- a/src/test/java/com/snowflake/kafka/connector/config/SnowflakeSinkConnectorConfigBuilder.java
+++ b/src/test/java/com/snowflake/kafka/connector/config/SnowflakeSinkConnectorConfigBuilder.java
@@ -106,6 +106,17 @@ public class SnowflakeSinkConnectorConfigBuilder {
     return this;
   }
 
+  public SnowflakeSinkConnectorConfigBuilder withOauthIncludeScope(boolean includeScope) {
+    config.put(
+        KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_INCLUDE_SCOPE, String.valueOf(includeScope));
+    return this;
+  }
+
+  public SnowflakeSinkConnectorConfigBuilder withOauthScope(String scope) {
+    config.put(KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_SCOPE, scope);
+    return this;
+  }
+
   public SnowflakeSinkConnectorConfigBuilder withoutPrivateKey() {
     config.remove(KafkaConnectorConfigParams.SNOWFLAKE_PRIVATE_KEY);
     return this;

--- a/src/test/java/com/snowflake/kafka/connector/internal/InternalUtilsTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/InternalUtilsTest.java
@@ -207,6 +207,81 @@ public class InternalUtilsTest {
   }
 
   @Test
+  public void resolveOauthScope_scopeDisabled_returnsEmpty() {
+    SinkTaskConfig config =
+        SinkTaskConfigTestBuilder.builder()
+            .connectorName("test")
+            .taskId("0")
+            .authenticator(AuthenticatorType.OAUTH)
+            .snowflakeRole("MY_ROLE")
+            .oauthIncludeScope(false)
+            .oauthScope("session:role:IGNORED")
+            .build();
+
+    assertTrue(InternalUtils.resolveOauthScope(config).isEmpty());
+  }
+
+  @Test
+  public void resolveOauthScope_explicitScope_isUsedAsIs() {
+    SinkTaskConfig config =
+        SinkTaskConfigTestBuilder.builder()
+            .connectorName("test")
+            .taskId("0")
+            .authenticator(AuthenticatorType.OAUTH)
+            .snowflakeRole("MY_ROLE")
+            .oauthIncludeScope(true)
+            .oauthScope("custom scope")
+            .build();
+
+    assertEquals("custom scope", InternalUtils.resolveOauthScope(config).orElse(null));
+  }
+
+  @Test
+  public void resolveOauthScope_derivesFromRole() {
+    SinkTaskConfig config =
+        SinkTaskConfigTestBuilder.builder()
+            .connectorName("test")
+            .taskId("0")
+            .authenticator(AuthenticatorType.OAUTH)
+            .snowflakeRole("MY_ROLE")
+            .oauthIncludeScope(true)
+            .build();
+
+    assertEquals("session:role:MY_ROLE", InternalUtils.resolveOauthScope(config).orElse(null));
+  }
+
+  @Test
+  public void resolveOauthScope_urlEncodesRoleWithReservedChars() {
+    SinkTaskConfig config =
+        SinkTaskConfigTestBuilder.builder()
+            .connectorName("test")
+            .taskId("0")
+            .authenticator(AuthenticatorType.OAUTH)
+            .snowflakeRole("My Custom Role")
+            .oauthIncludeScope(true)
+            .build();
+
+    // The role is percent-encoded (spaces as %20, matching the SDK) so it doesn't split the
+    // space-delimited scope value.
+    assertEquals(
+        "session:role:My%20Custom%20Role", InternalUtils.resolveOauthScope(config).orElse(null));
+  }
+
+  @Test
+  public void resolveOauthScope_blankRoleWithoutExplicitScope_returnsEmpty() {
+    SinkTaskConfig config =
+        SinkTaskConfigTestBuilder.builder()
+            .connectorName("test")
+            .taskId("0")
+            .authenticator(AuthenticatorType.OAUTH)
+            .snowflakeRole("   ")
+            .oauthIncludeScope(true)
+            .build();
+
+    assertTrue(InternalUtils.resolveOauthScope(config).isEmpty());
+  }
+
+  @Test
   public void testMakeJdbcDriverProperties_invalidAuthenticator_throws() {
     Map<String, String> rawConfig = new HashMap<>();
     rawConfig.put(KafkaConnectorConfigParams.SNOWFLAKE_DATABASE_NAME, "db");

--- a/src/test/java/com/snowflake/kafka/connector/internal/oauth/OAuthAccessTokenFetcherTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/oauth/OAuthAccessTokenFetcherTest.java
@@ -12,10 +12,15 @@ import com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Flow;
 import org.apache.kafka.common.config.types.Password;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 class OAuthAccessTokenFetcherTest {
 
@@ -44,6 +49,7 @@ class OAuthAccessTokenFetcherTest {
             "client_id",
             new Password("client_secret"),
             Optional.of(new Password("my_refresh_token")),
+            Optional.empty(),
             httpClient);
 
     assertThat(token).isEqualTo("my-access-token");
@@ -56,7 +62,12 @@ class OAuthAccessTokenFetcherTest {
 
     String token =
         OAuthAccessTokenFetcher.fetchAccessToken(
-            url, "client_id", new Password("client_secret"), Optional.empty(), httpClient);
+            url,
+            "client_id",
+            new Password("client_secret"),
+            Optional.empty(),
+            Optional.empty(),
+            httpClient);
 
     assertThat(token).isEqualTo("cc-token");
   }
@@ -68,7 +79,12 @@ class OAuthAccessTokenFetcherTest {
 
     String token =
         OAuthAccessTokenFetcher.fetchAccessToken(
-            url, "client_id", new Password("client_secret"), Optional.empty(), httpClient);
+            url,
+            "client_id",
+            new Password("client_secret"),
+            Optional.empty(),
+            Optional.empty(),
+            httpClient);
 
     assertThat(token).isEqualTo("cc-token");
   }
@@ -87,6 +103,7 @@ class OAuthAccessTokenFetcherTest {
                     "client_id",
                     new Password("client_secret"),
                     Optional.of(new Password("token")),
+                    Optional.empty(),
                     httpClient))
         .matches(exception -> exception.getCode().equals("1004"));
 
@@ -107,6 +124,7 @@ class OAuthAccessTokenFetcherTest {
                     "client_id",
                     new Password("client_secret"),
                     Optional.of(new Password("token")),
+                    Optional.empty(),
                     httpClient))
         .matches(exception -> exception.getCode().equals("1004"));
   }
@@ -125,6 +143,7 @@ class OAuthAccessTokenFetcherTest {
                     "client_id",
                     new Password("client_secret"),
                     Optional.of(new Password("token")),
+                    Optional.empty(),
                     httpClient))
         .matches(exception -> exception.getCode().equals("1004"));
   }
@@ -150,9 +169,78 @@ class OAuthAccessTokenFetcherTest {
             "client_id",
             new Password("client_secret"),
             Optional.of(new Password("token")),
+            Optional.empty(),
             httpClient);
 
     assertThat(token).isEqualTo("retry-token");
     verify(httpClient, times(2)).send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void fetchAccessToken_withScope_addsScopeFormParam() throws Exception {
+    when(httpResponse.statusCode()).thenReturn(200);
+    when(httpResponse.body()).thenReturn("{\"access_token\": \"scoped-token\"}");
+
+    OAuthAccessTokenFetcher.fetchAccessToken(
+        url,
+        "client_id",
+        new Password("client_secret"),
+        Optional.of(new Password("my_refresh_token")),
+        Optional.of("session:role:MY_ROLE"),
+        httpClient);
+
+    ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
+    verify(httpClient).send(captor.capture(), any(HttpResponse.BodyHandler.class));
+    assertThat(requestBody(captor.getValue())).contains("scope=session%3Arole%3AMY_ROLE");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void fetchAccessToken_withoutScope_omitsScopeFormParam() throws Exception {
+    when(httpResponse.statusCode()).thenReturn(200);
+    when(httpResponse.body()).thenReturn("{\"access_token\": \"unscoped-token\"}");
+
+    OAuthAccessTokenFetcher.fetchAccessToken(
+        url,
+        "client_id",
+        new Password("client_secret"),
+        Optional.of(new Password("my_refresh_token")),
+        Optional.empty(),
+        httpClient);
+
+    ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
+    verify(httpClient).send(captor.capture(), any(HttpResponse.BodyHandler.class));
+    assertThat(requestBody(captor.getValue())).doesNotContain("scope=");
+  }
+
+  private static String requestBody(HttpRequest request) throws InterruptedException {
+    HttpRequest.BodyPublisher publisher = request.bodyPublisher().orElseThrow();
+    StringBuilder body = new StringBuilder();
+    CountDownLatch done = new CountDownLatch(1);
+    publisher.subscribe(
+        new Flow.Subscriber<>() {
+          @Override
+          public void onSubscribe(Flow.Subscription subscription) {
+            subscription.request(Long.MAX_VALUE);
+          }
+
+          @Override
+          public void onNext(ByteBuffer item) {
+            body.append(StandardCharsets.UTF_8.decode(item));
+          }
+
+          @Override
+          public void onError(Throwable throwable) {
+            done.countDown();
+          }
+
+          @Override
+          public void onComplete() {
+            done.countDown();
+          }
+        });
+    done.await();
+    return body.toString();
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientPropertiesTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientPropertiesTest.java
@@ -261,7 +261,55 @@ public class StreamingClientPropertiesTest {
         .containsEntry("oauth_client_secret", "test_client_secret")
         .containsEntry("oauth_refresh_token", "test_refresh_token")
         .containsEntry("oauth_token_endpoint", "https://oauth.example.com/token")
+        // Defaults to disabling scope so the SDK doesn't derive session:role:{role}.
+        .containsEntry("oauth_include_scope", "false")
+        .doesNotContainKey("oauth_scope")
         .doesNotContainKey("private_key");
+  }
+
+  @Test
+  void oAuthConfig_includeScopeEnabled_forwardsScope() {
+    Map<String, String> connectorConfig =
+        SnowflakeSinkConnectorConfigBuilder.streamingConfig()
+            .withAuthenticator(AuthenticatorType.OAUTH.toConfigValue())
+            .withOauthClientId("test_client_id")
+            .withOauthClientSecret("test_client_secret")
+            .withOauthRefreshToken("test_refresh_token")
+            .withOauthTokenEndpoint("https://oauth.example.com/token")
+            .withOauthIncludeScope(true)
+            .withOauthScope("session:role:MY_ROLE")
+            .withoutPrivateKey()
+            .build();
+    connectorConfig.put(Utils.TASK_ID, "0");
+
+    SinkTaskConfig config = SinkTaskConfig.from(connectorConfig);
+    StreamingClientProperties properties = StreamingClientProperties.from(config);
+
+    assertThat(properties.clientProperties)
+        .containsEntry("oauth_include_scope", "true")
+        .containsEntry("oauth_scope", "session:role:MY_ROLE");
+  }
+
+  @Test
+  void oAuthConfig_includeScopeEnabledWithoutExplicitScope_letsSdkDeriveScope() {
+    Map<String, String> connectorConfig =
+        SnowflakeSinkConnectorConfigBuilder.streamingConfig()
+            .withAuthenticator(AuthenticatorType.OAUTH.toConfigValue())
+            .withOauthClientId("test_client_id")
+            .withOauthClientSecret("test_client_secret")
+            .withOauthRefreshToken("test_refresh_token")
+            .withOauthTokenEndpoint("https://oauth.example.com/token")
+            .withOauthIncludeScope(true)
+            .withoutPrivateKey()
+            .build();
+    connectorConfig.put(Utils.TASK_ID, "0");
+
+    SinkTaskConfig config = SinkTaskConfig.from(connectorConfig);
+    StreamingClientProperties properties = StreamingClientProperties.from(config);
+
+    assertThat(properties.clientProperties)
+        .containsEntry("oauth_include_scope", "true")
+        .doesNotContainKey("oauth_scope");
   }
 
   @Test


### PR DESCRIPTION
## Summary

The streaming SDK (>= 1.6.1) defaults `oauth_include_scope` to **true**, which makes it derive `session:role:{role}` and send it as the `scope` on OAuth refresh requests. External OAuth / IdP refresh tokens that were minted **without** a role scope are then rejected by the IdP (`access_denied` / "Denied scopes: session:role:***"). This is what broke the OAuth E2E test on `master` right after the SDK bump 1.6.0 → 1.6.1, and it would also break external OAuth customers (e.g. JPMC-style lambda-minted tokens).

Rather than hardcoding `oauth_include_scope=false`, this exposes the behavior as connector config so it can be turned back on when a deployment actually needs a role scope.

- **`snowflake.oauth.include.scope`** (boolean, default `false`): forwarded to the streaming SDK as `oauth_include_scope`. Default `false` restores KC v3 behavior (no scope) and fixes external OAuth out of the box.
- **`snowflake.oauth.scope`** (string, optional): explicit scope, forwarded to the SDK as `oauth_scope`. Only used when `include.scope` is `true`; otherwise the SDK derives `session:role:{role}`.

For symmetry, the JDBC `OAuthAccessTokenFetcher` now honors an explicit scope resolved from the same config (no scope by default; explicit scope, else `session:role:{role}`, only when `include.scope` is enabled). This mirrors what KC v3 did (no scope) by default. `validate()` rejects setting a scope while `include.scope` is `false`.

### Why default `false`?

- Matches KC v3, which never sent a scope on OAuth refresh.
- Works for external OAuth tokens minted without a role scope (the common failure mode).
- Users who rely on Snowflake role-scoped OAuth can opt in with `snowflake.oauth.include.scope=true` (and optionally an explicit `snowflake.oauth.scope`).

## Changes

- `Constants` / `ConnectorConfigDefinition`: new `snowflake.oauth.include.scope` (default false) and `snowflake.oauth.scope` params.
- `SinkTaskConfig`: parse the two new fields (`getOauthIncludeScope()`, `getOauthScope()`).
- `StreamingClientProperties`: always forward `oauth_include_scope`; forward `oauth_scope` when scopes are enabled.
- `InternalUtils` / `OAuthAccessTokenFetcher`: resolve and pass an optional scope on the JDBC token request.
- `DefaultConnectorConfigValidator`: reject `oauth.scope` set while `oauth.include.scope` is false.

## Test plan

- [x] `SinkTaskConfigTest` — parsing + defaults (`include.scope=false`, no scope).
- [x] `StreamingClientPropertiesTest` — `oauth_include_scope` always forwarded (default `false`), `oauth_scope` forwarded only when enabled.
- [x] `OAuthAccessTokenFetcherTest` — `scope` form param present when set, absent otherwise.
- [x] `ConnectorConfigValidatorTest` — scope-without-include is invalid; scope-with-include is valid.
- [ ] Re-run the OAuth E2E ingestion test on this branch (default config, no scope) to confirm master CI is green.