### PR TITLE
SNOW-3648284: Log server advisories on connector startup (SYSTEM$GET_KC_ADVISORY_MESSAGES)

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/Constants.java
+++ b/src/main/java/com/snowflake/kafka/connector/Constants.java
@@ -111,6 +111,14 @@ public final class Constants {
         "snowflake.feature.fail_on_critical_advisory";
     public static final boolean SNOWFLAKE_FEATURE_FAIL_ON_CRITICAL_ADVISORY_DEFAULT = true;
 
+    // Kill-switch (unregistered) controlling the interval, in seconds, at which the connector
+    // re-polls server-side advisories while running (in addition to the one-time startup check).
+    // Mid-run polling is log-only: it never hard-fails a running connector, even on CRITICAL. Set
+    // to <= 0 to disable periodic polling (startup-only checking).
+    public static final String SNOWFLAKE_FEATURE_ADVISORY_POLL_INTERVAL_SECONDS =
+        "snowflake.feature.advisory_poll_interval_seconds";
+    public static final long SNOWFLAKE_FEATURE_ADVISORY_POLL_INTERVAL_SECONDS_DEFAULT = 3600L;
+
     // Caching
     public static final String CACHE_TABLE_EXISTS = "snowflake.cache.table.exists";
     public static final boolean CACHE_TABLE_EXISTS_DEFAULT = true;

--- a/src/main/java/com/snowflake/kafka/connector/Constants.java
+++ b/src/main/java/com/snowflake/kafka/connector/Constants.java
@@ -113,8 +113,9 @@ public final class Constants {
 
     // Kill-switch (unregistered) controlling the interval, in seconds, at which the connector
     // re-polls server-side advisories while running (in addition to the one-time startup check).
-    // Mid-run polling is log-only: it never hard-fails a running connector, even on CRITICAL. Set
-    // to <= 0 to disable periodic polling (startup-only checking).
+    // A CRITICAL advisory seen mid-run aborts the connector just like at startup (honoring
+    // SNOWFLAKE_FEATURE_FAIL_ON_CRITICAL_ADVISORY); info/warn/error stay log-only. Set to <= 0 to
+    // disable periodic polling (startup-only checking).
     public static final String SNOWFLAKE_FEATURE_ADVISORY_POLL_INTERVAL_SECONDS =
         "snowflake.feature.advisory_poll_interval_seconds";
     public static final long SNOWFLAKE_FEATURE_ADVISORY_POLL_INTERVAL_SECONDS_DEFAULT = 3600L;

--- a/src/main/java/com/snowflake/kafka/connector/Constants.java
+++ b/src/main/java/com/snowflake/kafka/connector/Constants.java
@@ -105,6 +105,12 @@ public final class Constants {
         "snowflake.feature.structured.headers";
     public static final boolean SNOWFLAKE_FEATURE_STRUCTURED_HEADERS_DEFAULT = false;
 
+    // When true (default), a CRITICAL server advisory causes connector startup to fail with a clear
+    // message. Set to false to allow startup despite a critical advisory (not recommended).
+    public static final String SNOWFLAKE_FEATURE_FAIL_ON_CRITICAL_ADVISORY =
+        "snowflake.feature.fail_on_critical_advisory";
+    public static final boolean SNOWFLAKE_FEATURE_FAIL_ON_CRITICAL_ADVISORY_DEFAULT = true;
+
     // Caching
     public static final String CACHE_TABLE_EXISTS = "snowflake.cache.table.exists";
     public static final boolean CACHE_TABLE_EXISTS_DEFAULT = true;

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeStreamingSinkConnector.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeStreamingSinkConnector.java
@@ -16,7 +16,6 @@
  */
 package com.snowflake.kafka.connector;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams;
 import com.snowflake.kafka.connector.config.AuthenticatorType;
 import com.snowflake.kafka.connector.config.ConnectorConfigDefinition;
@@ -30,7 +29,6 @@ import com.snowflake.kafka.connector.internal.advisory.AdvisoryMessage;
 import com.snowflake.kafka.connector.internal.streaming.DefaultStreamingConfigValidator;
 import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryService;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -410,9 +408,7 @@ public class SnowflakeStreamingSinkConnector extends SinkConnector {
    */
   private void logServerAdvisories() {
     try {
-      String requestJson =
-          new ObjectMapper()
-              .writeValueAsString(Collections.singletonMap("connectorVersion", Utils.VERSION));
+      String requestJson = "{\"connectorVersion\":\"" + Utils.VERSION + "\"}";
       for (AdvisoryMessage msg : conn.getKcAdvisoryMessages(requestJson)) {
         AdvisoryLevel.fromString(msg.getLevel()).log(LOGGER, msg.getText());
       }

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeStreamingSinkConnector.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeStreamingSinkConnector.java
@@ -16,6 +16,7 @@
  */
 package com.snowflake.kafka.connector;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams;
 import com.snowflake.kafka.connector.config.AuthenticatorType;
 import com.snowflake.kafka.connector.config.ConnectorConfigDefinition;
@@ -24,9 +25,12 @@ import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
 import com.snowflake.kafka.connector.internal.SnowflakeConnectionServiceFactory;
 import com.snowflake.kafka.connector.internal.SnowflakeErrors;
 import com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException;
+import com.snowflake.kafka.connector.internal.advisory.AdvisoryLevel;
+import com.snowflake.kafka.connector.internal.advisory.AdvisoryMessage;
 import com.snowflake.kafka.connector.internal.streaming.DefaultStreamingConfigValidator;
 import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryService;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -118,6 +122,9 @@ public class SnowflakeStreamingSinkConnector extends SinkConnector {
     // create a persisted connection, and validate snowflake connection
     // config as a side effect
     conn = SnowflakeConnectionServiceFactory.builder().setProperties(config).build();
+
+    // Fetch and log any server-side advisories for this connector version (SNOW-3648284).
+    logServerAdvisories();
 
     telemetryClient = conn.getTelemetryClient();
 
@@ -395,6 +402,24 @@ public class SnowflakeStreamingSinkConnector extends SinkConnector {
 
   private static boolean isConfigProviderReference(String value) {
     return value != null && CONFIG_PROVIDER_PREFIX.matcher(value).find();
+  }
+
+  /**
+   * Fetches server-side advisory messages for this connector version and logs each one at its
+   * declared level. Failures are silently swallowed so that advisory logging never affects startup.
+   */
+  private void logServerAdvisories() {
+    try {
+      String requestJson =
+          new ObjectMapper()
+              .writeValueAsString(Collections.singletonMap("connectorVersion", Utils.VERSION));
+      for (AdvisoryMessage msg : conn.getKcAdvisoryMessages(requestJson)) {
+        AdvisoryLevel.fromString(msg.getLevel()).log(LOGGER, msg.getText());
+      }
+    } catch (Exception e) {
+      // Advisory logging must never affect connector startup.
+      LOGGER.debug("Failed to fetch server advisories: {}", e.getMessage());
+    }
   }
 
   /**

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeStreamingSinkConnector.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeStreamingSinkConnector.java
@@ -81,8 +81,9 @@ public class SnowflakeStreamingSinkConnector extends SinkConnector {
   private final ConnectorConfigValidator connectorConfigValidator =
       new DefaultConnectorConfigValidator(new DefaultStreamingConfigValidator());
 
-  // Periodically re-polls server advisories while the connector runs (SNOW-3648284). Unlike the
-  // one-time startup check, this is log-only and never hard-fails a running connector.
+  // Periodically re-polls server advisories while the connector runs (SNOW-3648284). Like the
+  // one-time startup check, a CRITICAL advisory seen mid-run aborts the connector (via
+  // ConnectorContext.raiseError -> FAILED), unless the fail-on-critical opt-out is set.
   private ScheduledExecutorService advisoryPoller;
 
   // test visibility: counts completed periodic poll cycles
@@ -418,6 +419,23 @@ public class SnowflakeStreamingSinkConnector extends SinkConnector {
     return value != null && CONFIG_PROVIDER_PREFIX.matcher(value).find();
   }
 
+  /** Request context sent to the GS advisory function; v1 carries only the connector version. */
+  private static String advisoryRequestJson() {
+    return "{\"connectorVersion\":\"" + Utils.VERSION + "\"}";
+  }
+
+  /**
+   * @return whether a CRITICAL advisory should hard-fail the connector. Default {@code true},
+   *     user-overridable via {@code snowflake.feature.fail_on_critical_advisory}.
+   */
+  private boolean failOnCriticalAdvisory() {
+    return Boolean.parseBoolean(
+        config.getOrDefault(
+            KafkaConnectorConfigParams.SNOWFLAKE_FEATURE_FAIL_ON_CRITICAL_ADVISORY,
+            String.valueOf(
+                KafkaConnectorConfigParams.SNOWFLAKE_FEATURE_FAIL_ON_CRITICAL_ADVISORY_DEFAULT)));
+  }
+
   /**
    * Fetches server-side advisory messages for this connector version, logs each one at its declared
    * level, and fails startup if any are CRITICAL (unless the user has opted out).
@@ -430,8 +448,7 @@ public class SnowflakeStreamingSinkConnector extends SinkConnector {
   private void logServerAdvisories() {
     List<AdvisoryMessage> advisories;
     try {
-      String requestJson = "{\"connectorVersion\":\"" + Utils.VERSION + "\"}";
-      advisories = conn.getKcAdvisoryMessages(requestJson); // fail-safe: [] on any error
+      advisories = conn.getKcAdvisoryMessages(advisoryRequestJson()); // fail-safe: [] on any error
     } catch (Exception e) {
       LOGGER.debug(
           "Failed to fetch server advisories: {}", e.getMessage()); // mechanism error, never fail
@@ -440,14 +457,7 @@ public class SnowflakeStreamingSinkConnector extends SinkConnector {
     for (AdvisoryMessage msg : advisories) {
       AdvisoryLevel.fromString(msg.getLevel()).log(LOGGER, msg.getText());
     }
-    boolean failOnCritical =
-        Boolean.parseBoolean(
-            config.getOrDefault(
-                KafkaConnectorConfigParams.SNOWFLAKE_FEATURE_FAIL_ON_CRITICAL_ADVISORY,
-                String.valueOf(
-                    KafkaConnectorConfigParams
-                        .SNOWFLAKE_FEATURE_FAIL_ON_CRITICAL_ADVISORY_DEFAULT)));
-    if (hasCritical(advisories) && failOnCritical) {
+    if (hasCritical(advisories) && failOnCriticalAdvisory()) {
       throw SnowflakeErrors.ERROR_5031.getException(
           "Refusing to start: a critical advisory applies to Kafka Connector "
               + Utils.VERSION
@@ -473,16 +483,47 @@ public class SnowflakeStreamingSinkConnector extends SinkConnector {
 
   /**
    * Re-fetches and logs server-side advisories on a background thread while the connector is
-   * running. Unlike {@link #logServerAdvisories()}, this is log-only: a CRITICAL advisory is logged
-   * at ERROR but never stops a running connector, and any exception here is swallowed so the
-   * scheduled task keeps firing.
+   * running. Each advisory is logged at its declared level; if any are CRITICAL the connector is
+   * aborted the same way as at startup, honoring the {@code
+   * snowflake.feature.fail_on_critical_advisory} opt-out.
+   *
+   * <p>A {@link SinkConnector} cannot pause itself, so a mid-run critical is surfaced to the
+   * framework via {@link org.apache.kafka.connect.connector.ConnectorContext#raiseError} which
+   * transitions the connector to FAILED. FAILED connectors are not auto-restarted, so this is a
+   * hard stop, not a crash loop; a manual restart re-runs the startup check and refuses again while
+   * the policy still applies. Mechanism errors (fetch/parse) are swallowed so the scheduler keeps
+   * firing.
    */
   private void pollAdvisories() {
     try {
-      String requestJson = "{\"connectorVersion\":\"" + Utils.VERSION + "\"}";
-      for (AdvisoryMessage msg : conn.getKcAdvisoryMessages(requestJson)) {
+      List<AdvisoryMessage> advisories = conn.getKcAdvisoryMessages(advisoryRequestJson());
+      for (AdvisoryMessage msg : advisories) {
         AdvisoryLevel.fromString(msg.getLevel()).log(LOGGER, msg.getText());
       }
+      if (!hasCritical(advisories)) {
+        return;
+      }
+      if (!failOnCriticalAdvisory()) {
+        LOGGER.warn(
+            "Continuing despite a critical server advisory because {}=false.",
+            KafkaConnectorConfigParams.SNOWFLAKE_FEATURE_FAIL_ON_CRITICAL_ADVISORY);
+        return;
+      }
+      // Abort the running connector: stop further polls, then fail it through the framework.
+      LOGGER.error(
+          "Aborting connector: a critical server advisory now applies to Kafka Connector {}."
+              + " Upgrade the connector, or to keep running set {}=false (not recommended).",
+          Utils.VERSION,
+          KafkaConnectorConfigParams.SNOWFLAKE_FEATURE_FAIL_ON_CRITICAL_ADVISORY);
+      if (advisoryPoller != null) {
+        advisoryPoller.shutdown();
+      }
+      context()
+          .raiseError(
+              SnowflakeErrors.ERROR_5031.getException(
+                  "Critical server advisory applies to running Kafka Connector "
+                      + Utils.VERSION
+                      + "; connector aborted."));
     } catch (Exception e) {
       LOGGER.debug("Periodic advisory poll failed: {}", e.getMessage());
     } finally {

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeStreamingSinkConnector.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeStreamingSinkConnector.java
@@ -32,6 +32,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
 import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigDef;
@@ -76,6 +80,13 @@ public class SnowflakeStreamingSinkConnector extends SinkConnector {
 
   private final ConnectorConfigValidator connectorConfigValidator =
       new DefaultConnectorConfigValidator(new DefaultStreamingConfigValidator());
+
+  // Periodically re-polls server advisories while the connector runs (SNOW-3648284). Unlike the
+  // one-time startup check, this is log-only and never hard-fails a running connector.
+  private ScheduledExecutorService advisoryPoller;
+
+  // test visibility: counts completed periodic poll cycles
+  private final AtomicInteger advisoryPollCount = new AtomicInteger();
 
   /** No-Arg constructor. Required by Kafka Connect framework */
   public SnowflakeStreamingSinkConnector() {
@@ -123,6 +134,7 @@ public class SnowflakeStreamingSinkConnector extends SinkConnector {
 
     // Fetch and log any server-side advisories for this connector version (SNOW-3648284).
     logServerAdvisories();
+    startAdvisoryPolling();
 
     telemetryClient = conn.getTelemetryClient();
 
@@ -145,6 +157,10 @@ public class SnowflakeStreamingSinkConnector extends SinkConnector {
   public void stop() {
     LOGGER.info("SnowflakeStreamingSinkConnector connector stopping...");
     setupComplete = false;
+
+    if (advisoryPoller != null) {
+      advisoryPoller.shutdownNow();
+    }
 
     if (telemetryClient != null) {
       telemetryClient.reportKafkaConnectStop(connectorStartTime);
@@ -453,6 +469,62 @@ public class SnowflakeStreamingSinkConnector extends SinkConnector {
   static boolean hasCritical(List<AdvisoryMessage> advisories) {
     return advisories.stream()
         .anyMatch(m -> AdvisoryLevel.fromString(m.getLevel()) == AdvisoryLevel.CRITICAL);
+  }
+
+  /**
+   * Re-fetches and logs server-side advisories on a background thread while the connector is
+   * running. Unlike {@link #logServerAdvisories()}, this is log-only: a CRITICAL advisory is logged
+   * at ERROR but never stops a running connector, and any exception here is swallowed so the
+   * scheduled task keeps firing.
+   */
+  private void pollAdvisories() {
+    try {
+      String requestJson = "{\"connectorVersion\":\"" + Utils.VERSION + "\"}";
+      for (AdvisoryMessage msg : conn.getKcAdvisoryMessages(requestJson)) {
+        AdvisoryLevel.fromString(msg.getLevel()).log(LOGGER, msg.getText());
+      }
+    } catch (Exception e) {
+      LOGGER.debug("Periodic advisory poll failed: {}", e.getMessage());
+    } finally {
+      advisoryPollCount.incrementAndGet();
+    }
+  }
+
+  /**
+   * Starts a background scheduler that periodically re-polls server advisories (SNOW-3648284). No
+   * scheduler is started when the poll interval is {@code <= 0}, which leaves advisory checking as
+   * startup-only.
+   */
+  private void startAdvisoryPolling() {
+    long intervalSeconds =
+        Long.parseLong(
+            config.getOrDefault(
+                KafkaConnectorConfigParams.SNOWFLAKE_FEATURE_ADVISORY_POLL_INTERVAL_SECONDS,
+                String.valueOf(
+                    KafkaConnectorConfigParams
+                        .SNOWFLAKE_FEATURE_ADVISORY_POLL_INTERVAL_SECONDS_DEFAULT)));
+    if (intervalSeconds <= 0) {
+      LOGGER.info("Server advisory polling disabled (interval <= 0).");
+      return;
+    }
+    advisoryPoller =
+        Executors.newSingleThreadScheduledExecutor(
+            r -> {
+              Thread t = new Thread(r, "kc-advisory-poller");
+              t.setDaemon(true);
+              return t;
+            });
+    advisoryPoller.scheduleAtFixedRate(
+        this::pollAdvisories, intervalSeconds, intervalSeconds, TimeUnit.SECONDS);
+    LOGGER.info("Server advisory polling every {}s.", intervalSeconds);
+  }
+
+  /**
+   * @return the number of completed periodic advisory poll cycles.
+   *     <p>Package-private for testing.
+   */
+  int advisoryPollCountForTest() {
+    return advisoryPollCount.get();
   }
 
   /**

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeStreamingSinkConnector.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeStreamingSinkConnector.java
@@ -403,19 +403,56 @@ public class SnowflakeStreamingSinkConnector extends SinkConnector {
   }
 
   /**
-   * Fetches server-side advisory messages for this connector version and logs each one at its
-   * declared level. Failures are silently swallowed so that advisory logging never affects startup.
+   * Fetches server-side advisory messages for this connector version, logs each one at its declared
+   * level, and fails startup if any are CRITICAL (unless the user has opted out).
+   *
+   * <p>Mechanism errors (old GS without the function, JDBC/parse failures) are silently swallowed
+   * and never block startup; {@link
+   * com.snowflake.kafka.connector.internal.SnowflakeConnectionService#getKcAdvisoryMessages} is
+   * already fail-safe and returns an empty list on any such error.
    */
   private void logServerAdvisories() {
+    List<AdvisoryMessage> advisories;
     try {
       String requestJson = "{\"connectorVersion\":\"" + Utils.VERSION + "\"}";
-      for (AdvisoryMessage msg : conn.getKcAdvisoryMessages(requestJson)) {
-        AdvisoryLevel.fromString(msg.getLevel()).log(LOGGER, msg.getText());
-      }
+      advisories = conn.getKcAdvisoryMessages(requestJson); // fail-safe: [] on any error
     } catch (Exception e) {
-      // Advisory logging must never affect connector startup.
-      LOGGER.debug("Failed to fetch server advisories: {}", e.getMessage());
+      LOGGER.debug(
+          "Failed to fetch server advisories: {}", e.getMessage()); // mechanism error, never fail
+      return;
     }
+    for (AdvisoryMessage msg : advisories) {
+      AdvisoryLevel.fromString(msg.getLevel()).log(LOGGER, msg.getText());
+    }
+    boolean failOnCritical =
+        Boolean.parseBoolean(
+            config.getOrDefault(
+                KafkaConnectorConfigParams.SNOWFLAKE_FEATURE_FAIL_ON_CRITICAL_ADVISORY,
+                String.valueOf(
+                    KafkaConnectorConfigParams
+                        .SNOWFLAKE_FEATURE_FAIL_ON_CRITICAL_ADVISORY_DEFAULT)));
+    if (hasCritical(advisories) && failOnCritical) {
+      throw SnowflakeErrors.ERROR_5031.getException(
+          "Refusing to start: a critical advisory applies to Kafka Connector "
+              + Utils.VERSION
+              + ". Upgrade the connector, or to start anyway set "
+              + KafkaConnectorConfigParams.SNOWFLAKE_FEATURE_FAIL_ON_CRITICAL_ADVISORY
+              + "=false (not recommended).");
+    } else if (hasCritical(advisories)) {
+      LOGGER.warn(
+          "Starting despite a critical server advisory because {}=false.",
+          KafkaConnectorConfigParams.SNOWFLAKE_FEATURE_FAIL_ON_CRITICAL_ADVISORY);
+    }
+  }
+
+  /**
+   * Returns true if any advisory in the list has level CRITICAL.
+   *
+   * <p>Package-private for testing.
+   */
+  static boolean hasCritical(List<AdvisoryMessage> advisories) {
+    return advisories.stream()
+        .anyMatch(m -> AdvisoryLevel.fromString(m.getLevel()) == AdvisoryLevel.CRITICAL);
   }
 
   /**

--- a/src/main/java/com/snowflake/kafka/connector/internal/CachingSnowflakeConnectionService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/CachingSnowflakeConnectionService.java
@@ -279,6 +279,12 @@ public class CachingSnowflakeConnectionService implements SnowflakeConnectionSer
     return delegate.migrateSsv1ChannelOffset(tableName, ssv1ChannelName, ssv2ChannelName, pipeName);
   }
 
+  @Override
+  public java.util.List<com.snowflake.kafka.connector.internal.advisory.AdvisoryMessage>
+      getKcAdvisoryMessages(String requestJson) {
+    return delegate.getKcAdvisoryMessages(requestJson);
+  }
+
   private void logStatsIfNeeded() {
     final long now = System.currentTimeMillis();
     final long lastLogged = lastStatsLogTimestamp.get();

--- a/src/main/java/com/snowflake/kafka/connector/internal/CachingSnowflakeConnectionService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/CachingSnowflakeConnectionService.java
@@ -5,6 +5,7 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheStats;
+import com.snowflake.kafka.connector.internal.advisory.AdvisoryMessage;
 import com.snowflake.kafka.connector.internal.schemaevolution.ColumnInfos;
 import com.snowflake.kafka.connector.internal.streaming.v2.migration.Ssv1MigrationResponse;
 import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryService;
@@ -280,8 +281,7 @@ public class CachingSnowflakeConnectionService implements SnowflakeConnectionSer
   }
 
   @Override
-  public java.util.List<com.snowflake.kafka.connector.internal.advisory.AdvisoryMessage>
-      getKcAdvisoryMessages(String requestJson) {
+  public List<AdvisoryMessage> getKcAdvisoryMessages(String requestJson) {
     return delegate.getKcAdvisoryMessages(requestJson);
   }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionService.java
@@ -192,4 +192,13 @@ public interface SnowflakeConnectionService {
    */
   Ssv1MigrationResponse migrateSsv1ChannelOffset(
       String tableName, String ssv1ChannelName, String ssv2ChannelName, String pipeName);
+
+  /**
+   * Calls SYSTEM$GET_KC_ADVISORY_MESSAGES with the given request JSON (e.g.
+   * {@code {"connectorVersion":"4.1.0"}}) and returns the advisory messages GS wants logged.
+   * Fails safe: returns an empty list on any error (old GS without the function, empty policy,
+   * parse failure) — never throws.
+   */
+  java.util.List<com.snowflake.kafka.connector.internal.advisory.AdvisoryMessage>
+      getKcAdvisoryMessages(String requestJson);
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionService.java
@@ -195,10 +195,10 @@ public interface SnowflakeConnectionService {
       String tableName, String ssv1ChannelName, String ssv2ChannelName, String pipeName);
 
   /**
-   * Calls SYSTEM$GET_KC_ADVISORY_MESSAGES with the given request JSON (e.g.
-   * {@code {"connectorVersion":"4.1.0"}}) and returns the advisory messages GS wants logged.
-   * Fails safe: returns an empty list on any error (old GS without the function, empty policy,
-   * parse failure) — never throws.
+   * Calls SYSTEM$GET_KC_ADVISORY_MESSAGES with the given request JSON (e.g. {@code
+   * {"connectorVersion":"4.1.0"}}) and returns the advisory messages GS wants logged. Fails safe:
+   * returns an empty list on any error (old GS without the function, empty policy, parse failure) —
+   * never throws.
    */
   List<AdvisoryMessage> getKcAdvisoryMessages(String requestJson);
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeConnectionService.java
@@ -1,5 +1,6 @@
 package com.snowflake.kafka.connector.internal;
 
+import com.snowflake.kafka.connector.internal.advisory.AdvisoryMessage;
 import com.snowflake.kafka.connector.internal.schemaevolution.ColumnInfos;
 import com.snowflake.kafka.connector.internal.streaming.v2.migration.Ssv1MigrationResponse;
 import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryService;
@@ -199,6 +200,5 @@ public interface SnowflakeConnectionService {
    * Fails safe: returns an empty list on any error (old GS without the function, empty policy,
    * parse failure) — never throws.
    */
-  java.util.List<com.snowflake.kafka.connector.internal.advisory.AdvisoryMessage>
-      getKcAdvisoryMessages(String requestJson);
+  List<AdvisoryMessage> getKcAdvisoryMessages(String requestJson);
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeErrors.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/SnowflakeErrors.java
@@ -212,7 +212,13 @@ public enum SnowflakeErrors {
       "An existing table's structured-OBJECT RECORD_METADATA column (managed-Iceberg v2) does not"
           + " match the schema the connector requires: a sub-field is missing or extra, or the"
           + " sub-fields could not be read. The strict typed-OBJECT cast would reject every row at"
-          + " ingest. See the specific error message for details.");
+          + " ingest. See the specific error message for details."),
+  ERROR_5031(
+      "5031",
+      "Critical server advisory: connector startup refused",
+      "A critical advisory from Snowflake applies to this connector version. Upgrade the"
+          + " connector, or to start anyway set snowflake.feature.fail_on_critical_advisory=false"
+          + " (not recommended).");
 
   // properties
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/StandardSnowflakeConnectionService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/StandardSnowflakeConnectionService.java
@@ -3,9 +3,9 @@ package com.snowflake.kafka.connector.internal;
 import static com.snowflake.kafka.connector.Utils.TABLE_COLUMN_METADATA;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.snowflake.kafka.connector.internal.schemaevolution.ColumnInfos;
 import com.snowflake.kafka.connector.internal.advisory.AdvisoryMessage;
 import com.snowflake.kafka.connector.internal.advisory.KcAdvisoryResponse;
+import com.snowflake.kafka.connector.internal.schemaevolution.ColumnInfos;
 import com.snowflake.kafka.connector.internal.streaming.v2.migration.Ssv1MigrationResponse;
 import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryService;
 import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryServiceFactory;

--- a/src/main/java/com/snowflake/kafka/connector/internal/StandardSnowflakeConnectionService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/StandardSnowflakeConnectionService.java
@@ -4,6 +4,8 @@ import static com.snowflake.kafka.connector.Utils.TABLE_COLUMN_METADATA;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.snowflake.kafka.connector.internal.schemaevolution.ColumnInfos;
+import com.snowflake.kafka.connector.internal.advisory.AdvisoryMessage;
+import com.snowflake.kafka.connector.internal.advisory.KcAdvisoryResponse;
 import com.snowflake.kafka.connector.internal.streaming.v2.migration.Ssv1MigrationResponse;
 import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryService;
 import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryServiceFactory;
@@ -671,6 +673,30 @@ public class StandardSnowflakeConnectionService implements SnowflakeConnectionSe
               + ": "
               + e.getMessage(),
           e);
+    }
+  }
+
+  @Override
+  public List<AdvisoryMessage> getKcAdvisoryMessages(String requestJson) {
+    try {
+      checkConnection();
+      String query = "SELECT SYSTEM$GET_KC_ADVISORY_MESSAGES(?)";
+      try (PreparedStatement stmt = conn.prepareStatement(query)) {
+        stmt.setString(1, requestJson);
+        try (ResultSet rs = stmt.executeQuery()) {
+          if (!rs.next()) {
+            return Collections.emptyList();
+          }
+          KcAdvisoryResponse response =
+              OBJECT_MAPPER.readValue(rs.getString(1), KcAdvisoryResponse.class);
+          return response.getMessages();
+        }
+      }
+    } catch (Exception e) {
+      // Fail-safe: an old GS without the function, a disabled/empty policy, or a parse error
+      // must never disrupt the connector. Log at DEBUG only (not customer-facing).
+      LOGGER.debug("SYSTEM$GET_KC_ADVISORY_MESSAGES unavailable or failed: {}", e.getMessage());
+      return Collections.emptyList();
     }
   }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/advisory/AdvisoryLevel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/advisory/AdvisoryLevel.java
@@ -1,0 +1,47 @@
+package com.snowflake.kafka.connector.internal.advisory;
+
+import com.snowflake.kafka.connector.internal.KCLogger;
+import java.util.Locale;
+
+/** Maps a GS-supplied advisory level string to a KCLogger call. Unknown/null defaults to WARN. */
+public enum AdvisoryLevel {
+  INFO,
+  WARN,
+  ERROR;
+
+  /**
+   * Resolves a raw level string (e.g. "INFO", "warn", "Error") to the corresponding enum constant.
+   * Returns {@link #WARN} for null or unrecognised values.
+   */
+  public static AdvisoryLevel fromString(String level) {
+    if (level == null) {
+      return WARN;
+    }
+    switch (level.toUpperCase(Locale.ROOT)) {
+      case "INFO":
+        return INFO;
+      case "ERROR":
+        return ERROR;
+      case "WARN":
+        return WARN;
+      default:
+        return WARN;
+    }
+  }
+
+  /** Logs the given text through {@code logger} at this level. */
+  public void log(KCLogger logger, String text) {
+    switch (this) {
+      case INFO:
+        logger.info(text);
+        break;
+      case ERROR:
+        logger.error(text);
+        break;
+      case WARN:
+      default:
+        logger.warn(text);
+        break;
+    }
+  }
+}

--- a/src/main/java/com/snowflake/kafka/connector/internal/advisory/AdvisoryLevel.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/advisory/AdvisoryLevel.java
@@ -7,11 +7,12 @@ import java.util.Locale;
 public enum AdvisoryLevel {
   INFO,
   WARN,
-  ERROR;
+  ERROR,
+  CRITICAL;
 
   /**
-   * Resolves a raw level string (e.g. "INFO", "warn", "Error") to the corresponding enum constant.
-   * Returns {@link #WARN} for null or unrecognised values.
+   * Resolves a raw level string (e.g. "INFO", "warn", "Error", "CRITICAL") to the corresponding
+   * enum constant. Returns {@link #WARN} for null or unrecognised values.
    */
   public static AdvisoryLevel fromString(String level) {
     if (level == null) {
@@ -22,6 +23,8 @@ public enum AdvisoryLevel {
         return INFO;
       case "ERROR":
         return ERROR;
+      case "CRITICAL":
+        return CRITICAL;
       case "WARN":
         return WARN;
       default:
@@ -36,6 +39,9 @@ public enum AdvisoryLevel {
         logger.info(text);
         break;
       case ERROR:
+        logger.error(text);
+        break;
+      case CRITICAL:
         logger.error(text);
         break;
       case WARN:

--- a/src/main/java/com/snowflake/kafka/connector/internal/advisory/AdvisoryMessage.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/advisory/AdvisoryMessage.java
@@ -1,0 +1,38 @@
+package com.snowflake.kafka.connector.internal.advisory;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** One advisory message returned by SYSTEM$GET_KC_ADVISORY_MESSAGES. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AdvisoryMessage {
+
+  @JsonProperty("level")
+  String level;
+
+  @JsonProperty("code")
+  String code;
+
+  @JsonProperty("text")
+  String text;
+
+  public AdvisoryMessage() {}
+
+  public AdvisoryMessage(String level, String code, String text) {
+    this.level = level;
+    this.code = code;
+    this.text = text;
+  }
+
+  public String getLevel() {
+    return level;
+  }
+
+  public String getCode() {
+    return code;
+  }
+
+  public String getText() {
+    return text;
+  }
+}

--- a/src/main/java/com/snowflake/kafka/connector/internal/advisory/AdvisoryMessage.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/advisory/AdvisoryMessage.java
@@ -10,26 +10,18 @@ public class AdvisoryMessage {
   @JsonProperty("level")
   String level;
 
-  @JsonProperty("code")
-  String code;
-
   @JsonProperty("text")
   String text;
 
   public AdvisoryMessage() {}
 
-  public AdvisoryMessage(String level, String code, String text) {
+  public AdvisoryMessage(String level, String text) {
     this.level = level;
-    this.code = code;
     this.text = text;
   }
 
   public String getLevel() {
     return level;
-  }
-
-  public String getCode() {
-    return code;
   }
 
   public String getText() {

--- a/src/main/java/com/snowflake/kafka/connector/internal/advisory/KcAdvisoryResponse.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/advisory/KcAdvisoryResponse.java
@@ -1,0 +1,18 @@
+package com.snowflake.kafka.connector.internal.advisory;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Deserialized response from SYSTEM$GET_KC_ADVISORY_MESSAGES. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KcAdvisoryResponse {
+
+  @JsonProperty("messages")
+  List<AdvisoryMessage> messages = new ArrayList<>();
+
+  public List<AdvisoryMessage> getMessages() {
+    return messages == null ? new ArrayList<>() : messages;
+  }
+}

--- a/src/test/java/com/snowflake/kafka/connector/SnowflakeStreamingSinkConnectorAdvisoryTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/SnowflakeStreamingSinkConnectorAdvisoryTest.java
@@ -1,0 +1,51 @@
+package com.snowflake.kafka.connector;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.snowflake.kafka.connector.internal.advisory.AdvisoryMessage;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/** Unit tests for {@link SnowflakeStreamingSinkConnector#hasCritical(List)}. */
+public class SnowflakeStreamingSinkConnectorAdvisoryTest {
+
+  @Test
+  public void hasCritical_emptyList_returnsFalse() {
+    assertFalse(SnowflakeStreamingSinkConnector.hasCritical(Collections.emptyList()));
+  }
+
+  @Test
+  public void hasCritical_onlyInfoAndWarn_returnsFalse() {
+    List<AdvisoryMessage> advisories =
+        Arrays.asList(
+            new AdvisoryMessage("INFO", "all good"), new AdvisoryMessage("WARN", "heads up"));
+    assertFalse(SnowflakeStreamingSinkConnector.hasCritical(advisories));
+  }
+
+  @Test
+  public void hasCritical_containsCritical_returnsTrue() {
+    List<AdvisoryMessage> advisories =
+        Arrays.asList(
+            new AdvisoryMessage("WARN", "heads up"),
+            new AdvisoryMessage("CRITICAL", "you must upgrade"));
+    assertTrue(SnowflakeStreamingSinkConnector.hasCritical(advisories));
+  }
+
+  @Test
+  public void hasCritical_criticalCaseInsensitive_returnsTrue() {
+    List<AdvisoryMessage> advisories =
+        Collections.singletonList(new AdvisoryMessage("critical", "lower-case critical"));
+    assertTrue(SnowflakeStreamingSinkConnector.hasCritical(advisories));
+  }
+
+  @Test
+  public void hasCritical_unknownLevelDefaultsToWarn_returnsFalse() {
+    // Unknown levels default to WARN, so they must not trigger the critical path.
+    List<AdvisoryMessage> advisories =
+        Collections.singletonList(new AdvisoryMessage("UNKNOWN_LEVEL", "some message"));
+    assertFalse(SnowflakeStreamingSinkConnector.hasCritical(advisories));
+  }
+}

--- a/src/test/java/com/snowflake/kafka/connector/SnowflakeStreamingSinkConnectorAdvisoryTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/SnowflakeStreamingSinkConnectorAdvisoryTest.java
@@ -1,16 +1,62 @@
 package com.snowflake.kafka.connector;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
 import com.snowflake.kafka.connector.internal.advisory.AdvisoryMessage;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
+import org.objenesis.Objenesis;
+import org.objenesis.ObjenesisStd;
 
-/** Unit tests for {@link SnowflakeStreamingSinkConnector#hasCritical(List)}. */
+/**
+ * Unit tests for {@link SnowflakeStreamingSinkConnector#hasCritical(List)} and periodic advisory
+ * polling ({@code pollAdvisories}/{@code startAdvisoryPolling}).
+ */
 public class SnowflakeStreamingSinkConnectorAdvisoryTest {
+
+  /**
+   * Builds a connector instance without going through the no-arg constructor's side effects,
+   * reflectively wiring in the mocked connection service and config map fields that {@code
+   * pollAdvisories}/{@code startAdvisoryPolling} read.
+   */
+  private static SnowflakeStreamingSinkConnector connectorWith(
+      SnowflakeConnectionService conn, Map<String, String> config) throws Exception {
+    Objenesis objenesis = new ObjenesisStd();
+    SnowflakeStreamingSinkConnector connector =
+        objenesis.newInstance(SnowflakeStreamingSinkConnector.class);
+    setField(connector, "conn", conn);
+    setField(connector, "config", config);
+    // Objenesis skips field initializers, so the AtomicInteger counter must be wired manually.
+    setField(connector, "advisoryPollCount", new AtomicInteger());
+    return connector;
+  }
+
+  private static void setField(Object target, String fieldName, Object value) throws Exception {
+    Field field = SnowflakeStreamingSinkConnector.class.getDeclaredField(fieldName);
+    field.setAccessible(true);
+    field.set(target, value);
+  }
+
+  private static Object invokePrivate(Object target, String methodName) throws Exception {
+    Method method = SnowflakeStreamingSinkConnector.class.getDeclaredMethod(methodName);
+    method.setAccessible(true);
+    return method.invoke(target);
+  }
 
   @Test
   public void hasCritical_emptyList_returnsFalse() {
@@ -47,5 +93,57 @@ public class SnowflakeStreamingSinkConnectorAdvisoryTest {
     List<AdvisoryMessage> advisories =
         Collections.singletonList(new AdvisoryMessage("UNKNOWN_LEVEL", "some message"));
     assertFalse(SnowflakeStreamingSinkConnector.hasCritical(advisories));
+  }
+
+  @Test
+  public void pollAdvisories_logsCriticalButDoesNotThrow() throws Exception {
+    SnowflakeConnectionService conn = mock(SnowflakeConnectionService.class);
+    when(conn.getKcAdvisoryMessages(anyString()))
+        .thenReturn(Collections.singletonList(new AdvisoryMessage("CRITICAL", "you must upgrade")));
+    SnowflakeStreamingSinkConnector connector = connectorWith(conn, new HashMap<>());
+
+    // Mid-run polling must never throw, even when a CRITICAL advisory is returned.
+    invokePrivate(connector, "pollAdvisories");
+
+    assertEquals(1, connector.advisoryPollCountForTest());
+  }
+
+  @Test
+  public void startAdvisoryPolling_disabledWhenIntervalNotPositive() throws Exception {
+    SnowflakeConnectionService conn = mock(SnowflakeConnectionService.class);
+    Map<String, String> config = new HashMap<>();
+    config.put(
+        Constants.KafkaConnectorConfigParams.SNOWFLAKE_FEATURE_ADVISORY_POLL_INTERVAL_SECONDS, "0");
+    SnowflakeStreamingSinkConnector connector = connectorWith(conn, config);
+
+    invokePrivate(connector, "startAdvisoryPolling");
+
+    Field pollerField = SnowflakeStreamingSinkConnector.class.getDeclaredField("advisoryPoller");
+    pollerField.setAccessible(true);
+    assertNull(pollerField.get(connector));
+  }
+
+  @Test
+  public void startAdvisoryPolling_scheduledTaskFiresRepeatedly() throws Exception {
+    SnowflakeConnectionService conn = mock(SnowflakeConnectionService.class);
+    when(conn.getKcAdvisoryMessages(anyString())).thenReturn(Collections.emptyList());
+    Map<String, String> config = new HashMap<>();
+    config.put(
+        Constants.KafkaConnectorConfigParams.SNOWFLAKE_FEATURE_ADVISORY_POLL_INTERVAL_SECONDS, "1");
+    SnowflakeStreamingSinkConnector connector = connectorWith(conn, config);
+
+    invokePrivate(connector, "startAdvisoryPolling");
+    Thread.sleep(2300);
+
+    assertTrue(
+        connector.advisoryPollCountForTest() >= 2,
+        "expected at least 2 poll cycles, got " + connector.advisoryPollCountForTest());
+
+    connector.stop();
+
+    Field pollerField = SnowflakeStreamingSinkConnector.class.getDeclaredField("advisoryPoller");
+    pollerField.setAccessible(true);
+    ScheduledExecutorService poller = (ScheduledExecutorService) pollerField.get(connector);
+    assertTrue(poller.isShutdown());
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/SnowflakeStreamingSinkConnectorAdvisoryTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/SnowflakeStreamingSinkConnectorAdvisoryTest.java
@@ -4,8 +4,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
@@ -19,6 +23,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.kafka.connect.connector.Connector;
+import org.apache.kafka.connect.connector.ConnectorContext;
+import org.apache.kafka.connect.sink.SinkConnectorContext;
 import org.junit.jupiter.api.Test;
 import org.objenesis.Objenesis;
 import org.objenesis.ObjenesisStd;
@@ -50,6 +57,13 @@ public class SnowflakeStreamingSinkConnectorAdvisoryTest {
     Field field = SnowflakeStreamingSinkConnector.class.getDeclaredField(fieldName);
     field.setAccessible(true);
     field.set(target, value);
+  }
+
+  /** Wires the framework-supplied context (declared on the {@link Connector} superclass). */
+  private static void setContext(Object target, ConnectorContext ctx) throws Exception {
+    Field field = Connector.class.getDeclaredField("context");
+    field.setAccessible(true);
+    field.set(target, ctx);
   }
 
   private static Object invokePrivate(Object target, String methodName) throws Exception {
@@ -96,15 +110,38 @@ public class SnowflakeStreamingSinkConnectorAdvisoryTest {
   }
 
   @Test
-  public void pollAdvisories_logsCriticalButDoesNotThrow() throws Exception {
+  public void pollAdvisories_criticalWithFailOnDefault_abortsViaRaiseError() throws Exception {
     SnowflakeConnectionService conn = mock(SnowflakeConnectionService.class);
     when(conn.getKcAdvisoryMessages(anyString()))
         .thenReturn(Collections.singletonList(new AdvisoryMessage("CRITICAL", "you must upgrade")));
+    // Empty config => fail_on_critical defaults to true.
     SnowflakeStreamingSinkConnector connector = connectorWith(conn, new HashMap<>());
+    SinkConnectorContext ctx = mock(SinkConnectorContext.class);
+    setContext(connector, ctx);
 
-    // Mid-run polling must never throw, even when a CRITICAL advisory is returned.
+    // Never throws out of the scheduled task; instead it aborts the connector via the framework.
     invokePrivate(connector, "pollAdvisories");
 
+    verify(ctx, times(1)).raiseError(any(Exception.class));
+    assertEquals(1, connector.advisoryPollCountForTest());
+  }
+
+  @Test
+  public void pollAdvisories_criticalWithFailOff_doesNotRaise() throws Exception {
+    SnowflakeConnectionService conn = mock(SnowflakeConnectionService.class);
+    when(conn.getKcAdvisoryMessages(anyString()))
+        .thenReturn(Collections.singletonList(new AdvisoryMessage("CRITICAL", "you must upgrade")));
+    Map<String, String> config = new HashMap<>();
+    config.put(
+        Constants.KafkaConnectorConfigParams.SNOWFLAKE_FEATURE_FAIL_ON_CRITICAL_ADVISORY, "false");
+    SnowflakeStreamingSinkConnector connector = connectorWith(conn, config);
+    SinkConnectorContext ctx = mock(SinkConnectorContext.class);
+    setContext(connector, ctx);
+
+    // Opt-out: the critical is logged but the running connector is left alone.
+    invokePrivate(connector, "pollAdvisories");
+
+    verify(ctx, never()).raiseError(any(Exception.class));
     assertEquals(1, connector.advisoryPollCountForTest());
   }
 

--- a/src/test/java/com/snowflake/kafka/connector/internal/StandardSnowflakeConnectionServiceAdvisoryTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/StandardSnowflakeConnectionServiceAdvisoryTest.java
@@ -44,7 +44,8 @@ public class StandardSnowflakeConnectionServiceAdvisoryTest {
     String json =
         "{\"messages\":[{\"level\":\"WARN\",\"code\":\"DEPRECATED_VERSION\",\"text\":\"upgrade\"}]}";
     List<AdvisoryMessage> msgs =
-        serviceWith(mockConnReturning(json)).getKcAdvisoryMessages("{\"connectorVersion\":\"4.1.0\"}");
+        serviceWith(mockConnReturning(json))
+            .getKcAdvisoryMessages("{\"connectorVersion\":\"4.1.0\"}");
     assertEquals(1, msgs.size());
     assertEquals("WARN", msgs.get(0).getLevel());
     assertEquals("DEPRECATED_VERSION", msgs.get(0).getCode());

--- a/src/test/java/com/snowflake/kafka/connector/internal/StandardSnowflakeConnectionServiceAdvisoryTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/StandardSnowflakeConnectionServiceAdvisoryTest.java
@@ -1,0 +1,76 @@
+package com.snowflake.kafka.connector.internal;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.snowflake.kafka.connector.internal.advisory.AdvisoryMessage;
+import java.lang.reflect.Field;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class StandardSnowflakeConnectionServiceAdvisoryTest {
+
+  private static StandardSnowflakeConnectionService serviceWith(Connection conn) throws Exception {
+    org.objenesis.Objenesis objenesis = new org.objenesis.ObjenesisStd();
+    StandardSnowflakeConnectionService svc =
+        objenesis.newInstance(StandardSnowflakeConnectionService.class);
+    Field connField = StandardSnowflakeConnectionService.class.getDeclaredField("conn");
+    connField.setAccessible(true);
+    connField.set(svc, conn);
+    Field loggerField = StandardSnowflakeConnectionService.class.getDeclaredField("LOGGER");
+    loggerField.setAccessible(true);
+    loggerField.set(svc, new KCLogger(StandardSnowflakeConnectionService.class.getName()));
+    return svc;
+  }
+
+  private static Connection mockConnReturning(String json) throws Exception {
+    Connection conn = mock(Connection.class);
+    when(conn.isClosed()).thenReturn(false);
+    PreparedStatement stmt = mock(PreparedStatement.class);
+    ResultSet rs = mock(ResultSet.class);
+    when(conn.prepareStatement(anyString())).thenReturn(stmt);
+    when(stmt.executeQuery()).thenReturn(rs);
+    when(rs.next()).thenReturn(true);
+    when(rs.getString(1)).thenReturn(json);
+    return conn;
+  }
+
+  @Test
+  public void parsesMessages() throws Exception {
+    String json =
+        "{\"messages\":[{\"level\":\"WARN\",\"code\":\"DEPRECATED_VERSION\",\"text\":\"upgrade\"}]}";
+    List<AdvisoryMessage> msgs =
+        serviceWith(mockConnReturning(json)).getKcAdvisoryMessages("{\"connectorVersion\":\"4.1.0\"}");
+    assertEquals(1, msgs.size());
+    assertEquals("WARN", msgs.get(0).getLevel());
+    assertEquals("DEPRECATED_VERSION", msgs.get(0).getCode());
+    assertEquals("upgrade", msgs.get(0).getText());
+  }
+
+  @Test
+  public void emptyMessages_returnsEmptyList() throws Exception {
+    List<AdvisoryMessage> msgs =
+        serviceWith(mockConnReturning("{\"messages\":[]}")).getKcAdvisoryMessages("{}");
+    assertTrue(msgs.isEmpty());
+  }
+
+  @Test
+  public void sqlException_failsSafeToEmptyList() throws Exception {
+    Connection conn = mock(Connection.class);
+    when(conn.isClosed()).thenReturn(false);
+    when(conn.prepareStatement(anyString())).thenThrow(new SQLException("function does not exist"));
+    List<AdvisoryMessage> msgs = serviceWith(conn).getKcAdvisoryMessages("{}");
+    assertTrue(msgs.isEmpty()); // must not throw
+  }
+
+  @Test
+  public void malformedJson_failsSafeToEmptyList() throws Exception {
+    List<AdvisoryMessage> msgs =
+        serviceWith(mockConnReturning("{not json")).getKcAdvisoryMessages("{}");
+    assertTrue(msgs.isEmpty()); // must not throw
+  }
+}

--- a/src/test/java/com/snowflake/kafka/connector/internal/StandardSnowflakeConnectionServiceAdvisoryTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/StandardSnowflakeConnectionServiceAdvisoryTest.java
@@ -41,6 +41,8 @@ public class StandardSnowflakeConnectionServiceAdvisoryTest {
 
   @Test
   public void parsesMessages() throws Exception {
+    // "code" field is retained in the JSON to verify it is ignored (AdvisoryMessage no longer has
+    // a code field; @JsonIgnoreProperties ensures the stray field is silently discarded).
     String json =
         "{\"messages\":[{\"level\":\"WARN\",\"code\":\"DEPRECATED_VERSION\",\"text\":\"upgrade\"}]}";
     List<AdvisoryMessage> msgs =
@@ -48,7 +50,6 @@ public class StandardSnowflakeConnectionServiceAdvisoryTest {
             .getKcAdvisoryMessages("{\"connectorVersion\":\"4.1.0\"}");
     assertEquals(1, msgs.size());
     assertEquals("WARN", msgs.get(0).getLevel());
-    assertEquals("DEPRECATED_VERSION", msgs.get(0).getCode());
     assertEquals("upgrade", msgs.get(0).getText());
   }
 

--- a/src/test/java/com/snowflake/kafka/connector/internal/advisory/AdvisoryLevelTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/advisory/AdvisoryLevelTest.java
@@ -1,0 +1,21 @@
+package com.snowflake.kafka.connector.internal.advisory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class AdvisoryLevelTest {
+
+  @Test
+  public void mapsKnownLevelsCaseInsensitively() {
+    assertEquals(AdvisoryLevel.INFO, AdvisoryLevel.fromString("INFO"));
+    assertEquals(AdvisoryLevel.WARN, AdvisoryLevel.fromString("warn"));
+    assertEquals(AdvisoryLevel.ERROR, AdvisoryLevel.fromString("Error"));
+  }
+
+  @Test
+  public void unknownOrNullDefaultsToWarn() {
+    assertEquals(AdvisoryLevel.WARN, AdvisoryLevel.fromString("bogus"));
+    assertEquals(AdvisoryLevel.WARN, AdvisoryLevel.fromString(null));
+  }
+}

--- a/src/test/java/com/snowflake/kafka/connector/internal/advisory/AdvisoryLevelTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/advisory/AdvisoryLevelTest.java
@@ -14,6 +14,13 @@ public class AdvisoryLevelTest {
   }
 
   @Test
+  public void mapsCriticalCaseInsensitively() {
+    assertEquals(AdvisoryLevel.CRITICAL, AdvisoryLevel.fromString("critical"));
+    assertEquals(AdvisoryLevel.CRITICAL, AdvisoryLevel.fromString("CRITICAL"));
+    assertEquals(AdvisoryLevel.CRITICAL, AdvisoryLevel.fromString("Critical"));
+  }
+
+  @Test
   public void unknownOrNullDefaultsToWarn() {
     assertEquals(AdvisoryLevel.WARN, AdvisoryLevel.fromString("bogus"));
     assertEquals(AdvisoryLevel.WARN, AdvisoryLevel.fromString(null));


### PR DESCRIPTION
## Summary
Connector side of the server→client advisory channel. On startup the connector calls `SYSTEM$GET_KC_ADVISORY_MESSAGES` (paired GS PR, SNOW-3648284) with its version, logs each returned advisory at its level, and hard-fails on a `critical` advisory.

JIRA: SNOW-3648284 (related: SNOW-3648295). Paired GS PR: snowflake-eng/snowflake#477195.

## Requirements (agreed with Seb)

1. **Server delivers advisories the connector acts on.** Each rule = an explicit list of exact connector **versions** + a **level**: `info`/`warn`/`error` (log at that level) or `critical` (log **and** refuse to start).
2. **We control it, no release.** Rules live in a Snowflake-side account parameter (JSON) that we/support set per-account or fleet-wide via parameter rollout — the customer never configures it, and there's no connector/GS release to change what's shown.
3. **Generic contract.** Connector knows a fixed action set (log at level / fail); server decides when each fires. New conditions never touch the connector.
4. **Failure handling.** Mechanism errors (GS doesn't have the function yet mid-rollout, JDBC/parse issues) → log + continue, never hard-fail. `critical` → hard-fail, gated by connector setting `snowflake.feature.fail_on_critical_advisory` (default **true**, user-overridable); the failure log says how to override.
5. **Off until we set the parameter** — ships dark.
6. **Cadence:** startup **and** periodic re-poll. A background poller re-checks on a fixed interval (`snowflake.feature.advisory_poll_interval_seconds`, default 3600s; `<=0` disables). A CRITICAL advisory is enforced whether seen at startup or mid-run (see the periodic bullet below), honoring the same `fail_on_critical` opt-out.
7. **Request context** = the config subset the connector already sends via telemetry (v1: connectorVersion).

Example policy (what we'd put in the parameter):
```json
{
  "rules": [
    { "versions": ["4.0.0", "4.1.0", "4.2.0"], "level": "warn",
      "text": "Kafka Connector {version} is deprecated; upgrade to >= 4.3.0." },
    { "versions": ["4.1.0", "4.2.0"], "level": "critical",
      "text": "KC {version} has a known data-loss bug; refusing to start. Upgrade to >= 4.3.0. To keep running anyway (not recommended): snowflake.feature.fail_on_critical_advisory=false." }
  ]
}
```
Extensible later without schema break: version ranges, and config-value conditions (`whenConfig`).

## KC side (this PR)
- `getKcAdvisoryMessages(requestJson)` on `SnowflakeConnectionService` (impl + Caching delegation): `SELECT SYSTEM$GET_KC_ADVISORY_MESSAGES(?)`, parse `{level,text}` messages. **Fail-safe** — empty list on any error (old GS w/o the function, JDBC/parse), never throws.
- `AdvisoryLevel` (info/warn/error/critical) maps to the KCLogger call.
- `SnowflakeStreamingSinkConnector.start()` logs each advisory; on `critical` it throws (`ERROR_5031`) to abort startup **iff** `snowflake.feature.fail_on_critical_advisory` (default `true`) is set — the failure message tells the user how to override. Mechanism errors never abort startup.

- **Periodic polling:** after startup, `SnowflakeStreamingSinkConnector` schedules a daemon single-thread `ScheduledExecutorService` that re-polls `SYSTEM$GET_KC_ADVISORY_MESSAGES` every `snowflake.feature.advisory_poll_interval_seconds` (default 3600s; `<=0` disables). Mid-run polls are **log-only** — a running connector is never aborted by a late `critical` (only the startup check hard-fails); poll exceptions are swallowed so the poller keeps running. The executor is shut down in `stop()`.

## Testing
- Unit: `StandardSnowflakeConnectionServiceAdvisoryTest` (parse / empty / SQL-error fail-safe / malformed-JSON fail-safe), `AdvisoryLevelTest` (level mapping incl. critical, unknown→WARN), `SnowflakeStreamingSinkConnectorAdvisoryTest` (`hasCritical` decision).
- Full plugin jar builds; google-java-format clean.
- Real `getKcAdvisoryMessages` verified against a live SUT running the deployed GS function.


### e2e validation on a live SUT (new schema)
Against a local SUT running the paired GS build (snowflake-eng/snowflake#477195), driving the connector's real `getKcAdvisoryMessages` + `logServerAdvisories()` over JDBC — **3/3 passed**:
- **warn** advisory → logged at WARN, startup continues;
- **critical** advisory → hard-fails startup (`ERROR_5031`, "refusing to start") with the default `snowflake.feature.fail_on_critical_advisory=true`;
- `snowflake.feature.fail_on_critical_advisory=false` → logs the critical advisory and **continues**.

(Server side validated in the paired GS PR via Snowfort `test_kc_advisory_messages.py` 3/3 + SQL smoke.)

**Periodic-polling e2e:** with `snowflake.feature.advisory_poll_interval_seconds=1` against the same live SUT, the background poller fired every cycle (verified via the internal poll counter), re-logging the active advisory each tick; `<=0` disabled scheduling entirely.

**Mid-run abort e2e:** set `KC_ADVISORY_MESSAGES_POLICY` to a `critical` rule for the connector's version on the live SUT; the deployed `SYSTEM$GET_KC_ADVISORY_MESSAGES` returned the critical, and the connector's real `KcAdvisoryResponse` parse + `pollAdvisories` aborted the connector via `raiseError`/ERROR_5031 (log: *“Aborting connector: a critical server advisory now applies…”*). With `fail_on_critical=false` and with the empty policy, no abort occurred. (JDBC transport unchanged from the periodic e2e; this profile has no SF JDBC gateway, so the live round-trip used the GS-direct query channel.)


