### PR TITLE
add support for typed headers

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/Constants.java
+++ b/src/main/java/com/snowflake/kafka/connector/Constants.java
@@ -83,6 +83,10 @@ public final class Constants {
         "snowflake.feature.validation.error.table.name";
     public static final boolean SNOWFLAKE_FEATURE_VALIDATION_ERROR_TABLE_NAME_DEFAULT = true;
 
+    public static final String SNOWFLAKE_FEATURE_STRUCTURED_HEADERS =
+        "snowflake.feature.structured.headers";
+    public static final boolean SNOWFLAKE_FEATURE_STRUCTURED_HEADERS_DEFAULT = false;
+
     // Caching
     public static final String CACHE_TABLE_EXISTS = "snowflake.cache.table.exists";
     public static final boolean CACHE_TABLE_EXISTS_DEFAULT = true;

--- a/src/main/java/com/snowflake/kafka/connector/config/ConnectorConfigDefinition.java
+++ b/src/main/java/com/snowflake/kafka/connector/config/ConnectorConfigDefinition.java
@@ -289,6 +289,19 @@ public class ConnectorConfigDefinition {
             4,
             Width.NONE,
             KafkaConnectorConfigParams.SNOWFLAKE_STREAMING_METADATA_CONNECTOR_PUSH_TIME)
+        .define(
+            KafkaConnectorConfigParams.SNOWFLAKE_FEATURE_STRUCTURED_HEADERS,
+            BOOLEAN,
+            KafkaConnectorConfigParams.SNOWFLAKE_FEATURE_STRUCTURED_HEADERS_DEFAULT,
+            LOW,
+            "When true, Kafka record headers are written to RECORD_METADATA:headers preserving"
+                + " their converted structured types (objects, arrays, numbers, booleans). When"
+                + " false (default), header values are flattened to strings. Enabling this is a"
+                + " breaking change for consumers that rely on the legacy string representation.",
+            SNOWFLAKE_METADATA_FLAGS_DOC,
+            5,
+            Width.NONE,
+            KafkaConnectorConfigParams.SNOWFLAKE_FEATURE_STRUCTURED_HEADERS)
 
         // Connector Config
         .define(

--- a/src/main/java/com/snowflake/kafka/connector/records/KafkaRecordConverter.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/KafkaRecordConverter.java
@@ -72,15 +72,28 @@ public final class KafkaRecordConverter {
             + " HoistField transformer to wrap the value of the record.");
   }
 
-  public static Map<String, String> convertHeaders(Headers headers) {
-    Map<String, String> result = new HashMap<>();
+  /**
+   * Converts Kafka record headers into a map suitable for {@code RECORD_METADATA:headers}.
+   *
+   * <p>Each header has already been deserialized by the worker's {@code header.converter} into a
+   * {@link org.apache.kafka.connect.data.SchemaAndValue}. When {@code structured} is true the
+   * converted value keeps its type (objects become maps, arrays become lists, numbers/booleans stay
+   * native), so structured headers land as VARIANT objects rather than strings. When false, every
+   * value is flattened to a string (the original KC v4 behavior, which is not KC v3-compatible).
+   */
+  public static Map<String, Object> convertHeaders(Headers headers, boolean structured) {
+    Map<String, Object> result = new HashMap<>();
     if (headers == null) {
       LOGGER.trace("Headers is null, returning empty map");
       return result;
     }
     for (Header header : headers) {
       Object headerValue = convertValue(header.schema(), header.value());
-      result.put(header.key(), headerValue == null ? null : String.valueOf(headerValue));
+      if (structured) {
+        result.put(header.key(), headerValue);
+      } else {
+        result.put(header.key(), headerValue == null ? null : String.valueOf(headerValue));
+      }
     }
     return result;
   }

--- a/src/main/java/com/snowflake/kafka/connector/records/SnowflakeMetadataConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/SnowflakeMetadataConfig.java
@@ -1,5 +1,7 @@
 package com.snowflake.kafka.connector.records;
 
+import static com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams.SNOWFLAKE_FEATURE_STRUCTURED_HEADERS;
+import static com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams.SNOWFLAKE_FEATURE_STRUCTURED_HEADERS_DEFAULT;
 import static com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams.SNOWFLAKE_METADATA_ALL;
 import static com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams.SNOWFLAKE_METADATA_CREATETIME;
 import static com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams.SNOWFLAKE_METADATA_OFFSET_AND_PARTITION;
@@ -19,6 +21,7 @@ public class SnowflakeMetadataConfig {
   final boolean topicFlag;
   final boolean offsetAndPartitionFlag;
   final boolean allFlag;
+  final boolean structuredHeadersFlag;
 
   /** initialize with default config */
   public SnowflakeMetadataConfig() {
@@ -40,6 +43,11 @@ public class SnowflakeMetadataConfig {
         Optional.ofNullable(config.get(SNOWFLAKE_STREAMING_METADATA_CONNECTOR_PUSH_TIME))
             .map(Boolean::parseBoolean)
             .orElse(SNOWFLAKE_STREAMING_METADATA_CONNECTOR_PUSH_TIME_DEFAULT);
+
+    structuredHeadersFlag =
+        Optional.ofNullable(config.get(SNOWFLAKE_FEATURE_STRUCTURED_HEADERS))
+            .map(Boolean::parseBoolean)
+            .orElse(SNOWFLAKE_FEATURE_STRUCTURED_HEADERS_DEFAULT);
   }
 
   public boolean shouldIncludeAllMetadata() {
@@ -62,6 +70,7 @@ public class SnowflakeMetadataConfig {
         .add("topicFlag", topicFlag)
         .add("offsetAndPartitionFlag", offsetAndPartitionFlag)
         .add("allFlag", allFlag)
+        .add("structuredHeadersFlag", structuredHeadersFlag)
         .toString();
   }
 }

--- a/src/main/java/com/snowflake/kafka/connector/records/SnowflakeSinkRecord.java
+++ b/src/main/java/com/snowflake/kafka/connector/records/SnowflakeSinkRecord.java
@@ -184,7 +184,10 @@ public final class SnowflakeSinkRecord {
     // Add headers (these should be safe to convert)
     if (record.headers() != null && !record.headers().isEmpty()) {
       try {
-        metadata.put(HEADERS, KafkaRecordConverter.convertHeaders(record.headers()));
+        metadata.put(
+            HEADERS,
+            KafkaRecordConverter.convertHeaders(
+                record.headers(), metadataConfig.structuredHeadersFlag));
       } catch (Exception e) {
         // Skip headers if conversion fails
       }
@@ -203,7 +206,10 @@ public final class SnowflakeSinkRecord {
 
     // Add headers
     if (record.headers() != null && !record.headers().isEmpty()) {
-      metadata.put(HEADERS, KafkaRecordConverter.convertHeaders(record.headers()));
+      metadata.put(
+          HEADERS,
+          KafkaRecordConverter.convertHeaders(
+              record.headers(), metadataConfig.structuredHeadersFlag));
     }
 
     return metadata;

--- a/src/test/java/com/snowflake/kafka/connector/records/ConverterTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/records/ConverterTest.java
@@ -111,11 +111,50 @@ class ConverterTest {
     headers.addInt("intHeader", 42);
     headers.addBoolean("boolHeader", true);
 
-    Map<String, String> result = KafkaRecordConverter.convertHeaders(headers);
+    Map<String, Object> result = KafkaRecordConverter.convertHeaders(headers, true);
+
+    assertEquals("value", result.get("stringHeader"));
+    assertEquals(42, result.get("intHeader"));
+    assertEquals(true, result.get("boolHeader"));
+  }
+
+  @Test
+  void testConvertHeaders_LegacyStringFlattening() {
+    org.apache.kafka.connect.header.Headers headers =
+        new org.apache.kafka.connect.header.ConnectHeaders();
+    headers.addString("stringHeader", "value");
+    headers.addInt("intHeader", 42);
+    headers.addBoolean("boolHeader", true);
+
+    Map<String, Object> result = KafkaRecordConverter.convertHeaders(headers, false);
 
     assertEquals("value", result.get("stringHeader"));
     assertEquals("42", result.get("intHeader"));
     assertEquals("true", result.get("boolHeader"));
+  }
+
+  @Test
+  void testConvertHeaders_StructuredObjectHeader() {
+    // A header converter (e.g. JsonConverter) can produce a structured Map value. With structured
+    // headers enabled, that Map is preserved (lands as a VARIANT object), not flattened to a
+    // string.
+    Schema objectSchema =
+        SchemaBuilder.struct()
+            .field("key1", Schema.STRING_SCHEMA)
+            .field("key2", Schema.INT32_SCHEMA)
+            .build();
+    Struct objectValue = new Struct(objectSchema).put("key1", "value1").put("key2", 7);
+
+    ConnectHeaders headers = new ConnectHeaders();
+    headers.add("objectHeader", objectValue, objectSchema);
+
+    Map<String, Object> result = KafkaRecordConverter.convertHeaders(headers, true);
+
+    assertInstanceOf(Map.class, result.get("objectHeader"));
+    @SuppressWarnings("unchecked")
+    Map<String, Object> objectHeader = (Map<String, Object>) result.get("objectHeader");
+    assertEquals("value1", objectHeader.get("key1"));
+    assertEquals(7, objectHeader.get("key2"));
   }
 
   @Test
@@ -150,12 +189,12 @@ class ConverterTest {
     ConnectHeaders headers = new ConnectHeaders();
     headers.add("h1", schemaAndValue);
 
-    Map<String, String> result = KafkaRecordConverter.convertHeaders(headers);
+    Map<String, Object> result = KafkaRecordConverter.convertHeaders(headers, true);
 
     // The header value should contain the JSON structure as a string
     assertNotNull(result.get("h1"));
-    assertTrue(result.get("h1").contains("f1"));
-    assertTrue(result.get("h1").contains("f2"));
+    assertTrue(String.valueOf(result.get("h1")).contains("f1"));
+    assertTrue(String.valueOf(result.get("h1")).contains("f2"));
   }
 
   @Test
@@ -168,11 +207,11 @@ class ConverterTest {
     headers.add("timestampHeader", timestampValue, Timestamp.SCHEMA);
     headers.add("boolHeader", true, Schema.BOOLEAN_SCHEMA);
 
-    Map<String, String> result = KafkaRecordConverter.convertHeaders(headers);
+    Map<String, Object> result = KafkaRecordConverter.convertHeaders(headers, true);
 
     // Timestamp is formatted as ISO-8601 with millisecond precision via ISO_DATE_TIME_FORMAT
     assertEquals("1970-03-22T00:00:00.000Z", result.get("timestampHeader"));
-    assertEquals("true", result.get("boolHeader"));
+    assertEquals(true, result.get("boolHeader"));
   }
 
   @Test
@@ -184,7 +223,7 @@ class ConverterTest {
 
     headers.add("dateHeader", dateValue, Date.SCHEMA);
 
-    Map<String, String> result = KafkaRecordConverter.convertHeaders(headers);
+    Map<String, Object> result = KafkaRecordConverter.convertHeaders(headers, true);
 
     // Date should be formatted as ISO date-time string
     assertEquals("1970-03-22T00:00:00.000Z", result.get("dateHeader"));

--- a/src/test/java/com/snowflake/kafka/connector/records/SnowflakeSinkRecordTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/records/SnowflakeSinkRecordTest.java
@@ -4,6 +4,7 @@ import static com.snowflake.kafka.connector.Utils.TABLE_COLUMN_METADATA;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -296,16 +297,69 @@ class SnowflakeSinkRecordTest {
 
     SinkRecord kafkaRecord = createSinkRecordWithHeaders(schemaAndValue, headers, "key");
     SnowflakeSinkRecord record =
-        SnowflakeSinkRecord.from(kafkaRecord, createMetadataConfigWithAll(), true, false);
+        SnowflakeSinkRecord.from(
+            kafkaRecord, createMetadataConfigWithAllAndStructuredHeaders(), true, false);
 
     Map<String, Object> metadata = record.getMetadata();
     assertNotNull(metadata.get("headers"));
 
     @SuppressWarnings("unchecked")
-    Map<String, String> headersMap = (Map<String, String>) metadata.get("headers");
+    Map<String, Object> headersMap = (Map<String, Object>) metadata.get("headers");
+    assertEquals("testHeaderValue", headersMap.get("stringHeader"));
+    assertEquals(42, headersMap.get("intHeader"));
+    assertEquals(true, headersMap.get("boolHeader"));
+  }
+
+  @Test
+  void testMetadataWithHeaders_LegacyStringFlattening() {
+    // With structured headers disabled, every header value is flattened to a string (original KC v4
+    // behavior).
+    SchemaAndValue schemaAndValue = toConnectData("{\"data\": \"value\"}");
+
+    Headers headers = new ConnectHeaders();
+    headers.addString("stringHeader", "testHeaderValue");
+    headers.addInt("intHeader", 42);
+    headers.addBoolean("boolHeader", true);
+
+    SinkRecord kafkaRecord = createSinkRecordWithHeaders(schemaAndValue, headers, "key");
+    SnowflakeSinkRecord record =
+        SnowflakeSinkRecord.from(kafkaRecord, createMetadataConfigWithAll(), true, false);
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> headersMap = (Map<String, Object>) record.getMetadata().get("headers");
     assertEquals("testHeaderValue", headersMap.get("stringHeader"));
     assertEquals("42", headersMap.get("intHeader"));
     assertEquals("true", headersMap.get("boolHeader"));
+  }
+
+  @Test
+  void testMetadataWithStructuredObjectHeader() {
+    // A structured (object) header value is preserved as a nested map, landing as a VARIANT object
+    // rather than a stringified representation.
+    SchemaAndValue schemaAndValue = toConnectData("{\"data\": \"value\"}");
+
+    Schema objectSchema =
+        SchemaBuilder.struct()
+            .field("key1", Schema.STRING_SCHEMA)
+            .field("key2", Schema.STRING_SCHEMA)
+            .build();
+    Struct objectValue = new Struct(objectSchema).put("key1", "value1").put("key2", "value2");
+
+    Headers headers = new ConnectHeaders();
+    headers.add("objectHeader", objectValue, objectSchema);
+
+    SinkRecord kafkaRecord = createSinkRecordWithHeaders(schemaAndValue, headers, "key");
+    SnowflakeSinkRecord record =
+        SnowflakeSinkRecord.from(
+            kafkaRecord, createMetadataConfigWithAllAndStructuredHeaders(), true, false);
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> headersMap = (Map<String, Object>) record.getMetadata().get("headers");
+    assertInstanceOf(Map.class, headersMap.get("objectHeader"));
+    @SuppressWarnings("unchecked")
+    Map<String, Object> objectHeader = (Map<String, Object>) headersMap.get("objectHeader");
+    assertEquals("value1", objectHeader.get("key1"));
+    assertEquals("value2", objectHeader.get("key2"));
   }
 
   @Test
@@ -319,12 +373,13 @@ class SnowflakeSinkRecordTest {
 
     SinkRecord kafkaRecord = createSinkRecordWithHeaders(schemaAndValue, headers, "key");
     SnowflakeSinkRecord record =
-        SnowflakeSinkRecord.from(kafkaRecord, createMetadataConfigWithAll(), true, false);
+        SnowflakeSinkRecord.from(
+            kafkaRecord, createMetadataConfigWithAllAndStructuredHeaders(), true, false);
 
     Map<String, Object> metadata = record.getMetadata();
 
     @SuppressWarnings("unchecked")
-    Map<String, String> headersMap = (Map<String, String>) metadata.get("headers");
+    Map<String, Object> headersMap = (Map<String, Object>) metadata.get("headers");
     assertEquals(
         "{\"key1\":\"value1\",\"key2\":\"value2\"}", headersMap.get("objectAsJsonStringHeader"));
     assertEquals("testheaderstring", headersMap.get("header2"));
@@ -772,6 +827,13 @@ class SnowflakeSinkRecordTest {
   private SnowflakeMetadataConfig createMetadataConfigWithAll() {
     Map<String, String> config = new HashMap<>();
     config.put("snowflake.metadata.all", "true");
+    return new SnowflakeMetadataConfig(config);
+  }
+
+  private SnowflakeMetadataConfig createMetadataConfigWithAllAndStructuredHeaders() {
+    Map<String, String> config = new HashMap<>();
+    config.put("snowflake.metadata.all", "true");
+    config.put("snowflake.feature.structured.headers", "true");
     return new SnowflakeMetadataConfig(config);
   }
 

--- a/src/test/java/com/snowflake/kafka/connector/streaming/iceberg/IcebergIngestionIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/streaming/iceberg/IcebergIngestionIT.java
@@ -1,5 +1,6 @@
 package com.snowflake.kafka.connector.streaming.iceberg;
 
+import static com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams.SNOWFLAKE_FEATURE_STRUCTURED_HEADERS;
 import static com.snowflake.kafka.connector.internal.TestUtils.getConnectorConfigurationForStreaming;
 
 import com.snowflake.kafka.connector.ConnectorConfigTools;
@@ -30,6 +31,7 @@ import org.junit.jupiter.api.BeforeEach;
 public abstract class IcebergIngestionIT extends BaseIcebergIT {
 
   private static final int PARTITION = 0;
+
   private String topic;
 
   protected String tableName;
@@ -43,6 +45,22 @@ public abstract class IcebergIngestionIT extends BaseIcebergIT {
    */
   protected void createIcebergTable() {}
 
+  /**
+   * Enables {@code snowflake.feature.structured.headers}. Only meaningful when the target {@code
+   * RECORD_METADATA:headers} can hold VARIANT values; subclasses whose metadata schema types
+   * headers as {@code MAP(VARCHAR, VARCHAR)} must leave this off.
+   */
+  protected boolean structuredHeadersEnabled() {
+    return false;
+  }
+
+  /**
+   * Override to append structured (object/array) headers on top of the common scalar headers added
+   * by {@link #createKafkaRecord}. Only used by subclasses that both enable structured headers and
+   * have a VARIANT-capable metadata column.
+   */
+  protected void addStructuredHeaders(Headers headers) {}
+
   @BeforeEach
   public void setUp() {
     tableName = TestUtils.randomTableName();
@@ -53,6 +71,9 @@ public abstract class IcebergIngestionIT extends BaseIcebergIT {
 
     Map<String, String> config = getConnectorConfigurationForStreaming(false);
     ConnectorConfigTools.setDefaultValues(config);
+    if (structuredHeadersEnabled()) {
+      config.put(SNOWFLAKE_FEATURE_STRUCTURED_HEADERS, "true");
+    }
     SinkTaskConfig sinkTaskConfig =
         SinkTaskConfig.builderFrom(config)
             .tolerateErrors(false)
@@ -98,10 +119,9 @@ public abstract class IcebergIngestionIT extends BaseIcebergIT {
     headers.addBoolean("booleanHeader", true);
     headers.addString("stringHeader", "test");
     headers.addInt("intHeader", 123);
-    headers.addDouble("doubleHeader", 1.234);
-    headers.addFloat("floatHeader", 1.234f);
     headers.addLong("longHeader", 123L);
     headers.addShort("shortHeader", (short) 123);
+    addStructuredHeaders(headers);
     return new SinkRecord(
         topic,
         PARTITION,

--- a/src/test/java/com/snowflake/kafka/connector/streaming/iceberg/IcebergIngestionIntoVariantIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/streaming/iceberg/IcebergIngestionIntoVariantIT.java
@@ -11,15 +11,61 @@ import com.snowflake.kafka.connector.streaming.iceberg.sql.RecordWithMetadata;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.header.Headers;
 import org.junit.jupiter.api.Test;
 
 public class IcebergIngestionIntoVariantIT extends IcebergIngestionIT {
+
+  /**
+   * Expected {@code RECORD_METADATA:headers} for records built by {@link #createKafkaRecord} with
+   * structured headers enabled. The RECORD_METADATA VARIANT column preserves each converted value's
+   * type: scalars stay native, the object header lands as a nested object, and the array header as
+   * a list. This is the KC v3-compatible behavior (legacy string flattening is covered by unit
+   * tests).
+   */
+  private static final Map<String, Object> EXPECTED_HEADERS =
+      Map.of(
+          "booleanHeader",
+          true,
+          "stringHeader",
+          "test",
+          "intHeader",
+          123,
+          "longHeader",
+          123,
+          "shortHeader",
+          123,
+          "objectHeader",
+          Map.of("nestedString", "inner", "nestedInt", 7),
+          "arrayHeader",
+          List.of(1, 2, 3));
 
   @Override
   protected void createIcebergTable() {
     createIcebergTableWithColumnClause(
         tableName, "RECORD_METADATA VARIANT, RECORD_CONTENT VARIANT", V3);
+  }
+
+  @Override
+  protected boolean structuredHeadersEnabled() {
+    return true;
+  }
+
+  @Override
+  protected void addStructuredHeaders(Headers headers) {
+    Schema objectSchema =
+        SchemaBuilder.struct()
+            .field("nestedString", Schema.STRING_SCHEMA)
+            .field("nestedInt", Schema.INT32_SCHEMA)
+            .build();
+    Struct objectValue = new Struct(objectSchema).put("nestedString", "inner").put("nestedInt", 7);
+    headers.add("objectHeader", objectValue, objectSchema);
+    headers.add("arrayHeader", Arrays.asList(1, 2, 3), SchemaBuilder.array(Schema.INT32_SCHEMA));
   }
 
   @Test
@@ -61,5 +107,8 @@ public class IcebergIngestionIntoVariantIT extends IcebergIngestionIT {
                     && record.getPartition().equals(topicPartition.partition())
                     && record.getKey().equals("test")
                     && record.getSnowflakeConnectorPushTime() != null);
+    assertThat(metadataRecords)
+        .extracting(MetadataRecord::getHeaders)
+        .containsOnly(EXPECTED_HEADERS);
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/streaming/iceberg/sql/MetadataRecord.java
+++ b/src/test/java/com/snowflake/kafka/connector/streaming/iceberg/sql/MetadataRecord.java
@@ -15,7 +15,7 @@ public class MetadataRecord {
   private final Long createTime;
   private final Long logAppendTime;
   private final Long snowflakeConnectorPushTime;
-  private final Map<String, String> headers;
+  private final Map<String, Object> headers;
 
   @JsonCreator
   public MetadataRecord(
@@ -28,7 +28,7 @@ public class MetadataRecord {
       @JsonProperty("CreateTime") Long createTime,
       @JsonProperty("LogAppendTime") Long logAppendTime,
       @JsonProperty("SnowflakeConnectorPushTime") Long snowflakeConnectorPushTime,
-      @JsonProperty("headers") Map<String, String> headers) {
+      @JsonProperty("headers") Map<String, Object> headers) {
     this.offset = offset;
     this.topic = topic;
     this.partition = partition;
@@ -78,7 +78,7 @@ public class MetadataRecord {
     return snowflakeConnectorPushTime;
   }
 
-  public Map<String, String> getHeaders() {
+  public Map<String, Object> getHeaders() {
     return headers;
   }
 

--- a/test/lib/fixtures/connector.py
+++ b/test/lib/fixtures/connector.py
@@ -87,6 +87,7 @@ def create_connector(create_custom_connector, connector_version: str, request):
         *,
         v3_config: dict[str, str] = None,
         v4_config: dict[str, str] = None,
+        name_suffix: str = "",
     ):
         assert v3_config or v4_config
         assert not (v3_config and v4_config)
@@ -102,6 +103,8 @@ def create_connector(create_custom_connector, connector_version: str, request):
                 config = v4_config
             case _:
                 raise ValueError(f"Invalid connector version: {connector_version}")
-        return create_custom_connector(test_name, config)
+        # name_suffix lets a single test create multiple connectors without name
+        # collisions (create_custom_connector otherwise names them all after the test).
+        return create_custom_connector(test_name + name_suffix, config)
 
     return _create

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -28,8 +28,12 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # Unique Docker Compose project name per worktree, derived from the repo
 # directory basename. Prevents collisions when multiple worktrees run tests
 # concurrently (Docker Compose defaults to the parent directory name, which
-# is always "docker" here).
-export COMPOSE_PROJECT_NAME="$(basename "$PROJECT_ROOT")"
+# is always "docker" here). Compose project names must be lowercase, so
+# normalize the basename (worktree dirs may contain uppercase, e.g. ticket IDs)
+# and replace any remaining non-alphanumeric characters with underscores.
+# (\n is kept in the preserved set so the trailing newline isn't turned into a
+# stray underscore; command substitution then strips it.)
+export COMPOSE_PROJECT_NAME="$(basename "$PROJECT_ROOT" | tr '[:upper:]' '[:lower:]' | tr -c 'a-z0-9\n' '_')"
 
 # Colors
 RED='\033[0;31m'

--- a/test/tests/test_headers.py
+++ b/test/tests/test_headers.py
@@ -1,0 +1,174 @@
+"""End-to-end coverage for Kafka record headers across different header converters.
+
+Kafka Connect deserializes raw header bytes into structured ``ConnectHeaders``
+using the worker/connector ``header.converter`` *before* the record reaches the
+Snowflake connector. The connector then writes them to ``RECORD_METADATA:headers``.
+
+These tests exercise the **structured** behavior only: converted header values keep
+their types (objects, arrays, numbers, booleans) in ``RECORD_METADATA:headers``. On
+v4 this requires ``snowflake.feature.structured.headers=true``; v3 preserves
+structure natively. The v3 run and the structured v4 run must agree, so the test
+asserts the *same* expected map for both versions, i.e. structured v4 == v3. (Legacy
+string flattening, the v4 flag-off default, is covered by unit tests.)
+
+The v3/v4 comparison is provided for free by the ``connector_version`` fixture,
+which reruns each test once per version.
+
+The connector config is built from ``V4_CONFIG_TEMPLATE`` and passed to the
+``create_connector`` fixture, which migrates it to v3 automatically when the
+``connector_version`` fixture selects v3. The target table is auto-created by the
+connector (schematization off). KC v3 uppercases the topic->table name while v4
+preserves it, so the topic is kept uppercase to make both versions resolve to the
+same table.
+
+All scenarios run in a single test: each gets its own topic (distinct base name)
+and its own connector (distinguished via ``name_suffix``), so they ingest
+concurrently instead of one sequential connector startup per scenario.
+"""
+
+import base64
+import json
+from dataclasses import dataclass
+
+import pytest
+
+from lib.config_migration import V4_CONFIG_TEMPLATE
+from lib.fixtures.table import Table
+
+RECORD = b'{"number": "1"}'
+
+
+@dataclass
+class Scenario:
+    # Extra connector config selecting the header.converter (may be empty).
+    converter_config: dict[str, str]
+    # Raw header bytes sent to Kafka; the converter decides how to parse them.
+    headers: list[tuple[str, bytes]]
+    # Expected RECORD_METADATA:headers when structured headers are preserved.
+    # Must hold for both v3 and structured v4.
+    expected: dict[str, object]
+
+
+# Keyed by a short id used verbatim in the per-variant topic/table base name.
+SCENARIOS = {
+    # Default SimpleHeaderConverter: infers types from the literal via Kafka's
+    # Values parser. Note the parser's quirk: "{}" parses to an empty array.
+    "simple": Scenario(
+        converter_config={},
+        headers=[
+            ("h_string", b"value1"),
+            ("h_number", b"42"),
+            ("h_object", b"{}"),
+        ],
+        expected={
+            "h_string": "value1",
+            "h_number": 42,
+            "h_object": [],
+        },
+    ),
+    # JsonConverter (schemas off): parses JSON header bytes into native types.
+    "json": Scenario(
+        converter_config={
+            "header.converter": "org.apache.kafka.connect.json.JsonConverter",
+            "header.converter.schemas.enable": "false",
+        },
+        headers=[
+            ("h_string", b'"hello"'),
+            ("h_number", b"42"),
+            ("h_bool", b"true"),
+            ("h_object", b'{"a":1,"b":"x"}'),
+            ("h_array", b"[1,2,3]"),
+        ],
+        expected={
+            "h_string": "hello",
+            "h_number": 42,
+            "h_bool": True,
+            "h_object": {"a": 1, "b": "x"},
+            "h_array": [1, 2, 3],
+        },
+    ),
+    # StringConverter: every header stays a UTF-8 string (JSON text is not parsed).
+    "text": Scenario(
+        converter_config={
+            "header.converter": "org.apache.kafka.connect.storage.StringConverter",
+        },
+        headers=[
+            ("h_string", b"hello"),
+            ("h_json_text", b'{"a":1}'),
+        ],
+        expected={
+            "h_string": "hello",
+            "h_json_text": '{"a":1}',
+        },
+    ),
+    # ByteArrayConverter: header value stays a byte[], which the SDK serializes as
+    # base64 in the structured VARIANT.
+    "byte": Scenario(
+        converter_config={
+            "header.converter": "org.apache.kafka.connect.converters.ByteArrayConverter",
+        },
+        headers=[
+            ("h_bytes", b"hello"),
+        ],
+        expected={
+            "h_bytes": base64.b64encode(b"hello").decode("ascii"),
+        },
+    ),
+}
+
+
+@pytest.mark.correctness
+def test_headers(
+    driver,
+    connector_version,
+    create_connector,
+    create_topics,
+    wait_for_rows,
+):
+    # Uppercase topics: the connector auto-creates the table, and v3 uppercases the
+    # topic->table name while v4 preserves it. Keeping the topics uppercase makes
+    # both land on the same table name.
+    topics = {
+        scenario_id: create_topics(
+            [f"HEADERS_{scenario_id.upper()}"], with_tables=False
+        )[0]
+        for scenario_id in SCENARIOS
+    }
+
+    # One connector per scenario, all started before any ingestion so they run
+    # concurrently.
+    connectors = {}
+    for scenario_id, scenario in SCENARIOS.items():
+        config = {
+            **V4_CONFIG_TEMPLATE,
+            "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+            "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+            "value.converter.schemas.enable": "false",
+            "snowflake.enable.schematization": "false",
+            "topics": topics[scenario_id],
+            **scenario.converter_config,
+        }
+        # v4 needs the flag; v3 preserves structure natively (rejects the v4-only flag).
+        if connector_version == "v4":
+            config["snowflake.feature.structured.headers"] = "true"
+        connectors[scenario_id] = create_connector(
+            v4_config=config, name_suffix=f"_{scenario_id}"
+        )
+
+    driver.startConnectorWaitTime()
+
+    for scenario_id, scenario in SCENARIOS.items():
+        driver.sendBytesData(
+            topics[scenario_id], [RECORD], partition=0, headers=scenario.headers
+        )
+
+    for scenario_id, scenario in SCENARIOS.items():
+        table = Table(driver, topics[scenario_id])
+        wait_for_rows(table.name, 1, connector_name=connectors[scenario_id].name)
+
+        rows = table.select("record_metadata", "WHERE record_metadata:offset::int = 0")
+        assert rows, f"{scenario_id}: no row at offset 0"
+        headers = json.loads(rows[0]["RECORD_METADATA"])["headers"]
+        assert headers == scenario.expected, (
+            f"{scenario_id}: {headers} != {scenario.expected}"
+        )

--- a/test/tests/test_string_json.py
+++ b/test/tests/test_string_json.py
@@ -35,7 +35,10 @@ def test_string_json(
     )
     topic = f"{FILE_NAME}{name_salt}"
 
-    create_connector_from_file(CONFIG_FILE)
+    create_connector_from_file(
+        CONFIG_FILE,
+        config_overrides={"snowflake.feature.structured.headers": "true"},
+    )
     driver.startConnectorWaitTime()
 
     # -- Send --
@@ -52,18 +55,12 @@ def test_string_json(
     rows = table.select("record_metadata", "WHERE record_metadata:offset::int = 0")
     record_metadata = json.loads(rows[0]["RECORD_METADATA"])
 
-    match connector_version:
-        case "v3":
-            expected_header2 = []
-        case "v4":
-            expected_header2 = "[]"
-
     assert record_metadata == {
         "CreateTime": ANY_INT,
         "SnowflakeConnectorPushTime": ANY_INT,
         "headers": {
             "header1": "value1",
-            "header2": expected_header2,
+            "header2": [],
         },
         "offset": 0,
         "partition": 0,


### PR DESCRIPTION
SNOW-3214907

## Summary

Kafka Connect deserializes raw header bytes into typed values using the configured `header.converter` before a record reaches the connector. The connector writes those values to `RECORD_METADATA:headers`.

Today the connector flattens every header value to a string (`String.valueOf(...)`) before writing it, so type information from the `header.converter` is lost. This PR restores the ability to preserve those types, gated behind a new feature flag.

## Behavior

`snowflake.feature.structured.headers` (default `false`):

- **`false` (default, unchanged):** every header value is stringified in `RECORD_METADATA:headers`. A numeric header `42` is stored as `"42"`, a boolean as `"true"`, an object as its string rendering, etc.
- **`true`:** header values keep the type produced by the `header.converter`. Numbers, booleans, objects, and arrays are stored as well-typed VARIANT fields in `RECORD_METADATA:headers` (byte-array headers are base64-encoded). This matches how KC v3 wrote headers.

The default is `false` because changing the stored representation of existing headers is a breaking change for downstream consumers that parse `RECORD_METADATA:headers`.