### PR TITLE
SNOW-3766306: align client REAL/semi-structured validation to SSv2 XP

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/validation/DataValidationUtil.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/validation/DataValidationUtil.java
@@ -74,9 +74,10 @@ class DataValidationUtil {
   public static final int BYTES_8_MB = 8 * 1024 * 1024;
   public static final int BYTES_16_MB = 2 * BYTES_8_MB;
 
-  // TODO SNOW-664249: There is a few-byte mismatch between the value sent by the user and its
-  // server-side representation. Validation leaves a small buffer for this difference.
-  static final int MAX_SEMI_STRUCTURED_LENGTH = BYTES_16_MB - 64;
+  // Aligned to XP DEFAULT_MAX_LOB_LENGTH (16,777,216). NOTE: the client measures the minified
+  // JSON-string byte length while XP limits the ObjectData binary encoding — different quantities,
+  // so this is a close proxy, not a byte-perfect match (SNOW-664249, SNOW-3766306).
+  static final int MAX_SEMI_STRUCTURED_LENGTH = BYTES_16_MB;
 
   private static final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -1038,14 +1039,17 @@ class DataValidationUtil {
       try {
         return Double.parseDouble(stringInput);
       } catch (NumberFormatException err) {
-        stringInput = stringInput.toLowerCase();
-        switch (stringInput) {
+        String v = stringInput.toLowerCase();
+        boolean neg = v.startsWith("-");
+        if (v.startsWith("+") || v.startsWith("-")) {
+          v = v.substring(1);
+        }
+        switch (v) {
           case "nan":
             return Double.NaN;
           case "inf":
-            return Double.POSITIVE_INFINITY;
-          case "-inf":
-            return Double.NEGATIVE_INFINITY;
+          case "infinity":
+            return neg ? Double.NEGATIVE_INFINITY : Double.POSITIVE_INFINITY;
           default:
             throw valueFormatNotAllowedException(
                 columnName, "REAL", "Not a valid decimal number", insertRowIndex);

--- a/src/test/java/com/snowflake/kafka/connector/internal/validation/DataValidationUtilTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/validation/DataValidationUtilTest.java
@@ -1061,19 +1061,19 @@ public class DataValidationUtilTest {
         ErrorCode.INVALID_VALUE_ROW,
         "The given row cannot be converted to the internal format due to invalid value: Value"
             + " cannot be ingested into Snowflake column COL of type VARIANT, rowIndex:0, reason:"
-            + " Variant too long: length=18874376 maxLength=16777152",
+            + " Variant too long: length=18874376 maxLength=16777216",
         () -> validateAndParseVariant("COL", m, 0));
     expectErrorCodeAndMessage(
         ErrorCode.INVALID_VALUE_ROW,
         "The given row cannot be converted to the internal format due to invalid value: Value"
             + " cannot be ingested into Snowflake column COL of type ARRAY, rowIndex:0, reason:"
-            + " Array too large. length=18874378 maxLength=16777152",
+            + " Array too large. length=18874378 maxLength=16777216",
         () -> validateAndParseArray("COL", m, 0));
     expectErrorCodeAndMessage(
         ErrorCode.INVALID_VALUE_ROW,
         "The given row cannot be converted to the internal format due to invalid value: Value"
             + " cannot be ingested into Snowflake column COL of type OBJECT, rowIndex:0, reason:"
-            + " Object too large. length=18874376 maxLength=16777152",
+            + " Object too large. length=18874376 maxLength=16777216",
         () -> validateAndParseObject("COL", m, 0));
   }
 
@@ -1713,6 +1713,24 @@ public class DataValidationUtilTest {
     } catch (JsonProcessingException e) {
       throw new RuntimeException(e);
     }
+  }
+
+  // ================ XP-parity scalar/semi-structured tests (SNOW-3766306) ================
+
+  @Test
+  public void real_acceptsServerInfNanSpellings() {
+    assertEquals(Double.POSITIVE_INFINITY, validateAndParseReal("COL", "+inf", 0), 0.0);
+    assertEquals(Double.POSITIVE_INFINITY, validateAndParseReal("COL", "infinity", 0), 0.0);
+    assertEquals(Double.POSITIVE_INFINITY, validateAndParseReal("COL", "INFINITY", 0), 0.0);
+    assertEquals(Double.NEGATIVE_INFINITY, validateAndParseReal("COL", "-inf", 0), 0.0);
+    Assert.assertTrue(Double.isNaN(validateAndParseReal("COL", "+nan", 0)));
+  }
+
+  @Test
+  public void variant_acceptsUpToServerLimit() {
+    // A minified JSON string just under 16MB (previously rejected by the 64-byte margin).
+    String almost = "\"" + buildString("a", DataValidationUtil.BYTES_16_MB - 2) + "\"";
+    validateAndParseVariant("COL", almost, 0); // must not throw
   }
 
   // ================ XP-parity temporal tests (SNOW-3766306) ================


### PR DESCRIPTION
## Context
Stacked on #1522 (temporal XP-parity). Same root cause: the client-side validator (a SSv1-SDK port) diverges from what the SSv2 XP server accepts. This PR covers the scalar / semi-structured gaps.

## JIRA
SNOW-3766306

## Changes (align-acceptance to XP)
- **REAL**: accept the server's inf/nan spellings — strip a leading `+`, case-insensitive `nan`/`inf`/`infinity`. Previously `"+inf"`, `"+nan"`, `"infinity"`, `"INFINITY"` were rejected client-side (→ spurious DLQ) though XP accepts them. `-inf`/`inf`/`nan` behavior unchanged.
- **Semi-structured (VARIANT/ARRAY/OBJECT)**: raise `MAX_SEMI_STRUCTURED_LENGTH` from `16MB − 64` to the server's `16,777,216`. NOTE documented in code: the client measures the minified **JSON-string** byte length while XP limits the **ObjectData binary encoding** — different quantities, so this is a close proxy, not a byte-perfect match.

## Testing
`DataValidationUtilTest`: 38 tests green, incl. new `real_acceptsServerInfNanSpellings` and `variant_acceptsUpToServerLimit`; one existing max-length assertion updated to the new limit. `google-java-format` applied.

## Note
Stacked PR — review/merge #1522 first.