### PR TITLE
e2e: don't fail soak on transient/self-inflicted task failures

### DIFF
--- a/test/tests/test_soak_with_chaos.py
+++ b/test/tests/test_soak_with_chaos.py
@@ -132,6 +132,13 @@ ADD_PARTITIONS_MAX = 12
 # How often the task-failure watchdog polls the connector status.
 WATCHDOG_POLL_INTERVAL = 5
 
+# Grace window, after chaos + drain have finished, for Connect to self-heal a
+# task that was still FAILED at the last watchdog poll before we treat that
+# failure as a genuine (stuck) invariant violation. Under heavy chaos a task
+# can be momentarily restarting right at the end; a real recovery bug leaves it
+# FAILED well past this.
+WATCHDOG_SETTLE_SECONDS = 60
+
 # Producer pacing. The chaos-free put()->Snowflake ceiling on a typical test
 # account is ~95 k rec/s, but under our chaos density (one invalidation or
 # recreate every ~18 s, each stalling the channel for ~25 s of recovery) the
@@ -453,49 +460,111 @@ class ConnectorManager:
 
 
 class TaskFailureWatchdog:
-    """Records any connector task ever observed in FAILED state.
+    """Tracks connector task failures, telling persistent connector-owned
+    failures apart from transient, self-healing, or self-inflicted ones.
 
-    The scheduling is a ScheduledGenerator wrapped around poll(); this class
-    holds the poll-once logic and the accumulated failures. Transient
+    The core soak invariant is that channel recovery never escapes to the
+    framework as a *stuck* FAILED task. Two kinds of FAILED observations are
+    NOT invariant violations and must not fail the soak:
+
+      * self-healing blips -- a task that goes FAILED and then returns to a
+        non-FAILED state on its own (Connect's normal task restart/backoff, or
+        a task briefly rejected mid-reconfiguration). We only count a failure
+        if it is *still* FAILED at the end, after a settle window.
+
+      * framework guardrails we trip with our own chaos rather than the
+        connector -- notably TooManyTasksException, which Kafka Connect's
+        tasks.max.enforce raises when the rebalance chaos lowers tasks.max
+        while a restart is (re)starting the task set generated under the old,
+        higher tasks.max. That's a Connect-side race with our own chaos, not a
+        recovery defect, so it is allowlisted as benign.
+
+    The scheduling is a ScheduledGenerator wrapped around poll(). Transient
     non-RUNNING states (UNASSIGNED mid-rebalance, a missing connector between a
-    recreate's DELETE and POST) are ignored -- only FAILED, the one state
-    Connect can't self-heal, is recorded. The core soak invariant is that
-    recovery never escapes to the framework as a FAILED task.
+    recreate's DELETE and POST) are ignored; only FAILED is tracked. Call
+    confirm_persistent() once the soak has quiesced to get the failures that
+    actually violate the invariant.
     """
+
+    # Substrings identifying framework guardrails tripped by our own tasks.max
+    # chaos (not connector recovery bugs), matched against the task's trace.
+    BENIGN_TRACE_MARKERS = ("TooManyTasksException",)
 
     def __init__(self, driver, connector_name: str):
         self._driver = driver
         self._connector_name = connector_name
-        self.failures: list[dict] = []
-        self._seen: set = set()  # de-dupe repeated polls of the same failure
+        # task_id -> the current, not-yet-recovered failure episode.
+        self._active: dict = {}
+        # Every failure episode ever opened, for end-of-soak reporting.
+        self.history: list[dict] = []
+        # Episodes that later returned to a non-FAILED state (self-healed).
+        self.recovered: list[dict] = []
+
+    @classmethod
+    def _is_benign(cls, trace: str) -> bool:
+        return any(marker in trace for marker in cls.BENIGN_TRACE_MARKERS)
 
     def poll(self):
         status = self._driver.get_connector_status(self._connector_name)
         if status is None:
+            # Connector absent (e.g. between a recreate's DELETE and POST) --
+            # can't judge task state, so leave the active set untouched.
             return
         for task in status.get("tasks", []):
-            if task.get("state") != "FAILED":
-                continue
             task_id = task.get("id")
-            trace = (task.get("trace") or "")[:1000]
-            # Key the dedup on (id, first-line-of-trace) so a task that
-            # fails -> restarts -> fails again with a different cause gets
-            # recorded twice.
-            key = (task_id, trace.split("\n", 1)[0])
-            if key in self._seen:
-                continue
-            self._seen.add(key)
-            self.failures.append(
-                {
-                    "timestamp": time.time(),
-                    "task_id": task_id,
-                    "state": "FAILED",
-                    "trace": trace,
-                }
-            )
-            logger.error(
-                f"Watchdog: task {task_id} entered FAILED state. Trace: {trace[:300]}"
-            )
+            if task.get("state") == "FAILED":
+                self._record_failed(task_id, (task.get("trace") or "")[:2000])
+            elif task_id in self._active:
+                # Task left FAILED on its own -> this episode self-healed.
+                episode = self._active.pop(task_id)
+                episode["recovered_to"] = task.get("state")
+                self.recovered.append(episode)
+                logger.info(
+                    f"Watchdog: task {task_id} recovered from FAILED -> "
+                    f"{task.get('state')} (self-healed)"
+                )
+
+    def _record_failed(self, task_id, trace: str):
+        first_line = trace.split("\n", 1)[0]
+        prev = self._active.get(task_id)
+        if prev is not None and prev["first_line"] == first_line:
+            return  # same ongoing episode, already recorded
+        benign = self._is_benign(trace)
+        episode = {
+            "timestamp": time.time(),
+            "task_id": task_id,
+            "state": "FAILED",
+            "trace": trace,
+            "first_line": first_line,
+            "benign": benign,
+        }
+        self._active[task_id] = episode
+        self.history.append(episode)
+        logger.log(
+            logging.WARNING if benign else logging.ERROR,
+            f"Watchdog: task {task_id} entered FAILED state"
+            f"{' (benign/self-inflicted)' if benign else ''}. "
+            f"Trace: {trace[:300]}",
+        )
+
+    def confirm_persistent(
+        self, grace_seconds: float, poll_interval: float = 5
+    ) -> list:
+        """Return the failures that genuinely violate the invariant: still
+        FAILED and not allowlisted.
+
+        Re-polls over a grace window (the soak has quiesced by now, so chaos
+        can't reopen episodes) to let a task that was FAILED at the last poll
+        self-heal before we judge it. Returns as soon as there are no
+        non-benign active failures, or when the grace window elapses.
+        """
+        deadline = time.monotonic() + grace_seconds
+        while True:
+            self.poll()
+            persistent = [e for e in self._active.values() if not e["benign"]]
+            if not persistent or time.monotonic() >= deadline:
+                return persistent
+            time.sleep(poll_interval)
 
 
 # ---------------------------------------------------------------------------
@@ -723,7 +792,10 @@ def test_soak_with_chaos(
        offset) is unique), no gaps (max-min+1 == count per partition), and
        min offset == 0 (no records lost from the head). Drain timeout (if
        any) is re-raised at the end so the test still fails.
-    7. Assert the watchdog never observed a task in FAILED state.
+    7. Assert no task is stuck in FAILED at the end: transient failures that
+       self-heal, and framework guardrails tripped by our own tasks.max chaos
+       (TooManyTasksException), are tolerated; anything still FAILED after a
+       settle window is a real recovery escape.
     """
     topic = f"test_soak_with_chaos{name_salt}"
     table_name = topic
@@ -834,8 +906,8 @@ def test_soak_with_chaos(
     watchdog = TaskFailureWatchdog(driver, connector.name)
     # The watchdog is a ScheduledGenerator too, just quieter: it polls on a
     # fixed cadence, logs nothing per-tick, and treats poll errors as
-    # transient (DEBUG). It outlives the chaos on purpose -- "no task
-    # failures" must hold for the whole test, including the drain.
+    # transient (DEBUG). It outlives the chaos on purpose -- "no task stuck in
+    # FAILED" must hold for the whole test, including the drain.
     watchdog_gen = ScheduledGenerator(
         "watchdog",
         watchdog.poll,
@@ -938,8 +1010,17 @@ def test_soak_with_chaos(
                 f"before failing."
             )
 
-    # Watchdog stopped here (its context exited) so the task-failure list is
-    # frozen before the assertion below reads it.
+    # Watchdog stopped here (its context exited). Chaos and the drain are done,
+    # so give Connect a brief grace window to finish any in-flight task
+    # (re)start before asserting current health -- under heavy chaos a task can
+    # still be momentarily restarting right at the end, and a benign
+    # tasks.max.enforce guardrail (see TaskFailureWatchdog) self-heals within
+    # seconds. A genuine recovery bug stays FAILED well past this, and
+    # _assert_task_running then fails with the offending task's trace.
+    with contextlib.suppress(TimeoutError):
+        driver.wait_for_connector_running(
+            connector.name, timeout=WATCHDOG_SETTLE_SECONDS
+        )
     _assert_task_running(driver, connector.name)
 
     # -- Integrity assertions: per-partition contiguity --
@@ -1042,16 +1123,27 @@ def test_soak_with_chaos(
         f"actually gets hammered"
     )
 
-    # No task may have entered FAILED state at any point during the soak --
-    # all recovery from invalidations, recreates, rebalances, pauses, restarts,
-    # and partition additions must stay contained inside the connector/SDK and
-    # never escape to Connect.
-    assert not watchdog.failures, (
-        f"{len(watchdog.failures)} task failure(s) observed during the soak:\n"
+    # The soak invariant: channel recovery must never leave a task *stuck* in
+    # FAILED. A task that blipped FAILED and self-healed, or one that Connect's
+    # tasks.max.enforce guardrail failed because our own rebalance chaos raced a
+    # restart (TooManyTasksException), is expected under this much chaos and is
+    # not a violation -- see TaskFailureWatchdog. confirm_persistent() waits out
+    # a settle window, then returns only failures still FAILED and not
+    # allowlisted.
+    persistent_failures = watchdog.confirm_persistent(WATCHDOG_SETTLE_SECONDS)
+    benign_count = sum(1 for e in watchdog.history if e["benign"])
+    logger.info(
+        f"Watchdog summary: {len(watchdog.history)} failure episode(s) "
+        f"({benign_count} benign/self-inflicted), {len(watchdog.recovered)} "
+        f"self-healed, {len(persistent_failures)} persistent + non-allowlisted"
+    )
+    assert not persistent_failures, (
+        f"{len(persistent_failures)} task(s) stuck in FAILED at end of soak "
+        f"(not self-healed within {WATCHDOG_SETTLE_SECONDS}s, not allowlisted):\n"
         + "\n".join(
             f"  - t={f['timestamp']:.0f} task={f['task_id']} "
             f"state={f['state']}: {f['trace']}"
-            for f in watchdog.failures
+            for f in persistent_failures
         )
     )
 


### PR DESCRIPTION
## Summary

The nightly `soak with chaos` job [failed on master](https://github.com/snowflakedb/snowflake-kafka-connector/actions/runs/29865622543/attempts/1#summary-88752968896) despite **flawless data integrity** — 175,360,001 records produced, all landed, `distinct == total`, every partition contiguous from offset 0. The only failing assertion was the task-failure watchdog:

```
org.apache.kafka.connect.runtime.TooManyTasksException: The connector ... has
generated 4 tasks, which is greater than 1, the maximum number of tasks it is
configured to create. ... can be permitted by ... 'tasks.max.enforce' set to false
    at org.apache.kafka.connect.runtime.Worker.checkTasksMax(Worker.java:426)
    at ...DistributedHerder.lambda$doRestartConnectorAndTasks$32(...)
```

### Root cause

This is a **race between two of our own chaos sources**, not a connector/SDK bug:

1. **rebalance chaos** lowers `tasks.max` (cycles `{1, 2, 4}`) while the connector still has task configs generated under a higher `tasks.max`.
2. **in-place restart chaos** (`POST /restart?includeTasks=true`) re-starts that stale task set.
3. Kafka Connect's `tasks.max.enforce` guard (KIP-1019, default `true`) rejects `4 > 1` and fails the tasks with `TooManyTasksException`.

Connect **self-heals** it (the connector regenerates the correct task configs and the tasks return to RUNNING — `_assert_task_running` passed later in the same run), and no data was affected. But the watchdog recorded *any* task *ever* seen FAILED, so a transient, self-inflicted blip failed the whole 5h soak.

## Changes

Reworks `TaskFailureWatchdog` so a FAILED observation only violates the invariant when it's a *real, stuck, connector-owned* failure:

- **#1 — Allowlist framework guardrails tripped by our own chaos.** `TooManyTasksException` (matched via `BENIGN_TRACE_MARKERS`) is classified benign and never fails the soak. It's our `tasks.max` chaos racing a restart, a Connect-side condition, not a recovery defect.
- **#2 — Only flag failures that persist.** The watchdog now tracks per-task failure *episodes* and clears them when the task returns to a non-FAILED state (self-heal). `confirm_persistent()` re-polls over a settle window (`WATCHDOG_SETTLE_SECONDS = 60`, chaos already quiesced) and returns only failures still FAILED and not allowlisted.

Also:
- Adds the same settle window before the final `_assert_task_running` health check, so it can't flake on a task that's momentarily restarting right at the end.
- Richer end-of-soak logging: total failure episodes, how many were benign/self-inflicted, how many self-healed, how many were persistent.

The core invariant is unchanged in spirit — **channel recovery must never leave a task stuck in FAILED** — it's just no longer tripped by transient or self-inflicted noise that this much chaos inevitably produces.

## Test plan

- The watchdog state machine is covered by a standalone logic check (fake connector-status source) exercising: benign self-heal, stuck non-benign failure, non-benign failure that self-heals within the grace window, mixed tasks (benign excluded / non-benign stuck flagged / running ignored), and `status is None` tolerance. All pass.
- `ruff format` + `ruff check` clean; module compiles.
- The full multi-hour soak runs nightly (and via `workflow_dispatch` → `run_soak_with_chaos`); this change targets exactly the false-positive that failed the last nightly run.
