### PR TITLE
Bump Jackson, snowflake-jdbc, and Snowpipe Streaming SDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,10 +61,10 @@
         <protobuf.version>3.25.5</protobuf.version>
         <guava.version>33.6.0-jre</guava.version>
 
-        <jackson.version>2.22.0</jackson.version>
+        <jackson.version>2.22.1</jackson.version>
         <commons-compress.version>1.28.0</commons-compress.version>
         <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
-        <snowflake-jdbc.version>4.3.1</snowflake-jdbc.version>
+        <snowflake-jdbc.version>4.3.2</snowflake-jdbc.version>
         <slf4j-api.version>2.0.18</slf4j-api.version>
         <commons-lang3.version>3.20.0</commons-lang3.version>
         <auto-value.version>1.11.1</auto-value.version>
@@ -77,7 +77,7 @@
             http://mitmproxy:8080 destination at the request-builder layer.
             Tracking ticket: SNOW-3683451.
         -->
-        <snowpipe-streaming.version>1.6.1</snowpipe-streaming.version>
+        <snowpipe-streaming.version>1.6.2</snowpipe-streaming.version>
 
     </properties>
 

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -71,10 +71,10 @@
         <protobuf.version>3.25.5</protobuf.version>
         <guava.version>33.6.0-jre</guava.version>
 
-        <jackson.version>2.22.0</jackson.version>
+        <jackson.version>2.22.1</jackson.version>
         <commons-compress.version>1.28.0</commons-compress.version>
         <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
-        <snowflake-jdbc.version>4.3.1</snowflake-jdbc.version>
+        <snowflake-jdbc.version>4.3.2</snowflake-jdbc.version>
         <slf4j-api.version>2.0.18</slf4j-api.version>
         <parquet.version>1.14.4</parquet.version>
         <commons-lang3.version>3.20.0</commons-lang3.version>
@@ -88,7 +88,7 @@
             http://mitmproxy:8080 destination at the request-builder layer.
             Tracking ticket: SNOW-3683451.
         -->
-        <snowpipe-streaming.version>1.6.1</snowpipe-streaming.version>
+        <snowpipe-streaming.version>1.6.2</snowpipe-streaming.version>
 
     </properties>
 


### PR DESCRIPTION
Dependency bumps for the 4.1.0 release, in both `pom.xml` and `pom_confluent.xml`.

- **Jackson `2.22.0` → `2.22.1`** — fixes three advisories affecting `2.22.0` (all fixed in `2.22.1`): CVE-2026-59889 (`@JsonView` bypassed for `@JsonUnwrapped` container properties on deserialization), CVE-2026-54515 (case-insensitive deserialization bypasses per-property `@JsonIgnoreProperties`), and GHSA-r7wm-3cxj-wff9 (`jackson-core` async parser `maxNumberLength` bypass → DoS). Driven by the shared `jackson.version` property, covering `jackson-core` and `jackson-databind`.
- **snowflake-jdbc `4.3.1` → `4.3.2`** — currency bump; the JDBC is a shaded fat jar whose patch releases pick up bundled transitive fixes.
- **snowpipe-streaming (SSv2 SDK) `1.6.1` → `1.6.2`** — shaded artifact (not the `-unshaded` variant).