### PR TITLE
e2e: fix flaky test_nullable_values_after_smt ordering assertion

### DIFF
--- a/test/tests/test_nullable_values_after_smt.py
+++ b/test/tests/test_nullable_values_after_smt.py
@@ -38,8 +38,11 @@ def test_nullable_values_after_smt(
     wait_for_rows(table.name, EXPECTED_ROWS)
 
     # -- Verify content --
+    # ORDER BY offset: Snowflake does not guarantee row order without it, and
+    # the assertion below compares against an offset-ordered expected list.
     rows = table.select(
         "index, from_optional_field, record_metadata:offset::number AS offset",
+        "ORDER BY offset",
     )
 
     parsed = [


### PR DESCRIPTION
`test_nullable_values_after_smt` compares the query result against an expected list built in ascending offset order, but `table.select(...)` issued a bare `SELECT` with no `ORDER BY`. Snowflake makes no ordering guarantee without one, so the order-sensitive `assert parsed == expected` is flaky — the data (100 rows, correct indices/offsets) can come back unsorted and fail the comparison.

Observed in [run 29927307081](https://github.com/snowflakedb/snowflake-kafka-connector/actions/runs/29927307081/attempts/1) (`core_legacy apache 3.9.2, Java 11, GCP`), where the `[v3]` parametrization failed with `parsed[0]` starting at offset 164 while `[v4]` happened to come back sorted and passed.

Fix: add `ORDER BY offset` to the query. The schema-evolution sibling `test_se_nullable_values_after_smt.py` already orders by offset; this brings the SMT test in line.

I audited every other multi-row read in `test/tests/` (`table.select`, `select_scalar`, and direct `cursor.execute(...).fetchall()`): all others either filter to a single row (`WHERE offset = N`), already use `ORDER BY`, key results into a dict, or compare counts/sets. This was the only remaining order-sensitive comparison against an unordered SELECT.