### PR TITLE
e2e: await topic creation in create_topics fixture

### DIFF
--- a/test/lib/driver.py
+++ b/test/lib/driver.py
@@ -186,7 +186,10 @@ class KafkaDriver:
             raise NonRetryableError()
 
     def createTopics(self, topicName, partitionNum=1, replicationNum=1):
-        self.adminClient.create_topics(
+        # create_topics is asynchronous: it returns a {topic: Future} dict and
+        # the broker may not have created the topic by the time this returns.
+        # Callers that must produce immediately should await the futures.
+        return self.adminClient.create_topics(
             [NewTopic(topicName, partitionNum, replicationNum)]
         )
 

--- a/test/lib/fixtures/connector.py
+++ b/test/lib/fixtures/connector.py
@@ -19,8 +19,17 @@ def create_topics(driver: KafkaDriver, name_salt):
     def _create_one(topic, num_partitions, replication_factor, with_table):
         salted = f"{topic}{name_salt}"
         logger.info(f"Creating topic {salted}")
-        driver.createTopics(salted, num_partitions, replication_factor)
+        # Track before awaiting so a topic whose creation partially succeeded is
+        # still torn down.
         created_topics.append(salted)
+        # Block until the broker confirms creation. createTopics is otherwise
+        # fire-and-forget, so without this the caller can start producing before
+        # the topic exists and fail with _UNKNOWN_PARTITION. A creation timeout
+        # or error surfaces here instead of as a confusing downstream failure.
+        for future in driver.createTopics(
+            salted, num_partitions, replication_factor
+        ).values():
+            future.result()
         if with_table:
             driver.create_table(salted)
             created_tables.append(salted)
@@ -30,10 +39,16 @@ def create_topics(driver: KafkaDriver, name_salt):
         topics: List[str], *, num_partitions=1, replication_factor=1, with_tables=True
     ):
         with ThreadPoolExecutor(max_workers=10) as executor:
-            for t in topics:
+            futures = [
                 executor.submit(
                     _create_one, t, num_partitions, replication_factor, with_tables
                 )
+                for t in topics
+            ]
+            # Re-raise the first failure; the ThreadPoolExecutor context manager
+            # otherwise waits for tasks but swallows their exceptions.
+            for future in futures:
+                future.result()
         return [f"{t}{name_salt}" for t in topics]
 
     try:


### PR DESCRIPTION
`KafkaDriver.createTopics` is fire-and-forget — it calls `AdminClient.create_topics([...])` but never awaits the returned futures. The `create_topics` fixture inherited that: it submitted all creations to a thread pool and returned as soon as the requests were *issued*, not once the broker confirmed them. Tests then started producing immediately.

At high topic counts this races the broker. In `test_pressure_init[v4]` (200 topics × 12 partitions) on a single-broker stress stack, several `CreateTopicsRequest`s timed out (~60s each), so some topics didn't exist yet when the producer ran, failing with `_UNKNOWN_PARTITION` ("Unable to produce message: Local: Unknown partition") — see [run 29935154653](https://github.com/snowflakedb/snowflake-kafka-connector/actions/runs/29935154653/job/88974703914).

Fix: make the fixture block until the broker confirms each topic before returning:
- `createTopics` now returns the `{topic: Future}` dict (previously the return value was unused).
- `_create_one` awaits `future.result()`, so a creation timeout/error surfaces at creation time instead of as a confusing downstream `_UNKNOWN_PARTITION`.
- `_create` now collects the per-topic executor futures and calls `.result()` on each — the `ThreadPoolExecutor` context manager waits for tasks but otherwise swallows their exceptions, which would have masked creation failures.

This does not by itself raise the broker's creation throughput, but it converts the silent race into a deterministic wait (and a clear failure if creation genuinely times out).