### PR TITLE
ci: cache protobuf builder image via buildx GitHub Actions cache

### DIFF
--- a/.github/actions/run-e2e-tests/action.yml
+++ b/.github/actions/run-e2e-tests/action.yml
@@ -35,10 +35,30 @@ inputs:
     description: "Enable JMX metrics scraping via the Jolokia javaagent (sets KAFKA_OPTS so the connector JVM exposes MBeans on port 8778)"
     required: false
     default: 'false'
+  dockerhub-username:
+    description: "Docker Hub username for authenticated image pulls (avoids anonymous pull rate limits on confluentinc/* and the maven base image). Login is skipped when empty."
+    required: false
+    default: ''
+  dockerhub-token:
+    description: "Docker Hub access token/password paired with dockerhub-username."
+    required: false
+    default: ''
 
 runs:
   using: composite
   steps:
+    - name: Log in to Docker Hub (avoids anonymous pull rate limits)
+      # Both platforms pull from Docker Hub (the maven base image for the
+      # protobuf builder, and confluentinc/cp-* for the Confluent stack).
+      # Anonymous pulls share the runner egress IP's rate limit and surface as
+      # "unauthorized: authentication required". Authenticating avoids that.
+      # Skipped (no-op) when the DOCKERHUB_* secrets are not configured.
+      if: inputs.dockerhub-username != ''
+      uses: docker/login-action@v3
+      with:
+        username: ${{ inputs.dockerhub-username }}
+        password: ${{ inputs.dockerhub-token }}
+
     - name: Log in to GHCR (for prebuilt Apache Kafka image)
       if: inputs.platform == 'apache'
       uses: docker/login-action@v3
@@ -47,11 +67,29 @@ runs:
         username: ${{ github.actor }}
         password: ${{ github.token }}
 
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build protobuf builder image (GitHub Actions layer cache)
+      # Prebuild the protobuf builder here so its layers (apt-get, protoc
+      # download, git clone, maven builds) are restored from the GHA cache
+      # instead of re-fetched from flaky external mirrors on every run. The
+      # loaded image is reused by run_tests.sh (PROTOBUF_BUILDER_PREBUILT).
+      uses: docker/build-push-action@v6
+      with:
+        context: test
+        file: test/docker/Dockerfile.builder
+        tags: protobuf-builder:latest
+        load: true
+        cache-from: type=gha,scope=protobuf-builder
+        cache-to: type=gha,mode=max,scope=protobuf-builder
+
     - name: Run end-to-end tests
       shell: bash
       working-directory: test
       env:
         SNOWFLAKE_CREDENTIAL_FILE: "${{ github.workspace }}/profile.json"
+        PROTOBUF_BUILDER_PREBUILT: 'true'
         PLATFORM: ${{ inputs.platform }}
         PLATFORM_VERSION: ${{ inputs['platform-version'] }}
         SNOWFLAKE_CLOUD: ${{ inputs['snowflake-cloud'] }}

--- a/.github/actions/run-e2e-tests/action.yml
+++ b/.github/actions/run-e2e-tests/action.yml
@@ -35,30 +35,10 @@ inputs:
     description: "Enable JMX metrics scraping via the Jolokia javaagent (sets KAFKA_OPTS so the connector JVM exposes MBeans on port 8778)"
     required: false
     default: 'false'
-  dockerhub-username:
-    description: "Docker Hub username for authenticated image pulls (avoids anonymous pull rate limits on confluentinc/* and the maven base image). Login is skipped when empty."
-    required: false
-    default: ''
-  dockerhub-token:
-    description: "Docker Hub access token/password paired with dockerhub-username."
-    required: false
-    default: ''
 
 runs:
   using: composite
   steps:
-    - name: Log in to Docker Hub (avoids anonymous pull rate limits)
-      # Both platforms pull from Docker Hub (the maven base image for the
-      # protobuf builder, and confluentinc/cp-* for the Confluent stack).
-      # Anonymous pulls share the runner egress IP's rate limit and surface as
-      # "unauthorized: authentication required". Authenticating avoids that.
-      # Skipped (no-op) when the DOCKERHUB_* secrets are not configured.
-      if: inputs.dockerhub-username != ''
-      uses: docker/login-action@v3
-      with:
-        username: ${{ inputs.dockerhub-username }}
-        password: ${{ inputs.dockerhub-token }}
-
     - name: Log in to GHCR (for prebuilt Apache Kafka image)
       if: inputs.platform == 'apache'
       uses: docker/login-action@v3

--- a/.github/workflows/end-to-end.yaml
+++ b/.github/workflows/end-to-end.yaml
@@ -107,6 +107,8 @@ jobs:
         java-version: ${{ matrix.java_test_version || '11' }}
         marker-filter: ${{ matrix.marker_filter }}
         test-group: ${{ matrix.test_group }}
+        dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+        dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
 
   fault_injection:
     # Exercises error-recovery paths using mitmproxy to inject HTTP 410 responses.
@@ -144,6 +146,8 @@ jobs:
         with-mitmproxy: 'true'
         marker-filter: 'fault_injection'
         test-group: fault-injection
+        dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+        dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
 
   core_legacy:
     # Runs the core e2e suite on older Kafka platform versions.
@@ -201,6 +205,8 @@ jobs:
         java-version: ${{ matrix.java_test_version || '11' }}
         marker-filter: 'not compatibility and not schema_evolution and not correctness and not pressure and not soak'
         test-group: core
+        dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+        dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
 
   stress:
     if: >
@@ -240,6 +246,8 @@ jobs:
         platform-version: ${{ matrix.platform_version }}
         snowflake-cloud: ${{ matrix.snowflake_cloud }}
         pressure: 'true'
+        dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+        dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
 
   soak_with_chaos:
     if: >
@@ -272,3 +280,5 @@ jobs:
         marker-filter: 'soak'
         test-group: soak
         jmx: 'true'
+        dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+        dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/end-to-end.yaml
+++ b/.github/workflows/end-to-end.yaml
@@ -107,8 +107,6 @@ jobs:
         java-version: ${{ matrix.java_test_version || '11' }}
         marker-filter: ${{ matrix.marker_filter }}
         test-group: ${{ matrix.test_group }}
-        dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
-        dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
 
   fault_injection:
     # Exercises error-recovery paths using mitmproxy to inject HTTP 410 responses.
@@ -146,8 +144,6 @@ jobs:
         with-mitmproxy: 'true'
         marker-filter: 'fault_injection'
         test-group: fault-injection
-        dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
-        dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
 
   core_legacy:
     # Runs the core e2e suite on older Kafka platform versions.
@@ -205,8 +201,6 @@ jobs:
         java-version: ${{ matrix.java_test_version || '11' }}
         marker-filter: 'not compatibility and not schema_evolution and not correctness and not pressure and not soak'
         test-group: core
-        dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
-        dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
 
   stress:
     if: >
@@ -246,8 +240,6 @@ jobs:
         platform-version: ${{ matrix.platform_version }}
         snowflake-cloud: ${{ matrix.snowflake_cloud }}
         pressure: 'true'
-        dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
-        dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
 
   soak_with_chaos:
     if: >
@@ -280,5 +272,3 @@ jobs:
         marker-filter: 'soak'
         test-group: soak
         jmx: 'true'
-        dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
-        dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -332,9 +332,17 @@ mkdir -p "$EXTRA_JARS_DIR"
 compile_protobuf_dependencies() {
     info "Building protobuf dependencies..."
     cd "$DOCKER_DIR"
-    
-    docker build -t protobuf-builder -f Dockerfile.builder ..
-    
+
+    # In CI the run-e2e-tests action prebuilds this image with a GitHub Actions
+    # layer cache (buildx --cache-to type=gha) and loads it into the local
+    # image store, so we reuse it here instead of rebuilding. Locally the env
+    # var is unset and we build as before.
+    if [ "${PROTOBUF_BUILDER_PREBUILT:-}" = "true" ] && docker image inspect protobuf-builder >/dev/null 2>&1; then
+        info "Reusing prebuilt protobuf-builder image"
+    else
+        docker build -t protobuf-builder -f Dockerfile.builder ..
+    fi
+
     info "Extracting JARs from image..."
     CONTAINER_ID=$(docker create protobuf-builder)
     docker cp "$CONTAINER_ID:/output/." "$EXTRA_JARS_DIR/"


### PR DESCRIPTION
The protobuf builder image (`test/docker/Dockerfile.builder`) is rebuilt from scratch on every e2e job: `run_tests.sh` runs `docker build -t protobuf-builder`, which re-runs `apt-get` (Ubuntu mirrors), a `protoc` download, a `git clone`, and two `mvn` builds each time. Those external fetches flake — e.g. a run failed when `apt-get` couldn't reach `archive.ubuntu.com` ([core_legacy apache 2.8.2](https://github.com/snowflakedb/snowflake-kafka-connector/actions/runs/29935154653/job/88974704072)).

## Change

The `run-e2e-tests` action prebuilds `protobuf-builder` with `docker/build-push-action` using a GitHub Actions layer cache (`cache-from`/`cache-to: type=gha, scope=protobuf-builder`, `load: true`), and `run_tests.sh` reuses the loaded image (gated by `PROTOBUF_BUILDER_PREBUILT` so local runs still build as before). On a warm cache the apt/protoc/git/maven layers are restored instead of re-fetched, removing those flaky external dependencies from the hot path.

Notes on behavior:
- The **first** build on a branch (cold cache) still builds the full image and populates the cache; the benefit applies to **subsequent** builds on that branch.
- Cache busts only when `Dockerfile.builder`, `sensor.proto`, `pom.xml`, or the `maven:3.9-eclipse-temurin-11` base digest change.
- A single shared `scope=protobuf-builder` is used since the image is identical across all matrix jobs/platforms.

Not a connector code change.