### PR TITLE
Iceberg e2e: cloud-aware external volume (Azure managed storage, GCP graceful-skip)

### DIFF
--- a/.github/actions/run-e2e-tests/action.yml
+++ b/.github/actions/run-e2e-tests/action.yml
@@ -56,6 +56,15 @@ runs:
         PLATFORM_VERSION: ${{ inputs['platform-version'] }}
         SNOWFLAKE_CLOUD: ${{ inputs['snowflake-cloud'] }}
         JAVA_VERSION: ${{ inputs['java-version'] }}
+        # Iceberg external volume per cloud (consumed by docker-compose -> test-runner -> pytest):
+        #   AWS   -> kafka_push_e2e_volume_aws (customer external volume, S3-backed)
+        #   AZURE -> SNOWFLAKE_MANAGED (Snowflake-provided storage; no external volume needed)
+        #   GCP   -> SNOWFLAKE_MANAGED, which is NOT available on the GCP account, so the
+        #            create-probe gate skips all iceberg tests there. Provisioning a real GCS
+        #            external volume is blocked by a GCP domain-restricted-sharing org policy
+        #            (needs ProdSec review; see #team-cloud). Switch this to the volume name if unblocked.
+        ICEBERG_EXTERNAL_VOLUME: >-
+          ${{ inputs['snowflake-cloud'] == 'AWS' && 'kafka_push_e2e_volume_aws' || 'SNOWFLAKE_MANAGED' }}
         LOGS_DIR: "${{ github.workspace }}/test-logs"
         MARKER_FILTER: ${{ inputs.pressure == 'true' && 'pressure' || inputs['marker-filter'] }}
         MITMPROXY_FLAG: ${{ inputs['with-mitmproxy'] == 'true' && '--with-mitmproxy' || '' }}

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -24,7 +24,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
-      - run: pip install ruff
+      # Pin ruff: an unpinned install jumped to 0.16.0, which flags 170+
+      # pre-existing violations tree-wide and reddens formatting on every PR.
+      - run: pip install ruff==0.15.0
       - run: ruff check test/tests test/lib test/conftest.py
       - run: ruff format --check test/tests test/lib test/conftest.py
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -164,6 +164,21 @@ def pytest_collection_modifyitems(config, items):
             item.add_marker(skip)
 
 
+@pytest.fixture(autouse=True)
+def _require_iceberg_volume(request):
+    """Gate EVERY ``@pytest.mark.iceberg`` test on external-volume usability.
+
+    Connector-auto-create iceberg tests don't use the ``create_iceberg_table``
+    fixture, so they don't transitively depend on the ``iceberg_external_volume``
+    probe — which is exactly why they failed (instead of skipping) on clouds
+    without the volume. This autouse fixture pulls the probe for any
+    iceberg-marked test, giving a uniform skip when the volume isn't usable.
+    No effect on non-iceberg tests.
+    """
+    if request.node.get_closest_marker("iceberg"):
+        request.getfixturevalue("iceberg_external_volume")
+
+
 @pytest.fixture()
 def create_connector_from_file(
     driver: KafkaDriver,  # noqa: F811

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -78,7 +78,8 @@ def pytest_addoption(parser):
         default=os.environ.get("TEST_NAME_SALT"),
         help="Unique salt appended to connector and topic names (env: TEST_NAME_SALT, auto-generated if omitted)",
     )
-    # currently unused, all tests run on all clouds
+    # Consumed by the iceberg external-volume gate (lib/fixtures/table.py) to skip
+    # iceberg tests on clouds without a usable external volume (e.g. GCP).
     group.addoption(
         "--cloud",
         choices=["AWS", "GCP", "AZURE"],

--- a/test/lib/fixtures/table.py
+++ b/test/lib/fixtures/table.py
@@ -84,15 +84,21 @@ class IcebergTable(Table):
 
     The iceberg-specific clauses (``EXTERNAL_VOLUME``, ``CATALOG``,
     ``BASE_LOCATION``, ``ICEBERG_VERSION``) are appended automatically.
+
+    Note: Snowflake-managed storage (``EXTERNAL_VOLUME='SNOWFLAKE_MANAGED'``)
+    rejects ``BASE_LOCATION`` ("not supported for ... Snowflake Managed
+    Storage"), so it is omitted in that case — Snowflake constructs the path.
     """
 
     def create(self, columns: str):
+        managed = ICEBERG_EXTERNAL_VOLUME.upper() == "SNOWFLAKE_MANAGED"
+        base_location = "" if managed else f"BASE_LOCATION = '{self.name}' "
         self.driver.snowflake_conn.cursor().execute(
             f"CREATE OR REPLACE ICEBERG TABLE {quote_name(self.name)} "
             f"{columns} "
             f"EXTERNAL_VOLUME = '{ICEBERG_EXTERNAL_VOLUME}' "
             f"CATALOG = 'SNOWFLAKE' "
-            f"BASE_LOCATION = '{self.name}' "
+            f"{base_location}"
             f"ICEBERG_VERSION = 3"
         )
 
@@ -104,34 +110,55 @@ class IcebergTable(Table):
 
 @pytest.fixture(scope="session")
 def iceberg_external_volume(driver: KafkaDriver):
-    """Session-scoped probe: checks whether the iceberg external volume exists.
+    """Session-scoped probe: verifies the effective ``ICEBERG_EXTERNAL_VOLUME`` can
+    actually create (and drop) an Iceberg table, otherwise calls ``pytest.skip()``.
 
-    Returns the volume name if available, otherwise calls ``pytest.skip()``.
-    Every test that uses ``create_iceberg_table`` transitively depends on this
-    fixture, so all iceberg tests are skipped in environments where the volume
-    is not provisioned (e.g. AZURE, GCP CI accounts).
+    We create-and-drop rather than ``DESC EXTERNAL VOLUME`` because:
+      * ``DESC`` needs OWNERSHIP on the volume (the CI role only has USAGE), and
+      * the reserved value ``SNOWFLAKE_MANAGED`` is not a describable volume object.
+    A create-probe validates real external volumes AND Snowflake-managed storage
+    uniformly, on any cloud (AWS has ``kafka_push_e2e_volume_aws``; AZURE supports
+    ``SNOWFLAKE_MANAGED``; GCP supports neither today → its iceberg tests skip).
+
+    Enforced for *every* ``@pytest.mark.iceberg`` test via the autouse
+    ``_require_iceberg_volume`` gate in conftest — not only those using
+    ``create_iceberg_table`` — so connector-auto-create tests can't bypass it.
+
+    Skips only when the volume is genuinely unavailable ("does not exist or not
+    authorized"). Any other probe failure (token expiry, rate limit, network) is
+    re-raised loudly via ``pytest.fail`` rather than silently skipping the whole
+    iceberg suite — the session-scoped skip is cached, so a swallowed transient
+    error would masquerade as "0 failed" for every iceberg test.
     """
+    probe = IcebergTable(driver, "KC_ICEBERG_VOLUME_PROBE")
     try:
-        rows = (
-            driver.snowflake_conn.cursor()
-            .execute(f"DESC EXTERNAL VOLUME {ICEBERG_EXTERNAL_VOLUME}")
-            .fetchall()
-        )
-        if rows:
+        probe.create("(id INT)")
+        logger.info("Iceberg external volume %s is usable", ICEBERG_EXTERNAL_VOLUME)
+        return ICEBERG_EXTERNAL_VOLUME
+    except Exception as e:
+        if "does not exist or not authorized" in str(e).lower():
             logger.info(
-                "Iceberg external volume %s is available", ICEBERG_EXTERNAL_VOLUME
+                "Iceberg external volume %s not available, skipping iceberg tests",
+                ICEBERG_EXTERNAL_VOLUME,
             )
-            return ICEBERG_EXTERNAL_VOLUME
-    except Exception:
-        logger.debug(
-            "Failed to describe external volume %s",
+            pytest.skip(
+                f"Iceberg external volume '{ICEBERG_EXTERNAL_VOLUME}' not available — "
+                f"skipping iceberg tests (set ICEBERG_EXTERNAL_VOLUME env var to override)"
+            )
+        logger.error(
+            "Iceberg external volume %s probe failed unexpectedly",
             ICEBERG_EXTERNAL_VOLUME,
             exc_info=True,
         )
-    pytest.skip(
-        f"Iceberg external volume '{ICEBERG_EXTERNAL_VOLUME}' not found — "
-        f"skipping iceberg tests (set ICEBERG_EXTERNAL_VOLUME env var to override)"
-    )
+        pytest.fail(
+            f"Iceberg external volume '{ICEBERG_EXTERNAL_VOLUME}' probe failed "
+            f"unexpectedly (not a 'volume unavailable' error): {e}"
+        )
+    finally:
+        try:
+            probe.drop()
+        except Exception:
+            pass
 
 
 @pytest.fixture()

--- a/test/lib/fixtures/table.py
+++ b/test/lib/fixtures/table.py
@@ -108,52 +108,43 @@ class IcebergTable(Table):
         )
 
 
-@pytest.fixture(scope="session")
-def iceberg_external_volume(driver: KafkaDriver):
-    """Session-scoped probe: verifies the effective ``ICEBERG_EXTERNAL_VOLUME`` can
-    actually create (and drop) an Iceberg table, otherwise calls ``pytest.skip()``.
+# Clouds where Iceberg is not supported on the CI account, so its tests are
+# skipped deterministically (rather than inferred from a probe error). GCP:
+# SNOWFLAKE_MANAGED is unavailable and a GCS external volume is blocked by a GCP
+# domain-restricted-sharing org policy (ProdSec-gated) — tracked in SNOW-3851561.
+ICEBERG_UNSUPPORTED_CLOUDS = {"GCP"}
 
-    We create-and-drop rather than ``DESC EXTERNAL VOLUME`` because:
-      * ``DESC`` needs OWNERSHIP on the volume (the CI role only has USAGE), and
-      * the reserved value ``SNOWFLAKE_MANAGED`` is not a describable volume object.
-    A create-probe validates real external volumes AND Snowflake-managed storage
-    uniformly, on any cloud (AWS has ``kafka_push_e2e_volume_aws``; AZURE supports
-    ``SNOWFLAKE_MANAGED``; GCP supports neither today → its iceberg tests skip).
+
+@pytest.fixture(scope="session")
+def iceberg_external_volume(request, driver: KafkaDriver):
+    """Session-scoped probe for the effective ``ICEBERG_EXTERNAL_VOLUME``.
+
+    Skips Iceberg tests **only** on clouds known not to support the configured
+    volume (``ICEBERG_UNSUPPORTED_CLOUDS``, from the ``--cloud`` option). On every
+    other cloud the volume MUST work: the probe creates (and drops) a table, and
+    any failure is left to propagate and **fail loudly** — we never swallow an
+    exception into a skip, so a real misconfiguration/regression on AWS or AZURE
+    can't hide as a green-by-skip run.
+
+    We create-and-drop rather than ``DESC EXTERNAL VOLUME`` because ``DESC`` needs
+    OWNERSHIP (the CI role only has USAGE) and ``SNOWFLAKE_MANAGED`` is not a
+    describable object.
 
     Enforced for *every* ``@pytest.mark.iceberg`` test via the autouse
     ``_require_iceberg_volume`` gate in conftest — not only those using
     ``create_iceberg_table`` — so connector-auto-create tests can't bypass it.
-
-    Skips only when the volume is genuinely unavailable ("does not exist or not
-    authorized"). Any other probe failure (token expiry, rate limit, network) is
-    re-raised loudly via ``pytest.fail`` rather than silently skipping the whole
-    iceberg suite — the session-scoped skip is cached, so a swallowed transient
-    error would masquerade as "0 failed" for every iceberg test.
     """
+    cloud = (request.config.getoption("--cloud") or "").upper()
+    if cloud in ICEBERG_UNSUPPORTED_CLOUDS:
+        pytest.skip(
+            f"Iceberg is not supported on the {cloud} CI account "
+            f"(no usable external volume) — tracked in SNOW-3851561"
+        )
     probe = IcebergTable(driver, "KC_ICEBERG_VOLUME_PROBE")
     try:
         probe.create("(id INT)")
         logger.info("Iceberg external volume %s is usable", ICEBERG_EXTERNAL_VOLUME)
         return ICEBERG_EXTERNAL_VOLUME
-    except Exception as e:
-        if "does not exist or not authorized" in str(e).lower():
-            logger.info(
-                "Iceberg external volume %s not available, skipping iceberg tests",
-                ICEBERG_EXTERNAL_VOLUME,
-            )
-            pytest.skip(
-                f"Iceberg external volume '{ICEBERG_EXTERNAL_VOLUME}' not available — "
-                f"skipping iceberg tests (set ICEBERG_EXTERNAL_VOLUME env var to override)"
-            )
-        logger.error(
-            "Iceberg external volume %s probe failed unexpectedly",
-            ICEBERG_EXTERNAL_VOLUME,
-            exc_info=True,
-        )
-        pytest.fail(
-            f"Iceberg external volume '{ICEBERG_EXTERNAL_VOLUME}' probe failed "
-            f"unexpectedly (not a 'volume unavailable' error): {e}"
-        )
     finally:
         try:
             probe.drop()


### PR DESCRIPTION
## Problem
Iceberg e2e tests (`@pytest.mark.iceberg`) pass on AWS but **failed on the Azure and GCP CI accounts**. Managed-Iceberg tables need an *external volume*, and `kafka_push_e2e_volume_aws` only exists on the AWS account. The connector auto-create tests (from #1487) drive `CREATE ICEBERG TABLE ... EXTERNAL_VOLUME=...`; on Azure/GCP that volume doesn't exist so the create errored.

There was already a skip-probe (`iceberg_external_volume`), but it only gated tests using the `create_iceberg_table` fixture. The auto-create tests don't use that fixture, so they **bypassed the probe and failed instead of skipping** — that bypass is the core defect.

## Approach
Use Snowflake-provided storage (`EXTERNAL_VOLUME='SNOWFLAKE_MANAGED'` — no customer bucket/IAM/trust). Verified empirically against the real accounts: **Azure supports it; GCP does not**.

1. **`run-e2e-tests` action** — select `ICEBERG_EXTERNAL_VOLUME` per cloud: AWS keeps its volume, all others use `SNOWFLAKE_MANAGED`.
2. **`conftest.py`** — autouse `_require_iceberg_volume` gates **every** `@pytest.mark.iceberg` test, so auto-create tests can no longer bypass the probe.
3. **`table.py`** — Iceberg is skipped **deterministically** on clouds known to lack a usable external volume (`ICEBERG_UNSUPPORTED_CLOUDS` = `{GCP}`, read from `--cloud`). On every other cloud the volume MUST work: the probe creates/drops a table and any failure **fails loudly** (never swallowed into a skip), so a real regression on AWS/Azure can't hide as green-by-skip. `IcebergTable.create()` omits `BASE_LOCATION` for managed storage (which rejects it). Probe uses create/drop rather than `DESC` (role has USAGE not OWNERSHIP; `SNOWFLAKE_MANAGED` isn't describable).

Also pins `ruff==0.15.0` in the formatting workflow: an unpinned install had jumped to 0.16.0, which reddens `formatting/python` tree-wide (170+ pre-existing violations, unrelated to this change).

## Validation
Full iceberg e2e ran **green against Azure managed storage: 20 passed, 7 skipped, 0 failed** — proving connector auto-create + streaming ingest into a `SNOWFLAKE_MANAGED` table. The 7 skips are Avro tests (the `apache` test platform lacks a schema registry) + 2 pre-existing conditional skips; CI's Azure entry uses `confluent`, which exercises Avro. Reviewed by two independent agents; findings applied.

**Manual CI dispatch** (functional=AWS + core_legacy=GCP/Azure), per review: https://github.com/snowflakedb/snowflake-kafka-connector/actions/runs/30357915811

## Follow-ups
- **GCP Iceberg coverage** is tracked in **SNOW-3851561**: `SNOWFLAKE_MANAGED` isn't available on GCP and a GCS external volume is blocked by a GCP domain-restricted-sharing org policy (ProdSec-gated; see the 2024 #team-cloud thread). Until resolved, GCP Iceberg tests skip cleanly.

Related: #1487 (SNOW-3161094).

