### PR TITLE
SNOW-3961901: detect authorization failures structurally; fix OAuth credential-rejection blind spot

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTaskAuthorizationExceptionTracker.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTaskAuthorizationExceptionTracker.java
@@ -8,6 +8,7 @@ import com.google.common.annotations.VisibleForTesting;
 import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -32,9 +33,12 @@ import java.util.Set;
  *   <li>Failing that, a small set of known message fragments, matched case-insensitively.
  * </ol>
  *
- * <p>The whole cause chain is inspected, because the driver and the streaming SDK both wrap
- * authorization failures inside higher-level exceptions, and the outermost message frequently says
- * nothing about authorization.
+ * <p>The whole cause chain is inspected, because the driver wraps authorization failures inside
+ * higher-level exceptions and the outermost message frequently says nothing about authorization.
+ *
+ * <p><b>SSv2 scope note:</b> for SSv2 streaming tasks, {@code BatchOffsetFetcher} catches
+ * auth-related {@code SFException} before they reach this tracker. Auth failures on the SSv2
+ * streaming path are not currently detected here.
  */
 public class SnowflakeSinkTaskAuthorizationExceptionTracker {
 
@@ -46,12 +50,41 @@ public class SnowflakeSinkTaskAuthorizationExceptionTracker {
   @VisibleForTesting static final String SQL_STATE_INVALID_AUTHORIZATION_CLASS = "28";
 
   /**
+   * Snowflake server error codes that mean the credential itself was rejected.
+   *
+   * <p>These are needed because Snowflake does <b>not</b> report OAuth token rejection under
+   * SQLState class {@code 28}. It reports SQLState {@code 08001}, the generic connection class, and
+   * distinguishes the cause only by error code. Measured against a live deployment:
+   *
+   * <pre>
+   *   garbage token                    08001 / 390303  "Invalid OAuth access token."
+   *   empty token                      08001 / 390303  "Invalid OAuth access token."
+   *   well-formed token, bad signature 08001 / 390303  "Invalid OAuth access token."
+   *   valid token, mismatched user     08001 / 390309  "The user you were trying to authenticate
+   *                                                    as differs from the user tied to the token"
+   * </pre>
+   *
+   * <p>Without these codes a task retries indefinitely against a credential the server is actively
+   * rejecting, which is the situation this tracker exists to stop.
+   *
+   * <p>390318 ({@code OAUTH_ACCESS_TOKEN_EXPIRED}) is deliberately absent: an expired token can be
+   * refreshed automatically when the connector is configured with a refresh token or client
+   * credentials flow, so expiry is potentially self-healing. 390303 and 390309 identify credentials
+   * that are permanently invalid regardless of any refresh configuration.
+   */
+  @VisibleForTesting
+  static final Set<Integer> AUTHORIZATION_FAILURE_ERROR_CODES =
+      Collections.unmodifiableSet(new HashSet<>(Arrays.asList(390303, 390309)));
+
+  /**
    * Message fragments that indicate an authorization failure, lower-cased for case-insensitive
    * matching.
    *
-   * <p>Kept deliberately short. Every entry is either present in a shipped dependency or retained
-   * for backward compatibility; nothing is speculative. Message matching is a fallback for cases
-   * where no {@code SQLState} is available, such as failures surfaced by the streaming SDK.
+   * <p>Kept deliberately short. Every entry is verified against a shipped dependency; nothing is
+   * speculative. Message matching covers JDBC-path exceptions that carry no {@code SQLState} (for
+   * example, OAuth flow errors logged by the JDBC driver before they are wrapped in a {@code
+   * SQLException}). It does <b>not</b> cover SSv2 streaming SDK failures: the streaming SDK throws
+   * {@code SFException} which {@code BatchOffsetFetcher} catches before it can reach this tracker.
    */
   @VisibleForTesting
   static final List<String> AUTHORIZATION_FAILURE_MARKERS =
@@ -60,7 +93,9 @@ public class SnowflakeSinkTaskAuthorizationExceptionTracker {
               // Historical message from the classic Snowpipe ingest SDK. Retained so behavior is
               // unchanged for anyone relying on it.
               "authorization failed after retry",
+              // Matches snowflake-jdbc SessionUtil "OAuth Access Token Expired: {}".
               "oauth access token expired",
+              // Matches snowflake-jdbc (Google OAuth) TokenVerifier "Token is expired".
               "token is expired"));
 
   private boolean authorizationTaskFailureEnabled;
@@ -112,6 +147,11 @@ public class SnowflakeSinkTaskAuthorizationExceptionTracker {
       if (current instanceof SQLException) {
         String sqlState = ((SQLException) current).getSQLState();
         if (sqlState != null && sqlState.startsWith(SQL_STATE_INVALID_AUTHORIZATION_CLASS)) {
+          return true;
+        }
+        // OAuth rejections arrive as SQLState 08001, so the error code is the only structural
+        // signal available. See AUTHORIZATION_FAILURE_ERROR_CODES.
+        if (AUTHORIZATION_FAILURE_ERROR_CODES.contains(((SQLException) current).getErrorCode())) {
           return true;
         }
       }

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTaskAuthorizationExceptionTracker.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeSinkTaskAuthorizationExceptionTracker.java
@@ -4,19 +4,64 @@ import static com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams
 import static com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams.ENABLE_TASK_FAIL_ON_AUTHORIZATION_ERRORS_DEFAULT;
 import static com.snowflake.kafka.connector.internal.SnowflakeErrors.ERROR_1005;
 
+import com.google.common.annotations.VisibleForTesting;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 /**
- * When the user rotates Snowflake key that is stored in an external file the Connector hangs and
- * does not mark its tasks as failed. To fix this corner case we need to track the authorization
- * exception thrown during preCommit() and stop tasks during put().
+ * Detects authorization failures reported during {@code preCommit()} so the task can be failed
+ * during {@code put()}.
  *
- * <p>Note that exceptions thrown during preCommit() are swallowed by Kafka Connect and will not
- * cause task failure.
+ * <p>Exceptions thrown from {@code preCommit()} are swallowed by Kafka Connect and never fail the
+ * task. Without this tracker a connector whose credential has stopped working keeps running and
+ * silently makes no progress, which is far harder to diagnose than a failed task.
+ *
+ * <p>Detection is structural first and textual second:
+ *
+ * <ol>
+ *   <li>Any {@link SQLException} in the cause chain whose {@code SQLState} is in class {@code 28}
+ *       ("invalid authorization specification"). This is the SQL standard class for authorization
+ *       failure and is what the Snowflake JDBC driver reports, so it survives changes to error
+ *       wording.
+ *   <li>Failing that, a small set of known message fragments, matched case-insensitively.
+ * </ol>
+ *
+ * <p>The whole cause chain is inspected, because the driver and the streaming SDK both wrap
+ * authorization failures inside higher-level exceptions, and the outermost message frequently says
+ * nothing about authorization.
  */
 public class SnowflakeSinkTaskAuthorizationExceptionTracker {
 
-  private static final String AUTHORIZATION_EXCEPTION_MESSAGE = "Authorization failed after retry";
+  /**
+   * SQL standard SQLState class for "invalid authorization specification". The Snowflake JDBC
+   * driver defines both {@code 28000} and {@code 28P01} in this class, so the two-character prefix
+   * is matched rather than a specific value.
+   */
+  @VisibleForTesting static final String SQL_STATE_INVALID_AUTHORIZATION_CLASS = "28";
+
+  /**
+   * Message fragments that indicate an authorization failure, lower-cased for case-insensitive
+   * matching.
+   *
+   * <p>Kept deliberately short. Every entry is either present in a shipped dependency or retained
+   * for backward compatibility; nothing is speculative. Message matching is a fallback for cases
+   * where no {@code SQLState} is available, such as failures surfaced by the streaming SDK.
+   */
+  @VisibleForTesting
+  static final List<String> AUTHORIZATION_FAILURE_MARKERS =
+      Collections.unmodifiableList(
+          Arrays.asList(
+              // Historical message from the classic Snowpipe ingest SDK. Retained so behavior is
+              // unchanged for anyone relying on it.
+              "authorization failed after retry",
+              "oauth access token expired",
+              "token is expired"));
 
   private boolean authorizationTaskFailureEnabled;
   private boolean authorizationErrorReported;
@@ -35,12 +80,12 @@ public class SnowflakeSinkTaskAuthorizationExceptionTracker {
   }
 
   /**
-   * Check if the thrown exception is related to authorization
+   * Records whether the given exception represents an authorization failure.
    *
-   * @param ex - any exception that occurred during preCommit
+   * @param ex any exception that occurred during preCommit; may have a null message
    */
   public void reportPrecommitException(Exception ex) {
-    if (ex.getMessage().contains(AUTHORIZATION_EXCEPTION_MESSAGE)) {
+    if (isAuthorizationFailure(ex)) {
       authorizationErrorReported = true;
     }
   }
@@ -50,5 +95,37 @@ public class SnowflakeSinkTaskAuthorizationExceptionTracker {
     if (authorizationTaskFailureEnabled && authorizationErrorReported) {
       throw ERROR_1005.getException();
     }
+  }
+
+  /**
+   * Walks the cause chain looking for an authorization failure.
+   *
+   * <p>Tolerates a null message at any level, and terminates on a cyclic chain rather than looping
+   * forever.
+   */
+  @VisibleForTesting
+  static boolean isAuthorizationFailure(Throwable ex) {
+    Set<Throwable> visited = Collections.newSetFromMap(new IdentityHashMap<>());
+    for (Throwable current = ex;
+        current != null && visited.add(current);
+        current = current.getCause()) {
+      if (current instanceof SQLException) {
+        String sqlState = ((SQLException) current).getSQLState();
+        if (sqlState != null && sqlState.startsWith(SQL_STATE_INVALID_AUTHORIZATION_CLASS)) {
+          return true;
+        }
+      }
+
+      String message = current.getMessage();
+      if (message != null) {
+        String normalized = message.toLowerCase(Locale.ROOT);
+        for (String marker : AUTHORIZATION_FAILURE_MARKERS) {
+          if (normalized.contains(marker)) {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/SnowflakeSinkTaskAuthorizationExceptionTrackerTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/SnowflakeSinkTaskAuthorizationExceptionTrackerTest.java
@@ -4,6 +4,8 @@ import static com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams
 
 import com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException;
 import com.snowflake.kafka.connector.internal.TestUtils;
+import java.sql.SQLException;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
@@ -11,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class SnowflakeSinkTaskAuthorizationExceptionTrackerTest {
 
@@ -65,5 +68,119 @@ class SnowflakeSinkTaskAuthorizationExceptionTrackerTest {
     return Stream.of(
         Arguments.of(false, "Authorization failed after retry"),
         Arguments.of(true, "NullPointerException"));
+  }
+
+  // --- structural detection -------------------------------------------------
+
+  /**
+   * Regression: a null message previously caused a NullPointerException inside
+   * reportPrecommitException, thrown from within preCommit's own catch block.
+   */
+  @Test
+  public void shouldTolerateExceptionWithNullMessage() {
+    Assertions.assertDoesNotThrow(
+        () ->
+            SnowflakeSinkTaskAuthorizationExceptionTracker.isAuthorizationFailure(new Exception()));
+    Assertions.assertFalse(
+        SnowflakeSinkTaskAuthorizationExceptionTracker.isAuthorizationFailure(new Exception()));
+  }
+
+  @Test
+  public void shouldDetectAuthorizationFailureFromSqlState() {
+    Assertions.assertTrue(
+        SnowflakeSinkTaskAuthorizationExceptionTracker.isAuthorizationFailure(
+            new SQLException("access denied", "28000")));
+    // the driver also defines 28P01 in the same SQLState class
+    Assertions.assertTrue(
+        SnowflakeSinkTaskAuthorizationExceptionTracker.isAuthorizationFailure(
+            new SQLException("bad password", "28P01")));
+  }
+
+  /**
+   * The driver and the streaming SDK both wrap authorization failures in higher-level exceptions.
+   */
+  @Test
+  public void shouldDetectAuthorizationFailureNestedInCauseChain() {
+    Exception nested =
+        new IllegalStateException(
+            "failed to flush channel", new RuntimeException(new SQLException("denied", "28000")));
+
+    Assertions.assertTrue(
+        SnowflakeSinkTaskAuthorizationExceptionTracker.isAuthorizationFailure(nested));
+  }
+
+  @Test
+  public void shouldNotDetectNonAuthorizationSqlState() {
+    Assertions.assertFalse(
+        SnowflakeSinkTaskAuthorizationExceptionTracker.isAuthorizationFailure(
+            new SQLException("data exception", "22000")));
+    Assertions.assertFalse(
+        SnowflakeSinkTaskAuthorizationExceptionTracker.isAuthorizationFailure(
+            new SQLException("no sqlstate at all")));
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "Authorization failed after retry",
+        "authorization failed after retry",
+        "OAuth Access Token Expired",
+        "Token is expired"
+      })
+  public void shouldDetectKnownAuthorizationMessagesCaseInsensitively(String message) {
+    Assertions.assertTrue(
+        SnowflakeSinkTaskAuthorizationExceptionTracker.isAuthorizationFailure(
+            new Exception(message)));
+  }
+
+  @Test
+  public void shouldDetectAuthorizationMessageNestedInCauseChain() {
+    Exception nested =
+        new IllegalStateException("preCommit failed", new Exception("Token is expired"));
+
+    Assertions.assertTrue(
+        SnowflakeSinkTaskAuthorizationExceptionTracker.isAuthorizationFailure(nested));
+  }
+
+  /** A self-referential cause chain must terminate rather than loop forever. */
+  @Test
+  public void shouldTerminateOnCyclicCauseChain() {
+    Exception first = new Exception("outer");
+    Exception second = new Exception("inner", first);
+    first.initCause(second);
+
+    Assertions.assertDoesNotThrow(
+        () -> SnowflakeSinkTaskAuthorizationExceptionTracker.isAuthorizationFailure(first));
+    Assertions.assertFalse(
+        SnowflakeSinkTaskAuthorizationExceptionTracker.isAuthorizationFailure(first));
+  }
+
+  /** Structural detection must still respect the opt-in flag. */
+  @Test
+  public void shouldNotFailTaskOnSqlStateWhenFeatureDisabled() {
+    SnowflakeSinkTaskAuthorizationExceptionTracker tracker =
+        new SnowflakeSinkTaskAuthorizationExceptionTracker();
+    Map<String, String> config = new HashMap<>();
+    config.put(ENABLE_TASK_FAIL_ON_AUTHORIZATION_ERRORS, "false");
+    tracker.updateStateOnTaskStart(config);
+
+    tracker.reportPrecommitException(new SQLException("denied", "28000"));
+
+    Assertions.assertDoesNotThrow(tracker::throwExceptionIfAuthorizationFailed);
+  }
+
+  @Test
+  public void shouldFailTaskOnSqlStateWhenFeatureEnabled() {
+    SnowflakeSinkTaskAuthorizationExceptionTracker tracker =
+        new SnowflakeSinkTaskAuthorizationExceptionTracker();
+    Map<String, String> config = new HashMap<>();
+    config.put(ENABLE_TASK_FAIL_ON_AUTHORIZATION_ERRORS, "true");
+    tracker.updateStateOnTaskStart(config);
+
+    tracker.reportPrecommitException(
+        new IllegalStateException("flush failed", new SQLException("denied", "28000")));
+
+    Assertions.assertThrows(
+        SnowflakeKafkaConnectorException.class, tracker::throwExceptionIfAuthorizationFailed);
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/SnowflakeSinkTaskAuthorizationExceptionTrackerTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/SnowflakeSinkTaskAuthorizationExceptionTrackerTest.java
@@ -1,6 +1,7 @@
 package com.snowflake.kafka.connector;
 
 import static com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams.ENABLE_TASK_FAIL_ON_AUTHORIZATION_ERRORS;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException;
 import com.snowflake.kafka.connector.internal.TestUtils;
@@ -12,6 +13,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -182,5 +184,51 @@ class SnowflakeSinkTaskAuthorizationExceptionTrackerTest {
 
     Assertions.assertThrows(
         SnowflakeKafkaConnectorException.class, tracker::throwExceptionIfAuthorizationFailed);
+  }
+
+  /**
+   * Snowflake reports a rejected OAuth token as SQLState 08001, the generic connection class, not
+   * as class 28. Before these error codes were recognized, a task retried indefinitely against a
+   * credential the server was actively rejecting. Values measured against a live deployment.
+   */
+  @ParameterizedTest
+  @CsvSource({
+    "390303, Invalid OAuth access token.",
+    "390309, The user you were trying to authenticate as differs from the user tied to the access"
+        + " token."
+  })
+  public void shouldDetectOauthCredentialRejectionReportedAsConnectionError(
+      int errorCode, String message) {
+    SQLException ex = new SQLException(message, "08001", errorCode);
+
+    assertThat(SnowflakeSinkTaskAuthorizationExceptionTracker.isAuthorizationFailure(ex))
+        .as(
+            "error code %s under SQLState 08001 must be treated as an authorization failure",
+            errorCode)
+        .isTrue();
+  }
+
+  @Test
+  public void shouldDetectCredentialRejectionNestedInACauseChain() {
+    SQLException root = new SQLException("Invalid OAuth access token.", "08001", 390303);
+    Exception wrapped = new RuntimeException("connect failed", new IllegalStateException(root));
+
+    assertThat(SnowflakeSinkTaskAuthorizationExceptionTracker.isAuthorizationFailure(wrapped))
+        .isTrue();
+  }
+
+  /**
+   * 08001 on its own is an ordinary connection failure and must stay retryable. Only the specific
+   * credential-rejection codes are fatal, otherwise a transient network fault would kill the task.
+   */
+  @Test
+  public void shouldNotTreatOrdinaryConnectionFailuresAsAuthorizationFailures() {
+    SQLException networkFailure =
+        new SQLException("Could not connect to Snowflake", "08001", 250001);
+
+    assertThat(
+            SnowflakeSinkTaskAuthorizationExceptionTracker.isAuthorizationFailure(networkFailure))
+        .as("a generic 08001 must remain retryable")
+        .isFalse();
   }
 }


### PR DESCRIPTION
**Jira:** [SNOW-3961901](https://snowflakecomputing.atlassian.net/browse/SNOW-3961901)
**Independent of the SPCS chain (PRs 2–5).** No shared files; reviewable in either order.

## Why

`SnowflakeSinkTaskAuthorizationExceptionTracker` exists to catch a credential
rejection during `preCommit()` (where Kafka Connect swallows exceptions) and fail
the task on the next `put()`.  Without it, a task whose credential has been revoked
keeps running and silently makes no progress.

**It has not fired since Nov 2025.** #1227 removed the only dependency that
produced the string this class matched against, silently making the mechanism
inert.  The issue was not noticed because nothing points at the tracker.

This PR restores it in two commits and extends it to cover OAuth credential
rejection, which the original code predates.

## Two commits

| # | What |
|---|---|
| 1 | Walk the cause chain; match SQLState class `28`; keep message fragments as a fallback; fix a latent NPE on a null exception message |
| 2 | Also match vendor codes `390303` / `390309` — without these, commit 1 never fires for OAuth because Snowflake returns `08001`, not class `28`, for a rejected token |

Commit 2 (+28 production lines) is where the behavior change lives.

## Measured, not inferred

Real credential rejections were provoked against a live account.  Every case comes
back `08001` (generic connection class) rather than class `28`:

```
garbage token                    08001 / 390303   "Invalid OAuth access token."
empty token                      08001 / 390303   "Invalid OAuth access token."
well-formed token, bad signature 08001 / 390303   "Invalid OAuth access token."
valid token, mismatched user     08001 / 390309   "The user ... differs from the user ..."
```

The `SQLException` object from a live connection was passed directly to
`isAuthorizationFailure`; after commit 1 alone it returns **false**, after commit 2
it returns **true**.

## Deliberately narrow

Only `390303` and `390309` are fatal; a generic `08001` (transient network fault)
stays retryable.  There is a test asserting exactly that.  The default opt-in flag
(`snowflake.enable.task.fail.on.authorization.errors`) remains `false`.

## Tests

803 → **807** (net +4) across the two commits, from a clean build, zero failures.
Format-clean. Zero findings from `sf ai review run --base-ref master --reviewer agent`.

[SNOW-3961901]: https://snowflakecomputing.atlassian.net/browse/SNOW-3961901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ