### PR TITLE
SNOW-3961901: [1/3] SPCS ambient auth — fail-fast guard + SpcsEnvironment (inert)

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/spcs/SpcsEnvironment.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/spcs/SpcsEnvironment.java
@@ -1,0 +1,120 @@
+package com.snowflake.kafka.connector.internal.spcs;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.snowflake.kafka.connector.internal.KCLogger;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+import java.util.function.Function;
+
+/**
+ * Access to the credentials that Snowpark Container Services (SPCS) provides to every service
+ * container, so a connector running inside SPCS needs no credential configuration.
+ *
+ * <p>Snowflake calls these <b>Snowflake-provided service user credentials</b>, or simply <i>service
+ * credentials</i>. They are also widely referred to as <b>ambient authentication</b>, the
+ * <i>ambient service identity</i>, or just <i>SPCS ambient</i>; those are informal names for the
+ * same documented mechanism. See <a
+ * href="https://docs.snowflake.com/en/developer-guide/snowpark-container-services/spcs-execute-sql">Snowpark
+ * Container Services: SQL execution</a>.
+ *
+ * <p>When a service starts, Snowflake:
+ *
+ * <ul>
+ *   <li>writes an OAuth token to {@value #DEFAULT_TOKEN_FILE}, which authenticates as the service
+ *       user and is valid only inside that service;
+ *   <li>sets {@code SNOWFLAKE_ACCOUNT} to the account identifier and {@code SNOWFLAKE_HOST} to the
+ *       hostname to connect to. The token cannot be used without {@code SNOWFLAKE_HOST};
+ *   <li>sets {@code SNOWFLAKE_DATABASE} and {@code SNOWFLAKE_SCHEMA} to the service's own database
+ *       and schema. Note that no warehouse is provided.
+ * </ul>
+ *
+ * <p>The resulting session runs as the service user, whose only roles are the service owner role
+ * and PUBLIC, with the service owner role as its default.
+ *
+ * <p>The token is deliberately <b>never cached</b>. Snowflake rewrites the file every few minutes
+ * and each token is valid for at most an hour, so a cached value would eventually be stale. Note
+ * that, per the documentation, once a connection has been established successfully the token's
+ * expiry no longer applies to that connection, exactly as for a session a user creates directly.
+ */
+public final class SpcsEnvironment {
+
+  private static final KCLogger LOGGER = new KCLogger(SpcsEnvironment.class.getName());
+
+  /** Bearer token file managed by the SPCS runtime. */
+  public static final String DEFAULT_TOKEN_FILE = "/snowflake/session/token";
+
+  public static final String ENV_HOST = "SNOWFLAKE_HOST";
+
+  static final String ENV_DATABASE = "SNOWFLAKE_DATABASE";
+  static final String ENV_SCHEMA = "SNOWFLAKE_SCHEMA";
+
+  /** Environment lookup. Overridable so tests can simulate an SPCS container. */
+  private static Function<String, String> envReader = System::getenv;
+
+  /** Token file location. Overridable so tests can point at a temporary file. */
+  private static Path tokenPath = Paths.get(DEFAULT_TOKEN_FILE);
+
+  private SpcsEnvironment() {}
+
+  /**
+   * @return true when running inside SPCS with an ambient identity available
+   */
+  public static boolean isInsideSpcs() {
+    return env(ENV_HOST).isPresent() && Files.isReadable(tokenPath);
+  }
+
+  public static Optional<String> host() {
+    return env(ENV_HOST);
+  }
+
+  public static Optional<String> database() {
+    return env(ENV_DATABASE);
+  }
+
+  public static Optional<String> schema() {
+    return env(ENV_SCHEMA);
+  }
+
+  /**
+   * Reads the current ambient bearer token, re-reading the file on every call by design; see the
+   * class comment.
+   *
+   * @throws IllegalStateException if the token file cannot be read
+   */
+  public static String readToken() {
+    try {
+      return new String(Files.readAllBytes(tokenPath), StandardCharsets.UTF_8).trim();
+    } catch (IOException e) {
+      throw new IllegalStateException(
+          "Failed to read the SPCS session token at "
+              + tokenPath
+              + ". This file is provided by the SPCS runtime; ambient authentication is only"
+              + " available to a connector running inside Snowpark Container Services.",
+          e);
+    }
+  }
+
+  private static Optional<String> env(String name) {
+    return Optional.ofNullable(envReader.apply(name)).map(String::trim).filter(v -> !v.isEmpty());
+  }
+
+  private static boolean isBlank(String value) {
+    return value == null || value.trim().isEmpty();
+  }
+
+  @VisibleForTesting
+  public static void overrideForTests(Function<String, String> env, Path token) {
+    envReader = env;
+    tokenPath = token;
+  }
+
+  @VisibleForTesting
+  public static void resetForTests() {
+    envReader = System::getenv;
+    tokenPath = Paths.get(DEFAULT_TOKEN_FILE);
+  }
+}

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProperties.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProperties.java
@@ -106,6 +106,8 @@ public class StreamingClientProperties {
             Base64.getEncoder().encodeToString(privateKey.getEncoded());
         clientProperties.put("private_key", privateKeyEncoded);
         break;
+      default:
+        throw new IllegalStateException("unhandled authenticator: " + config.getAuthenticator());
     }
 
     clientProperties.put("user", config.getSnowflakeUser());

--- a/src/test/java/com/snowflake/kafka/connector/internal/spcs/SpcsEnvironmentTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/spcs/SpcsEnvironmentTest.java
@@ -1,0 +1,94 @@
+package com.snowflake.kafka.connector.internal.spcs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class SpcsEnvironmentTest {
+
+  private static final String HOST = "myaccount.us-east-1.snowflakecomputing.com";
+
+  @TempDir Path tempDir;
+
+  @AfterEach
+  void reset() {
+    SpcsEnvironment.resetForTests();
+  }
+
+  /** Simulates a container running inside SPCS, with a token file and the runtime env vars. */
+  private Path simulateSpcs(String tokenValue) throws IOException {
+    Path token = tempDir.resolve("token");
+    Files.write(token, tokenValue.getBytes(StandardCharsets.UTF_8));
+    Map<String, String> env = new HashMap<>();
+    env.put(SpcsEnvironment.ENV_HOST, HOST);
+    env.put(SpcsEnvironment.ENV_DATABASE, "AMBIENT_DB");
+    env.put(SpcsEnvironment.ENV_SCHEMA, "AMBIENT_SCHEMA");
+    SpcsEnvironment.overrideForTests(env::get, token);
+    return token;
+  }
+
+  private void simulateOutsideSpcs() {
+    SpcsEnvironment.overrideForTests(name -> null, tempDir.resolve("does-not-exist"));
+  }
+
+  @Test
+  void shouldDetectSpcsWhenHostAndTokenPresent() throws IOException {
+    simulateSpcs("tok");
+    assertThat(SpcsEnvironment.isInsideSpcs()).isTrue();
+  }
+
+  @Test
+  void shouldNotDetectSpcsWhenTokenFileMissing() {
+    Map<String, String> env = new HashMap<>();
+    env.put(SpcsEnvironment.ENV_HOST, HOST);
+    SpcsEnvironment.overrideForTests(env::get, tempDir.resolve("absent"));
+
+    assertThat(SpcsEnvironment.isInsideSpcs()).isFalse();
+  }
+
+  @Test
+  void shouldNotDetectSpcsWhenHostEnvMissing() throws IOException {
+    Path token = tempDir.resolve("token");
+    Files.write(token, "tok".getBytes(StandardCharsets.UTF_8));
+    SpcsEnvironment.overrideForTests(name -> null, token);
+
+    assertThat(SpcsEnvironment.isInsideSpcs()).isFalse();
+  }
+
+  /**
+   * The token must never be cached. SPCS rewrites the file every few minutes and each token is
+   * valid for at most an hour, so a cached value would expire silently.
+   */
+  @Test
+  void shouldRereadTokenOnEveryCallRatherThanCachingIt() throws IOException {
+    Path token = simulateSpcs("first-token");
+    assertThat(SpcsEnvironment.readToken()).isEqualTo("first-token");
+
+    Files.write(token, "rotated-token".getBytes(StandardCharsets.UTF_8));
+
+    assertThat(SpcsEnvironment.readToken()).isEqualTo("rotated-token");
+  }
+
+  @Test
+  void shouldTrimWhitespaceFromToken() throws IOException {
+    simulateSpcs("  padded-token\n");
+    assertThat(SpcsEnvironment.readToken()).isEqualTo("padded-token");
+  }
+
+  @Test
+  void shouldFailWithActionableMessageWhenTokenUnreadable() {
+    simulateOutsideSpcs();
+    assertThatThrownBy(SpcsEnvironment::readToken)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Snowpark Container Services");
+  }
+}

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientPropertiesTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientPropertiesTest.java
@@ -40,11 +40,47 @@ import java.util.Properties;
 import org.apache.kafka.common.config.types.Password;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 public class StreamingClientPropertiesTest {
 
   private static final String EXAMPLE_PARAM1 = "EXAMPLE_PARAM1".toLowerCase();
   private static final String EXAMPLE_PARAM2 = "EXAMPLE_PARAM2".toLowerCase();
+
+  /**
+   * Guards the exhaustiveness of the authenticator switch in {@link
+   * StreamingClientProperties#from}. Before the explicit {@code default: throw}, an unhandled
+   * {@link AuthenticatorType} fell through silently and produced client properties with no
+   * credential material at all, surfacing later as an unrelated error inside the streaming SDK.
+   * Adding a new enum constant without handling it here now fails this test immediately.
+   */
+  @ParameterizedTest
+  @EnumSource(AuthenticatorType.class)
+  void shouldHandleEveryAuthenticatorType(AuthenticatorType authenticator) {
+    // GIVEN a config that is valid for this authenticator
+    SnowflakeSinkConnectorConfigBuilder builder =
+        SnowflakeSinkConnectorConfigBuilder.streamingConfig()
+            .withAuthenticator(authenticator.toConfigValue())
+            .withPrivateKey(Base64.getEncoder().encodeToString(generatePrivateKey().getEncoded()));
+    if (authenticator == AuthenticatorType.OAUTH) {
+      builder =
+          builder
+              .withOauthClientId("testClientId")
+              .withOauthClientSecret("testClientSecret")
+              .withOauthRefreshToken("testRefreshToken");
+    }
+    Map<String, String> connectorConfig = builder.build();
+    connectorConfig.put(Utils.TASK_ID, "0");
+
+    // WHEN
+    Properties clientProperties =
+        StreamingClientProperties.from(SinkTaskConfig.from(connectorConfig)).clientProperties;
+
+    // THEN the switch handled it and emitted this authenticator's credential material
+    assertThat(clientProperties.stringPropertyNames())
+        .containsAnyOf("authorization_type", "private_key");
+  }
 
   @Test
   public void testGetValidProperties() {


### PR DESCRIPTION
**Jira:** [SNOW-3961901](https://snowflakecomputing.atlassian.net/browse/SNOW-3961901)
**Design document:** [https://docs.google.com/document/d/1NqtBk9tCD5C8Z1TMtJZT5qf367aYxaBB3LAQ2hDR92c/edit?usp=sharing](https://docs.google.com/document/d/1NqtBk9tCD5C8Z1TMtJZT5qf367aYxaBB3LAQ2hDR92c/edit?usp=sharing)

## Stack

This is a three-PR stack.  **No configuration produces an SPCS setup until PR [3/3]**, so these first two PRs are inert by construction and nothing can enter the new code paths yet.  Start reading here, but all review effort belongs in [3/3].

| PR | Commits | What | Inert? |
|---|---|---|---|
| **[1/3] ← you are here** | `spcs-1-fail-fast`, `spcs-2-environment` | Fail-fast guard + `SpcsEnvironment` | Yes |
| [2/3] | `spcs-3-credential-paths`, `spcs-4-resolve` | Credential paths + resolution | Yes |
| [3/3] | `spcs-5-enable`, `spcs-6-concurrency` | Entry points wired up + concurrency cover | **Live** |

Chain A (PR #1541) and Chain C (PR #1545, the blank-config fix — **merged 2026-08-19**) are independent and can be reviewed in parallel.

## Why this exists

On `master` today, the connector has zero awareness of Snowpark Container Services.
A search for `SNOWFLAKE_HOST`, `SNOWFLAKE_DATABASE`, `/snowflake/session/token` returns
no matches.  Running KC inside SPCS today requires a full credential configuration,
meaning a key pair or OAuth client stored as a secret — the same setup as on bare metal.
SPCS provides a service user credential automatically; this change teaches KC to use it.

## This PR: two preparatory commits

**Commit 1 — `fail fast on unhandled authenticator in StreamingClientProperties`** (+2 prod, +36 test)

The authenticator switch in `StreamingClientProperties.from()` fell through silently
for any unknown `AuthenticatorType`.  A `default: throw` is added.  This is a guard
that makes the next commit safe to add: a new `case SPCS` can be handled explicitly
knowing that any future enum value that is not handled will immediately fail the build
via an existing exhaustiveness test.

**Commit 2 — `add SpcsEnvironment for read-only access to the SPCS service credentials`** (+120 prod, +94 test)

Adds the `SpcsEnvironment` class.  It knows three things:
- Whether the runtime is SPCS (`isInsideSpcs()`: env var `SNOWFLAKE_HOST` present AND token file readable)
- The ambient values (`host()`, `account()`, `database()`, `schema()`)
- The ambient bearer token (`readToken()`, re-read on every call — rotation requires this)

Nothing in the connector calls any of these methods yet.  The class is deliberately
isolated from connector configuration to keep environment access separate from config
policy.

## Tests

793 → **799** across these two commits, from a clean build, zero failures.

[SNOW-3961901]: https://snowflakecomputing.atlassian.net/browse/SNOW-3961901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ