### PR TITLE
SNOW-3961901: [2/3] SPCS ambient auth — credential paths + resolution (inert)

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/config/AuthenticatorType.java
+++ b/src/main/java/com/snowflake/kafka/connector/config/AuthenticatorType.java
@@ -12,7 +12,46 @@ public enum AuthenticatorType {
   SNOWFLAKE_JWT,
 
   /** External OAuth authentication. */
-  OAUTH;
+  OAUTH,
+
+  /**
+   * Ambient Snowpark Container Services (SPCS) authentication, using the Snowflake-provided service
+   * user credentials. The bearer token is supplied by the SPCS runtime, so no credential is
+   * configured. Only valid for a connector running inside SPCS.
+   *
+   * @see <a
+   *     href="https://docs.snowflake.com/en/developer-guide/snowpark-container-services/spcs-execute-sql">Snowpark
+   *     Container Services: SQL execution</a>
+   */
+  SPCS;
+
+  /**
+   * Whether the credential itself identifies the Snowflake user, so the connector must not assert
+   * one.
+   *
+   * <p>This is a property of the authentication method, not of a particular enum constant, and the
+   * call sites are written against it rather than against {@code == SPCS} so that a future ambient
+   * authenticator (for example workload identity federation) gets the correct behavior by declaring
+   * it here, instead of by finding every place that compares the enum.
+   *
+   * <p>When this is true, two things follow, both verified against a live SPCS service:
+   *
+   * <ul>
+   *   <li>The {@code user} property must be omitted from the credentials handed to the JDBC driver
+   *       and to the streaming SDK. Snowflake rejects a session whose asserted user differs from
+   *       the subject of the supplied token: {@code 390309 The user you were trying to authenticate
+   *       as differs from the user tied to the access token}.
+   *   <li>{@code SnowflakeErrors.ERROR_0016}, which requires a user to be present in the JDBC
+   *       properties, must not fire, because the user is deliberately absent.
+   * </ul>
+   *
+   * <p>A synthetic user is still written into the <i>configuration</i> so the existing validator
+   * checks pass unchanged; it simply never reaches Snowflake. See {@code
+   * SpcsEnvironment.AMBIENT_USER_PLACEHOLDER}.
+   */
+  public boolean suppliesAmbientIdentity() {
+    return this == SPCS;
+  }
 
   /** The config string value, matching the v3 connector convention (lowercase with underscores). */
   public String toConfigValue() {

--- a/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
@@ -7,6 +7,7 @@ import com.snowflake.kafka.connector.config.AuthenticatorType;
 import com.snowflake.kafka.connector.config.SinkTaskConfig;
 import com.snowflake.kafka.connector.internal.oauth.OAuthAccessTokenFetcher;
 import com.snowflake.kafka.connector.internal.oauth.OAuthURL;
+import com.snowflake.kafka.connector.internal.spcs.SpcsEnvironment;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.sql.ResultSet;
@@ -92,7 +93,16 @@ public class InternalUtils {
 
     putIfNotBlank(properties, JDBC_DATABASE, config.getSnowflakeDatabase());
     putIfNotBlank(properties, JDBC_SCHEMA, config.getSnowflakeSchema());
-    putIfNotBlank(properties, JDBC_USER, config.getSnowflakeUser());
+    if (!config.getAuthenticator().suppliesAmbientIdentity()) {
+      // Deliberately NOT set when the credential identifies the user itself. Snowflake rejects a
+      // session whose asserted user differs from the token's subject:
+      //   The user you were trying to authenticate as differs from the user tied to the
+      //   access token.
+      // The connector has no way to know the generated service user's name, so it must not
+      // claim one. Verified against a live SPCS service: sending the placeholder user fails,
+      // omitting the user succeeds.
+      putIfNotBlank(properties, JDBC_USER, config.getSnowflakeUser());
+    }
     putIfNotBlank(properties, JdbcPropertyKeys.ROLE, config.getSnowflakeRole());
 
     switch (config.getAuthenticator()) {
@@ -125,6 +135,15 @@ public class InternalUtils {
                     .orElseThrow(SnowflakeErrors.ERROR_0013::getException),
                 config.getSnowflakePrivateKeyPassphrase()));
         break;
+      case SPCS:
+        // Snowflake-provided service user credentials ("ambient" authentication). The driver has
+        // no SPCS mode: as the SPCS documentation prescribes, the container connects with
+        // authenticator=oauth and the token from the file Snowflake manages. The token is read
+        // here, while properties are assembled, so every new connection uses the current one --
+        // Snowflake rewrites the file every few minutes.
+        properties.put(JdbcPropertyKeys.AUTHENTICATOR, AuthenticatorType.OAUTH.toConfigValue());
+        properties.put(JDBC_TOKEN, SpcsEnvironment.readToken());
+        break;
       default:
         throw new IllegalStateException("unhandled authenticator: " + config.getAuthenticator());
     }
@@ -142,7 +161,10 @@ public class InternalUtils {
     if (!properties.containsKey(JDBC_DATABASE)) {
       throw SnowflakeErrors.ERROR_0015.getException();
     }
-    if (!properties.containsKey(JDBC_USER)) {
+    // Not required when the credential supplies the identity: the user is deliberately omitted
+    // above, because the token identifies the user and asserting any other one is rejected.
+    if (!config.getAuthenticator().suppliesAmbientIdentity()
+        && !properties.containsKey(JDBC_USER)) {
       throw SnowflakeErrors.ERROR_0016.getException();
     }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/spcs/SpcsEnvironment.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/spcs/SpcsEnvironment.java
@@ -1,12 +1,16 @@
 package com.snowflake.kafka.connector.internal.spcs;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams;
+import com.snowflake.kafka.connector.config.AuthenticatorType;
 import com.snowflake.kafka.connector.internal.KCLogger;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -52,6 +56,24 @@ public final class SpcsEnvironment {
   static final String ENV_DATABASE = "SNOWFLAKE_DATABASE";
   static final String ENV_SCHEMA = "SNOWFLAKE_SCHEMA";
 
+  /**
+   * Placeholder written to {@code snowflake.user.name} in ambient mode. The effective identity is
+   * carried by the token rather than by this value, but several code paths require a non-blank
+   * user.
+   *
+   * <p>Not the real service user name. Snowflake names the service user after the service itself,
+   * or {@code SF$SERVICE$<unique-id>} for services created before the 8.35 release, which this
+   * class has no reliable way to discover from inside the container.
+   *
+   * <p><b>This value must never be sent to Snowflake.</b> It exists only to satisfy the connector's
+   * own requirement that a user name be configured. The ambient token already identifies the
+   * service user, and a session that asserts a different user is rejected with "The user you were
+   * trying to authenticate as differs from the user tied to the access token". Both {@code
+   * InternalUtils.makeJdbcDriverProperties} and {@code StreamingClientProperties} therefore omit
+   * the user entirely when the authenticator is {@code spcs}. Verified against a live SPCS service.
+   */
+  public static final String AMBIENT_USER_PLACEHOLDER = "spcs-service-user";
+
   /** Environment lookup. Overridable so tests can simulate an SPCS container. */
   private static Function<String, String> envReader = System::getenv;
 
@@ -86,8 +108,9 @@ public final class SpcsEnvironment {
    * @throws IllegalStateException if the token file cannot be read
    */
   public static String readToken() {
+    String token;
     try {
-      return new String(Files.readAllBytes(tokenPath), StandardCharsets.UTF_8).trim();
+      token = new String(Files.readAllBytes(tokenPath), StandardCharsets.UTF_8).trim();
     } catch (IOException e) {
       throw new IllegalStateException(
           "Failed to read the SPCS session token at "
@@ -95,6 +118,110 @@ public final class SpcsEnvironment {
               + ". This file is provided by the SPCS runtime; ambient authentication is only"
               + " available to a connector running inside Snowpark Container Services.",
           e);
+    }
+    if (token.isEmpty()) {
+      // Fail here rather than sending an empty bearer token. Snowflake rejects it with
+      //   390303 Invalid OAuth access token.
+      // which is accurate but says nothing about which file was empty or why, and arrives
+      // only after a network round trip. An empty token means the platform did not supply a
+      // credential, which is a local, inspectable condition.
+      throw new IllegalStateException(
+          "The SPCS session token at "
+              + tokenPath
+              + " is empty. Check that the service specification sets"
+              + " capabilities.securityContext.enableCustomCredentials: true"
+              + " — without it the server returns 390303 Invalid OAuth access token.");
+    }
+    return token;
+  }
+
+  /**
+   * Fills in the values Snowflake provides to a service container, so the rest of the connector
+   * sees an ordinary, complete configuration.
+   *
+   * <p>This is the single entry point for resolving the Snowflake-provided service user
+   * credentials. It is a no-op outside SPCS and never overwrites a value the user supplied, so
+   * explicit configuration always wins. It is also idempotent, so applying it at more than one
+   * layer is safe.
+   *
+   * @param raw raw connector configuration
+   * @return {@code raw} unchanged when outside SPCS, otherwise a copy with ambient values added
+   */
+  public static Map<String, String> resolve(Map<String, String> raw) {
+    if (raw == null || !isInsideSpcs()) {
+      return raw;
+    }
+
+    String configuredAuthenticator = raw.get(KafkaConnectorConfigParams.SNOWFLAKE_AUTHENTICATOR);
+
+    if (isBlank(configuredAuthenticator)) {
+      // No authenticator was configured. That does NOT mean "no credential": an absent value
+      // makes AuthenticatorType.fromConfig return SNOWFLAKE_JWT, so a deployment that supplies
+      // only a private key is a key-pair deployment that never had to name its authenticator.
+      // Adopting ambient authentication here would silently ignore that credential and connect
+      // as the SPCS service user instead, which is a different identity with different grants.
+      // So only adopt when there is no credential at all to ignore.
+      if (hasConfiguredCredential(raw)) {
+        LOGGER.info(
+            "Running inside Snowpark Container Services, but a credential is configured, so the"
+                + " existing authentication method is kept. Set '{}' to '{}' to use ambient SPCS"
+                + " authentication instead.",
+            KafkaConnectorConfigParams.SNOWFLAKE_AUTHENTICATOR,
+            AuthenticatorType.SPCS.toConfigValue());
+        return raw;
+      }
+      LOGGER.info(
+          "Running inside Snowpark Container Services and '{}' was not configured; using ambient"
+              + " SPCS authentication.",
+          KafkaConnectorConfigParams.SNOWFLAKE_AUTHENTICATOR);
+    } else if (!AuthenticatorType.SPCS
+        .toConfigValue()
+        .equalsIgnoreCase(configuredAuthenticator.trim())) {
+      // An authenticator was chosen explicitly. Change nothing.
+      // The value is trimmed before comparison so this agrees with
+      // AuthenticatorType.fromConfig, which also trims. Without the trim, a configuration
+      // written as "snowflake.authenticator = spcs " parses as SPCS later but is treated
+      // here as some other authenticator, so nothing is resolved and the connector then
+      // fails with "snowflake.url.name must be provided" for no visible reason.
+      return raw;
+    }
+
+    Map<String, String> resolved = new HashMap<>(raw);
+    resolved.put(
+        KafkaConnectorConfigParams.SNOWFLAKE_AUTHENTICATOR, AuthenticatorType.SPCS.toConfigValue());
+    putIfBlank(resolved, KafkaConnectorConfigParams.SNOWFLAKE_URL_NAME, host());
+    putIfBlank(resolved, KafkaConnectorConfigParams.SNOWFLAKE_DATABASE_NAME, database());
+    putIfBlank(resolved, KafkaConnectorConfigParams.SNOWFLAKE_SCHEMA_NAME, schema());
+    putIfBlank(
+        resolved,
+        KafkaConnectorConfigParams.SNOWFLAKE_USER_NAME,
+        Optional.of(AMBIENT_USER_PLACEHOLDER));
+
+    if (!isBlank(resolved.get(KafkaConnectorConfigParams.SNOWFLAKE_PRIVATE_KEY))) {
+      LOGGER.warn(
+          "'{}' is set but will be ignored: ambient SPCS authentication uses the token supplied by"
+              + " the SPCS runtime.",
+          KafkaConnectorConfigParams.SNOWFLAKE_PRIVATE_KEY);
+    }
+
+    return resolved;
+  }
+
+  /**
+   * True when the configuration already carries a credential, so switching authentication method
+   * would discard it. Covers the key-pair and OAuth credential fields; the non-secret OAuth
+   * settings (token endpoint, scope) are not credentials and are deliberately not consulted.
+   */
+  private static boolean hasConfiguredCredential(Map<String, String> config) {
+    return !isBlank(config.get(KafkaConnectorConfigParams.SNOWFLAKE_PRIVATE_KEY))
+        || !isBlank(config.get(KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_CLIENT_ID))
+        || !isBlank(config.get(KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_CLIENT_SECRET))
+        || !isBlank(config.get(KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_REFRESH_TOKEN));
+  }
+
+  private static void putIfBlank(Map<String, String> config, String key, Optional<String> value) {
+    if (isBlank(config.get(key))) {
+      value.ifPresent(v -> config.put(key, v));
     }
   }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProperties.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProperties.java
@@ -106,11 +106,26 @@ public class StreamingClientProperties {
             Base64.getEncoder().encodeToString(privateKey.getEncoded());
         clientProperties.put("private_key", privateKeyEncoded);
         break;
+      case SPCS:
+        // Snowflake-provided service user credentials ("ambient" authentication). Deliberately
+        // sets no spcs_* keys: the SDK already defaults spcs_token_path and
+        // spcs_service_token_path to the standard SPCS locations, and its exclusive-field check
+        // treats them as user-set only when they differ from those defaults. Leaving them alone
+        // also keeps the connector clear of the config-key injection path tracked in
+        // SNOW-3686036. Note no oauth_* key may be set here, including oauth_include_scope, which
+        // the SDK counts as set when false.
+        clientProperties.put("authorization_type", AuthenticatorType.SPCS.toConfigValue());
+        break;
       default:
         throw new IllegalStateException("unhandled authenticator: " + config.getAuthenticator());
     }
 
-    clientProperties.put("user", config.getSnowflakeUser());
+    if (!config.getAuthenticator().suppliesAmbientIdentity()) {
+      // See the note in InternalUtils.makeJdbcDriverProperties: when the credential itself
+      // identifies the user, asserting any other user is rejected. The connector cannot know
+      // the generated service user's name, so it must not send one.
+      clientProperties.put("user", config.getSnowflakeUser());
+    }
     clientProperties.put("role", config.getSnowflakeRole());
     clientProperties.put("account", url.getAccount());
     clientProperties.put("host", url.getUrlWithoutPort());

--- a/src/test/java/com/snowflake/kafka/connector/config/AuthenticatorTypeTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/config/AuthenticatorTypeTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2025 Snowflake Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.snowflake.kafka.connector.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+class AuthenticatorTypeTest {
+
+  /**
+   * Pins the exact set of authenticators whose credential identifies the user. This is the property
+   * that suppresses the {@code user} property on both credential paths and exempts {@code
+   * ERROR_0016}, so widening it silently would change what the connector sends to Snowflake.
+   *
+   * <p>If a new ambient authenticator is added, update this set deliberately rather than letting
+   * the assertion be relaxed to fit.
+   */
+  @Test
+  void exactlySpcsSuppliesAmbientIdentity() {
+    Set<AuthenticatorType> ambient =
+        Arrays.stream(AuthenticatorType.values())
+            .filter(AuthenticatorType::suppliesAmbientIdentity)
+            .collect(Collectors.toCollection(() -> EnumSet.noneOf(AuthenticatorType.class)));
+
+    assertThat(ambient).containsExactly(AuthenticatorType.SPCS);
+  }
+
+  /**
+   * The credential-based authenticators must keep asserting a user. Written as a parameterised test
+   * over the enum so that adding a constant without considering this property fails here rather
+   * than at a call site.
+   */
+  @ParameterizedTest
+  @EnumSource(
+      value = AuthenticatorType.class,
+      names = {"SNOWFLAKE_JWT", "OAUTH"})
+  void credentialAuthenticatorsDoNotSupplyAmbientIdentity(AuthenticatorType authenticator) {
+    assertThat(authenticator.suppliesAmbientIdentity()).isFalse();
+  }
+}

--- a/src/test/java/com/snowflake/kafka/connector/config/SnowflakeSinkConnectorConfigBuilder.java
+++ b/src/test/java/com/snowflake/kafka/connector/config/SnowflakeSinkConnectorConfigBuilder.java
@@ -51,6 +51,17 @@ public class SnowflakeSinkConnectorConfigBuilder {
     return this;
   }
 
+  /**
+   * Removes the preset URL, so that a test can assert on a URL supplied from elsewhere. Needed by
+   * the ambient SPCS tests: {@code SpcsEnvironment.resolve()} fills the URL from {@code
+   * SNOWFLAKE_HOST} only when the configured value is blank, so a test that leaves the preset URL
+   * in place is asserting on its own input rather than on ambient resolution.
+   */
+  public SnowflakeSinkConnectorConfigBuilder withoutUrl() {
+    config.remove(SNOWFLAKE_URL_NAME);
+    return this;
+  }
+
   public SnowflakeSinkConnectorConfigBuilder withDatabase(String database) {
     config.put(SNOWFLAKE_DATABASE_NAME, database);
     return this;

--- a/src/test/java/com/snowflake/kafka/connector/internal/InternalUtilsNonSpcsRegressionTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/InternalUtilsNonSpcsRegressionTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2025 Snowflake Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.snowflake.kafka.connector.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.snowflake.kafka.connector.config.SinkTaskConfig;
+import com.snowflake.kafka.connector.internal.spcs.SpcsEnvironment;
+import java.util.Map;
+import java.util.Properties;
+import java.util.TreeSet;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Whole-key-set regression guard for the credential-based path to the JDBC driver.
+ *
+ * <p>The ambient SPCS change touches shared code on the way to the driver: it makes the {@code
+ * user} property conditional and exempts one validation gate. The surrounding suites assert
+ * individual properties, which proves the new behavior but would not notice a property quietly
+ * appearing or disappearing for {@code snowflake_jwt}.
+ *
+ * <p>This pins the <b>entire</b> key set, so any future change that adds, removes or renames a JDBC
+ * property on the key-pair path fails here and has to be justified. The equivalent whole-map check
+ * for the streaming path already exists in {@code StreamingClientPropertiesTest}; the OAuth JDBC
+ * path deliberately has no unit-level equivalent because building it calls {@code
+ * OAuthAccessTokenFetcher} and would require a live token endpoint.
+ */
+public class InternalUtilsNonSpcsRegressionTest {
+
+  @AfterEach
+  public void reset() {
+    SpcsEnvironment.resetForTests();
+  }
+
+  @Test
+  public void keyPairJdbcPropertyKeySetIsUnchanged() {
+    Map<String, String> config = TestUtils.transformProfileFileToConnectorConfiguration(true);
+    SnowflakeURL url = TestUtils.getUrl();
+
+    Properties props =
+        InternalUtils.makeJdbcDriverProperties(SinkTaskConfig.from(config, true), url);
+
+    // keySet(), not stringPropertyNames(): the latter silently omits entries whose value is not a
+    // String, and "privateKey" holds a java.security.PrivateKey. Using stringPropertyNames() here
+    // would make this guard blind to exactly the property that matters most on this path.
+    TreeSet<String> keys = new TreeSet<>();
+    props.keySet().forEach(k -> keys.add(String.valueOf(k)));
+
+    assertThat(keys)
+        .as(
+            "the JDBC property key set for the key-pair path must not change; ambient SPCS support"
+                + " must not add or remove properties here")
+        .containsExactly(
+            "JDBC_QUERY_RESULT_FORMAT",
+            "allowUnderscoresInHost",
+            "authenticator",
+            "client_session_keep_alive",
+            "db",
+            "privateKey",
+            "role",
+            "schema",
+            "ssl",
+            "user");
+
+    // The two properties the ambient change is most likely to have disturbed.
+    assertThat(props.getProperty("authenticator")).isEqualTo("snowflake_jwt");
+    assertThat(keys)
+        .as("a key-pair connection must never carry an ambient bearer token")
+        .doesNotContain("token");
+  }
+}

--- a/src/test/java/com/snowflake/kafka/connector/internal/InternalUtilsTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/InternalUtilsTest.java
@@ -9,7 +9,11 @@ import com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams;
 import com.snowflake.kafka.connector.config.AuthenticatorType;
 import com.snowflake.kafka.connector.config.SinkTaskConfig;
 import com.snowflake.kafka.connector.config.SinkTaskConfigTestBuilder;
+import com.snowflake.kafka.connector.internal.spcs.SpcsEnvironment;
 import com.snowflake.kafka.connector.mock.MockResultSetForSizeTest;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Base64;
@@ -19,6 +23,7 @@ import java.util.Optional;
 import java.util.Properties;
 import org.apache.kafka.common.config.types.Password;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class InternalUtilsTest {
   @Test
@@ -432,5 +437,115 @@ public class InternalUtilsTest {
     assertFalse(
         props.containsKey(JdbcPropertyKeys.ROLE),
         "JDBC properties should not contain role when role is whitespace");
+  }
+
+  /**
+   * Ambient SPCS authentication reuses the driver's OAuth mode: the driver has no SPCS mode, it
+   * simply accepts a caller-supplied bearer token read from the file SPCS manages.
+   */
+  @Test
+  public void testMakeJdbcDriverProperties_spcsUsesOauthWithAmbientToken(@TempDir Path tempDir)
+      throws Exception {
+    Path token = tempDir.resolve("token");
+    Files.write(token, "ambient-bearer-token".getBytes(StandardCharsets.UTF_8));
+    Map<String, String> env = new HashMap<>();
+    env.put(SpcsEnvironment.ENV_HOST, "account.snowflakecomputing.com");
+    SpcsEnvironment.overrideForTests(env::get, token);
+    try {
+      SinkTaskConfig config =
+          SinkTaskConfigTestBuilder.builder()
+              .connectorName("test")
+              .taskId("0")
+              .snowflakeDatabase("db")
+              .snowflakeSchema("schema")
+              .snowflakeUser("user")
+              .snowflakeUrl("https://account.snowflakecomputing.com")
+              .authenticator(AuthenticatorType.SPCS)
+              .build();
+
+      Properties props =
+          InternalUtils.makeJdbcDriverProperties(
+              config, new SnowflakeURL("https://account.snowflakecomputing.com"));
+
+      assertEquals(
+          AuthenticatorType.OAUTH.toConfigValue(),
+          props.getProperty(JdbcPropertyKeys.AUTHENTICATOR),
+          "SPCS must authenticate to the driver as oauth with a supplied token");
+      assertEquals("ambient-bearer-token", props.getProperty(InternalUtils.JDBC_TOKEN));
+      assertFalse(
+          props.containsKey(InternalUtils.JDBC_PRIVATE_KEY), "SPCS must not send a private key");
+      assertFalse(
+          props.containsKey(InternalUtils.JDBC_USER),
+          "SPCS must not send a user: the token identifies the service user, and Snowflake"
+              + " rejects a session whose asserted user differs from the token's subject"
+              + " (\"The user you were trying to authenticate as differs from the user tied to"
+              + " the access token\"). Verified against a live SPCS service: sending a user"
+              + " fails, omitting it succeeds.");
+    } finally {
+      SpcsEnvironment.resetForTests();
+    }
+  }
+
+  /**
+   * The user is required for every other authenticator, and its absence must still be an error.
+   * This guards the SPCS exemption from being widened by accident.
+   */
+  @Test
+  public void testMakeJdbcDriverProperties_userStillRequiredForKeyPair() {
+    String pemKey = Base64.getEncoder().encodeToString(TestUtils.generatePrivateKey().getEncoded());
+    SinkTaskConfig config =
+        SinkTaskConfigTestBuilder.builder()
+            .connectorName("test")
+            .taskId("0")
+            .snowflakeDatabase("db")
+            .snowflakeSchema("schema")
+            .snowflakeUrl("https://account.snowflakecomputing.com")
+            .authenticator(AuthenticatorType.SNOWFLAKE_JWT)
+            .snowflakePrivateKey(new Password(pemKey))
+            .build();
+    assertThrows(
+        SnowflakeKafkaConnectorException.class,
+        () ->
+            InternalUtils.makeJdbcDriverProperties(
+                config, new SnowflakeURL("https://account.snowflakecomputing.com")),
+        "a missing user must remain an error for credential-based authenticators");
+  }
+
+  /** The token must be re-read per connection, not captured once. */
+  @Test
+  public void testMakeJdbcDriverProperties_spcsRereadsRotatedToken(@TempDir Path tempDir)
+      throws Exception {
+    Path token = tempDir.resolve("token");
+    Files.write(token, "first".getBytes(StandardCharsets.UTF_8));
+    Map<String, String> env = new HashMap<>();
+    env.put(SpcsEnvironment.ENV_HOST, "account.snowflakecomputing.com");
+    SpcsEnvironment.overrideForTests(env::get, token);
+    try {
+      SinkTaskConfig config =
+          SinkTaskConfigTestBuilder.builder()
+              .connectorName("test")
+              .taskId("0")
+              .snowflakeDatabase("db")
+              .snowflakeSchema("schema")
+              .snowflakeUser("user")
+              .snowflakeUrl("https://account.snowflakecomputing.com")
+              .authenticator(AuthenticatorType.SPCS)
+              .build();
+      SnowflakeURL url = new SnowflakeURL("https://account.snowflakecomputing.com");
+
+      assertEquals(
+          "first",
+          InternalUtils.makeJdbcDriverProperties(config, url)
+              .getProperty(InternalUtils.JDBC_TOKEN));
+
+      Files.write(token, "rotated".getBytes(StandardCharsets.UTF_8));
+
+      assertEquals(
+          "rotated",
+          InternalUtils.makeJdbcDriverProperties(config, url)
+              .getProperty(InternalUtils.JDBC_TOKEN));
+    } finally {
+      SpcsEnvironment.resetForTests();
+    }
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/internal/spcs/SpcsEnvironmentTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/spcs/SpcsEnvironmentTest.java
@@ -3,6 +3,8 @@ package com.snowflake.kafka.connector.internal.spcs;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams;
+import com.snowflake.kafka.connector.config.AuthenticatorType;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -12,6 +14,8 @@ import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class SpcsEnvironmentTest {
 
@@ -90,5 +94,266 @@ public class SpcsEnvironmentTest {
     assertThatThrownBy(SpcsEnvironment::readToken)
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("Snowpark Container Services");
+  }
+
+  @Test
+  void shouldBeNoOpOutsideSpcs() {
+    simulateOutsideSpcs();
+    Map<String, String> raw = new HashMap<>();
+    raw.put(KafkaConnectorConfigParams.NAME, "testConnector");
+
+    Map<String, String> resolved = SpcsEnvironment.resolve(raw);
+
+    assertThat(resolved).isEqualTo(raw);
+    assertThat(resolved).doesNotContainKey(KafkaConnectorConfigParams.SNOWFLAKE_AUTHENTICATOR);
+  }
+
+  @Test
+  void shouldTolerateNullConfig() {
+    simulateOutsideSpcs();
+    assertThat(SpcsEnvironment.resolve(null)).isNull();
+  }
+
+  @Test
+  void shouldFillInAmbientValuesInsideSpcs() throws IOException {
+    simulateSpcs("tok");
+
+    Map<String, String> resolved = SpcsEnvironment.resolve(new HashMap<>());
+
+    assertThat(resolved)
+        .containsEntry(
+            KafkaConnectorConfigParams.SNOWFLAKE_AUTHENTICATOR,
+            AuthenticatorType.SPCS.toConfigValue())
+        .containsEntry(KafkaConnectorConfigParams.SNOWFLAKE_URL_NAME, HOST)
+        .containsEntry(KafkaConnectorConfigParams.SNOWFLAKE_DATABASE_NAME, "AMBIENT_DB")
+        .containsEntry(KafkaConnectorConfigParams.SNOWFLAKE_SCHEMA_NAME, "AMBIENT_SCHEMA")
+        .containsEntry(
+            KafkaConnectorConfigParams.SNOWFLAKE_USER_NAME,
+            SpcsEnvironment.AMBIENT_USER_PLACEHOLDER);
+  }
+
+  @Test
+  void shouldNotOverwriteUserSuppliedValues() throws IOException {
+    simulateSpcs("tok");
+    Map<String, String> raw = new HashMap<>();
+    raw.put(KafkaConnectorConfigParams.SNOWFLAKE_DATABASE_NAME, "MY_DB");
+    raw.put(KafkaConnectorConfigParams.SNOWFLAKE_SCHEMA_NAME, "MY_SCHEMA");
+
+    Map<String, String> resolved = SpcsEnvironment.resolve(raw);
+
+    assertThat(resolved)
+        .containsEntry(KafkaConnectorConfigParams.SNOWFLAKE_DATABASE_NAME, "MY_DB")
+        .containsEntry(KafkaConnectorConfigParams.SNOWFLAKE_SCHEMA_NAME, "MY_SCHEMA");
+  }
+
+  /** An explicitly configured authenticator must always win over ambient detection. */
+  @Test
+  void shouldLeaveConfigAloneWhenAnotherAuthenticatorIsExplicit() throws IOException {
+    simulateSpcs("tok");
+    Map<String, String> raw = new HashMap<>();
+    raw.put(
+        KafkaConnectorConfigParams.SNOWFLAKE_AUTHENTICATOR,
+        AuthenticatorType.SNOWFLAKE_JWT.toConfigValue());
+
+    Map<String, String> resolved = SpcsEnvironment.resolve(raw);
+
+    assertThat(resolved)
+        .containsEntry(
+            KafkaConnectorConfigParams.SNOWFLAKE_AUTHENTICATOR,
+            AuthenticatorType.SNOWFLAKE_JWT.toConfigValue())
+        .doesNotContainKey(KafkaConnectorConfigParams.SNOWFLAKE_URL_NAME)
+        .doesNotContainKey(KafkaConnectorConfigParams.SNOWFLAKE_USER_NAME);
+  }
+
+  /**
+   * The regression this guards against: an absent {@code snowflake.authenticator} does NOT mean "no
+   * credential". {@link AuthenticatorType#fromConfig} returns {@code SNOWFLAKE_JWT} for an absent
+   * value, so a deployment that supplies only a private key is a key-pair deployment that never had
+   * to name its authenticator. If ambient authentication were adopted here, that key would be
+   * ignored and the connector would silently connect as the SPCS service user, a different identity
+   * with different grants. The configuration must be returned untouched.
+   */
+  @Test
+  void shouldNotAdoptAmbientAuthWhenAKeyPairCredentialIsConfigured() throws IOException {
+    simulateSpcs("tok");
+    Map<String, String> raw = new HashMap<>();
+    raw.put(KafkaConnectorConfigParams.SNOWFLAKE_PRIVATE_KEY, "a-private-key");
+
+    Map<String, String> resolved = SpcsEnvironment.resolve(raw);
+
+    assertThat(resolved).isSameAs(raw);
+    assertThat(resolved)
+        .doesNotContainKey(KafkaConnectorConfigParams.SNOWFLAKE_AUTHENTICATOR)
+        .doesNotContainKey(KafkaConnectorConfigParams.SNOWFLAKE_URL_NAME)
+        .doesNotContainKey(KafkaConnectorConfigParams.SNOWFLAKE_USER_NAME)
+        .containsEntry(KafkaConnectorConfigParams.SNOWFLAKE_PRIVATE_KEY, "a-private-key");
+  }
+
+  /** The same protection must apply to an OAuth deployment that did not name its authenticator. */
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_CLIENT_ID,
+        KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_CLIENT_SECRET,
+        KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_REFRESH_TOKEN
+      })
+  void shouldNotAdoptAmbientAuthWhenAnOauthCredentialIsConfigured(String credentialKey)
+      throws IOException {
+    simulateSpcs("tok");
+    Map<String, String> raw = new HashMap<>();
+    raw.put(credentialKey, "a-value");
+
+    Map<String, String> resolved = SpcsEnvironment.resolve(raw);
+
+    assertThat(resolved).isSameAs(raw);
+    assertThat(resolved).doesNotContainKey(KafkaConnectorConfigParams.SNOWFLAKE_AUTHENTICATOR);
+  }
+
+  /**
+   * The non-secret OAuth settings are not credentials, so they must not suppress adoption. Only a
+   * client id, client secret, refresh token, or private key counts.
+   */
+  @Test
+  void shouldStillAdoptAmbientAuthWhenOnlyNonSecretOauthSettingsArePresent() throws IOException {
+    simulateSpcs("tok");
+    Map<String, String> raw = new HashMap<>();
+    raw.put(KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_TOKEN_ENDPOINT, "https://example/token");
+
+    Map<String, String> resolved = SpcsEnvironment.resolve(raw);
+
+    assertThat(resolved)
+        .containsEntry(
+            KafkaConnectorConfigParams.SNOWFLAKE_AUTHENTICATOR,
+            AuthenticatorType.SPCS.toConfigValue());
+  }
+
+  /**
+   * An operator who asks for ambient authentication explicitly has made the choice knowingly, so a
+   * leftover credential must not block it. It is ignored, with a warning.
+   */
+  @Test
+  void shouldAdoptAmbientAuthDespiteACredentialWhenSpcsIsExplicit() throws IOException {
+    simulateSpcs("tok");
+    Map<String, String> raw = new HashMap<>();
+    raw.put(
+        KafkaConnectorConfigParams.SNOWFLAKE_AUTHENTICATOR, AuthenticatorType.SPCS.toConfigValue());
+    raw.put(KafkaConnectorConfigParams.SNOWFLAKE_PRIVATE_KEY, "a-private-key");
+
+    Map<String, String> resolved = SpcsEnvironment.resolve(raw);
+
+    assertThat(resolved)
+        .containsEntry(
+            KafkaConnectorConfigParams.SNOWFLAKE_AUTHENTICATOR,
+            AuthenticatorType.SPCS.toConfigValue())
+        .containsEntry(
+            KafkaConnectorConfigParams.SNOWFLAKE_USER_NAME,
+            SpcsEnvironment.AMBIENT_USER_PLACEHOLDER)
+        .containsKey(KafkaConnectorConfigParams.SNOWFLAKE_URL_NAME);
+  }
+
+  /**
+   * resolve() is applied at three layers (connector start, config validation, and config parsing),
+   * so it must be idempotent: resolving an already-resolved map must change nothing.
+   */
+  @Test
+  void shouldBeIdempotent() throws IOException {
+    simulateSpcs("tok");
+
+    Map<String, String> once = SpcsEnvironment.resolve(new HashMap<>());
+    Map<String, String> twice = SpcsEnvironment.resolve(once);
+
+    assertThat(twice).isEqualTo(once);
+  }
+
+  @Test
+  void shouldStillFillValuesWhenSpcsAuthenticatorIsExplicit() throws IOException {
+    simulateSpcs("tok");
+    Map<String, String> raw = new HashMap<>();
+    raw.put(
+        KafkaConnectorConfigParams.SNOWFLAKE_AUTHENTICATOR, AuthenticatorType.SPCS.toConfigValue());
+
+    Map<String, String> resolved = SpcsEnvironment.resolve(raw);
+
+    assertThat(resolved).containsEntry(KafkaConnectorConfigParams.SNOWFLAKE_URL_NAME, HOST);
+  }
+
+  /**
+   * {@code resolve()} compares the configured authenticator with {@code equalsIgnoreCase}, so a
+   * user who writes {@code SPCS} or {@code Spcs} must get ambient resolution just as one who writes
+   * {@code spcs} does. Kafka Connect passes configuration through verbatim, so the casing is
+   * whatever the operator typed.
+   */
+  @Test
+  void shouldTreatExplicitSpcsAuthenticatorCaseInsensitively() throws IOException {
+    for (String spelling : new String[] {"spcs", "SPCS", "Spcs", " spcs "}) {
+      simulateSpcs("tok");
+      Map<String, String> raw = new HashMap<>();
+      raw.put(KafkaConnectorConfigParams.SNOWFLAKE_AUTHENTICATOR, spelling);
+
+      Map<String, String> resolved = SpcsEnvironment.resolve(raw);
+
+      assertThat(resolved)
+          .as("authenticator spelled '%s' must still resolve ambient values", spelling)
+          .containsEntry(KafkaConnectorConfigParams.SNOWFLAKE_URL_NAME, HOST)
+          .containsEntry(
+              KafkaConnectorConfigParams.SNOWFLAKE_USER_NAME,
+              SpcsEnvironment.AMBIENT_USER_PLACEHOLDER);
+      SpcsEnvironment.resetForTests();
+    }
+  }
+
+  /**
+   * The database and schema are supplied by the SPCS runtime, but nothing guarantees they are
+   * present. When they are absent, resolution must leave them absent rather than invent them, so
+   * that the existing validator reports a clear configuration error instead of the connector
+   * failing later against the wrong schema.
+   */
+  @Test
+  void shouldNotInventDatabaseOrSchemaWhenTheRuntimeDoesNotSupplyThem() throws IOException {
+    Path token = tempDir.resolve("token");
+    Files.write(token, "tok".getBytes(StandardCharsets.UTF_8));
+    Map<String, String> env = new HashMap<>();
+    env.put(SpcsEnvironment.ENV_HOST, HOST);
+    // deliberately no SNOWFLAKE_DATABASE / SNOWFLAKE_SCHEMA
+    SpcsEnvironment.overrideForTests(env::get, token);
+
+    Map<String, String> resolved = SpcsEnvironment.resolve(new HashMap<>());
+
+    assertThat(resolved).containsEntry(KafkaConnectorConfigParams.SNOWFLAKE_URL_NAME, HOST);
+    assertThat(resolved).doesNotContainKey(KafkaConnectorConfigParams.SNOWFLAKE_DATABASE_NAME);
+    assertThat(resolved).doesNotContainKey(KafkaConnectorConfigParams.SNOWFLAKE_SCHEMA_NAME);
+  }
+
+  /**
+   * An empty token file fails fast, locally, rather than being sent to Snowflake.
+   *
+   * <p>Snowflake rejects an empty bearer token with {@code 390303 Invalid OAuth access token}
+   * (measured). That is accurate but names neither the file nor the cause, and it costs a network
+   * round trip. An empty token means the runtime supplied no credential, which is a local and
+   * inspectable condition, so the message names the path, quotes the error that would otherwise be
+   * returned, and points at the most common cause.
+   */
+  @Test
+  void shouldFailFastOnAnEmptyTokenFileRatherThanSendingIt() throws IOException {
+    simulateSpcs("");
+
+    // Detection is unchanged: the file exists and is readable, so this still looks like SPCS.
+    assertThat(SpcsEnvironment.isInsideSpcs()).isTrue();
+
+    assertThatThrownBy(SpcsEnvironment::readToken)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("is empty")
+        .hasMessageContaining("390303")
+        .hasMessageContaining("enableCustomCredentials");
+  }
+
+  /** Whitespace-only is empty for this purpose: the token is trimmed before it is judged. */
+  @Test
+  void shouldTreatWhitespaceOnlyTokenAsEmpty() throws IOException {
+    simulateSpcs("   \n\t  ");
+
+    assertThatThrownBy(SpcsEnvironment::readToken)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("is empty");
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientPropertiesTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientPropertiesTest.java
@@ -31,6 +31,11 @@ import com.snowflake.kafka.connector.config.SnowflakeSinkConnectorConfigBuilder;
 import com.snowflake.kafka.connector.internal.PrivateKeyTool;
 import com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException;
 import com.snowflake.kafka.connector.internal.SnowflakeURL;
+import com.snowflake.kafka.connector.internal.spcs.SpcsEnvironment;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.PrivateKey;
 import java.util.Base64;
 import java.util.HashMap;
@@ -40,6 +45,7 @@ import java.util.Properties;
 import org.apache.kafka.common.config.types.Password;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
@@ -57,7 +63,8 @@ public class StreamingClientPropertiesTest {
    */
   @ParameterizedTest
   @EnumSource(AuthenticatorType.class)
-  void shouldHandleEveryAuthenticatorType(AuthenticatorType authenticator) {
+  void shouldHandleEveryAuthenticatorType(AuthenticatorType authenticator, @TempDir Path tempDir)
+      throws IOException {
     // GIVEN a config that is valid for this authenticator
     SnowflakeSinkConnectorConfigBuilder builder =
         SnowflakeSinkConnectorConfigBuilder.streamingConfig()
@@ -70,16 +77,28 @@ public class StreamingClientPropertiesTest {
               .withOauthClientSecret("testClientSecret")
               .withOauthRefreshToken("testRefreshToken");
     }
+    if (authenticator == AuthenticatorType.SPCS) {
+      // ambient auth is only valid inside SPCS, so simulate that runtime
+      Path token = tempDir.resolve("token");
+      Files.write(token, "ambient-token".getBytes(StandardCharsets.UTF_8));
+      Map<String, String> env = new HashMap<>();
+      env.put(SpcsEnvironment.ENV_HOST, "myaccount.us-east-1.snowflakecomputing.com");
+      SpcsEnvironment.overrideForTests(env::get, token);
+    }
     Map<String, String> connectorConfig = builder.build();
     connectorConfig.put(Utils.TASK_ID, "0");
 
-    // WHEN
-    Properties clientProperties =
-        StreamingClientProperties.from(SinkTaskConfig.from(connectorConfig)).clientProperties;
+    try {
+      // WHEN
+      Properties clientProperties =
+          StreamingClientProperties.from(SinkTaskConfig.from(connectorConfig)).clientProperties;
 
-    // THEN the switch handled it and emitted this authenticator's credential material
-    assertThat(clientProperties.stringPropertyNames())
-        .containsAnyOf("authorization_type", "private_key");
+      // THEN the switch handled it and emitted this authenticator's credential material
+      assertThat(clientProperties.stringPropertyNames())
+          .containsAnyOf("authorization_type", "private_key");
+    } finally {
+      SpcsEnvironment.resetForTests();
+    }
   }
 
   @Test


### PR DESCRIPTION
**Jira:** [SNOW-3961901](https://snowflakecomputing.atlassian.net/browse/SNOW-3961901)
**Design document:** [https://docs.google.com/document/d/1NqtBk9tCD5C8Z1TMtJZT5qf367aYxaBB3LAQ2hDR92c/edit?usp=sharing](https://docs.google.com/document/d/1NqtBk9tCD5C8Z1TMtJZT5qf367aYxaBB3LAQ2hDR92c/edit?usp=sharing)

## Stack

| PR | Commits | What | Inert? |
|---|---|---|---|
| [1/3] | `spcs-1-fail-fast`, `spcs-2-environment` | Fail-fast guard + `SpcsEnvironment` | Yes |
| **[2/3] ← you are here** | `spcs-3-credential-paths`, `spcs-4-resolve` | Credential paths + resolution | Yes |
| [3/3] | `spcs-5-enable`, `spcs-6-concurrency` | Entry points wired up + concurrency cover | **Live** |

**Still inert.** No configuration produces an SPCS setup until [3/3].  All review effort belongs there.

## This PR: two commits

**Commit 3 — `teach both credential paths about an ambient identity`** (+80 -4 prod, +300 -8 test)

Adds the `SPCS` enum constant to `AuthenticatorType` and a capability method:

```java
/** True when the credential itself identifies the user, so the connector must not assert one. */
public boolean suppliesAmbientIdentity() { return this == SPCS; }
```

Why a capability method rather than `== SPCS`: the condition is "this credential supplies its own identity", which today maps only to SPCS but will also be true for workload identity federation.  Enum comparisons would require finding all three call sites manually; a missed site reintroduces the live `390309` failure (wrong user in token).  `AuthenticatorTypeTest` pins the set to exactly `{SPCS}`.

Both credential paths are taught about the new authenticator:
- **JDBC** (`InternalUtils`): sets `authenticator=oauth` and reads the ambient token.  Omits `user` — the token already identifies the service user; asserting a different name is rejected by Snowflake with `390309`.
- **Streaming SDK** (`StreamingClientProperties`): sets `authorization_type=spcs` and nothing else.  The SDK defaults the token path and owns its own file read.  Setting any `oauth_*` key here would be rejected by the SDK's exclusive-field validation (documented in #1519).

Also carries the **golden non-SPCS regression test** pinning the exact property key set for every existing authenticator, so any accidental addition of an SPCS-only key to a non-SPCS path fails immediately.

**Commit 4 — `resolve the ambient SPCS values into a configuration`** (+131 -1 prod, +265 test)

Adds `SpcsEnvironment.resolve()`.  This is the single function that fills in the
Snowflake-provided ambient values — host, account, database, schema, user placeholder —
into a configuration map.  Key design properties:

- **Pure map-to-map**: takes raw config, returns an enriched copy.  No side effects.
- **No-op outside SPCS**: first line is `if (!isInsideSpcs()) return raw`.
- **`putIfBlank` only**: never overwrites a value the operator supplied.  Explicit configuration always wins.
- **Credential guard**: if any credential is present and no authenticator is set, auto-adoption is blocked with a WARN.  A deployment with a key pair that happens to run inside SPCS keeps its key-pair auth and the operator is told what is happening.
- **Explicit authenticator wins**: any `snowflake.authenticator` that is not `spcs` causes an immediate `return raw`.

Nothing calls `resolve()` in production yet.  That is commit 5.

## Tests

799 → **807** (commit 3) → **824** (commit 4), zero failures at each step.

[SNOW-3961901]: https://snowflakecomputing.atlassian.net/browse/SNOW-3961901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ