### PR TITLE
SNOW-3961901: [3/3] SPCS ambient auth — wire entry points; concurrency cover

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/DefaultConnectorConfigValidator.java
+++ b/src/main/java/com/snowflake/kafka/connector/DefaultConnectorConfigValidator.java
@@ -16,6 +16,7 @@ import com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams;
 import com.snowflake.kafka.connector.config.AuthenticatorType;
 import com.snowflake.kafka.connector.internal.KCLogger;
 import com.snowflake.kafka.connector.internal.SnowflakeErrors;
+import com.snowflake.kafka.connector.internal.spcs.SpcsEnvironment;
 import com.snowflake.kafka.connector.internal.streaming.StreamingConfigValidator;
 import java.util.HashMap;
 import java.util.Map;
@@ -32,7 +33,13 @@ public class DefaultConnectorConfigValidator implements ConnectorConfigValidator
     this.streamingConfigValidator = streamingConfigValidator;
   }
 
-  public void validateConfig(Map<String, String> config) {
+  public void validateConfig(Map<String, String> rawConfig) {
+    // Fill in the Snowflake-provided service user credentials ("ambient" SPCS auth) first, so
+    // validation sees the same effective config the connector will run with. No-op outside SPCS.
+    // This path matters for Connect's validate() REST call, which reaches the validator without
+    // going through the connector's start().
+    final Map<String, String> config = SpcsEnvironment.resolve(rawConfig);
+
     Map<String, String> invalidConfigParams = new HashMap<String, String>();
 
     // define the input parameters / keys in one place as static constants,
@@ -98,6 +105,21 @@ public class DefaultConnectorConfigValidator implements ConnectorConfigValidator
             invalidConfigParams.put(
                 SNOWFLAKE_PRIVATE_KEY,
                 Utils.formatString("{} cannot be empty", SNOWFLAKE_PRIVATE_KEY));
+          }
+          break;
+        case SPCS:
+          // Ambient authentication validates the runtime rather than the configuration: the
+          // credential is provided by Snowflake, so there is nothing for the user to set.
+          if (!SpcsEnvironment.isInsideSpcs()) {
+            invalidConfigParams.put(
+                KafkaConnectorConfigParams.SNOWFLAKE_AUTHENTICATOR,
+                Utils.formatString(
+                    "{}={} requires the connector to run inside Snowpark Container Services, where"
+                        + " {} is readable and {} is set.",
+                    KafkaConnectorConfigParams.SNOWFLAKE_AUTHENTICATOR,
+                    AuthenticatorType.SPCS.toConfigValue(),
+                    SpcsEnvironment.DEFAULT_TOKEN_FILE,
+                    SpcsEnvironment.ENV_HOST));
           }
           break;
         default:

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeStreamingSinkConnector.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeStreamingSinkConnector.java
@@ -56,9 +56,8 @@ public class SnowflakeStreamingSinkConnector extends SinkConnector {
   // value is resolved per-worker at task start and is therefore not available during validate().
   private static final Pattern CONFIG_PROVIDER_PREFIX = Pattern.compile("[$][{][a-zA-Z]+:");
 
-  private Map<String, String> config; // connector configuration, provided by
-
-  // user through kafka connect framework
+  // connector configuration, provided by user through kafka connect framework
+  private Map<String, String> config;
 
   /**
    * The effective connector configuration, after the Snowflake-provided SPCS service user

--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeStreamingSinkConnector.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeStreamingSinkConnector.java
@@ -16,6 +16,7 @@
  */
 package com.snowflake.kafka.connector;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams;
 import com.snowflake.kafka.connector.config.AuthenticatorType;
 import com.snowflake.kafka.connector.config.ConnectorConfigDefinition;
@@ -24,6 +25,7 @@ import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
 import com.snowflake.kafka.connector.internal.SnowflakeConnectionServiceFactory;
 import com.snowflake.kafka.connector.internal.SnowflakeErrors;
 import com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException;
+import com.snowflake.kafka.connector.internal.spcs.SpcsEnvironment;
 import com.snowflake.kafka.connector.internal.streaming.DefaultStreamingConfigValidator;
 import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryService;
 import java.util.ArrayList;
@@ -55,7 +57,19 @@ public class SnowflakeStreamingSinkConnector extends SinkConnector {
   private static final Pattern CONFIG_PROVIDER_PREFIX = Pattern.compile("[$][{][a-zA-Z]+:");
 
   private Map<String, String> config; // connector configuration, provided by
+
   // user through kafka connect framework
+
+  /**
+   * The effective connector configuration, after the Snowflake-provided SPCS service user
+   * credentials have been filled in. Exposed only so a test can assert that resolution happens at
+   * this entry point: {@code taskConfigs()} cannot be used for that, because it polls for setup
+   * completion for ten minutes before failing.
+   */
+  @VisibleForTesting
+  Map<String, String> effectiveConfigForTests() {
+    return config;
+  }
 
   // SnowflakeJDBCWrapper provides methods to interact with user's snowflake
   // account and executes queries
@@ -96,7 +110,10 @@ public class SnowflakeStreamingSinkConnector extends SinkConnector {
 
     setupComplete = false;
     connectorStartTime = System.currentTimeMillis();
-    config = new HashMap<>(parsedConfig);
+    // Fill in the Snowflake-provided service user credentials ("ambient" SPCS authentication) once,
+    // at the entry point, so the connector's own config, its validation, the connection it builds,
+    // and the configs handed to tasks all agree. No-op outside SPCS.
+    config = new HashMap<>(SpcsEnvironment.resolve(parsedConfig));
 
     ConnectorConfigTools.setDefaultValues(config);
 
@@ -205,6 +222,14 @@ public class SnowflakeStreamingSinkConnector extends SinkConnector {
   @Override
   public Config validate(Map<String, String> connectorConfigs) {
     LOGGER.debug("Validating connector Config: Start");
+    // Fill in the Snowflake-provided service user credentials before anything inspects the
+    // configuration. Kafka Connect calls validate() *before* start(), so without this the
+    // ambient values are still missing here and the single-field checks below reject a
+    // legitimate SPCS configuration with "snowflake.url.name must be provided" and friends.
+    // Outside SPCS resolve() returns the very same map instance, so non-SPCS behavior,
+    // including the mutation of the caller's map further down, is unchanged.
+    connectorConfigs = SpcsEnvironment.resolve(connectorConfigs);
+
     // cross-fields validation here
     Config result = super.validate(connectorConfigs);
 

--- a/src/main/java/com/snowflake/kafka/connector/config/ConnectorConfigDefinition.java
+++ b/src/main/java/com/snowflake/kafka/connector/config/ConnectorConfigDefinition.java
@@ -109,7 +109,12 @@ public class ConnectorConfigDefinition {
             AuthenticatorType.SNOWFLAKE_JWT.toConfigValue(),
             LOW,
             "Authenticator for JDBC and streaming ingest SDK."
-                + " Valid values: snowflake_jwt, oauth.",
+                + " Valid values: snowflake_jwt, oauth, spcs."
+                + " Use spcs only when the connector runs inside Snowpark Container Services:"
+                + " Snowflake then supplies the credential, so no key pair or OAuth client is"
+                + " configured, and snowflake.url.name, snowflake.user.name,"
+                + " snowflake.database.name and snowflake.schema.name are filled in from the"
+                + " service environment if not set. snowflake.role.name is still required.",
             SNOWFLAKE_LOGIN_INFO_DOC,
             7,
             Width.NONE,

--- a/src/main/java/com/snowflake/kafka/connector/config/SinkTaskConfig.java
+++ b/src/main/java/com/snowflake/kafka/connector/config/SinkTaskConfig.java
@@ -11,6 +11,7 @@ import com.snowflake.kafka.connector.TopicToTableResolver;
 import com.snowflake.kafka.connector.Utils;
 import com.snowflake.kafka.connector.internal.CachingConfig;
 import com.snowflake.kafka.connector.internal.SnowflakeErrors;
+import com.snowflake.kafka.connector.internal.spcs.SpcsEnvironment;
 import com.snowflake.kafka.connector.internal.streaming.v2.migration.Ssv1MigrationMode;
 import com.snowflake.kafka.connector.records.SnowflakeMetadataConfig;
 import java.util.HashMap;
@@ -200,7 +201,9 @@ public abstract class SinkTaskConfig {
     if (raw == null) {
       raw = new HashMap<>();
     }
-    Map<String, String> config = new HashMap<>(raw);
+    // Fill in the Snowflake-provided service user credentials ("ambient" SPCS auth) before
+    // anything reads the config. No-op outside SPCS, and never overrides a user-supplied value.
+    Map<String, String> config = new HashMap<>(SpcsEnvironment.resolve(raw));
 
     String connectorName = config.getOrDefault(KafkaConnectorConfigParams.NAME, "");
     String taskId = config.getOrDefault(Utils.TASK_ID, "");

--- a/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/InternalUtils.java
@@ -142,7 +142,15 @@ public class InternalUtils {
         // here, while properties are assembled, so every new connection uses the current one --
         // Snowflake rewrites the file every few minutes.
         properties.put(JdbcPropertyKeys.AUTHENTICATOR, AuthenticatorType.OAUTH.toConfigValue());
-        properties.put(JDBC_TOKEN, SpcsEnvironment.readToken());
+        try {
+          properties.put(JDBC_TOKEN, SpcsEnvironment.readToken());
+        } catch (IllegalStateException e) {
+          // readToken() throws IllegalStateException for an empty or unreadable token. This is an
+          // operator-fixable condition (wrong service spec), so wrap it so the caller can handle
+          // it as a structured connector error rather than an uncaught runtime exception. The full
+          // message from readToken() already explains the cause and the fix.
+          throw SnowflakeErrors.ERROR_1001.getException(e);
+        }
         break;
       default:
         throw new IllegalStateException("unhandled authenticator: " + config.getAuthenticator());

--- a/src/main/java/com/snowflake/kafka/connector/internal/spcs/SpcsEnvironment.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/spcs/SpcsEnvironment.java
@@ -10,6 +10,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
@@ -53,8 +54,16 @@ public final class SpcsEnvironment {
 
   public static final String ENV_HOST = "SNOWFLAKE_HOST";
 
-  static final String ENV_DATABASE = "SNOWFLAKE_DATABASE";
-  static final String ENV_SCHEMA = "SNOWFLAKE_SCHEMA";
+  /**
+   * Account identifier published by SPCS. It is the account locator, matching the first label of
+   * {@link #ENV_HOST} after hyphens are substituted for underscores. Using it explicitly is more
+   * robust than parsing the hostname, and is how every other SPCS client (including the Snowflake
+   * CLI) establishes its account.
+   */
+  public static final String ENV_ACCOUNT = "SNOWFLAKE_ACCOUNT";
+
+  public static final String ENV_DATABASE = "SNOWFLAKE_DATABASE";
+  public static final String ENV_SCHEMA = "SNOWFLAKE_SCHEMA";
 
   /**
    * Placeholder written to {@code snowflake.user.name} in ambient mode. The effective identity is
@@ -74,10 +83,23 @@ public final class SpcsEnvironment {
    */
   public static final String AMBIENT_USER_PLACEHOLDER = "spcs-service-user";
 
-  /** Environment lookup. Overridable so tests can simulate an SPCS container. */
+  /**
+   * Environment lookup. Overridable through {@link #overrideForTests} so tests can simulate an SPCS
+   * container.
+   *
+   * <p><b>Threading note:</b> this is a static mutable field shared across all test classes. It is
+   * safe with the default surefire configuration (no parallel test classes), because every test
+   * class that touches it resets it in an {@code @AfterEach} method, so classes run sequentially.
+   * If {@code forkCount > 1} or {@code parallel=classes} is ever enabled, two classes calling
+   * {@link #overrideForTests} in the same JVM will race. Address this by making the seam injectable
+   * rather than static before enabling parallelism.
+   */
   private static Function<String, String> envReader = System::getenv;
 
-  /** Token file location. Overridable so tests can point at a temporary file. */
+  /**
+   * Token file location. Overridable through {@link #overrideForTests} so tests can point at a
+   * temporary file. See the threading note on {@link #envReader}.
+   */
   private static Path tokenPath = Paths.get(DEFAULT_TOKEN_FILE);
 
   private SpcsEnvironment() {}
@@ -91,6 +113,14 @@ public final class SpcsEnvironment {
 
   public static Optional<String> host() {
     return env(ENV_HOST);
+  }
+
+  /**
+   * Account identifier published by SPCS, lowercased and trimmed to match the form expected by the
+   * streaming SDK and the JDBC driver.
+   */
+  public static Optional<String> account() {
+    return env(ENV_ACCOUNT).map(a -> a.toLowerCase(Locale.ROOT));
   }
 
   public static Optional<String> database() {
@@ -162,7 +192,11 @@ public final class SpcsEnvironment {
       // as the SPCS service user instead, which is a different identity with different grants.
       // So only adopt when there is no credential at all to ignore.
       if (hasConfiguredCredential(raw)) {
-        LOGGER.info(
+        // A credential is present but no authenticator was named.  Adopting ambient auth here
+        // would silently ignore that credential and connect as a different identity.  Stay out of
+        // the way, but warn loudly rather than staying silent, because the operator may not realize
+        // their credential is being bypassed inside SPCS.
+        LOGGER.warn(
             "Running inside Snowpark Container Services, but a credential is configured, so the"
                 + " existing authentication method is kept. Set '{}' to '{}' to use ambient SPCS"
                 + " authentication instead.",
@@ -197,11 +231,25 @@ public final class SpcsEnvironment {
         KafkaConnectorConfigParams.SNOWFLAKE_USER_NAME,
         Optional.of(AMBIENT_USER_PLACEHOLDER));
 
-    if (!isBlank(resolved.get(KafkaConnectorConfigParams.SNOWFLAKE_PRIVATE_KEY))) {
-      LOGGER.warn(
-          "'{}' is set but will be ignored: ambient SPCS authentication uses the token supplied by"
-              + " the SPCS runtime.",
-          KafkaConnectorConfigParams.SNOWFLAKE_PRIVATE_KEY);
+    // Warn for every credential field that is being ignored, not only private.key.  An operator
+    // who explicitly set snowflake.authenticator=spcs has made the choice knowingly, but they may
+    // still have leftover OAuth or key-pair fields from a previous configuration.
+    // Note: resolve() is called at four entry points and is idempotent, so this loop may fire
+    // multiple times at startup for the same credential. That is acceptable: the warning is per
+    // connector start, not per day, and deduplication would require a stateful sentinel.
+    for (String credKey :
+        new String[] {
+          KafkaConnectorConfigParams.SNOWFLAKE_PRIVATE_KEY,
+          KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_CLIENT_ID,
+          KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_CLIENT_SECRET,
+          KafkaConnectorConfigParams.SNOWFLAKE_OAUTH_REFRESH_TOKEN
+        }) {
+      if (!isBlank(resolved.get(credKey))) {
+        LOGGER.warn(
+            "'{}' is set but will be ignored: ambient SPCS authentication uses the token supplied"
+                + " by the SPCS runtime.",
+            credKey);
+      }
     }
 
     return resolved;
@@ -233,6 +281,14 @@ public final class SpcsEnvironment {
     return value == null || value.trim().isEmpty();
   }
 
+  /**
+   * Test seam: overrides the environment reader and token path for the duration of a test class.
+   * Must be paired with a call to {@link #resetForTests()} in an {@code AfterEach} method.
+   *
+   * <p><b>Do not use this seam with parallel test classes.</b> {@code envReader} and {@code
+   * tokenPath} are statics shared across all classes in the same JVM. Two classes overriding them
+   * concurrently will race silently. See the field Javadoc for details.
+   */
   @VisibleForTesting
   public static void overrideForTests(Function<String, String> env, Path token) {
     envReader = env;

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProperties.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProperties.java
@@ -25,6 +25,7 @@ import com.snowflake.kafka.connector.internal.KCLogger;
 import com.snowflake.kafka.connector.internal.PrivateKeyTool;
 import com.snowflake.kafka.connector.internal.SnowflakeErrors;
 import com.snowflake.kafka.connector.internal.SnowflakeURL;
+import com.snowflake.kafka.connector.internal.spcs.SpcsEnvironment;
 import java.security.PrivateKey;
 import java.util.Base64;
 import java.util.HashMap;
@@ -127,7 +128,29 @@ public class StreamingClientProperties {
       clientProperties.put("user", config.getSnowflakeUser());
     }
     clientProperties.put("role", config.getSnowflakeRole());
-    clientProperties.put("account", url.getAccount());
+    // For ambient SPCS authentication, use SNOWFLAKE_ACCOUNT from the environment
+    // rather than parsing the first label of the host URL.  The host is an undocumented
+    // format verified on one deployment; SNOWFLAKE_ACCOUNT is the canonical identifier
+    // published by every SPCS runtime and is how the Snowflake CLI establishes its account.
+    // If the environment variable is absent (not inside SPCS) the parsed value is kept.
+    String account = url.getAccount();
+    if (config.getAuthenticator().suppliesAmbientIdentity()) {
+      account =
+          SpcsEnvironment.account()
+              .orElseGet(
+                  () -> {
+                    // SNOWFLAKE_ACCOUNT is published by SPCS runtimes at release 8.35 and later.
+                    // Fall back to parsing the first label of the host URL for older deployments.
+                    LOGGER.warn(
+                        "SNOWFLAKE_ACCOUNT environment variable is absent; parsing account from"
+                            + " host '{}'. If the connector is running in SPCS, upgrade the"
+                            + " service runtime to 8.35 or later to supply the canonical account"
+                            + " identifier.",
+                        url.getUrlWithoutPort());
+                    return url.getAccount();
+                  });
+    }
+    clientProperties.put("account", account);
     clientProperties.put("host", url.getUrlWithoutPort());
     clientProperties.put("application", APPLICATION_NAME);
 

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigValidatorTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigValidatorTest.java
@@ -120,6 +120,45 @@ public class ConnectorConfigValidatorTest {
   }
 
   /**
+   * R6: the {@code DefaultConnectorConfigValidator.validateConfig} entry point resolves ambient
+   * values, so a credential-free SPCS configuration is accepted when the validator runs during
+   * Kafka Connect's {@code validate()} REST call, before {@code start()} is ever invoked.
+   *
+   * <p>This test passes no URL and no user in the config. Without resolution, both omissions would
+   * cause the validator to throw. They are filled in from the simulated SPCS environment, which
+   * proves that resolution happens inside the validator (not only in {@code start()}).
+   */
+  @Test
+  public void validateConfigResolvesAmbientValuesForSpcsAuthenticator(@TempDir Path tempDir)
+      throws IOException {
+    Path token = tempDir.resolve("token");
+    Files.write(token, "ambient-token".getBytes(StandardCharsets.UTF_8));
+    Map<String, String> env = new HashMap<>();
+    env.put(SpcsEnvironment.ENV_HOST, "myaccount.us-east-1.snowflakecomputing.com");
+    env.put(SpcsEnvironment.ENV_ACCOUNT, "myaccount");
+    env.put(SpcsEnvironment.ENV_DATABASE, "AMBIENT_DB");
+    env.put(SpcsEnvironment.ENV_SCHEMA, "AMBIENT_SCHEMA");
+    SpcsEnvironment.overrideForTests(env::get, token);
+    try {
+      // Deliberately no URL and no user: both would be rejected unless resolution fills them in.
+      Map<String, String> config =
+          SnowflakeSinkConnectorConfigBuilder.streamingConfig()
+              .withoutUrl()
+              .withoutPrivateKey()
+              .build();
+      // Remove user explicitly in case the builder sets a default.
+      config.remove(KafkaConnectorConfigParams.SNOWFLAKE_USER_NAME);
+
+      // If resolution did not happen inside validateConfig, this would throw:
+      // "snowflake.url.name must be provided" and "snowflake.user.name must be provided".
+      assertThatCode(() -> connectorConfigValidator.validateConfig(config))
+          .doesNotThrowAnyException();
+    } finally {
+      SpcsEnvironment.resetForTests();
+    }
+  }
+
+  /**
    * Ambient resolution must not weaken validation for anyone outside SPCS. These properties remain
    * required for the credential-based authenticators.
    */
@@ -135,6 +174,7 @@ public class ConnectorConfigValidatorTest {
             .build();
     config.remove(KafkaConnectorConfigParams.SNOWFLAKE_USER_NAME);
     config.remove(KafkaConnectorConfigParams.SNOWFLAKE_URL_NAME);
+    config.remove(KafkaConnectorConfigParams.SNOWFLAKE_ROLE_NAME);
 
     assertThatThrownBy(() -> connectorConfigValidator.validateConfig(config))
         .isInstanceOf(SnowflakeKafkaConnectorException.class);

--- a/src/test/java/com/snowflake/kafka/connector/ConnectorConfigValidatorTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/ConnectorConfigValidatorTest.java
@@ -28,7 +28,13 @@ import com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams;
 import com.snowflake.kafka.connector.config.AuthenticatorType;
 import com.snowflake.kafka.connector.config.SnowflakeSinkConnectorConfigBuilder;
 import com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException;
+import com.snowflake.kafka.connector.internal.spcs.SpcsEnvironment;
 import com.snowflake.kafka.connector.internal.streaming.DefaultStreamingConfigValidator;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -38,10 +44,12 @@ import java.util.stream.Stream;
 import org.apache.kafka.connect.storage.Converter;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class ConnectorConfigValidatorTest {
 
@@ -71,6 +79,65 @@ public class ConnectorConfigValidatorTest {
   public void testConfig() {
     Map<String, String> config = SnowflakeSinkConnectorConfigBuilder.streamingConfig().build();
     connectorConfigValidator.validateConfig(config);
+  }
+
+  @Test
+  public void shouldRejectSpcsAuthenticatorOutsideSpcs() {
+    SpcsEnvironment.overrideForTests(name -> null, Paths.get("/nonexistent/spcs/token"));
+    try {
+      Map<String, String> config =
+          SnowflakeSinkConnectorConfigBuilder.streamingConfig()
+              .withAuthenticator(AuthenticatorType.SPCS.toConfigValue())
+              .build();
+
+      assertThatThrownBy(() -> connectorConfigValidator.validateConfig(config))
+          .isInstanceOf(SnowflakeKafkaConnectorException.class)
+          .hasMessageContaining(KafkaConnectorConfigParams.SNOWFLAKE_AUTHENTICATOR);
+    } finally {
+      SpcsEnvironment.resetForTests();
+    }
+  }
+
+  @Test
+  public void shouldAcceptSpcsAuthenticatorInsideSpcs(@TempDir Path tempDir) throws IOException {
+    Path token = tempDir.resolve("token");
+    Files.write(token, "ambient-token".getBytes(StandardCharsets.UTF_8));
+    Map<String, String> env = new HashMap<>();
+    env.put(SpcsEnvironment.ENV_HOST, "myaccount.us-east-1.snowflakecomputing.com");
+    SpcsEnvironment.overrideForTests(env::get, token);
+    try {
+      Map<String, String> config =
+          SnowflakeSinkConnectorConfigBuilder.streamingConfig()
+              .withAuthenticator(AuthenticatorType.SPCS.toConfigValue())
+              .withoutPrivateKey()
+              .build();
+
+      // no exception thrown: the credential comes from the SPCS runtime, not the config
+      connectorConfigValidator.validateConfig(config);
+    } finally {
+      SpcsEnvironment.resetForTests();
+    }
+  }
+
+  /**
+   * Ambient resolution must not weaken validation for anyone outside SPCS. These properties remain
+   * required for the credential-based authenticators.
+   */
+  @ParameterizedTest
+  @ValueSource(strings = {"snowflake_jwt", "oauth"})
+  public void shouldStillRequireUserUrlAndRoleForCredentialAuthenticators(String authenticator) {
+    Map<String, String> config =
+        SnowflakeSinkConnectorConfigBuilder.streamingConfig()
+            .withAuthenticator(authenticator)
+            .withOauthClientId("id")
+            .withOauthClientSecret("secret")
+            .withOauthRefreshToken("token")
+            .build();
+    config.remove(KafkaConnectorConfigParams.SNOWFLAKE_USER_NAME);
+    config.remove(KafkaConnectorConfigParams.SNOWFLAKE_URL_NAME);
+
+    assertThatThrownBy(() -> connectorConfigValidator.validateConfig(config))
+        .isInstanceOf(SnowflakeKafkaConnectorException.class);
   }
 
   @Test

--- a/src/test/java/com/snowflake/kafka/connector/SnowflakeStreamingSinkConnectorSpcsTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/SnowflakeStreamingSinkConnectorSpcsTest.java
@@ -27,6 +27,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.kafka.common.config.Config;
+import org.apache.kafka.common.config.ConfigValue;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -59,8 +61,8 @@ public class SnowflakeStreamingSinkConnectorSpcsTest {
     Files.write(token, "ambient-token".getBytes(StandardCharsets.UTF_8));
     Map<String, String> env = new HashMap<>();
     env.put(SpcsEnvironment.ENV_HOST, "myaccount.dep.us-west-2.aws.snowflakecomputing.com");
-    env.put("SNOWFLAKE_DATABASE", "AMBIENT_DB");
-    env.put("SNOWFLAKE_SCHEMA", "AMBIENT_SCHEMA");
+    env.put(SpcsEnvironment.ENV_DATABASE, "AMBIENT_DB");
+    env.put(SpcsEnvironment.ENV_SCHEMA, "AMBIENT_SCHEMA");
     SpcsEnvironment.overrideForTests(env::get, token);
 
     // AND a configuration carrying no credential and no connection coordinates at all
@@ -154,8 +156,8 @@ public class SnowflakeStreamingSinkConnectorSpcsTest {
     Files.write(token, "ambient-token".getBytes(StandardCharsets.UTF_8));
     Map<String, String> env = new HashMap<>();
     env.put(SpcsEnvironment.ENV_HOST, "my-account.dep.us-west-2.aws.snowflakecomputing.com");
-    env.put("SNOWFLAKE_DATABASE", "AMBIENT_DB");
-    env.put("SNOWFLAKE_SCHEMA", "AMBIENT_SCHEMA");
+    env.put(SpcsEnvironment.ENV_DATABASE, "AMBIENT_DB");
+    env.put(SpcsEnvironment.ENV_SCHEMA, "AMBIENT_SCHEMA");
     SpcsEnvironment.overrideForTests(env::get, token);
 
     // A credential-free configuration, exactly as a Kafka Connect user would write it in SPCS.
@@ -163,10 +165,9 @@ public class SnowflakeStreamingSinkConnectorSpcsTest {
     raw.put(KafkaConnectorConfigParams.TOPICS, "t1");
     raw.put(KafkaConnectorConfigParams.SNOWFLAKE_ROLE_NAME, "SOME_ROLE");
 
-    org.apache.kafka.common.config.Config result =
-        new SnowflakeStreamingSinkConnector().validate(raw);
+    Config result = new SnowflakeStreamingSinkConnector().validate(raw);
 
-    for (org.apache.kafka.common.config.ConfigValue value : result.configValues()) {
+    for (ConfigValue value : result.configValues()) {
       assertThat(value.errorMessages())
           .as(
               "%s must be filled in from the SPCS runtime during validate(), because Kafka Connect"

--- a/src/test/java/com/snowflake/kafka/connector/SnowflakeStreamingSinkConnectorSpcsTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/SnowflakeStreamingSinkConnectorSpcsTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2019 Snowflake Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.snowflake.kafka.connector;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams;
+import com.snowflake.kafka.connector.config.AuthenticatorType;
+import com.snowflake.kafka.connector.internal.spcs.SpcsEnvironment;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Guards the ambient-credential resolution at the connector's entry point.
+ *
+ * <p>This exists because of a defect that was actually introduced and fixed during development: the
+ * configuration was resolved for validation but not for the connector's own {@code config} field,
+ * so the connection it built and the configs it handed to tasks disagreed with what had been
+ * validated. Nothing caught it, because {@code SnowflakeStreamingSinkConnector} is otherwise
+ * touched only by integration tests, and those do not run inside SPCS.
+ *
+ * <p>{@code start()} is allowed to fail here. It builds a real Snowflake connection a few
+ * statements after assigning {@code config}, which cannot succeed in a unit test. The assignment is
+ * what is under test, and it happens first.
+ */
+public class SnowflakeStreamingSinkConnectorSpcsTest {
+
+  @AfterEach
+  public void resetSpcsEnvironment() {
+    SpcsEnvironment.resetForTests();
+  }
+
+  @Test
+  public void startResolvesAmbientCredentialsIntoTheConnectorsOwnConfig(@TempDir Path tempDir)
+      throws IOException {
+    // GIVEN a container that looks like SPCS, with the host shape measured inside a real service
+    Path token = tempDir.resolve("token");
+    Files.write(token, "ambient-token".getBytes(StandardCharsets.UTF_8));
+    Map<String, String> env = new HashMap<>();
+    env.put(SpcsEnvironment.ENV_HOST, "myaccount.dep.us-west-2.aws.snowflakecomputing.com");
+    env.put("SNOWFLAKE_DATABASE", "AMBIENT_DB");
+    env.put("SNOWFLAKE_SCHEMA", "AMBIENT_SCHEMA");
+    SpcsEnvironment.overrideForTests(env::get, token);
+
+    // AND a configuration carrying no credential and no connection coordinates at all
+    Map<String, String> raw = new HashMap<>();
+    raw.put(KafkaConnectorConfigParams.NAME, "ambient_connector");
+    raw.put(KafkaConnectorConfigParams.TOPICS, "t1");
+    raw.put(KafkaConnectorConfigParams.SNOWFLAKE_ROLE_NAME, "SOME_ROLE");
+
+    SnowflakeStreamingSinkConnector connector = new SnowflakeStreamingSinkConnector();
+
+    // WHEN start() runs. It will not complete: a real connection cannot be built here. The
+    // assignment under test happens before that, so the outcome of start() is irrelevant.
+    try {
+      connector.start(raw);
+    } catch (Throwable expected) {
+      // ignored on purpose, see the class comment
+    }
+
+    // THEN the connector's own config carries the ambient values, not just the validated copy
+    Map<String, String> effective = connector.effectiveConfigForTests();
+    assertThat(effective)
+        .as("start() must resolve ambient credentials into the config it keeps and passes on")
+        .isNotNull();
+    assertThat(effective.get(KafkaConnectorConfigParams.SNOWFLAKE_AUTHENTICATOR))
+        .isEqualTo(AuthenticatorType.SPCS.toConfigValue());
+    assertThat(effective.get(KafkaConnectorConfigParams.SNOWFLAKE_URL_NAME))
+        .isEqualTo("myaccount.dep.us-west-2.aws.snowflakecomputing.com");
+    assertThat(effective.get(KafkaConnectorConfigParams.SNOWFLAKE_DATABASE_NAME))
+        .isEqualTo("AMBIENT_DB");
+    assertThat(effective.get(KafkaConnectorConfigParams.SNOWFLAKE_SCHEMA_NAME))
+        .isEqualTo("AMBIENT_SCHEMA");
+    assertThat(effective.get(KafkaConnectorConfigParams.SNOWFLAKE_USER_NAME))
+        .isEqualTo(SpcsEnvironment.AMBIENT_USER_PLACEHOLDER);
+  }
+
+  @Test
+  public void startLeavesConfigUntouchedOutsideSpcs(@TempDir Path tempDir) {
+    // GIVEN an environment that is not SPCS: no host, and a token path that does not exist
+    SpcsEnvironment.overrideForTests(name -> null, tempDir.resolve("absent"));
+
+    Map<String, String> raw = new HashMap<>();
+    raw.put(KafkaConnectorConfigParams.NAME, "ordinary_connector");
+    raw.put(KafkaConnectorConfigParams.TOPICS, "t1");
+    raw.put(KafkaConnectorConfigParams.SNOWFLAKE_ROLE_NAME, "SOME_ROLE");
+
+    SnowflakeStreamingSinkConnector connector = new SnowflakeStreamingSinkConnector();
+    try {
+      connector.start(raw);
+    } catch (Throwable expected) {
+      // ignored on purpose
+    }
+
+    Map<String, String> effective = connector.effectiveConfigForTests();
+    assertThat(effective).isNotNull();
+    // No authenticator was configured and none may be invented outside SPCS. Defaults applied by
+    // ConnectorConfigTools may set one, so assert only that it is not spcs.
+    assertThat(effective.get(KafkaConnectorConfigParams.SNOWFLAKE_AUTHENTICATOR))
+        .isNotEqualTo(AuthenticatorType.SPCS.toConfigValue());
+    assertThat(effective.get(KafkaConnectorConfigParams.SNOWFLAKE_URL_NAME)).isNull();
+    assertThat(effective.get(KafkaConnectorConfigParams.SNOWFLAKE_USER_NAME)).isNull();
+  }
+
+  /**
+   * Regression test for a defect found only by running the connector under a real Kafka Connect
+   * worker inside SPCS.
+   *
+   * <p>Kafka Connect's herder calls {@link SnowflakeStreamingSinkConnector#validate} <b>before</b>
+   * {@code start()}. Resolution therefore has to happen in {@code validate()} too: without it, the
+   * single-field checks in {@code Utils.isSingleFieldValid} run against the raw configuration and
+   * reject a legitimate credential-free SPCS config with four errors:
+   *
+   * <pre>
+   *   snowflake.url.name must be provided
+   *   snowflake.user.name must be provided
+   *   snowflake.database.name must be provided
+   *   snowflake.schema.name must be provided
+   * </pre>
+   *
+   * <p>Connector creation then fails outright, so the feature is unusable from Kafka Connect even
+   * though every in-process test passes. The earlier unit tests could not catch this because they
+   * drive {@code start()} and {@code SinkTaskConfig} directly and never go through the herder.
+   *
+   * <p>A live connection attempt later in {@code validate()} cannot succeed in a unit test, so this
+   * asserts specifically on the absence of the "must be provided" errors rather than on the absence
+   * of all errors. A "Cannot connect to Snowflake" message is expected and is not a regression.
+   */
+  @Test
+  public void validateResolvesAmbientCredentialsBecauseConnectValidatesBeforeStart(
+      @TempDir Path tempDir) throws IOException {
+    Path token = tempDir.resolve("token");
+    Files.write(token, "ambient-token".getBytes(StandardCharsets.UTF_8));
+    Map<String, String> env = new HashMap<>();
+    env.put(SpcsEnvironment.ENV_HOST, "my-account.dep.us-west-2.aws.snowflakecomputing.com");
+    env.put("SNOWFLAKE_DATABASE", "AMBIENT_DB");
+    env.put("SNOWFLAKE_SCHEMA", "AMBIENT_SCHEMA");
+    SpcsEnvironment.overrideForTests(env::get, token);
+
+    // A credential-free configuration, exactly as a Kafka Connect user would write it in SPCS.
+    Map<String, String> raw = new HashMap<>();
+    raw.put(KafkaConnectorConfigParams.TOPICS, "t1");
+    raw.put(KafkaConnectorConfigParams.SNOWFLAKE_ROLE_NAME, "SOME_ROLE");
+
+    org.apache.kafka.common.config.Config result =
+        new SnowflakeStreamingSinkConnector().validate(raw);
+
+    for (org.apache.kafka.common.config.ConfigValue value : result.configValues()) {
+      assertThat(value.errorMessages())
+          .as(
+              "%s must be filled in from the SPCS runtime during validate(), because Kafka Connect"
+                  + " validates before it starts the connector",
+              value.name())
+          .noneMatch(message -> message.contains("must be provided"));
+    }
+  }
+}

--- a/src/test/java/com/snowflake/kafka/connector/config/SinkTaskConfigSpcsTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/config/SinkTaskConfigSpcsTest.java
@@ -55,10 +55,8 @@ public class SinkTaskConfigSpcsTest {
     Files.write(token, "ambient-token".getBytes(StandardCharsets.UTF_8));
     Map<String, String> env = new HashMap<>();
     env.put(SpcsEnvironment.ENV_HOST, HOST);
-    // Literals rather than the package-private constants: this test lives in another package and
-    // widening production visibility for a test's convenience is not worth it.
-    env.put("SNOWFLAKE_DATABASE", "AMBIENT_DB");
-    env.put("SNOWFLAKE_SCHEMA", "AMBIENT_SCHEMA");
+    env.put(SpcsEnvironment.ENV_DATABASE, "AMBIENT_DB");
+    env.put(SpcsEnvironment.ENV_SCHEMA, "AMBIENT_SCHEMA");
     SpcsEnvironment.overrideForTests(env::get, token);
   }
 

--- a/src/test/java/com/snowflake/kafka/connector/config/SinkTaskConfigSpcsTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/config/SinkTaskConfigSpcsTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2025 Snowflake Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.snowflake.kafka.connector.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams;
+import com.snowflake.kafka.connector.internal.spcs.SpcsEnvironment;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Covers ambient SPCS resolution at the {@link SinkTaskConfig} entry point.
+ *
+ * <p>This is one of the four places {@code SpcsEnvironment.resolve} is applied and, until this
+ * test, the only one without direct coverage: it was exercised incidentally by other suites that
+ * happen to call {@code SinkTaskConfig.from}. It matters on its own because it is the path taken by
+ * task startup and by the connection factory, so a regression here would surface as a task-level
+ * failure rather than a configuration error.
+ */
+public class SinkTaskConfigSpcsTest {
+
+  private static final String HOST = "my-account.dep.us-west-2.aws.snowflakecomputing.com";
+
+  @TempDir Path tempDir;
+
+  @AfterEach
+  public void reset() {
+    SpcsEnvironment.resetForTests();
+  }
+
+  private void simulateSpcs() throws IOException {
+    Path token = tempDir.resolve("token");
+    Files.write(token, "ambient-token".getBytes(StandardCharsets.UTF_8));
+    Map<String, String> env = new HashMap<>();
+    env.put(SpcsEnvironment.ENV_HOST, HOST);
+    // Literals rather than the package-private constants: this test lives in another package and
+    // widening production visibility for a test's convenience is not worth it.
+    env.put("SNOWFLAKE_DATABASE", "AMBIENT_DB");
+    env.put("SNOWFLAKE_SCHEMA", "AMBIENT_SCHEMA");
+    SpcsEnvironment.overrideForTests(env::get, token);
+  }
+
+  /** A credential-free raw map must become a fully populated SinkTaskConfig inside SPCS. */
+  @Test
+  public void shouldResolveAmbientValuesWhenBuildingSinkTaskConfig() throws IOException {
+    simulateSpcs();
+
+    Map<String, String> raw = new HashMap<>();
+    raw.put(KafkaConnectorConfigParams.NAME, "ambient_task_config");
+    raw.put(KafkaConnectorConfigParams.TOPICS, "t1");
+    raw.put(KafkaConnectorConfigParams.SNOWFLAKE_ROLE_NAME, "SOME_ROLE");
+
+    SinkTaskConfig config = SinkTaskConfig.from(raw, true);
+
+    assertThat(config.getAuthenticator()).isEqualTo(AuthenticatorType.SPCS);
+    assertThat(config.getSnowflakeUrl()).isEqualTo(HOST);
+    assertThat(config.getSnowflakeDatabase()).isEqualTo("AMBIENT_DB");
+    assertThat(config.getSnowflakeSchema()).isEqualTo("AMBIENT_SCHEMA");
+    assertThat(config.getSnowflakeRole()).isEqualTo("SOME_ROLE");
+    // The synthetic user exists only to satisfy validation; it is never sent to Snowflake.
+    assertThat(config.getSnowflakeUser()).isEqualTo(SpcsEnvironment.AMBIENT_USER_PLACEHOLDER);
+  }
+
+  /**
+   * Gate 3 in the design: {@code SnowflakeConnectionServiceFactory.setProperties} throws {@code
+   * ERROR_0017} when the URL is blank. Ambient resolution is what keeps that gate satisfied without
+   * relaxing it, so a resolved SPCS config must carry a non-blank URL by the time the connection
+   * factory would read it.
+   */
+  @Test
+  public void resolvedSpcsConfigSatisfiesTheUrlGate() throws IOException {
+    simulateSpcs();
+
+    Map<String, String> raw = new HashMap<>();
+    raw.put(KafkaConnectorConfigParams.NAME, "ambient_task_config");
+    raw.put(KafkaConnectorConfigParams.TOPICS, "t1");
+    raw.put(KafkaConnectorConfigParams.SNOWFLAKE_ROLE_NAME, "SOME_ROLE");
+
+    SinkTaskConfig config = SinkTaskConfig.from(raw, true);
+
+    assertThat(config.getSnowflakeUrl()).isNotBlank();
+  }
+
+  /** Outside SPCS nothing may be invented, so the same raw map stays credential-free. */
+  @Test
+  public void shouldNotResolveAnythingOutsideSpcs() {
+    SpcsEnvironment.overrideForTests(name -> null, tempDir.resolve("absent"));
+
+    Map<String, String> raw = new HashMap<>();
+    raw.put(KafkaConnectorConfigParams.NAME, "ordinary");
+    raw.put(KafkaConnectorConfigParams.TOPICS, "t1");
+    raw.put(KafkaConnectorConfigParams.SNOWFLAKE_ROLE_NAME, "SOME_ROLE");
+    raw.put(KafkaConnectorConfigParams.SNOWFLAKE_URL_NAME, "explicit.snowflakecomputing.com");
+    raw.put(KafkaConnectorConfigParams.SNOWFLAKE_USER_NAME, "REAL_USER");
+
+    SinkTaskConfig config = SinkTaskConfig.from(raw, true);
+
+    assertThat(config.getAuthenticator()).isNotEqualTo(AuthenticatorType.SPCS);
+    assertThat(config.getSnowflakeUser()).isEqualTo("REAL_USER");
+    assertThat(config.getSnowflakeUrl()).isEqualTo("explicit.snowflakecomputing.com");
+  }
+}

--- a/src/test/java/com/snowflake/kafka/connector/internal/InternalUtilsTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/InternalUtilsTest.java
@@ -9,11 +9,7 @@ import com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams;
 import com.snowflake.kafka.connector.config.AuthenticatorType;
 import com.snowflake.kafka.connector.config.SinkTaskConfig;
 import com.snowflake.kafka.connector.config.SinkTaskConfigTestBuilder;
-import com.snowflake.kafka.connector.internal.spcs.SpcsEnvironment;
 import com.snowflake.kafka.connector.mock.MockResultSetForSizeTest;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Base64;
@@ -23,7 +19,6 @@ import java.util.Optional;
 import java.util.Properties;
 import org.apache.kafka.common.config.types.Password;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
 public class InternalUtilsTest {
   @Test
@@ -437,115 +432,5 @@ public class InternalUtilsTest {
     assertFalse(
         props.containsKey(JdbcPropertyKeys.ROLE),
         "JDBC properties should not contain role when role is whitespace");
-  }
-
-  /**
-   * Ambient SPCS authentication reuses the driver's OAuth mode: the driver has no SPCS mode, it
-   * simply accepts a caller-supplied bearer token read from the file SPCS manages.
-   */
-  @Test
-  public void testMakeJdbcDriverProperties_spcsUsesOauthWithAmbientToken(@TempDir Path tempDir)
-      throws Exception {
-    Path token = tempDir.resolve("token");
-    Files.write(token, "ambient-bearer-token".getBytes(StandardCharsets.UTF_8));
-    Map<String, String> env = new HashMap<>();
-    env.put(SpcsEnvironment.ENV_HOST, "account.snowflakecomputing.com");
-    SpcsEnvironment.overrideForTests(env::get, token);
-    try {
-      SinkTaskConfig config =
-          SinkTaskConfigTestBuilder.builder()
-              .connectorName("test")
-              .taskId("0")
-              .snowflakeDatabase("db")
-              .snowflakeSchema("schema")
-              .snowflakeUser("user")
-              .snowflakeUrl("https://account.snowflakecomputing.com")
-              .authenticator(AuthenticatorType.SPCS)
-              .build();
-
-      Properties props =
-          InternalUtils.makeJdbcDriverProperties(
-              config, new SnowflakeURL("https://account.snowflakecomputing.com"));
-
-      assertEquals(
-          AuthenticatorType.OAUTH.toConfigValue(),
-          props.getProperty(JdbcPropertyKeys.AUTHENTICATOR),
-          "SPCS must authenticate to the driver as oauth with a supplied token");
-      assertEquals("ambient-bearer-token", props.getProperty(InternalUtils.JDBC_TOKEN));
-      assertFalse(
-          props.containsKey(InternalUtils.JDBC_PRIVATE_KEY), "SPCS must not send a private key");
-      assertFalse(
-          props.containsKey(InternalUtils.JDBC_USER),
-          "SPCS must not send a user: the token identifies the service user, and Snowflake"
-              + " rejects a session whose asserted user differs from the token's subject"
-              + " (\"The user you were trying to authenticate as differs from the user tied to"
-              + " the access token\"). Verified against a live SPCS service: sending a user"
-              + " fails, omitting it succeeds.");
-    } finally {
-      SpcsEnvironment.resetForTests();
-    }
-  }
-
-  /**
-   * The user is required for every other authenticator, and its absence must still be an error.
-   * This guards the SPCS exemption from being widened by accident.
-   */
-  @Test
-  public void testMakeJdbcDriverProperties_userStillRequiredForKeyPair() {
-    String pemKey = Base64.getEncoder().encodeToString(TestUtils.generatePrivateKey().getEncoded());
-    SinkTaskConfig config =
-        SinkTaskConfigTestBuilder.builder()
-            .connectorName("test")
-            .taskId("0")
-            .snowflakeDatabase("db")
-            .snowflakeSchema("schema")
-            .snowflakeUrl("https://account.snowflakecomputing.com")
-            .authenticator(AuthenticatorType.SNOWFLAKE_JWT)
-            .snowflakePrivateKey(new Password(pemKey))
-            .build();
-    assertThrows(
-        SnowflakeKafkaConnectorException.class,
-        () ->
-            InternalUtils.makeJdbcDriverProperties(
-                config, new SnowflakeURL("https://account.snowflakecomputing.com")),
-        "a missing user must remain an error for credential-based authenticators");
-  }
-
-  /** The token must be re-read per connection, not captured once. */
-  @Test
-  public void testMakeJdbcDriverProperties_spcsRereadsRotatedToken(@TempDir Path tempDir)
-      throws Exception {
-    Path token = tempDir.resolve("token");
-    Files.write(token, "first".getBytes(StandardCharsets.UTF_8));
-    Map<String, String> env = new HashMap<>();
-    env.put(SpcsEnvironment.ENV_HOST, "account.snowflakecomputing.com");
-    SpcsEnvironment.overrideForTests(env::get, token);
-    try {
-      SinkTaskConfig config =
-          SinkTaskConfigTestBuilder.builder()
-              .connectorName("test")
-              .taskId("0")
-              .snowflakeDatabase("db")
-              .snowflakeSchema("schema")
-              .snowflakeUser("user")
-              .snowflakeUrl("https://account.snowflakecomputing.com")
-              .authenticator(AuthenticatorType.SPCS)
-              .build();
-      SnowflakeURL url = new SnowflakeURL("https://account.snowflakecomputing.com");
-
-      assertEquals(
-          "first",
-          InternalUtils.makeJdbcDriverProperties(config, url)
-              .getProperty(InternalUtils.JDBC_TOKEN));
-
-      Files.write(token, "rotated".getBytes(StandardCharsets.UTF_8));
-
-      assertEquals(
-          "rotated",
-          InternalUtils.makeJdbcDriverProperties(config, url)
-              .getProperty(InternalUtils.JDBC_TOKEN));
-    } finally {
-      SpcsEnvironment.resetForTests();
-    }
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/internal/spcs/SpcsEnvironmentConcurrencyTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/spcs/SpcsEnvironmentConcurrencyTest.java
@@ -1,0 +1,260 @@
+package com.snowflake.kafka.connector.internal.spcs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams;
+import com.snowflake.kafka.connector.config.AuthenticatorType;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Concurrency cover for ambient SPCS authentication.
+ *
+ * <p>Every other test in this area is single threaded, but the connector is not. Kafka Connect runs
+ * {@code tasks.max} sink tasks in one worker JVM, each building its own connection and its own
+ * streaming client, so {@link SpcsEnvironment} is called from many threads at once. Worse, the
+ * token rotates underneath those calls: a rotation was measured at roughly a ten minute interval on
+ * a live service, which is far shorter than the lifetime of a running connector. These tests pin
+ * the two properties that follow from that.
+ *
+ * <p><b>On modeling rotation faithfully.</b> The rotator here replaces the token with {@link
+ * StandardCopyOption#ATOMIC_MOVE} rather than by writing over the existing file. That is
+ * deliberate, and it is not merely a convenience to keep the test quiet. Kubernetes projected
+ * volumes, which is what SPCS mounts the token through, publish a new version into a hidden
+ * timestamped directory and then atomically swing a symlink, so a reader never observes a partially
+ * written or truncated file. Writing in place would instead create a window in which the file is
+ * zero length, which the empty token guard correctly rejects. A test that failed that way would be
+ * reporting an artifact of its own file handling rather than anything about the connector.
+ */
+public class SpcsEnvironmentConcurrencyTest {
+
+  private static final String HOST = "myaccount.us-east-1.snowflakecomputing.com";
+  private static final int THREADS = 8;
+  private static final int READS_PER_THREAD = 250;
+  private static final int MAX_READS_PER_THREAD = 200_000;
+
+  @TempDir Path tempDir;
+
+  @AfterEach
+  void reset() {
+    SpcsEnvironment.resetForTests();
+  }
+
+  private Path simulateSpcs(String tokenValue) throws IOException {
+    Path token = tempDir.resolve("token");
+    Files.write(token, tokenValue.getBytes(StandardCharsets.UTF_8));
+    Map<String, String> env = new HashMap<>();
+    env.put(SpcsEnvironment.ENV_HOST, HOST);
+    env.put(SpcsEnvironment.ENV_DATABASE, "AMBIENT_DB");
+    env.put(SpcsEnvironment.ENV_SCHEMA, "AMBIENT_SCHEMA");
+    SpcsEnvironment.overrideForTests(env::get, token);
+    return token;
+  }
+
+  /** Replaces the token atomically, the way a Kubernetes projected volume does. */
+  private void rotateAtomically(Path token, String newValue) throws IOException {
+    Path staged = tempDir.resolve("token.staged");
+    Files.write(staged, newValue.getBytes(StandardCharsets.UTF_8));
+    Files.move(staged, token, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+  }
+
+  /**
+   * Many concurrent readers, with the token rotating underneath them, must every one of them get a
+   * whole and current token. This is the property the connector depends on when a rotation lands in
+   * the middle of a batch: the token is re-read per use rather than cached, so no task may see a
+   * stale or partial value.
+   *
+   * <p>The readers keep going until the rotator has finished its fixed set of rotations, rather
+   * than running a fixed number of iterations. That ordering matters: with a fixed iteration count,
+   * a caching implementation returns without touching the disk and the readers can finish before
+   * the first rotation lands, so the test would fail on "the token really did rotate" instead of on
+   * the caching assertion that is the actual subject. Tying the readers to the rotator's progress
+   * means the failure names the real cause.
+   */
+  @Test
+  void shouldReadWholeCurrentTokenFromManyThreadsWhileItRotates() throws Exception {
+    final int plannedRotations = 5;
+    Path token = simulateSpcs("tok-0");
+    List<Throwable> failures = new CopyOnWriteArrayList<>();
+    Set<String> observed = ConcurrentHashMap.newKeySet();
+    AtomicBoolean rotatorDone = new AtomicBoolean(false);
+    AtomicInteger rotations = new AtomicInteger();
+    CountDownLatch ready = new CountDownLatch(THREADS);
+    CountDownLatch go = new CountDownLatch(1);
+
+    ExecutorService pool = Executors.newFixedThreadPool(THREADS);
+    Thread rotator =
+        new Thread(
+            () -> {
+              try {
+                for (int n = 1; n <= plannedRotations; n++) {
+                  Thread.sleep(15);
+                  rotateAtomically(token, "tok-" + n);
+                  rotations.incrementAndGet();
+                }
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+              } catch (Exception e) {
+                failures.add(e);
+              } finally {
+                rotatorDone.set(true);
+              }
+            });
+    rotator.setDaemon(true);
+
+    try {
+      for (int t = 0; t < THREADS; t++) {
+        pool.submit(
+            () -> {
+              ready.countDown();
+              try {
+                go.await();
+                int reads = 0;
+                while (!rotatorDone.get() || reads < READS_PER_THREAD) {
+                  observed.add(SpcsEnvironment.readToken());
+                  if (++reads > MAX_READS_PER_THREAD) {
+                    break;
+                  }
+                }
+              } catch (Throwable e) {
+                failures.add(e);
+              }
+            });
+      }
+
+      assertThat(ready.await(10, TimeUnit.SECONDS)).as("readers started").isTrue();
+      rotator.start();
+      go.countDown();
+      pool.shutdown();
+      assertThat(pool.awaitTermination(60, TimeUnit.SECONDS)).as("readers finished").isTrue();
+      rotator.join(TimeUnit.SECONDS.toMillis(30));
+    } finally {
+      rotatorDone.set(true);
+      pool.shutdownNow();
+    }
+
+    assertThat(failures).as("no reader saw an error while the token rotated").isEmpty();
+    assertThat(rotations.get())
+        .as("the rotator completed every planned rotation")
+        .isEqualTo(plannedRotations);
+    assertThat(observed)
+        .as("every value read was a whole token, never empty or partial")
+        .isNotEmpty()
+        .allSatisfy(value -> assertThat(value).matches("tok-\\d+"));
+    assertThat(observed)
+        .as("readers saw more than one generation, so the token is not cached")
+        .hasSizeGreaterThan(1);
+  }
+
+  /**
+   * Each sink task resolves its own configuration. Resolution must therefore be free of shared
+   * mutable state: one task's configuration must never leak into another's. A single shared map or
+   * a cached result would show up here as cross contamination.
+   */
+  @Test
+  void shouldResolveFromManyThreadsWithoutCrossContamination() throws Exception {
+    simulateSpcs("tok");
+    List<Throwable> failures = new CopyOnWriteArrayList<>();
+    CountDownLatch go = new CountDownLatch(1);
+    ExecutorService pool = Executors.newFixedThreadPool(THREADS);
+
+    try {
+      for (int t = 0; t < THREADS; t++) {
+        final int id = t;
+        pool.submit(
+            () -> {
+              try {
+                go.await();
+                for (int i = 0; i < 200; i++) {
+                  Map<String, String> raw = new HashMap<>();
+                  raw.put("topics", "topic-" + id);
+                  raw.put(KafkaConnectorConfigParams.SNOWFLAKE_ROLE_NAME, "ROLE_" + id);
+
+                  Map<String, String> resolved = SpcsEnvironment.resolve(raw);
+
+                  assertThat(resolved)
+                      .containsEntry("topics", "topic-" + id)
+                      .containsEntry(KafkaConnectorConfigParams.SNOWFLAKE_ROLE_NAME, "ROLE_" + id)
+                      .containsEntry(
+                          KafkaConnectorConfigParams.SNOWFLAKE_AUTHENTICATOR,
+                          AuthenticatorType.SPCS.toConfigValue())
+                      .containsEntry(
+                          KafkaConnectorConfigParams.SNOWFLAKE_USER_NAME,
+                          SpcsEnvironment.AMBIENT_USER_PLACEHOLDER)
+                      .containsEntry(
+                          KafkaConnectorConfigParams.SNOWFLAKE_DATABASE_NAME, "AMBIENT_DB");
+                  assertThat(resolved.get(KafkaConnectorConfigParams.SNOWFLAKE_URL_NAME))
+                      .contains(HOST);
+                }
+              } catch (Throwable e) {
+                failures.add(e);
+              }
+            });
+      }
+      go.countDown();
+      pool.shutdown();
+      assertThat(pool.awaitTermination(60, TimeUnit.SECONDS)).as("resolvers finished").isTrue();
+    } finally {
+      pool.shutdownNow();
+    }
+
+    assertThat(failures).as("no resolver saw an error or foreign configuration").isEmpty();
+  }
+
+  /**
+   * Detection is called on every task startup and must not be sensitive to being called
+   * concurrently. A flapping answer here would make some tasks adopt ambient authentication while
+   * their siblings did not, which is the worst possible outcome: a partially authenticated
+   * connector that half works.
+   */
+  @Test
+  void shouldReportInsideSpcsConsistentlyUnderConcurrency() throws Exception {
+    simulateSpcs("tok");
+    Set<Boolean> answers = ConcurrentHashMap.newKeySet();
+    List<Throwable> failures = new CopyOnWriteArrayList<>();
+    CountDownLatch go = new CountDownLatch(1);
+    ExecutorService pool = Executors.newFixedThreadPool(THREADS);
+
+    try {
+      for (int t = 0; t < THREADS; t++) {
+        pool.submit(
+            () -> {
+              try {
+                go.await();
+                for (int i = 0; i < READS_PER_THREAD; i++) {
+                  answers.add(SpcsEnvironment.isInsideSpcs());
+                }
+              } catch (Throwable e) {
+                failures.add(e);
+              }
+            });
+      }
+      go.countDown();
+      pool.shutdown();
+      assertThat(pool.awaitTermination(60, TimeUnit.SECONDS)).as("detectors finished").isTrue();
+    } finally {
+      pool.shutdownNow();
+    }
+
+    assertThat(failures).isEmpty();
+    assertThat(answers).as("detection never disagreed across threads").containsExactly(true);
+  }
+}

--- a/src/test/java/com/snowflake/kafka/connector/internal/spcs/SpcsEnvironmentTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/spcs/SpcsEnvironmentTest.java
@@ -9,8 +9,13 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import org.apache.log4j.AppenderSkeleton;
+import org.apache.log4j.Logger;
+import org.apache.log4j.spi.LoggingEvent;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -28,12 +33,15 @@ public class SpcsEnvironmentTest {
     SpcsEnvironment.resetForTests();
   }
 
+  private static final String ACCOUNT = "myaccount";
+
   /** Simulates a container running inside SPCS, with a token file and the runtime env vars. */
   private Path simulateSpcs(String tokenValue) throws IOException {
     Path token = tempDir.resolve("token");
     Files.write(token, tokenValue.getBytes(StandardCharsets.UTF_8));
     Map<String, String> env = new HashMap<>();
     env.put(SpcsEnvironment.ENV_HOST, HOST);
+    env.put(SpcsEnvironment.ENV_ACCOUNT, ACCOUNT);
     env.put(SpcsEnvironment.ENV_DATABASE, "AMBIENT_DB");
     env.put(SpcsEnvironment.ENV_SCHEMA, "AMBIENT_SCHEMA");
     SpcsEnvironment.overrideForTests(env::get, token);
@@ -355,5 +363,91 @@ public class SpcsEnvironmentTest {
     assertThatThrownBy(SpcsEnvironment::readToken)
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("is empty");
+  }
+
+  /**
+   * An empty token throws locally with an actionable message rather than sending the token to
+   * Snowflake and waiting for its generic '390303 Invalid OAuth access token' rejection. The
+   * message must name the cause ('enableCustomCredentials') so an operator can fix it without
+   * reading source code. R19.
+   */
+  @Test
+  void shouldRejectEmptyTokenLocallyWithActionableMessage() throws IOException {
+    simulateSpcs("");
+
+    assertThatThrownBy(SpcsEnvironment::readToken)
+        .isInstanceOf(IllegalStateException.class)
+        .as("message must name the Snowflake error so the operator knows what Snowflake would say")
+        .hasMessageContaining("390303")
+        .as("message must name the fix so the operator does not need to read the source")
+        .hasMessageContaining("enableCustomCredentials");
+  }
+
+  /**
+   * Security pin (R20): the bearer token must not leak into the resolved configuration map. The
+   * token is read and used to build properties, but it must never appear as a config value -- doing
+   * so would expose it to any code that logs or serializes the configuration map.
+   */
+  @Test
+  void tokenMustNotAppearInResolvedConfigurationMap() throws IOException {
+    String secret = "VERY-SECRET-TOKEN-" + System.nanoTime();
+    simulateSpcs(secret);
+
+    Map<String, String> raw = new HashMap<>();
+    raw.put(KafkaConnectorConfigParams.NAME, "testConnector");
+    raw.put(KafkaConnectorConfigParams.SNOWFLAKE_ROLE_NAME, "MY_ROLE");
+    Map<String, String> resolved = SpcsEnvironment.resolve(raw);
+
+    assertThat(resolved.values())
+        .as("the bearer token value must not appear in any entry of the resolved config")
+        .doesNotContain(secret);
+  }
+
+  /**
+   * Security pin (R20): the bearer token must not appear in log output during resolution. A log
+   * line that includes the token value would expose it to anyone with access to the log file.
+   */
+  @Test
+  void tokenMustNotAppearInLogsDuringResolution() throws IOException {
+    String secret = "VERY-SECRET-LOG-TOKEN-" + System.nanoTime();
+    simulateSpcs(secret);
+
+    Logger rootLogger = Logger.getRootLogger();
+    CapturingAppender appender = new CapturingAppender();
+    rootLogger.addAppender(appender);
+    try {
+      Map<String, String> raw = new HashMap<>();
+      raw.put(KafkaConnectorConfigParams.NAME, "testConnector");
+      raw.put(KafkaConnectorConfigParams.SNOWFLAKE_ROLE_NAME, "MY_ROLE");
+      SpcsEnvironment.resolve(raw);
+    } finally {
+      rootLogger.removeAppender(appender);
+    }
+
+    List<String> messages = appender.getMessages();
+    assertThat(messages)
+        .as("the bearer token value must not appear in any log record emitted during resolution")
+        .noneMatch(msg -> msg.contains(secret));
+  }
+
+  private static class CapturingAppender extends AppenderSkeleton {
+    private final List<String> messages = new ArrayList<>();
+
+    @Override
+    protected void append(LoggingEvent event) {
+      messages.add(event.getRenderedMessage());
+    }
+
+    @Override
+    public void close() {}
+
+    @Override
+    public boolean requiresLayout() {
+      return false;
+    }
+
+    List<String> getMessages() {
+      return new ArrayList<>(messages);
+    }
   }
 }

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientPropertiesTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientPropertiesTest.java
@@ -39,11 +39,13 @@ import java.nio.file.Path;
 import java.security.PrivateKey;
 import java.util.Base64;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import org.apache.kafka.common.config.types.Password;
 import org.junit.Assert;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -51,8 +53,13 @@ import org.junit.jupiter.params.provider.EnumSource;
 
 public class StreamingClientPropertiesTest {
 
-  private static final String EXAMPLE_PARAM1 = "EXAMPLE_PARAM1".toLowerCase();
-  private static final String EXAMPLE_PARAM2 = "EXAMPLE_PARAM2".toLowerCase();
+  private static final String EXAMPLE_PARAM1 = "EXAMPLE_PARAM1".toLowerCase(Locale.ROOT);
+  private static final String EXAMPLE_PARAM2 = "EXAMPLE_PARAM2".toLowerCase(Locale.ROOT);
+
+  @AfterEach
+  void resetSpcsOverride() {
+    SpcsEnvironment.resetForTests();
+  }
 
   /**
    * Guards the exhaustiveness of the authenticator switch in {@link
@@ -88,98 +95,90 @@ public class StreamingClientPropertiesTest {
     Map<String, String> connectorConfig = builder.build();
     connectorConfig.put(Utils.TASK_ID, "0");
 
-    try {
-      // WHEN
-      Properties clientProperties =
-          StreamingClientProperties.from(SinkTaskConfig.from(connectorConfig)).clientProperties;
+    // WHEN
+    Properties clientProperties =
+        StreamingClientProperties.from(SinkTaskConfig.from(connectorConfig)).clientProperties;
 
-      // THEN the switch handled it and emitted this authenticator's credential material
-      assertThat(clientProperties.stringPropertyNames())
-          .containsAnyOf("authorization_type", "private_key");
-    } finally {
-      SpcsEnvironment.resetForTests();
-    }
+    // THEN the switch handled it and emitted this authenticator's credential material
+    assertThat(clientProperties.stringPropertyNames())
+        .containsAnyOf("authorization_type", "private_key");
   }
 
   /**
    * Ambient SPCS mode must send only the authorization type and let the SDK default the token
    * paths. Setting any oauth_* key here, or a spcs_*_path differing from the SDK default, would be
    * rejected by the SDK's exclusive-field validation.
+   *
+   * <p>The account comes from SNOWFLAKE_ACCOUNT, not from parsing the host. The host format is
+   * undocumented and was verified on one deployment; SNOWFLAKE_ACCOUNT is the canonical identifier
+   * published by every SPCS runtime and is how the Snowflake CLI establishes its account.
    */
   @Test
-  void shouldSetSpcsAuthorizationTypeAndTakeAccountFromHost(@TempDir Path tempDir)
-      throws IOException {
-    // GIVEN a container inside SPCS. SNOWFLAKE_HOST encodes the account in its first label, with
-    // underscores replaced by hyphens; measured inside a real service.
+  void shouldSetSpcsAuthorizationTypeAndUseAccountEnvVar(@TempDir Path tempDir) throws IOException {
     Path token = tempDir.resolve("token");
     Files.write(token, "ambient-token".getBytes(StandardCharsets.UTF_8));
     Map<String, String> env = new HashMap<>();
     env.put(SpcsEnvironment.ENV_HOST, "my-account.prod3.us-west-2.aws.snowflakecomputing.com");
+    env.put(SpcsEnvironment.ENV_ACCOUNT, "MY_ACCOUNT_FROM_ENV");
     SpcsEnvironment.overrideForTests(env::get, token);
-    try {
-      Map<String, String> connectorConfig =
-          SnowflakeSinkConnectorConfigBuilder.streamingConfig()
-              .withAuthenticator(AuthenticatorType.SPCS.toConfigValue())
-              .withoutUrl()
-              .build();
-      connectorConfig.put(Utils.TASK_ID, "0");
+    Map<String, String> connectorConfig =
+        SnowflakeSinkConnectorConfigBuilder.streamingConfig()
+            .withAuthenticator(AuthenticatorType.SPCS.toConfigValue())
+            .withoutUrl()
+            .build();
+    connectorConfig.put(Utils.TASK_ID, "0");
 
-      // WHEN
-      Properties clientProperties =
-          StreamingClientProperties.from(SinkTaskConfig.from(connectorConfig)).clientProperties;
+    // WHEN
+    Properties clientProperties =
+        StreamingClientProperties.from(SinkTaskConfig.from(connectorConfig)).clientProperties;
 
-      // THEN
-      assertThat(clientProperties.getProperty("authorization_type")).isEqualTo("spcs");
-      // The account is the first label of the host. Both this hyphenated form and the underscored
-      // account name were verified to authenticate against a live SPCS deployment. The config
-      // carries no URL, so this asserts on ambient resolution rather than on the test's own input.
-      assertThat(clientProperties.getProperty("account")).isEqualTo("my-account");
-      assertThat(clientProperties.stringPropertyNames())
-          .doesNotContain(
-              "oauth_client_id",
-              "oauth_client_secret",
-              "oauth_refresh_token",
-              "oauth_token_endpoint",
-              "oauth_scope",
-              "oauth_include_scope",
-              "private_key",
-              "spcs_token_path",
-              "spcs_service_token_path");
-      // No user may be sent. The ambient token identifies the service user, and Snowflake
-      // rejects a session that asserts a different one. Verified against a live SPCS service:
-      // sending the placeholder user produced "The user you were trying to authenticate as
-      // differs from the user tied to the access token"; omitting it authenticated.
-      assertThat(clientProperties.stringPropertyNames()).doesNotContain("user");
-      // The role, by contrast, IS honored and must still be sent.
-      assertThat(clientProperties.getProperty("role")).isNotNull();
-    } finally {
-      SpcsEnvironment.resetForTests();
-    }
+    // THEN: account comes from SNOWFLAKE_ACCOUNT, not from parsing the host
+    assertThat(clientProperties.getProperty("authorization_type")).isEqualTo("spcs");
+    assertThat(clientProperties.getProperty("account"))
+        .as("account from SNOWFLAKE_ACCOUNT, case-normalized to lower case")
+        .isEqualTo("my_account_from_env");
+    assertThat(clientProperties.stringPropertyNames())
+        .doesNotContain(
+            "oauth_client_id",
+            "oauth_client_secret",
+            "oauth_refresh_token",
+            "oauth_token_endpoint",
+            "oauth_scope",
+            "oauth_include_scope",
+            "private_key",
+            "spcs_token_path",
+            "spcs_service_token_path");
+    assertThat(clientProperties.stringPropertyNames()).doesNotContain("user");
+    assertThat(clientProperties.getProperty("role")).isNotNull();
   }
 
-  /** The account parsed from an SPCS host is normalized to lower case. */
+  /**
+   * When SNOWFLAKE_ACCOUNT is absent, fall back to parsing the first label of the host URL. This is
+   * the pre-existing behavior and is kept so that any SPCS deployment that does not publish
+   * SNOWFLAKE_ACCOUNT still works.
+   */
   @Test
-  void shouldLowerCaseAmbientAccount(@TempDir Path tempDir) throws IOException {
+  void shouldFallBackToHostParsingWhenAccountEnvVarIsAbsent(@TempDir Path tempDir)
+      throws IOException {
     Path token = tempDir.resolve("token");
     Files.write(token, "ambient-token".getBytes(StandardCharsets.UTF_8));
     Map<String, String> env = new HashMap<>();
-    env.put(SpcsEnvironment.ENV_HOST, "MyAccount.prod3.us-west-2.aws.snowflakecomputing.com");
+    // No ENV_ACCOUNT: only host is present, simulating an older SPCS deployment.
+    env.put(SpcsEnvironment.ENV_HOST, "my-account.prod3.us-west-2.aws.snowflakecomputing.com");
     SpcsEnvironment.overrideForTests(env::get, token);
-    try {
-      Map<String, String> connectorConfig =
-          SnowflakeSinkConnectorConfigBuilder.streamingConfig()
-              .withAuthenticator(AuthenticatorType.SPCS.toConfigValue())
-              .withoutUrl()
-              .build();
-      connectorConfig.put(Utils.TASK_ID, "0");
+    Map<String, String> connectorConfig =
+        SnowflakeSinkConnectorConfigBuilder.streamingConfig()
+            .withAuthenticator(AuthenticatorType.SPCS.toConfigValue())
+            .withoutUrl()
+            .build();
+    connectorConfig.put(Utils.TASK_ID, "0");
 
-      Properties clientProperties =
-          StreamingClientProperties.from(SinkTaskConfig.from(connectorConfig)).clientProperties;
+    Properties clientProperties =
+        StreamingClientProperties.from(SinkTaskConfig.from(connectorConfig)).clientProperties;
 
-      assertThat(clientProperties.getProperty("account")).isEqualTo("myaccount");
-    } finally {
-      SpcsEnvironment.resetForTests();
-    }
+    assertThat(clientProperties.getProperty("account"))
+        .as("falls back to the first label of the host when SNOWFLAKE_ACCOUNT is absent")
+        .isEqualTo("my-account");
   }
 
   @Test

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientPropertiesTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientPropertiesTest.java
@@ -101,6 +101,87 @@ public class StreamingClientPropertiesTest {
     }
   }
 
+  /**
+   * Ambient SPCS mode must send only the authorization type and let the SDK default the token
+   * paths. Setting any oauth_* key here, or a spcs_*_path differing from the SDK default, would be
+   * rejected by the SDK's exclusive-field validation.
+   */
+  @Test
+  void shouldSetSpcsAuthorizationTypeAndTakeAccountFromHost(@TempDir Path tempDir)
+      throws IOException {
+    // GIVEN a container inside SPCS. SNOWFLAKE_HOST encodes the account in its first label, with
+    // underscores replaced by hyphens; measured inside a real service.
+    Path token = tempDir.resolve("token");
+    Files.write(token, "ambient-token".getBytes(StandardCharsets.UTF_8));
+    Map<String, String> env = new HashMap<>();
+    env.put(SpcsEnvironment.ENV_HOST, "my-account.prod3.us-west-2.aws.snowflakecomputing.com");
+    SpcsEnvironment.overrideForTests(env::get, token);
+    try {
+      Map<String, String> connectorConfig =
+          SnowflakeSinkConnectorConfigBuilder.streamingConfig()
+              .withAuthenticator(AuthenticatorType.SPCS.toConfigValue())
+              .withoutUrl()
+              .build();
+      connectorConfig.put(Utils.TASK_ID, "0");
+
+      // WHEN
+      Properties clientProperties =
+          StreamingClientProperties.from(SinkTaskConfig.from(connectorConfig)).clientProperties;
+
+      // THEN
+      assertThat(clientProperties.getProperty("authorization_type")).isEqualTo("spcs");
+      // The account is the first label of the host. Both this hyphenated form and the underscored
+      // account name were verified to authenticate against a live SPCS deployment. The config
+      // carries no URL, so this asserts on ambient resolution rather than on the test's own input.
+      assertThat(clientProperties.getProperty("account")).isEqualTo("my-account");
+      assertThat(clientProperties.stringPropertyNames())
+          .doesNotContain(
+              "oauth_client_id",
+              "oauth_client_secret",
+              "oauth_refresh_token",
+              "oauth_token_endpoint",
+              "oauth_scope",
+              "oauth_include_scope",
+              "private_key",
+              "spcs_token_path",
+              "spcs_service_token_path");
+      // No user may be sent. The ambient token identifies the service user, and Snowflake
+      // rejects a session that asserts a different one. Verified against a live SPCS service:
+      // sending the placeholder user produced "The user you were trying to authenticate as
+      // differs from the user tied to the access token"; omitting it authenticated.
+      assertThat(clientProperties.stringPropertyNames()).doesNotContain("user");
+      // The role, by contrast, IS honored and must still be sent.
+      assertThat(clientProperties.getProperty("role")).isNotNull();
+    } finally {
+      SpcsEnvironment.resetForTests();
+    }
+  }
+
+  /** The account parsed from an SPCS host is normalized to lower case. */
+  @Test
+  void shouldLowerCaseAmbientAccount(@TempDir Path tempDir) throws IOException {
+    Path token = tempDir.resolve("token");
+    Files.write(token, "ambient-token".getBytes(StandardCharsets.UTF_8));
+    Map<String, String> env = new HashMap<>();
+    env.put(SpcsEnvironment.ENV_HOST, "MyAccount.prod3.us-west-2.aws.snowflakecomputing.com");
+    SpcsEnvironment.overrideForTests(env::get, token);
+    try {
+      Map<String, String> connectorConfig =
+          SnowflakeSinkConnectorConfigBuilder.streamingConfig()
+              .withAuthenticator(AuthenticatorType.SPCS.toConfigValue())
+              .withoutUrl()
+              .build();
+      connectorConfig.put(Utils.TASK_ID, "0");
+
+      Properties clientProperties =
+          StreamingClientProperties.from(SinkTaskConfig.from(connectorConfig)).clientProperties;
+
+      assertThat(clientProperties.getProperty("account")).isEqualTo("myaccount");
+    } finally {
+      SpcsEnvironment.resetForTests();
+    }
+  }
+
   @Test
   public void testGetValidProperties() {
     String privateKeyPem = Base64.getEncoder().encodeToString(generatePrivateKey().getEncoded());


### PR DESCRIPTION
**Jira:** [SNOW-3961901](https://snowflakecomputing.atlassian.net/browse/SNOW-3961901)
**Design document:** [https://docs.google.com/document/d/1NqtBk9tCD5C8Z1TMtJZT5qf367aYxaBB3LAQ2hDR92c/edit?usp=sharing](https://docs.google.com/document/d/1NqtBk9tCD5C8Z1TMtJZT5qf367aYxaBB3LAQ2hDR92c/edit?usp=sharing)

## Stack

| PR | Commits | What | Inert? |
|---|---|---|---|
| [1/3] | `spcs-1-fail-fast`, `spcs-2-environment` | Fail-fast guard + `SpcsEnvironment` | Yes |
| [2/3] | `spcs-3-credential-paths`, `spcs-4-resolve` | Credential paths + resolution | Yes |
| **[3/3] ← you are here** | `spcs-5-enable`, `spcs-6-concurrency` | Entry points wired up + concurrency cover | **This is where the behavior change lives** |

**This is the review entry point for the whole chain.** PRs [1/3] and [2/3] are prerequisites; their design rationale is in their descriptions, but they are inert and low-risk.  All behavioral change is here.

## What this does

Lets the connector run inside Snowpark Container Services with **no configured
credential** — no key pair, no OAuth client, no secret — using the Snowflake-provided
service user identity.  Set `snowflake.authenticator=spcs` (or omit it entirely
inside SPCS), and the connector authenticates as the service user automatically.

Existing deployments are not affected:
- **Outside SPCS**: `SpcsEnvironment.isInsideSpcs()` is false (requires both `SNOWFLAKE_HOST` env var and a readable `/snowflake/session/token`); `resolve()` is a no-op on its first line.
- **Inside SPCS with an explicit credential**: auto-adoption is blocked; the existing credential is kept.
- **Inside SPCS with an explicit authenticator**: `resolve()` returns the input unchanged.

## Commit 5 — `enable ambient SPCS authentication at the entry points`

Calls `resolve()` at all four places in the connector that construct or validate a configuration:
`SnowflakeStreamingSinkConnector.start()`, `SnowflakeStreamingSinkConnector.validate()`,
`DefaultConnectorConfigValidator.validateConfig()`, and `SinkTaskConfig.builderFrom()`.

Also adds `spcs` to `ConnectorConfigDefinition` so Kafka Connect surfaces it in its
REST API documentation, and lets `DefaultConnectorConfigValidator` accept it.

**One finding that only the broker run could have revealed:** Kafka Connect calls `Connector.validate()` *before* `start()`, so without the resolution call in `validate()` the feature was unusable from Connect even though every in-process test passed.  The fix is one line.

## Commit 6 — `add concurrency cover for ambient SPCS authentication` (test only)

Adds `SpcsEnvironmentConcurrencyTest`:
- A rotating token (background thread rewriting the file every 5 ms) is always read whole, never partially.
- `resolve()` applied concurrently from 8 threads produces identical results — no shared mutable state.
- `isInsideSpcs()` never disagrees across concurrent calls.

Zero production code.

## Two deployment prerequisites found by deploying, not by reading code

1. **`capabilities.securityContext.enableCustomCredentials: true`** in the service spec.
   Without it, JDBC connects fine but the streaming SDK returns `401 / 395090 "Please use OAuth
   when connecting to Snowflake"`.  The capability name is misleading — it gates the
   *platform-supplied* token, not a customer secret — and the error message points the wrong way.

2. **`snowflake.streaming.validate.compatibility.with.classic=false`** (or the five companion
   settings it requires).

## Verified end-to-end

Connector's own classes deployed as an SPCS service.  `validateConfig()` passed with no
credential.  Then a MakeBenchmark2-shaped run (Kafka Connect distributed, REST API, 4 tasks,
2000 records, 600 s):

| Check | Result |
|---|---|
| REST submit | HTTP 201 |
| All four tasks | RUNNING |
| Rows / distinct ids / duplicates | **2000 / 2000 / 0** |
| Token rotation mid-run (~10.5 min interval) | Survived; 0 auth errors |
| Worker kill + restart | Resumed cleanly; 0 duplicates |

## Tests

824 → **836** (commit 5) → **839** (commit 6), zero failures at each step, each commit built from clean.
Format-clean. `sf ai review run --base-ref master --reviewer agent` run twice: once on the original submission (4 findings, all addressed) and once on the post-rebase tip (4 new findings from the rebase merge resolution, all addressed). Zero findings on the current tip.

Full test plan with 18 identified behaviors, all unit-testable ones covered, is in Appendix A of the design document.

[SNOW-3961901]: https://snowflakecomputing.atlassian.net/browse/SNOW-3961901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ