### PR TITLE
SNOW-3961901: reject a blank URL, user or role instead of accepting it silently

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/DefaultConnectorConfigValidator.java
+++ b/src/main/java/com/snowflake/kafka/connector/DefaultConnectorConfigValidator.java
@@ -105,20 +105,20 @@ public class DefaultConnectorConfigValidator implements ConnectorConfigValidator
       }
     }
 
-    if (!config.containsKey(KafkaConnectorConfigParams.SNOWFLAKE_USER_NAME)) {
+    if (isBlank(config.get(KafkaConnectorConfigParams.SNOWFLAKE_USER_NAME))) {
       invalidConfigParams.put(
           KafkaConnectorConfigParams.SNOWFLAKE_USER_NAME,
           Utils.formatString(
               "{} cannot be empty.", KafkaConnectorConfigParams.SNOWFLAKE_USER_NAME));
     }
 
-    if (!config.containsKey(KafkaConnectorConfigParams.SNOWFLAKE_URL_NAME)) {
+    if (isBlank(config.get(KafkaConnectorConfigParams.SNOWFLAKE_URL_NAME))) {
       invalidConfigParams.put(
           KafkaConnectorConfigParams.SNOWFLAKE_URL_NAME,
           Utils.formatString("{} cannot be empty.", KafkaConnectorConfigParams.SNOWFLAKE_URL_NAME));
     }
 
-    if (!config.containsKey(KafkaConnectorConfigParams.SNOWFLAKE_ROLE_NAME)) {
+    if (isBlank(config.get(KafkaConnectorConfigParams.SNOWFLAKE_ROLE_NAME))) {
       invalidConfigParams.put(
           KafkaConnectorConfigParams.SNOWFLAKE_ROLE_NAME,
           Utils.formatString(
@@ -419,5 +419,18 @@ public class DefaultConnectorConfigValidator implements ConnectorConfigValidator
       LOGGER.error("Invalid config: " + invalidParamsMessage);
       throw SnowflakeErrors.ERROR_0001.getException(invalidParamsMessage);
     }
+  }
+
+  /**
+   * True when a property is absent, empty, or whitespace only.
+   *
+   * <p>These three checks used to test {@code containsKey} while reporting "cannot be empty", so a
+   * property present with an empty value passed validation. That is not cosmetic: an empty {@code
+   * snowflake.url.name} was accepted here and then made {@code StreamingClientProperties.from}
+   * produce a properties map with zero entries, and the connector failed later inside the SDK with
+   * an unrelated error. The check now matches the message it has always printed.
+   */
+  private static boolean isBlank(String value) {
+    return value == null || value.trim().isEmpty();
   }
 }

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProperties.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/StreamingClientProperties.java
@@ -65,50 +65,54 @@ public class StreamingClientProperties {
   /** Creates streaming client properties from parsed {@link SinkTaskConfig}. */
   public static StreamingClientProperties from(SinkTaskConfig config) {
     final Properties clientProperties = new Properties();
-    if (!Strings.isNullOrEmpty(config.getSnowflakeUrl())) {
-      SnowflakeURL url = new SnowflakeURL(config.getSnowflakeUrl());
-      switch (config.getAuthenticator()) {
-        case OAUTH:
-          clientProperties.put("authorization_type", AuthenticatorType.OAUTH.toConfigValue());
-          config.getOauthClientId().ifPresent(v -> clientProperties.put("oauth_client_id", v));
-          config
-              .getOauthClientSecret()
-              .ifPresent(v -> clientProperties.put("oauth_client_secret", v.value()));
-          config
-              .getOauthRefreshToken()
-              .ifPresent(v -> clientProperties.put("oauth_refresh_token", v.value()));
-          config
-              .getOauthTokenEndpoint()
-              .ifPresent(v -> clientProperties.put("oauth_token_endpoint", v));
-          // The SDK defaults oauth_include_scope to true, which makes it derive
-          // "session:role:{role}" and send it as the scope on refresh. That breaks external OAuth /
-          // IdP refresh tokens minted without a role scope, so forward the connector's value
-          // explicitly (default false). Only send an explicit scope when scopes are enabled.
-          clientProperties.put(
-              "oauth_include_scope", String.valueOf(config.getOauthIncludeScope()));
-          if (config.getOauthIncludeScope()) {
-            config.getOauthScope().ifPresent(v -> clientProperties.put("oauth_scope", v));
-          }
-          break;
-        case SNOWFLAKE_JWT:
-          final PrivateKey privateKey =
-              PrivateKeyTool.parsePrivateKey(
-                  config
-                      .getSnowflakePrivateKey()
-                      .orElseThrow(SnowflakeErrors.ERROR_0013::getException),
-                  config.getSnowflakePrivateKeyPassphrase());
-          final String privateKeyEncoded =
-              Base64.getEncoder().encodeToString(privateKey.getEncoded());
-          clientProperties.put("private_key", privateKeyEncoded);
-          break;
-      }
-
-      clientProperties.put("user", config.getSnowflakeUser());
-      clientProperties.put("role", config.getSnowflakeRole());
-      clientProperties.put("account", url.getAccount());
-      clientProperties.put("host", url.getUrlWithoutPort());
-      clientProperties.put("application", APPLICATION_NAME);
+    if (Strings.isNullOrEmpty(config.getSnowflakeUrl())) {
+      // Without a URL there is no account or host: the authorization type and credential would be
+      // pointless on their own, and the SDK would fail with an unrelated error. Validated
+      // configurations cannot reach this branch; DefaultConnectorConfigValidator rejects a blank
+      // snowflake.url.name. Reaching here means a SinkTaskConfig was built without validation.
+      throw SnowflakeErrors.ERROR_0017.getException();
     }
+    SnowflakeURL url = new SnowflakeURL(config.getSnowflakeUrl());
+    switch (config.getAuthenticator()) {
+      case OAUTH:
+        clientProperties.put("authorization_type", AuthenticatorType.OAUTH.toConfigValue());
+        config.getOauthClientId().ifPresent(v -> clientProperties.put("oauth_client_id", v));
+        config
+            .getOauthClientSecret()
+            .ifPresent(v -> clientProperties.put("oauth_client_secret", v.value()));
+        config
+            .getOauthRefreshToken()
+            .ifPresent(v -> clientProperties.put("oauth_refresh_token", v.value()));
+        config
+            .getOauthTokenEndpoint()
+            .ifPresent(v -> clientProperties.put("oauth_token_endpoint", v));
+        // The SDK defaults oauth_include_scope to true, which makes it derive
+        // "session:role:{role}" and send it as the scope on refresh. That breaks external OAuth /
+        // IdP refresh tokens minted without a role scope, so forward the connector's value
+        // explicitly (default false). Only send an explicit scope when scopes are enabled.
+        clientProperties.put("oauth_include_scope", String.valueOf(config.getOauthIncludeScope()));
+        if (config.getOauthIncludeScope()) {
+          config.getOauthScope().ifPresent(v -> clientProperties.put("oauth_scope", v));
+        }
+        break;
+      case SNOWFLAKE_JWT:
+        final PrivateKey privateKey =
+            PrivateKeyTool.parsePrivateKey(
+                config
+                    .getSnowflakePrivateKey()
+                    .orElseThrow(SnowflakeErrors.ERROR_0013::getException),
+                config.getSnowflakePrivateKeyPassphrase());
+        final String privateKeyEncoded =
+            Base64.getEncoder().encodeToString(privateKey.getEncoded());
+        clientProperties.put("private_key", privateKeyEncoded);
+        break;
+    }
+
+    clientProperties.put("user", config.getSnowflakeUser());
+    clientProperties.put("role", config.getSnowflakeRole());
+    clientProperties.put("account", url.getAccount());
+    clientProperties.put("host", url.getUrlWithoutPort());
+    clientProperties.put("application", APPLICATION_NAME);
 
     String clientNamePrefix =
         STREAMING_CLIENT_V2_PREFIX_NAME

--- a/src/test/java/com/snowflake/kafka/connector/BlankRequiredConfigTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/BlankRequiredConfigTest.java
@@ -1,0 +1,111 @@
+package com.snowflake.kafka.connector;
+
+import static com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams.SNOWFLAKE_ROLE_NAME;
+import static com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams.SNOWFLAKE_URL_NAME;
+import static com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams.SNOWFLAKE_USER_NAME;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.snowflake.kafka.connector.config.SinkTaskConfig;
+import com.snowflake.kafka.connector.config.SnowflakeSinkConnectorConfigBuilder;
+import com.snowflake.kafka.connector.internal.streaming.DefaultStreamingConfigValidator;
+import com.snowflake.kafka.connector.internal.streaming.StreamingClientProperties;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * The three required connection properties reported errors that claimed to check for emptiness
+ * while actually testing only for key presence:
+ *
+ * <pre>
+ *   if (!config.containsKey(SNOWFLAKE_URL_NAME)) {
+ *     invalidConfigParams.put(SNOWFLAKE_URL_NAME, "snowflake.url.name cannot be empty.");
+ *   }
+ * </pre>
+ *
+ * <p>So a property present with an empty value passed validation. That was not cosmetic. Measured
+ * on the unfixed code, {@code snowflake.url.name=} was accepted by the validator and then made
+ * {@link StreamingClientProperties#from} return a property set with <b>zero entries</b>: no
+ * authorization type, no account, host, user or role, and no credential. The connector started and
+ * failed later inside the SDK with an error naming something unrelated. One missing value silently
+ * suppressed six.
+ */
+public class BlankRequiredConfigTest {
+
+  private final ConnectorConfigValidator validator =
+      new DefaultConnectorConfigValidator(new DefaultStreamingConfigValidator());
+
+  /**
+   * The point of the change: a present-but-empty value is now rejected, with the message the code
+   * has always printed. Whitespace counts as empty, because a properties file makes that easy to
+   * produce by accident and it is no more usable than a truly empty value.
+   */
+  @ParameterizedTest
+  @ValueSource(strings = {"", " ", "\t"})
+  void shouldRejectABlankUrl(String blank) {
+    Map<String, String> config = SnowflakeSinkConnectorConfigBuilder.streamingConfig().build();
+    config.put(SNOWFLAKE_URL_NAME, blank);
+
+    assertThatThrownBy(() -> validator.validateConfig(config))
+        .hasMessageContaining(SNOWFLAKE_URL_NAME);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"", " ", "\t"})
+  void shouldRejectABlankUser(String blank) {
+    Map<String, String> config = SnowflakeSinkConnectorConfigBuilder.streamingConfig().build();
+    config.put(SNOWFLAKE_USER_NAME, blank);
+
+    assertThatThrownBy(() -> validator.validateConfig(config))
+        .hasMessageContaining(SNOWFLAKE_USER_NAME);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"", " ", "\t"})
+  void shouldRejectABlankRole(String blank) {
+    Map<String, String> config = SnowflakeSinkConnectorConfigBuilder.streamingConfig().build();
+    config.put(SNOWFLAKE_ROLE_NAME, blank);
+
+    assertThatThrownBy(() -> validator.validateConfig(config))
+        .hasMessageContaining(SNOWFLAKE_ROLE_NAME);
+  }
+
+  /** An absent property must still be rejected, which is what the old check already did. */
+  @Test
+  void shouldStillRejectAnAbsentUrl() {
+    Map<String, String> config = SnowflakeSinkConnectorConfigBuilder.streamingConfig().build();
+    config.remove(SNOWFLAKE_URL_NAME);
+
+    assertThatThrownBy(() -> validator.validateConfig(config))
+        .hasMessageContaining(SNOWFLAKE_URL_NAME);
+  }
+
+  /** A properly populated configuration must still pass, so the check is not simply stricter. */
+  @Test
+  void shouldAcceptAPopulatedConfiguration() {
+    Map<String, String> config = SnowflakeSinkConnectorConfigBuilder.streamingConfig().build();
+
+    validator.validateConfig(config);
+  }
+
+  /**
+   * A blank URL now throws {@link
+   * com.snowflake.kafka.connector.internal.SnowflakeErrors#ERROR_0017} rather than silently
+   * returning an empty property set. A validated configuration cannot reach this branch; the tests
+   * above enforce that. This test pins the behaviour for the case where a caller builds a
+   * SinkTaskConfig without validating it first.
+   */
+  @Test
+  void shouldThrowOnBlankUrl() {
+    Map<String, String> raw = SnowflakeSinkConnectorConfigBuilder.streamingConfig().build();
+    raw.put(SNOWFLAKE_URL_NAME, "");
+    raw.put("task_id", "0");
+    SinkTaskConfig config = SinkTaskConfig.builderFrom(raw).build();
+
+    assertThatThrownBy(() -> StreamingClientProperties.from(config))
+        .as("blank URL is rejected with ERROR_0017 rather than silently returning empty properties")
+        .isInstanceOf(com.snowflake.kafka.connector.internal.SnowflakeKafkaConnectorException.class)
+        .hasMessageContaining("0017");
+  }
+}

--- a/src/test/java/com/snowflake/kafka/connector/config/SinkTaskConfigTestBuilder.java
+++ b/src/test/java/com/snowflake/kafka/connector/config/SinkTaskConfigTestBuilder.java
@@ -4,10 +4,13 @@ import com.snowflake.kafka.connector.ConnectorConfigTools;
 import com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams;
 import com.snowflake.kafka.connector.StaticTopicToTableResolver;
 import com.snowflake.kafka.connector.internal.CachingConfig;
+import com.snowflake.kafka.connector.internal.TestUtils;
 import com.snowflake.kafka.connector.internal.streaming.v2.migration.Ssv1MigrationMode;
 import com.snowflake.kafka.connector.records.SnowflakeMetadataConfig;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.Map;
+import org.apache.kafka.common.config.types.Password;
 
 /**
  * Test-only builder for {@link SinkTaskConfig}. Provides a builder with default values for all
@@ -25,6 +28,21 @@ public final class SinkTaskConfigTestBuilder {
    * and taskId before build().
    */
   public static SinkTaskConfig.Builder builder() {
+    return builderWithoutKey()
+        // A generated private key is needed for the SNOWFLAKE_JWT authenticator because
+        // StreamingClientProperties.from tries to load it when building the streaming client
+        // properties. Tests that call from() now reach that case; setting a key avoids ERROR_0013.
+        .snowflakePrivateKey(
+            new Password(
+                Base64.getEncoder().encodeToString(TestUtils.generatePrivateKey().getEncoded())));
+  }
+
+  /**
+   * Same as {@link #builder()} but without a private key. Use when the test specifically exercises
+   * behavior that requires the key to be absent, such as testing ERROR_0013 from {@code
+   * makeJdbcDriverProperties}.
+   */
+  public static SinkTaskConfig.Builder builderWithoutKey() {
     return SinkTaskConfig.builder()
         .topicToTableResolver(new StaticTopicToTableResolver(Map.of()))
         .behaviorOnNullValues(ConnectorConfigTools.BehaviorOnNullValues.DEFAULT)
@@ -45,7 +63,11 @@ public final class SinkTaskConfigTestBuilder {
         .streamingClientProviderOverrideMap("")
         .cachingConfig(CachingConfig.fromConfig(Collections.emptyMap()))
         .metadataConfig(new SnowflakeMetadataConfig())
-        .snowflakeUrl("")
+        // A non-blank URL is required because StreamingClientProperties.from now rejects a blank
+        // URL rather than silently returning an empty property map. Tests that do not connect to
+        // Snowflake still need a syntactically valid host so the URL parses. No real connection is
+        // made, so the exact value does not matter as long as it is not blank.
+        .snowflakeUrl("testaccount.snowflakecomputing.com:443")
         .snowflakeUser("")
         .snowflakeRole("")
         .authenticator(AuthenticatorType.SNOWFLAKE_JWT)

--- a/src/test/java/com/snowflake/kafka/connector/internal/InternalUtilsTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/InternalUtilsTest.java
@@ -344,7 +344,9 @@ public class InternalUtilsTest {
     SnowflakeURL url = new SnowflakeURL("https://testaccount.snowflakecomputing.com:443");
 
     SinkTaskConfig taskConfig =
-        SinkTaskConfigTestBuilder.builder()
+        // builderWithoutKey: this test specifically covers the case where no private key is
+        // configured, so the builder default key must not be present.
+        SinkTaskConfigTestBuilder.builderWithoutKey()
             .connectorName("test-connector")
             .taskId("0")
             .snowflakeDatabase("MY_DB")


### PR DESCRIPTION
**Jira:** [SNOW-3961901](https://snowflakecomputing.atlassian.net/browse/SNOW-3961901)
**Independent of the SPCS chain (PRs #1542–#1544) and of the auth-detection fix (PR #1541).** No shared files; reviewable in any order.

## The bug

`DefaultConnectorConfigValidator` checked three required properties with `containsKey`
while its own error message claimed to check for emptiness:

```java
if (!config.containsKey(KafkaConnectorConfigParams.SNOWFLAKE_URL_NAME)) {
    invalidConfigParams.put(..., "snowflake.url.name cannot be empty.");
}
```

A property present with an empty value (`snowflake.url.name=`) passes validation.
`StreamingClientProperties.from()` then returned a property set with **zero entries** —
no authorization type, no account, no host, no user, no role, no credential.  The connector
started and failed later inside the SDK with an error naming something unrelated.  One
missing value silently suppressed six.

Measured on `master`:
```
snowflake.url.name=
validator accepted   = true
getSnowflakeUrl()    = []
clientProperties     = []   ← zero entries
```

## The fix

**1. `DefaultConnectorConfigValidator`** — replace `containsKey` with `isBlank` for the
three required properties (`snowflake.url.name`, `snowflake.user.name`, `snowflake.role.name`).
Whitespace counts as blank; a whitespace-only URL is not usable and was already producing
a silent failure.

**2. `StreamingClientProperties.from()`** — throw `ERROR_0017` on a blank URL rather than
returning an empty property set.  `SinkTaskConfigTestBuilder` (used by 8 test classes) was
updated to supply a real URL and a generated private key so those tests continue to work; one
test that specifically covers the missing-key case uses a new `builderWithoutKey()` variant.

## Scope

Ambient SPCS authentication is immune to this defect: `SpcsEnvironment.resolve()` uses
`putIfBlank`, which checks blankness rather than key presence, so an empty
`snowflake.url.name` inside SPCS is replaced by the ambient host before validation runs.
The defect bites key-pair and OAuth deployments on `master` today.

## Tests

12 new cases in `BlankRequiredConfigTest`:
- Empty, space and tab rejected for each of the three required properties (9 cases)
- An absent URL still rejected
- A populated configuration still accepted
- `StreamingClientProperties.from()` throws `ERROR_0017` on a blank URL

Mutation-verified: restoring the `containsKey` check fails exactly the three blank-URL
cases and nothing else.  Overall suite green, zero failures.
Format-clean. Zero findings from `sf ai review run --base-ref master --reviewer agent`.

[SNOW-3961901]: https://snowflakecomputing.atlassian.net/browse/SNOW-3961901?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ