### PR TITLE
gitignore + surefire: keep JVM crash dumps out of the repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ venv
 *.iml
 target
 docker-setup
+*.core
 
 *.log
 *.log.*

--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,7 @@
                 <configuration>
                     <skipTests>${skipUnitTests}</skipTests>
                     <useModulePath>false</useModulePath>
+                    <workingDirectory>${project.build.directory}</workingDirectory>
                     <argLine>--add-opens java.base/java.util=ALL-UNNAMED</argLine>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Belt: add \*.core to .gitignore. Suspenders: set Surefire workingDirectory to target/ so forked test JVMs write crash dumps into target/ (already gitignored, wiped by mvn clean) instead of the project root. No test behaviour change -- no tests use relative file paths.