### PR TITLE
[DRAFT] Replace snowflake-jdbc with snowflake-jdbc-native (private preview)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <jackson.version>2.22.1</jackson.version>
         <commons-compress.version>1.28.0</commons-compress.version>
         <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
-        <snowflake-jdbc.version>4.3.2</snowflake-jdbc.version>
+        <snowflake-jdbc-native.version>0.0.1</snowflake-jdbc-native.version>
         <slf4j-api.version>2.0.18</slf4j-api.version>
         <commons-lang3.version>3.20.0</commons-lang3.version>
         <auto-value.version>1.11.1</auto-value.version>
@@ -322,8 +322,8 @@
         <!--JDBC driver for building connection with Snowflake-->
         <dependency>
             <groupId>net.snowflake</groupId>
-            <artifactId>snowflake-jdbc</artifactId>
-            <version>${snowflake-jdbc.version}</version>
+            <artifactId>snowflake-jdbc-native-all</artifactId>
+            <version>${snowflake-jdbc-native.version}</version>
         </dependency>
 
         <dependency>

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -74,7 +74,7 @@
         <jackson.version>2.22.1</jackson.version>
         <commons-compress.version>1.28.0</commons-compress.version>
         <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
-        <snowflake-jdbc.version>4.3.2</snowflake-jdbc.version>
+        <snowflake-jdbc-native.version>0.0.1</snowflake-jdbc-native.version>
         <slf4j-api.version>2.0.18</slf4j-api.version>
         <parquet.version>1.14.4</parquet.version>
         <commons-lang3.version>3.20.0</commons-lang3.version>
@@ -461,8 +461,8 @@
         <!--JDBC driver for building connection with Snowflake-->
         <dependency>
             <groupId>net.snowflake</groupId>
-            <artifactId>snowflake-jdbc</artifactId>
-            <version>${snowflake-jdbc.version}</version>
+            <artifactId>snowflake-jdbc-native-all</artifactId>
+            <version>${snowflake-jdbc-native.version}</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/telemetry/SnowflakeTelemetryChannelCreation.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/telemetry/SnowflakeTelemetryChannelCreation.java
@@ -21,9 +21,9 @@ import static com.snowflake.kafka.connector.internal.telemetry.TelemetryConstant
 import static com.snowflake.kafka.connector.internal.telemetry.TelemetryConstants.TOPIC_PARTITION_CHANNEL_CREATION_TIME;
 import static com.snowflake.kafka.connector.internal.telemetry.TelemetryConstants.TOPIC_PARTITION_CHANNEL_NAME;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryBasicInfo;
 import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryService;
-import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * This object is sent only once when a channel starts. No concurrent modification is made on this

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/telemetry/SnowflakeTelemetryChannelStatus.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/telemetry/SnowflakeTelemetryChannelStatus.java
@@ -22,6 +22,7 @@ import static com.snowflake.kafka.connector.internal.streaming.channel.TopicPart
 
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricRegistry;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.annotations.VisibleForTesting;
 import com.snowflake.ingest.streaming.ChannelStatus;
 import com.snowflake.kafka.connector.internal.metrics.MetricsJmxReporter;
@@ -31,7 +32,6 @@ import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryServic
 import com.snowflake.kafka.connector.internal.telemetry.TelemetryConstants;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
-import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * Extension of {@link SnowflakeTelemetryBasicInfo} class used to send data to snowflake when the

--- a/src/main/java/com/snowflake/kafka/connector/internal/streaming/telemetry/SnowflakeTelemetrySsv1Migration.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/streaming/telemetry/SnowflakeTelemetrySsv1Migration.java
@@ -7,12 +7,12 @@ import static com.snowflake.kafka.connector.internal.telemetry.TelemetryConstant
 import static com.snowflake.kafka.connector.internal.telemetry.TelemetryConstants.TABLE_NAME;
 import static com.snowflake.kafka.connector.internal.telemetry.TelemetryConstants.TOPIC_PARTITION_CHANNEL_NAME;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.snowflake.kafka.connector.internal.streaming.v2.migration.Ssv1MigrationMode;
 import com.snowflake.kafka.connector.internal.streaming.v2.migration.Ssv1MigrationResponse;
 import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryBasicInfo;
 import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryService;
 import java.util.Locale;
-import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * One-shot telemetry event sent when SSv1 offset migration is attempted for a channel. Only emitted

--- a/src/main/java/com/snowflake/kafka/connector/internal/telemetry/SnowflakeTelemetryBasicInfo.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/telemetry/SnowflakeTelemetryBasicInfo.java
@@ -1,9 +1,9 @@
 package com.snowflake.kafka.connector.internal.telemetry;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.snowflake.kafka.connector.internal.KCLogger;
-import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.node.ObjectNode;
 
 /** Minimum information needed to sent to Snowflake through Telemetry API */
 public abstract class SnowflakeTelemetryBasicInfo {

--- a/src/main/java/com/snowflake/kafka/connector/internal/telemetry/SnowflakeTelemetryService.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/telemetry/SnowflakeTelemetryService.java
@@ -1,5 +1,8 @@
 package com.snowflake.kafka.connector.internal.telemetry;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams;
 import com.snowflake.kafka.connector.Utils;
 import com.snowflake.kafka.connector.internal.KCLogger;
@@ -10,9 +13,6 @@ import java.util.Set;
 import net.snowflake.client.internal.jdbc.telemetry.Telemetry;
 import net.snowflake.client.internal.jdbc.telemetry.TelemetryClient;
 import net.snowflake.client.internal.jdbc.telemetry.TelemetryUtil;
-import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.JsonNode;
-import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.ObjectMapper;
-import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.kafka.common.utils.AppInfoParser;
 
 public class SnowflakeTelemetryService {

--- a/src/main/java/net/snowflake/client/internal/jdbc/telemetry/Telemetry.java
+++ b/src/main/java/net/snowflake/client/internal/jdbc/telemetry/Telemetry.java
@@ -1,0 +1,19 @@
+package net.snowflake.client.internal.jdbc.telemetry;
+
+import java.util.concurrent.Future;
+
+/**
+ * TEMPORARY SHIM — see {@code package-info}. Mirrors the subset of the classic snowflake-jdbc
+ * {@code Telemetry} interface the connector relies on, so the connector compiles against
+ * snowflake-jdbc-native (private preview), which does not yet expose this API.
+ */
+public interface Telemetry {
+
+  void addLogToBatch(TelemetryData log);
+
+  void close();
+
+  Future<Boolean> sendBatchAsync();
+
+  void postProcess(String queryId, String sqlState, int vendorCode, Throwable ex);
+}

--- a/src/main/java/net/snowflake/client/internal/jdbc/telemetry/TelemetryClient.java
+++ b/src/main/java/net/snowflake/client/internal/jdbc/telemetry/TelemetryClient.java
@@ -1,0 +1,49 @@
+package net.snowflake.client.internal.jdbc.telemetry;
+
+import java.sql.Connection;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+import java.util.logging.Logger;
+
+/**
+ * TEMPORARY SHIM — see {@code package-info}. No-op telemetry client that stands in for the classic
+ * snowflake-jdbc {@code TelemetryClient} until snowflake-jdbc-native (private preview) exposes a
+ * real in-band JDBC telemetry API. Every method is a no-op; connector telemetry is effectively
+ * disabled when running against snowflake-jdbc-native.
+ */
+public class TelemetryClient implements Telemetry {
+
+  private static final Logger LOGGER = Logger.getLogger(TelemetryClient.class.getName());
+
+  /**
+   * Drop-in replacement for the classic factory method used by the connector. Returns a no-op
+   * client because snowflake-jdbc-native does not yet ship a JDBC telemetry implementation.
+   */
+  public static Telemetry createTelemetry(Connection conn) {
+    LOGGER.warning(
+        "snowflake-jdbc-native does not expose a JDBC telemetry API yet; "
+            + "connector telemetry is disabled (no-op shim). See "
+            + "net.snowflake.client.internal.jdbc.telemetry package-info.");
+    return new TelemetryClient();
+  }
+
+  @Override
+  public void addLogToBatch(TelemetryData log) {
+    // no-op
+  }
+
+  @Override
+  public void close() {
+    // no-op
+  }
+
+  @Override
+  public Future<Boolean> sendBatchAsync() {
+    return CompletableFuture.completedFuture(Boolean.FALSE);
+  }
+
+  @Override
+  public void postProcess(String queryId, String sqlState, int vendorCode, Throwable ex) {
+    // no-op
+  }
+}

--- a/src/main/java/net/snowflake/client/internal/jdbc/telemetry/TelemetryData.java
+++ b/src/main/java/net/snowflake/client/internal/jdbc/telemetry/TelemetryData.java
@@ -1,0 +1,26 @@
+package net.snowflake.client.internal.jdbc.telemetry;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * TEMPORARY SHIM — see {@code package-info}. Minimal stand-in for the classic snowflake-jdbc
+ * telemetry payload, which snowflake-jdbc-native (private preview) does not yet expose.
+ */
+public class TelemetryData {
+
+  private final ObjectNode message;
+  private final long timeStamp;
+
+  public TelemetryData(ObjectNode message, long timeStamp) {
+    this.message = message;
+    this.timeStamp = timeStamp;
+  }
+
+  public ObjectNode getMessage() {
+    return message;
+  }
+
+  public long getTimeStamp() {
+    return timeStamp;
+  }
+}

--- a/src/main/java/net/snowflake/client/internal/jdbc/telemetry/TelemetryUtil.java
+++ b/src/main/java/net/snowflake/client/internal/jdbc/telemetry/TelemetryUtil.java
@@ -1,0 +1,17 @@
+package net.snowflake.client.internal.jdbc.telemetry;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+/**
+ * TEMPORARY SHIM — see {@code package-info}. Provides the single {@code buildJobData} helper the
+ * connector uses from the classic snowflake-jdbc {@code TelemetryUtil}, which snowflake-jdbc-native
+ * (private preview) does not yet expose.
+ */
+public final class TelemetryUtil {
+
+  private TelemetryUtil() {}
+
+  public static TelemetryData buildJobData(ObjectNode message) {
+    return new TelemetryData(message, System.currentTimeMillis());
+  }
+}

--- a/src/main/java/net/snowflake/client/internal/jdbc/telemetry/package-info.java
+++ b/src/main/java/net/snowflake/client/internal/jdbc/telemetry/package-info.java
@@ -1,0 +1,22 @@
+/**
+ * TEMPORARY SHIM PACKAGE — not production code.
+ *
+ * <p>The classic {@code net.snowflake:snowflake-jdbc} driver exposed an in-band JDBC telemetry API
+ * under {@code net.snowflake.client.internal.jdbc.telemetry} ({@link
+ * net.snowflake.client.internal.jdbc.telemetry.Telemetry Telemetry}, {@link
+ * net.snowflake.client.internal.jdbc.telemetry.TelemetryClient TelemetryClient}, {@link
+ * net.snowflake.client.internal.jdbc.telemetry.TelemetryData TelemetryData}, {@link
+ * net.snowflake.client.internal.jdbc.telemetry.TelemetryUtil TelemetryUtil}). The replacement
+ * {@code net.snowflake:snowflake-jdbc-native} artifact (private preview) does not yet ship this
+ * package, so the connector would not compile against it.
+ *
+ * <p>These minimal stand-ins let the connector build and run against snowflake-jdbc-native so the
+ * rest of the driver can be exercised in CI. {@link
+ * net.snowflake.client.internal.jdbc.telemetry.TelemetryClient#createTelemetry(java.sql.Connection)
+ * createTelemetry} returns a no-op client, so connector-side telemetry is silently disabled until
+ * the native driver provides a real implementation.
+ *
+ * <p>GAP: snowflake-jdbc-native must expose a JDBC telemetry API before connector telemetry works.
+ * Delete this package once it does.
+ */
+package net.snowflake.client.internal.jdbc.telemetry;

--- a/src/test/java/com/snowflake/kafka/connector/internal/telemetry/SnowflakeTelemetryChannelStatusTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/telemetry/SnowflakeTelemetryChannelStatusTest.java
@@ -7,12 +7,12 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.codahale.metrics.MetricRegistry;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.snowflake.kafka.connector.internal.metrics.MetricsJmxReporter;
 import com.snowflake.kafka.connector.internal.streaming.telemetry.SnowflakeTelemetryChannelStatus;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
-import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.ObjectMapper;
-import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.Test;
 import org.mockito.Mockito;
 

--- a/src/test/java/com/snowflake/kafka/connector/internal/telemetry/SnowflakeTelemetryServiceTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/telemetry/SnowflakeTelemetryServiceTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.snowflake.ingest.streaming.ChannelStatus;
 import com.snowflake.kafka.connector.ConnectorConfigTools;
 import com.snowflake.kafka.connector.Constants.KafkaConnectorConfigParams;
@@ -28,7 +29,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicLong;
 import net.snowflake.client.internal.jdbc.telemetry.Telemetry;
 import net.snowflake.client.internal.jdbc.telemetry.TelemetryData;
-import net.snowflake.client.jdbc.internal.fasterxml.jackson.databind.JsonNode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/test/docker/docker-compose.confluent.yml
+++ b/test/docker/docker-compose.confluent.yml
@@ -71,7 +71,11 @@ services:
       CONNECT_LOG4J_LOGGERS: com.snowflake=INFO
       CONNECT_LOG4J_APPENDER_STDOUT_LAYOUT_CONVERSIONPATTERN: "[%d] %p %X{connector.context}%m (%c:%L)%n"
       KAFKA_HEAP_OPTS: "-Xms512m -Xmx6g"
-      KAFKA_OPTS: "${KAFKA_OPTS:-}"
+      # snowflake-jdbc-native eagerly initializes its bundled Apache Arrow off-heap allocator,
+      # whose MemoryUtil needs reflective java.nio access on Java 9+. Without this flag connector
+      # creation fails: "Failed to initialize MemoryUtil. You must start Java with
+      # `--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED`".
+      KAFKA_OPTS: "--add-opens=java.base/java.nio=ALL-UNNAMED ${KAFKA_OPTS:-}"
       SS_LOG_LEVEL: warn
     volumes:
       - ${CONNECTOR_PLUGIN_PATH:-/tmp/sf-kafka-connect-plugin}:/opt/kafka-connect/plugins/snowflake-connector

--- a/test/docker/scripts/start-apache-kafka.sh
+++ b/test/docker/scripts/start-apache-kafka.sh
@@ -34,6 +34,16 @@ if [ -n "${CONNECT_TASK_SHUTDOWN_GRACEFUL_TIMEOUT_MS:-}" ]; then
   fi
 fi
 
+# snowflake-jdbc-native bundles Apache Arrow, whose off-heap MemoryUtil needs reflective
+# access to java.nio.Buffer on Java 9+. Unlike the classic pure-JVM snowflake-jdbc (which the
+# connector only exercised on the control plane, never triggering Arrow's off-heap allocator),
+# the native driver initializes its Arrow-backed result path eagerly, so the Connect worker JVM
+# must be started with this flag or connector creation fails with:
+#   "Failed to initialize MemoryUtil. You must start Java with
+#    `--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED`"
+# connect-distributed.sh forwards $KAFKA_OPTS to the worker JVM.
+export KAFKA_OPTS="--add-opens=java.base/java.nio=ALL-UNNAMED ${KAFKA_OPTS:-}"
+
 if [ "${KRAFT_MODE:-false}" = "true" ]; then
     #######################################################################
     # KRaft mode (Kafka 4.x+)


### PR DESCRIPTION
## What

Swaps the JDBC driver dependency from `net.snowflake:snowflake-jdbc:4.3.2` to the Rust-core **private-preview** artifact `net.snowflake:snowflake-jdbc-native-all:0.0.1` in both `pom.xml` and `pom_confluent.xml`.

`-native-all` is the fat jar (all five platform natives bundled + dependencies shaded) — the closest drop-in for the current fat `snowflake-jdbc` jar, portable across every OS the Kafka Connect plugin lands on. It resolves from Maven Central, so no repository config is needed.

**This is a draft — the goal is to run it through CI and get real signal on `snowflake-jdbc-native` from an actual downstream consumer, and to surface the remaining API gaps.**

## Why it (almost) just works

The connector source is already compatible with the native driver's public surface — it uses `net.snowflake.client.api.driver.SnowflakeDriver` and `net.snowflake.client.api.exception.SnowflakeSQLException`, both present in `snowflake-jdbc-native-all:0.0.1`. No production logic changed.

## Gaps that had to be bridged to compile

1. **Shaded Jackson coupling (fixed cleanly).** The telemetry classes imported the driver's *relocated* Jackson (`net.snowflake.client.jdbc.internal.fasterxml.jackson.*`). `snowflake-jdbc-native` relocates Jackson under a different path (`...internal.com.fasterxml.jackson.*`), so those imports broke. Switched them to the connector's **own** `com.fasterxml.jackson.*` (already a declared dependency, `jackson.version=2.22.1`). Reaching into the driver's shaded internals was never appropriate; this is a proper decoupling.

2. **Missing JDBC telemetry API (temporary shim — real gap).** `snowflake-jdbc-native:0.0.1` does **not** ship the `net.snowflake.client.internal.jdbc.telemetry` package that classic `snowflake-jdbc` exposed (`Telemetry`, `TelemetryClient`, `TelemetryData`, `TelemetryUtil`). Added a minimal **no-op shim** under that package so the connector compiles and runs. `TelemetryClient.createTelemetry(...)` returns a no-op client, so **connector telemetry is silently disabled** when running against the native driver. See the package `package-info.java`.

   > 🚩 **Action for the native driver team:** `snowflake-jdbc-native` needs to expose an in-band JDBC telemetry API before the connector's telemetry works end-to-end. The shim package should be deleted once it does.

`SFTimestamp` is referenced only in Javadoc `{@link}` comments (no code dependency), so no change was needed there.

## Files changed

- `pom.xml`, `pom_confluent.xml` — dependency swap + version property rename (`snowflake-jdbc.version` → `snowflake-jdbc-native.version`).
- `src/main/java/net/snowflake/client/internal/jdbc/telemetry/**` — temporary no-op telemetry shim (4 classes + `package-info`).
- 5 main + 2 test telemetry classes — Jackson import decoupling.

## Verified locally

- `mvn test-compile` (main + tests) against `snowflake-jdbc-native-all:0.0.1`: **BUILD SUCCESS**.
- `google-java-format` (v1.24.0, via `format.sh`): **clean**.

## Not yet validated (what CI is for)

- Runtime / integration + E2E tests against a live account (native library load, query/ingest paths).
- Whether disabled telemetry breaks any assertions beyond the unit tests already covered here.
