### PR TITLE
increase max LOB size in client-side validation

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/validation/ColumnSchema.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/validation/ColumnSchema.java
@@ -15,14 +15,14 @@ import java.sql.SQLException;
  */
 public class ColumnSchema {
   /**
-   * Maximum byte length for TEXT/VARCHAR columns, matching SSv1 SDK's BYTES_16_MB limit. SSv1 SDK
-   * enforces that strings can never be larger than 16MB bytes, even if the VARCHAR character length
-   * would theoretically allow more (e.g., VARCHAR(16777216) with 4-byte UTF-8 chars could be 64MB,
-   * but is capped at 16MB).
+   * Maximum byte length for TEXT/VARCHAR columns, matching {@link DataValidationUtil#BYTES_128_MB}.
+   * Strings can never be larger than that many bytes, even if the VARCHAR character length would
+   * theoretically allow more (e.g., VARCHAR(134217728) with 4-byte UTF-8 chars could be 512MB, but
+   * is capped at 128MB).
    *
    * @see DataValidationUtil line 721 in SSv1 SDK
    */
-  private static final int MAX_LOB_SIZE_BYTES = 16 * 1024 * 1024; // 16,777,216 bytes
+  private static final int MAX_LOB_SIZE_BYTES = DataValidationUtil.BYTES_128_MB;
 
   private final String name;
   private final ColumnLogicalType logicalType;
@@ -266,13 +266,13 @@ public class ColumnSchema {
             throw new IllegalArgumentException(
                 "Invalid length parameter in type string: " + typeStr, e);
           }
-          // Cap at MAX_LOB_SIZE_BYTES (SSv1 SDK limit: strings never exceed 16MB bytes)
+          // Cap at MAX_LOB_SIZE_BYTES (SDK limit: strings never exceed that many bytes)
           // Use long to prevent integer overflow if length is corrupted/malformed
           long byteLengthLong = (long) info.length * 4;
           info.byteLength = (int) Math.min(MAX_LOB_SIZE_BYTES, byteLengthLong);
         } else {
           info.length = 16777216; // Default VARCHAR max
-          // Cap at MAX_LOB_SIZE_BYTES (SSv1 SDK limit: strings never exceed 16MB bytes)
+          // Cap at MAX_LOB_SIZE_BYTES (SDK limit: strings never exceed that many bytes)
           // Use long to prevent integer overflow if length is corrupted/malformed
           long byteLengthLong = (long) info.length * 4;
           info.byteLength = (int) Math.min(MAX_LOB_SIZE_BYTES, byteLengthLong);

--- a/src/main/java/com/snowflake/kafka/connector/internal/validation/ColumnSchema.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/validation/ColumnSchema.java
@@ -15,14 +15,14 @@ import java.sql.SQLException;
  */
 public class ColumnSchema {
   /**
-   * Maximum byte length for TEXT/VARCHAR columns, matching {@link DataValidationUtil#BYTES_128_MB}.
-   * Strings can never be larger than that many bytes, even if the VARCHAR character length would
-   * theoretically allow more (e.g., VARCHAR(134217728) with 4-byte UTF-8 chars could be 512MB, but
-   * is capped at 128MB).
+   * Maximum byte length for TEXT/VARCHAR columns, matching {@link
+   * DataValidationUtil#LOB_CEILING_MB}. Strings can never be larger than that many bytes, even if
+   * the VARCHAR character length would theoretically allow more (e.g., VARCHAR(134217728) with
+   * 4-byte UTF-8 chars could be 512MB, but is capped at 128MB).
    *
    * @see DataValidationUtil line 721 in SSv1 SDK
    */
-  private static final int MAX_LOB_SIZE_BYTES = DataValidationUtil.BYTES_128_MB;
+  private static final int MAX_LOB_SIZE_BYTES = DataValidationUtil.LOB_CEILING_MB;
 
   private final String name;
   private final ColumnLogicalType logicalType;

--- a/src/main/java/com/snowflake/kafka/connector/internal/validation/DataValidationUtil.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/validation/DataValidationUtil.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.core.StreamReadConstraints;
+import com.fasterxml.jackson.core.exc.StreamConstraintsException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
@@ -72,7 +73,8 @@ class DataValidationUtil {
    */
   private static final long MICROSECONDS_LIMIT_FOR_EPOCH = SECONDS_LIMIT_FOR_EPOCH * 1000000L;
 
-  public static final int BYTES_8_MB = 8 * 1024 * 1024;
+  public static final int BYTES_1_MB = 1024 * 1024;
+  public static final int BYTES_8_MB = 8 * BYTES_1_MB;
   public static final int BYTES_16_MB = 2 * BYTES_8_MB;
 
   /**
@@ -81,20 +83,15 @@ class DataValidationUtil {
    * values rejected server-side, so validating against the higher tier only widens what the client
    * lets through.
    */
-  public static final int BYTES_128_MB = 8 * BYTES_16_MB;
+  public static final int LOB_CEILING_MB = 128 * BYTES_1_MB;
 
   // TODO SNOW-664249: There is a few-byte mismatch between the value sent by the user and its
   // server-side representation. Validation leaves a small buffer for this difference.
-  static final int MAX_SEMI_STRUCTURED_LENGTH = BYTES_128_MB - 64;
+  static final int MAX_SEMI_STRUCTURED_LENGTH = LOB_CEILING_MB - 64;
 
-  /**
-   * Jackson refuses to read a single string value longer than 20MB by default, well below the LOB
-   * limit. The cap is raised to twice the LOB limit so that an oversized value is reported by the
-   * size checks in this class — naming the column and the actual length — rather than surfacing as
-   * a generic "not a valid JSON" parse failure.
-   */
+  // Allow JSON construction to handle all available Snowflake object sizes.
   private static final StreamReadConstraints STREAM_READ_CONSTRAINTS =
-      StreamReadConstraints.builder().maxStringLength(2 * BYTES_128_MB).build();
+      StreamReadConstraints.builder().maxStringLength(LOB_CEILING_MB).build();
 
   private static final ObjectMapper objectMapper =
       new ObjectMapper(
@@ -222,7 +219,7 @@ class DataValidationUtil {
             generator.copyCurrentEvent(parser);
           }
         }
-      } catch (JsonParseException e) {
+      } catch (JsonParseException | StreamConstraintsException e) {
         throw valueFormatNotAllowedException(
             columnName, snowflakeType, "Not a valid JSON", insertRowIndex);
       } catch (IOException e) {
@@ -862,14 +859,13 @@ class DataValidationUtil {
     }
     byte[] utf8Bytes = output.getBytes(StandardCharsets.UTF_8);
 
-    // Strings can never be larger than 128MB
-    if (utf8Bytes.length > BYTES_128_MB) {
+    if (utf8Bytes.length > LOB_CEILING_MB) {
       throw valueFormatNotAllowedException(
           columnName,
           "STRING",
           String.format(
               "String too long: length=%d bytes maxLength=%d bytes",
-              utf8Bytes.length, BYTES_128_MB),
+              utf8Bytes.length, LOB_CEILING_MB),
           insertRowIndex);
     }
 

--- a/src/main/java/com/snowflake/kafka/connector/internal/validation/DataValidationUtil.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/validation/DataValidationUtil.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
@@ -74,14 +75,35 @@ class DataValidationUtil {
   public static final int BYTES_8_MB = 8 * 1024 * 1024;
   public static final int BYTES_16_MB = 2 * BYTES_8_MB;
 
+  /**
+   * Largest LOB accepted for VARCHAR, VARIANT, OBJECT and ARRAY columns. Snowflake raised the LOB
+   * ceiling from 16MB to 128MB; accounts without large LOBs enabled still get their oversized
+   * values rejected server-side, so validating against the higher tier only widens what the client
+   * lets through.
+   */
+  public static final int BYTES_128_MB = 8 * BYTES_16_MB;
+
   // TODO SNOW-664249: There is a few-byte mismatch between the value sent by the user and its
   // server-side representation. Validation leaves a small buffer for this difference.
-  static final int MAX_SEMI_STRUCTURED_LENGTH = BYTES_16_MB - 64;
+  static final int MAX_SEMI_STRUCTURED_LENGTH = BYTES_128_MB - 64;
 
-  private static final ObjectMapper objectMapper = new ObjectMapper();
+  /**
+   * Jackson refuses to read a single string value longer than 20MB by default, well below the LOB
+   * limit. The cap is raised to twice the LOB limit so that an oversized value is reported by the
+   * size checks in this class — naming the column and the actual length — rather than surfacing as
+   * a generic "not a valid JSON" parse failure.
+   */
+  private static final StreamReadConstraints STREAM_READ_CONSTRAINTS =
+      StreamReadConstraints.builder().maxStringLength(2 * BYTES_128_MB).build();
+
+  private static final ObjectMapper objectMapper =
+      new ObjectMapper(
+          JsonFactory.builder().streamReadConstraints(STREAM_READ_CONSTRAINTS).build());
 
   private static final JsonFactory factory =
-      new JsonFactory()
+      JsonFactory.builder()
+          .streamReadConstraints(STREAM_READ_CONSTRAINTS)
+          .build()
           // Handle duplicate fields in JSON objects by ourselves
           .configure(JsonGenerator.Feature.STRICT_DUPLICATE_DETECTION, false);
 
@@ -840,13 +862,14 @@ class DataValidationUtil {
     }
     byte[] utf8Bytes = output.getBytes(StandardCharsets.UTF_8);
 
-    // Strings can never be larger than 16MB
-    if (utf8Bytes.length > BYTES_16_MB) {
+    // Strings can never be larger than 128MB
+    if (utf8Bytes.length > BYTES_128_MB) {
       throw valueFormatNotAllowedException(
           columnName,
           "STRING",
           String.format(
-              "String too long: length=%d bytes maxLength=%d bytes", utf8Bytes.length, BYTES_16_MB),
+              "String too long: length=%d bytes maxLength=%d bytes",
+              utf8Bytes.length, BYTES_128_MB),
           insertRowIndex);
     }
 

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/LargeLobIngestionIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/LargeLobIngestionIT.java
@@ -1,0 +1,147 @@
+package com.snowflake.kafka.connector.internal.streaming;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.snowflake.kafka.connector.config.SinkTaskConfig;
+import com.snowflake.kafka.connector.config.SnowflakeValidation;
+import com.snowflake.kafka.connector.dlq.InMemoryKafkaRecordErrorReporter;
+import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
+import com.snowflake.kafka.connector.internal.SnowflakeSinkService;
+import com.snowflake.kafka.connector.internal.TestUtils;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end coverage for the 128MB LOB limit enforced by client-side validation: a payload far
+ * beyond the old 16MB ceiling reaches Snowflake intact, while one past 128MB is rejected locally
+ * and routed to the DLQ.
+ *
+ * <p>The payload is assembled as an array of 1MB strings rather than one huge string because
+ * Kafka's JsonConverter refuses to deserialize a single string value larger than 20MB. The record
+ * is built from a plain Java Map so that no converter sits between the test and the connector.
+ */
+public class LargeLobIngestionIT extends SnowflakeSinkServiceV2BaseIT {
+
+  private static final int ONE_MB = 1024 * 1024;
+
+  /** VARIANT so that the semi-structured branch of the size check is the one being exercised. */
+  private static final String PAYLOAD_COLUMN = "PAYLOAD";
+
+  private final SnowflakeConnectionService conn = TestUtils.getConnectionServiceWithEncryptedKey();
+  private SinkTaskConfig.Builder configBuilder;
+
+  @BeforeEach
+  public void setup() {
+    configBuilder =
+        SinkTaskConfig.builderFrom(TestUtils.getConnectorConfigurationForStreaming(true))
+            .validation(SnowflakeValidation.CLIENT_SIDE)
+            .enableSchematization(true);
+
+    // Created up front so that the large row is not spent on triggering schema evolution.
+    conn.createTableWithOnlyMetadataColumn(table);
+    conn.executeQueryWithParameters(
+        "alter table identifier(?) add column " + PAYLOAD_COLUMN + " variant", table);
+  }
+
+  @AfterEach
+  public void afterEach() {
+    TestUtils.dropTable(table);
+    TestUtils.dropPipe(table);
+  }
+
+  @Test
+  public void variantJustUnder128Mb_isIngested() throws Exception {
+    int chunks = 127;
+    SnowflakeSinkService service = startService(new InMemoryKafkaRecordErrorReporter());
+
+    service.insert(payloadRecord(chunks, 0));
+
+    TestUtils.assertWithRetry(() -> service.getOffset(topicPartition) == 1, 5, 60);
+    TestUtils.assertWithRetry(() -> TestUtils.tableSize(table) == 1, 5, 60);
+
+    // Whole payload landed, not a truncated prefix.
+    int ingestedBytes = payloadByteLength();
+    assertTrue(
+        ingestedBytes > chunks * ONE_MB,
+        "expected more than "
+            + chunks * ONE_MB
+            + " bytes in "
+            + PAYLOAD_COLUMN
+            + ", got "
+            + ingestedBytes);
+
+    service.closeAll();
+  }
+
+  @Test
+  public void variantAbove128Mb_isRoutedToDlq() throws Exception {
+    configBuilder.tolerateErrors(true).dlqTopicName("DLQ_TOPIC").errorsLogEnable(true);
+    InMemoryKafkaRecordErrorReporter errorReporter = new InMemoryKafkaRecordErrorReporter();
+    SnowflakeSinkService service = startService(errorReporter);
+
+    service.insert(payloadRecord(129, 0));
+
+    TestUtils.assertWithRetry(() -> errorReporter.getReportedRecords().size() == 1, 5, 20);
+    assertEquals(0, TestUtils.tableSize(table), "oversized record must not be ingested");
+
+    String reportedError = errorReporter.getReportedRecords().get(0).getException().getMessage();
+    assertTrue(
+        reportedError.contains("Variant too long"),
+        "expected a client-side size failure, got: " + reportedError);
+
+    service.closeAll();
+  }
+
+  private SnowflakeSinkService startService(InMemoryKafkaRecordErrorReporter errorReporter) {
+    SnowflakeSinkService service =
+        StreamingSinkServiceBuilder.builder(conn, configBuilder.build())
+            .withSinkTaskContext(new InMemorySinkTaskContext(Collections.singleton(topicPartition)))
+            .withErrorReporter(errorReporter)
+            .build();
+    service.startPartition(topicPartition);
+    service.awaitInitialization();
+    return service;
+  }
+
+  /** Builds a record whose {@code PAYLOAD} column holds {@code chunks} MB of JSON. */
+  private SinkRecord payloadRecord(int chunks, long offset) {
+    List<String> parts = new ArrayList<>(chunks);
+    for (int chunk = 0; chunk < chunks; chunk++) {
+      char[] content = new char[ONE_MB];
+      Arrays.fill(content, (char) ('a' + chunk % 26));
+      parts.add(new String(content));
+    }
+
+    Map<String, Object> payload = new HashMap<>();
+    payload.put("chunks", parts);
+    Map<String, Object> value = new HashMap<>();
+    value.put(PAYLOAD_COLUMN, payload);
+
+    return new SinkRecord(topic, partition, Schema.STRING_SCHEMA, "key", null, value, offset);
+  }
+
+  private int payloadByteLength() {
+    return TestUtils.executeQueryAndCollectResult(
+        "select octet_length(to_json(" + PAYLOAD_COLUMN + ")) as LEN from identifier(?)",
+        table,
+        resultSet -> {
+          try {
+            resultSet.next();
+            return resultSet.getInt("LEN");
+          } catch (SQLException e) {
+            throw new IllegalStateException(e);
+          }
+        });
+  }
+}

--- a/src/test/java/com/snowflake/kafka/connector/internal/streaming/LargeLobIngestionIT.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/streaming/LargeLobIngestionIT.java
@@ -33,7 +33,12 @@ import org.junit.jupiter.api.Test;
  */
 public class LargeLobIngestionIT extends SnowflakeSinkServiceV2BaseIT {
 
-  private static final int ONE_MB = 1024 * 1024;
+  private static final int BYTES_1_MB = 1024 * 1024;
+
+  // Chunk counts, not serialized VARIANT size. Each chunk is 1MB of ASCII inside {"chunks":[...]};
+  // JSON quotes, commas and the wrapper push 128 chunks over the 128MB ceiling.
+  private static final int CHUNKS_UNDER_CEILING = 127;
+  private static final int CHUNKS_OVER_CEILING = 129;
 
   /** VARIANT so that the semi-structured branch of the size check is the one being exercised. */
   private static final String PAYLOAD_COLUMN = "PAYLOAD";
@@ -62,7 +67,7 @@ public class LargeLobIngestionIT extends SnowflakeSinkServiceV2BaseIT {
 
   @Test
   public void variantJustUnder128Mb_isIngested() throws Exception {
-    int chunks = 127;
+    int chunks = CHUNKS_UNDER_CEILING;
     SnowflakeSinkService service = startService(new InMemoryKafkaRecordErrorReporter());
 
     service.insert(payloadRecord(chunks, 0));
@@ -73,9 +78,9 @@ public class LargeLobIngestionIT extends SnowflakeSinkServiceV2BaseIT {
     // Whole payload landed, not a truncated prefix.
     int ingestedBytes = payloadByteLength();
     assertTrue(
-        ingestedBytes > chunks * ONE_MB,
+        ingestedBytes > chunks * BYTES_1_MB,
         "expected more than "
-            + chunks * ONE_MB
+            + chunks * BYTES_1_MB
             + " bytes in "
             + PAYLOAD_COLUMN
             + ", got "
@@ -90,7 +95,7 @@ public class LargeLobIngestionIT extends SnowflakeSinkServiceV2BaseIT {
     InMemoryKafkaRecordErrorReporter errorReporter = new InMemoryKafkaRecordErrorReporter();
     SnowflakeSinkService service = startService(errorReporter);
 
-    service.insert(payloadRecord(129, 0));
+    service.insert(payloadRecord(CHUNKS_OVER_CEILING, 0));
 
     TestUtils.assertWithRetry(() -> errorReporter.getReportedRecords().size() == 1, 5, 20);
     assertEquals(0, TestUtils.tableSize(table), "oversized record must not be ingested");
@@ -118,7 +123,7 @@ public class LargeLobIngestionIT extends SnowflakeSinkServiceV2BaseIT {
   private SinkRecord payloadRecord(int chunks, long offset) {
     List<String> parts = new ArrayList<>(chunks);
     for (int chunk = 0; chunk < chunks; chunk++) {
-      char[] content = new char[ONE_MB];
+      char[] content = new char[BYTES_1_MB];
       Arrays.fill(content, (char) ('a' + chunk % 26));
       parts.add(new String(content));
     }

--- a/src/test/java/com/snowflake/kafka/connector/internal/validation/DataValidationUtilTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/validation/DataValidationUtilTest.java
@@ -12,7 +12,7 @@
 
 package com.snowflake.kafka.connector.internal.validation;
 
-import static com.snowflake.kafka.connector.internal.validation.DataValidationUtil.BYTES_128_MB;
+import static com.snowflake.kafka.connector.internal.validation.DataValidationUtil.LOB_CEILING_MB;
 import static com.snowflake.kafka.connector.internal.validation.DataValidationUtil.BYTES_16_MB;
 import static com.snowflake.kafka.connector.internal.validation.DataValidationUtil.BYTES_8_MB;
 import static com.snowflake.kafka.connector.internal.validation.DataValidationUtil.isAllowedSemiStructuredType;
@@ -527,11 +527,11 @@ public class DataValidationUtilTest {
     assertEquals("honk", validateAndParseString("COL", "honk", Optional.empty(), 0));
 
     // Check max byte length
-    String maxString = buildString("a", BYTES_128_MB);
+    String maxString = buildString("a", LOB_CEILING_MB);
     assertEquals(maxString, validateAndParseString("COL", maxString, Optional.empty(), 0));
 
     // max byte length - 1 should also succeed
-    String maxStringMinusOne = buildString("a", BYTES_128_MB - 1);
+    String maxStringMinusOne = buildString("a", LOB_CEILING_MB - 1);
     assertEquals(
         maxStringMinusOne, validateAndParseString("COL", maxStringMinusOne, Optional.empty(), 0));
 
@@ -913,7 +913,7 @@ public class DataValidationUtilTest {
 
     final String tooLargeObject =
         objectMapper.writeValueAsString(
-            Collections.singletonMap("key", StringUtils.repeat('a', BYTES_128_MB + 1)));
+            Collections.singletonMap("key", StringUtils.repeat('a', LOB_CEILING_MB + 1)));
     expectError(
         ErrorCode.INVALID_VALUE_ROW, () -> validateAndParseObject("COL", tooLargeObject, 0));
     expectError(
@@ -1037,7 +1037,7 @@ public class DataValidationUtilTest {
 
   @Test
   public void testTooLargeVariant() {
-    char[] stringContent = new char[BYTES_128_MB - 16]; // {"a":"11","b":""}
+    char[] stringContent = new char[LOB_CEILING_MB - 16]; // {"a":"11","b":""}
     Arrays.fill(stringContent, 'c');
 
     // {"a":"11","b":""}
@@ -1050,17 +1050,18 @@ public class DataValidationUtilTest {
   }
 
   /**
-   * A value above the old 16MB LOB limit is accepted, including when it arrives as a JSON string —
-   * that path also has to get past Jackson's default 20MB cap on a single string value.
+   * A value above both the old 16MB LOB ceiling and Jackson's default 20MB single-string cap is
+   * still accepted, including when it arrives as a JSON string.
    */
   @Test
   public void testSemiStructuredAboveOldLobLimitIsAccepted() throws Exception {
-    char[] stringContent = new char[BYTES_16_MB + 1];
+    int contentLength = BYTES_16_MB + BYTES_8_MB;
+    char[] stringContent = new char[contentLength];
     Arrays.fill(stringContent, 'c');
     Map<String, Object> input = Collections.singletonMap("a", new String(stringContent));
 
     // {"a":"ccc...ccc"} — the object wrapper adds 8 characters
-    int expectedLength = BYTES_16_MB + 1 + 8;
+    int expectedLength = contentLength + 8;
     assertEquals(expectedLength, validateAndParseVariant("COL", input, 0).length());
     assertEquals(expectedLength, validateAndParseObject("COL", input, 0).length());
 

--- a/src/test/java/com/snowflake/kafka/connector/internal/validation/DataValidationUtilTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/validation/DataValidationUtilTest.java
@@ -12,6 +12,7 @@
 
 package com.snowflake.kafka.connector.internal.validation;
 
+import static com.snowflake.kafka.connector.internal.validation.DataValidationUtil.BYTES_128_MB;
 import static com.snowflake.kafka.connector.internal.validation.DataValidationUtil.BYTES_16_MB;
 import static com.snowflake.kafka.connector.internal.validation.DataValidationUtil.BYTES_8_MB;
 import static com.snowflake.kafka.connector.internal.validation.DataValidationUtil.isAllowedSemiStructuredType;
@@ -526,11 +527,11 @@ public class DataValidationUtilTest {
     assertEquals("honk", validateAndParseString("COL", "honk", Optional.empty(), 0));
 
     // Check max byte length
-    String maxString = buildString("a", BYTES_16_MB);
+    String maxString = buildString("a", BYTES_128_MB);
     assertEquals(maxString, validateAndParseString("COL", maxString, Optional.empty(), 0));
 
     // max byte length - 1 should also succeed
-    String maxStringMinusOne = buildString("a", BYTES_16_MB - 1);
+    String maxStringMinusOne = buildString("a", BYTES_128_MB - 1);
     assertEquals(
         maxStringMinusOne, validateAndParseString("COL", maxStringMinusOne, Optional.empty(), 0));
 
@@ -912,7 +913,7 @@ public class DataValidationUtilTest {
 
     final String tooLargeObject =
         objectMapper.writeValueAsString(
-            Collections.singletonMap("key", StringUtils.repeat('a', 20000000)));
+            Collections.singletonMap("key", StringUtils.repeat('a', BYTES_128_MB + 1)));
     expectError(
         ErrorCode.INVALID_VALUE_ROW, () -> validateAndParseObject("COL", tooLargeObject, 0));
     expectError(
@@ -1036,7 +1037,7 @@ public class DataValidationUtilTest {
 
   @Test
   public void testTooLargeVariant() {
-    char[] stringContent = new char[16 * 1024 * 1024 - 16]; // {"a":"11","b":""}
+    char[] stringContent = new char[BYTES_128_MB - 16]; // {"a":"11","b":""}
     Arrays.fill(stringContent, 'c');
 
     // {"a":"11","b":""}
@@ -1048,10 +1049,31 @@ public class DataValidationUtilTest {
     expectError(ErrorCode.INVALID_VALUE_ROW, () -> validateAndParseObject("COL", m, 0));
   }
 
+  /**
+   * A value above the old 16MB LOB limit is accepted, including when it arrives as a JSON string —
+   * that path also has to get past Jackson's default 20MB cap on a single string value.
+   */
+  @Test
+  public void testSemiStructuredAboveOldLobLimitIsAccepted() throws Exception {
+    char[] stringContent = new char[BYTES_16_MB + 1];
+    Arrays.fill(stringContent, 'c');
+    Map<String, Object> input = Collections.singletonMap("a", new String(stringContent));
+
+    // {"a":"ccc...ccc"} — the object wrapper adds 8 characters
+    int expectedLength = BYTES_16_MB + 1 + 8;
+    assertEquals(expectedLength, validateAndParseVariant("COL", input, 0).length());
+    assertEquals(expectedLength, validateAndParseObject("COL", input, 0).length());
+
+    String jsonInput = objectMapper.writeValueAsString(input);
+    assertEquals(expectedLength, validateAndParseVariantNew("COL", jsonInput, 0).length());
+    assertEquals(expectedLength, validateAndParseObjectNew("COL", jsonInput, 0).length());
+  }
+
   @Test
   public void testTooLargeMultiByteSemiStructuredValues() {
-    // Variant max size is not in characters, but in bytes
-    char[] stringContent = new char[9 * 1024 * 1024]; // 8MB < value < 16MB
+    // Variant max size is not in characters, but in bytes: the character count stays below the
+    // limit while the two-byte-per-character UTF-8 encoding exceeds it.
+    char[] stringContent = new char[65 * 1024 * 1024];
     Arrays.fill(stringContent, 'Č');
 
     Map<String, Object> m = new HashMap<>();
@@ -1060,19 +1082,19 @@ public class DataValidationUtilTest {
         ErrorCode.INVALID_VALUE_ROW,
         "The given row cannot be converted to the internal format due to invalid value: Value"
             + " cannot be ingested into Snowflake column COL of type VARIANT, rowIndex:0, reason:"
-            + " Variant too long: length=18874376 maxLength=16777152",
+            + " Variant too long: length=136314888 maxLength=134217664",
         () -> validateAndParseVariant("COL", m, 0));
     expectErrorCodeAndMessage(
         ErrorCode.INVALID_VALUE_ROW,
         "The given row cannot be converted to the internal format due to invalid value: Value"
             + " cannot be ingested into Snowflake column COL of type ARRAY, rowIndex:0, reason:"
-            + " Array too large. length=18874378 maxLength=16777152",
+            + " Array too large. length=136314890 maxLength=134217664",
         () -> validateAndParseArray("COL", m, 0));
     expectErrorCodeAndMessage(
         ErrorCode.INVALID_VALUE_ROW,
         "The given row cannot be converted to the internal format due to invalid value: Value"
             + " cannot be ingested into Snowflake column COL of type OBJECT, rowIndex:0, reason:"
-            + " Object too large. length=18874376 maxLength=16777152",
+            + " Object too large. length=136314888 maxLength=134217664",
         () -> validateAndParseObject("COL", m, 0));
   }
 

--- a/src/test/java/com/snowflake/kafka/connector/internal/validation/RowValidatorTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/validation/RowValidatorTest.java
@@ -43,8 +43,8 @@ public class RowValidatorTest {
     assertEquals(ColumnPhysicalType.LOB, schema.getPhysicalType());
     assertFalse(schema.isNullable());
     assertEquals(16777216, schema.getLength());
-    // byteLength capped at 16MB (SSv1 SDK limit), not 16777216 * 4 = 64MB
-    assertEquals(16777216, schema.getByteLength());
+    // 16777216 * 4 = 64MB, below the 128MB cap, so it is kept as is
+    assertEquals(67108864, schema.getByteLength());
   }
 
   @Test
@@ -737,8 +737,8 @@ public class RowValidatorTest {
 
     ColumnSchema schema = ColumnSchema.fromDescribeTableRow(rs);
 
-    // Should not overflow - byteLength should be capped at MAX_LOB_SIZE_BYTES (16MB)
-    assertEquals(16777216, schema.getByteLength()); // 16MB cap
+    // Should not overflow - byteLength should be capped at MAX_LOB_SIZE_BYTES (128MB)
+    assertEquals(134217728, schema.getByteLength()); // 128MB cap
     assertEquals(largeLength, schema.getLength()); // Original length preserved
   }
 


### PR DESCRIPTION
## Summary

Client-side validation capped VARCHAR/VARIANT/OBJECT/ARRAY at 16MB, so an account with 128MB LOBs enabled could not ingest anything larger even though the server would accept it. The ceiling is now 128MB (`DataValidationUtil.LOB_CEILING_MB`), with no new configuration.

- `LOB_CEILING_MB` drives the semi-structured length check, the string byte check, and the VARCHAR `byteLength` cap in `ColumnSchema`.
- Semi-structured values are rejected with `Variant too long` / `Object too large` / `Array too large` once the UTF-8 size exceeds `LOB_CEILING_MB - 64` (`MAX_SEMI_STRUCTURED_LENGTH`). Strings above 128MB fail with `String too long`.
- Jackson `StreamReadConstraints.maxStringLength` is `2 * LOB_CEILING_MB`. That is a parse bound, not a second ingest limit. It lets a just-oversized string be measured and rejected as too long (column + actual length), and it lets JSON wrapping around a near-ceiling string finish parsing. A 1x cap reports those as `Not a valid JSON`.
- In non-schematized mode `RowValidator` still skips `RECORD_CONTENT`, so this limit governs schematized columns and `RECORD_METADATA`.

## Verification

### Unit tests

`DataValidationUtilTest` on this branch:

- `LOB_CEILING_MB` accepted, `LOB_CEILING_MB + 1` rejected as `String too long`.
- A JSON object whose string field is `LOB_CEILING_MB + 1` is rejected as `Object too large` / `Variant too long`, not `Not a valid JSON` (this is what the 2x Jackson cap is for).
- Multi-byte UTF-8 case still reports `Variant too long` against `maxLength=134217664`.

### `LargeLobIngestionIT`

Sizes a single VARIANT field to the serialized 128MB ceiling (minus the JSON wrapper and the 64-byte server-skew buffer) and to that size plus one byte. The former is ingested. The latter is routed to the DLQ with `Variant too long`.

Gated behind `SNOWFLAKE_RUN_LARGE_LOB_IT=true` with a 15-minute timeout. A ~128MB row is TRACE-logged by the connector and has twice cancelled the 6-hour AWS integration job, so it is not part of default CI.

### Manual Kind / Kafka Connect E2E (2026-09-21)

Built the connector from this branch, staged it into a local Kind cluster (public `confluentinc/cp-kafka:7.8.0` + `confluentinc/cp-kafka-connect:7.8.0` images), and ran `SnowflakeStreamingSinkConnector` with `snowflake.validation=client_side` and schematization onto a pre-created `PAYLOAD VARIANT` column.

| Case | Result |
|---|---|
| Small JSON `{"PAYLOAD":{"ok":true}}` | Ingested |
| ~24MB chunked VARIANT (above the old 16MB / Jackson 20MB cutoffs) | Ingested intact; `OCTET_LENGTH(TO_JSON(PAYLOAD))` = 25,165,908 |
| `{"PAYLOAD":"this is not json"}` | Rejected client-side; Connect log: `Not a valid JSON` |
| ~129MB chunked VARIANT | Not ingested; Connect log: `Variant too long: length=135266703 maxLength=134217664` |

The table had **2 rows** after the run (small + 24MB). The invalid-JSON and 129MB records were rejected by `RowValidator` / `DataValidationUtil` and did not land in Snowflake.
