### PR TITLE
Use maven.compiler.release instead of source/target

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,10 +45,13 @@
         <url>https://github.com/snowflakedb/snowflake-kafka-connector</url>
     </scm>
 
-    <!-- Set our Language Level to Java 11 -->
+    <!--
+        Set our Language Level to Java 11. Use `release`, not `source`/`target`: the latter
+        does not link against the Java 11 API, so building on a newer JDK silently accepts
+        APIs absent from 11 and fails at runtime with NoSuchMethodError.
+    -->
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
         <skipTests>false</skipTests>
         <skipUnitTests>${skipTests}</skipUnitTests>
         <skipIntegrationTests>${skipTests}</skipIntegrationTests>

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -45,10 +45,13 @@
         <url>https://github.com/snowflakedb/snowflake-kafka-connector</url>
     </scm>
 
-    <!-- Set our Language Level to Java 11 -->
+    <!--
+        Set our Language Level to Java 11. Use `release`, not `source`/`target`: the latter
+        does not link against the Java 11 API, so building on a newer JDK silently accepts
+        APIs absent from 11 and fails at runtime with NoSuchMethodError.
+    -->
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
         <skipTests>false</skipTests>
         <skipUnitTests>${skipTests}</skipUnitTests>
         <skipIntegrationTests>${skipTests}</skipIntegrationTests>


### PR DESCRIPTION
## This changes nothing in practice today

The shipped artifact is **byte-for-byte identical**. Compiling `master` and this branch on JDK 11 and hashing every class file gives the same digest:

```
master  (source/target 11)  ba10a258b65492571b9ea14df8f499a2f744ec58
this PR (release 11)        ba10a258b65492571b9ea14df8f499a2f744ec58
```

CI builds on Zulu 11, and on JDK 11 `release 11` and `source/target 11` are equivalent. There is no behaviour change to review for.

The value is positional: it makes the build correct on newer JDKs, which is a prerequisite for moving Java versions later.

## The problem

`source`/`target` sets the language level and stamps the bytecode version, but does **not** link against the Java 11 API. Building on a newer JDK therefore accepts APIs that do not exist on Java 11. The result compiles, is stamped class file version 55 so it looks valid, and fails only at runtime on a real Java 11 JVM.

Demonstrated with `String.indent(int)` (added in Java 12), compiled on JDK 21:

```
$ javac -source 11 -target 11 ...     # today
warning: [options] system modules path not set in conjunction with -source 11
   -> compiles, emits class file version 55

$ java -cp out RelDemo               # on a real JDK 11
java.lang.NoSuchMethodError: 'java.lang.String java.lang.String.indent(int)'

$ javac --release 11 ...              # this PR
error: cannot find symbol: method indent(int)
```

CI's Zulu 11 builder masks this. Anyone building locally on JDK 17 or 21 can produce an artifact that passes compilation and then breaks in a Java 11 customer environment.

## Why it matters for later Java versions

Compile target and runtime are distinct axes, and they move independently:

- **Runtime**: Kafka Connect 4.x already supports Java 17, 21 and 25. Customers are running our Java 11 bytecode on newer JVMs today.
- **Compile target**: stays at 11 while Confluent 7.x and Apache 3.x Java 11 Connect workers are supported. When it moves, it moves to 17, the Connect 4.x floor.

This PR does not touch the target. It makes the target *mean* something, so that when engineers build or test on 17/21 the build validates against the level we claim to support instead of silently drifting. It also makes the artifact reproducible on any JDK >= 11.

## Scope

Two files, one property each. No production Java touched.

```xml
-<maven.compiler.source>11</maven.compiler.source>
-<maven.compiler.target>11</maven.compiler.target>
+<maven.compiler.release>11</maven.compiler.release>
```

Applied to both `pom.xml` and `pom_confluent.xml`, whose compiler configuration was otherwise identical. Also clears the `system modules path not set in conjunction with -source 11` warning.

## Verification

- Unit tests identical on JDK 11 and JDK 21: 868 run, 828 pass, 40 pre-existing `SNOWFLAKE_CREDENTIAL_FILE` environment errors present on `master` too. Zero compile errors.
- `pom_confluent.xml` compiles clean.
- Class-file digest identical to `master` on JDK 11 (above).
- Guard confirmed live: a probe calling `String.indent(int)` is rejected at compile time, and was silently accepted before.
- No `sun.misc.Unsafe`, `SecurityManager`, `AccessController` or `doPrivileged` in source, so `--release`'s stricter ban on JDK-internal APIs has nothing to catch.

## Known limitation

`--release` constrains only first-party code. A dependency compiled against a newer JDK API will still fail with `NoSuchMethodError` on Java 11. This narrows the class of bug, it does not eliminate it.