### PR TITLE
Add Java 21 runtime coverage to the end-to-end matrix

### DIFF
--- a/.github/actions/run-e2e-tests/action.yml
+++ b/.github/actions/run-e2e-tests/action.yml
@@ -12,7 +12,7 @@ inputs:
     description: "Snowflake cloud provider: 'AWS', 'GCP', or 'AZURE'"
     required: true
   java-version:
-    description: "Java version for Apache Kafka (e.g. '11', '17'). Ignored for Confluent."
+    description: "Java version for Apache Kafka (e.g. '11', '17', '21'). Kafka 4.x requires 17 or newer. Ignored for Confluent."
     required: false
     default: '11'
   marker-filter:

--- a/.github/workflows/build-apache-kafka-images.yml
+++ b/.github/workflows/build-apache-kafka-images.yml
@@ -28,6 +28,13 @@ jobs:
           - kafka_version: '4.1.1'
             scala_version: '2.13'
             java_version: '17'
+          # Java 21 runtime coverage for the connector. Kafka 4.x supports 17, 21 and 25;
+          # this image backs the Java 21 end-to-end lane. run_tests.sh falls back to a
+          # local build if the tag is absent, so the e2e lane degrades to a slower build
+          # rather than failing outright.
+          - kafka_version: '4.1.1'
+            scala_version: '2.13'
+            java_version: '21'
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/build-apache-kafka-images.yml
+++ b/.github/workflows/build-apache-kafka-images.yml
@@ -28,8 +28,9 @@ jobs:
           - kafka_version: '4.1.1'
             scala_version: '2.13'
             java_version: '17'
-          # Java 21 runtime coverage for the connector. Kafka 4.x supports 17, 21 and 25;
-          # this image backs the Java 21 end-to-end lane. run_tests.sh falls back to a
+          # Java 21 runtime coverage for the connector. Apache Kafka 4.1 fully
+          # supports Java 17 and 21 and recommends the latest LTS; this image backs
+          # the Java 21 end-to-end lane. run_tests.sh falls back to a
           # local build if the tag is absent, so the e2e lane degrades to a slower build
           # rather than failing outright.
           - kafka_version: '4.1.1'

--- a/.github/workflows/end-to-end.yaml
+++ b/.github/workflows/end-to-end.yaml
@@ -71,6 +71,22 @@ jobs:
             test_group: core
             marker_filter: 'not compatibility and not schema_evolution and not correctness and not pressure and not soak'
 
+          # ── Java 21 runtime coverage ──────────────────────────────────────
+          # The connector is compiled to Java 11 bytecode but is increasingly run on
+          # newer Connect workers. Kafka 4.x supports Java 17, 21 and 25, so this lane
+          # exercises the shipped artifact on a Java 21 JVM without changing the compile
+          # target. Only the core group runs here to bound CI cost; the 17 lanes above
+          # remain the full-coverage matrix.
+          # test_group must stay distinct from the Java 17 'core' lane above, because the
+          # failure-log artifact name is derived from it and upload-artifact rejects
+          # duplicate names.
+          - platform: apache
+            platform_version: '4.1.1'
+            snowflake_cloud: 'AWS'
+            java_test_version: '21'
+            test_group: core_java21
+            marker_filter: 'not compatibility and not schema_evolution and not correctness and not pressure and not soak'
+
           - platform: confluent
             platform_version: '8.2.0'
             snowflake_cloud: 'AWS'

--- a/.github/workflows/end-to-end.yaml
+++ b/.github/workflows/end-to-end.yaml
@@ -73,7 +73,8 @@ jobs:
 
           # ── Java 21 runtime coverage ──────────────────────────────────────
           # The connector is compiled to Java 11 bytecode but is increasingly run on
-          # newer Connect workers. Kafka 4.x supports Java 17, 21 and 25, so this lane
+          # newer Connect workers. Apache Kafka 4.1 fully supports Java 17 and 21 and
+          # recommends running on the latest LTS, so this lane
           # exercises the shipped artifact on a Java 21 JVM without changing the compile
           # target. Only the core group runs here to bound CI cost; the 17 lanes above
           # remain the full-coverage matrix.

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -65,7 +65,7 @@ usage() {
     echo ""
     echo "Options:"
     echo "  --cloud=CLOUD        Snowflake cloud platform: AWS, GCP, or AZURE"
-    echo "  --java-version=VER   Java version for Apache Kafka (default: 11)"
+    echo "  --java-version=VER   Java version for Apache Kafka (default: 11; 17 for Kafka 4.x)"
     echo "  --jmx                Enable JMX metrics scraping via Jolokia"
     echo "  --profile            Enable JVM profiling (JFR, GC logs, JMX, async-profiler)"
     echo "  --with-mitmproxy     Enable mitmproxy for fault injection tests (410 injection)"
@@ -98,6 +98,10 @@ usage() {
 PLATFORM="confluent"
 PLATFORM_VERSION="7.8.0"
 JAVA_VERSION="11"
+# Tracks whether --java-version was given explicitly. Platform defaults below must
+# not clobber an explicit choice, otherwise a caller asking for one JDK silently
+# gets another and the run reports a Java version it never exercised.
+JAVA_VERSION_EXPLICIT="false"
 JMX_ENABLED="false"
 PROFILE_ENABLED="false"
 MITMPROXY_ENABLED="false"
@@ -123,6 +127,7 @@ while [[ $# -gt 0 ]]; do
             ;;
         --java-version=*)
             JAVA_VERSION="${1#*=}"
+            JAVA_VERSION_EXPLICIT="true"
             shift
             ;;
         --jmx)
@@ -171,6 +176,15 @@ done
 if [ -z "$PLATFORM" ]; then
     error_exit "Missing required argument: --platform=<confluent|apache>"
 fi
+
+# JAVA_VERSION feeds the Apache image tag (apache-kafka:<kafka>-java<java>) and the
+# platform floor check below, so it must be a bare major version. Reject anything else
+# here rather than letting it through to produce an unresolvable image tag.
+case $JAVA_VERSION in
+    ''|*[!0-9]*)
+        error_exit "--java-version must be a major version number (e.g. 11, 17, 21); got '$JAVA_VERSION'"
+        ;;
+esac
 
 if [ -z "$PLATFORM_VERSION" ]; then
     error_exit "Missing required argument: --platform-version=<version>"
@@ -221,13 +235,24 @@ case $PLATFORM in
 
         case $PLATFORM_VERSION in
             4.*)
-                info "Platform: Apache Kafka $PLATFORM_VERSION (KRaft mode)"
                 SCALA_VERSION="2.13"
                 KRAFT_MODE="true"
-                JAVA_VERSION="17"
+                # Kafka 4.x requires Java 17 or newer for brokers, Connect and tools
+                # (KIP-1013 / KIP-1032), so 11 is not a valid floor here. Only apply 17
+                # as a default; respect an explicit --java-version so newer JDKs can be
+                # exercised.
+                if [ "$JAVA_VERSION_EXPLICIT" != "true" ]; then
+                    JAVA_VERSION="17"
+                elif [ "$JAVA_VERSION" -lt 17 ]; then
+                    # Fail loudly rather than silently substituting 17. A caller asking
+                    # for an unsupported JDK has a broken assumption, and quietly running
+                    # a different one produces a green result for a version never tested.
+                    error_exit "Apache Kafka $PLATFORM_VERSION requires Java 17 or newer (got $JAVA_VERSION). Kafka 4.x dropped Java 11 for brokers, Connect and tools."
+                fi
+                info "Platform: Apache Kafka $PLATFORM_VERSION (KRaft mode), Java $JAVA_VERSION"
                 ;;
             *)
-                info "Platform: Apache Kafka $PLATFORM_VERSION (official tarball)"
+                info "Platform: Apache Kafka $PLATFORM_VERSION (official tarball), Java $JAVA_VERSION"
                 ;;
         esac
         ;;


### PR DESCRIPTION
## This changes nothing about what we ship

**The compile target is untouched.** No production Java is modified. The connector still compiles to Java 11 bytecode and the shipped artifact is unchanged.

This only adds *test* coverage: it runs the existing artifact on a newer JVM. It is positioning for a future Java move, not a Java move.

## Compile target and runtime are distinct

These two axes are easy to conflate and they move independently:

| Axis | Today | Changed here? |
|---|---|---|
| Compile target | Java 11 | **No** |
| Runtime tested | Java 11, 17 | Yes, adds 21 |
| Runtime fully supported by Apache Kafka 4.1 | Java 17, 21 | n/a |

We are already, in effect, shipping onto Java 21: customers choose the JDK their Connect worker runs on, and [Apache Kafka 4.1](https://kafka.apache.org/41/operations/java-version/) fully supports Java 17 and 21 and recommends running on the most recent LTS. Our Java 11 bytecode runs on Java 21 in the field today. This PR starts verifying what is already happening.

**Correction to an earlier version of this description:** it claimed Kafka Connect 4.x supports "17, 21 and 25". That list is [Confluent Platform's](https://docs.confluent.io/platform/current/installation/versions-interoperability.html) ("Java 11, 17, 21, and 25 are supported"), not Apache Kafka's. Apache Kafka 4.1 does not list Java 25. These lanes run Apache Kafka 4.1.1, so the Apache statement is the one that applies, and Java 21 is both fully supported and the recommended LTS. Any future Java 25 coverage belongs on a Confluent lane, where a vendor actually supports it -- not here.

Worth noting for reviewers: the existing `java_test_version: '17'` entries are the connector **runtime** JDK, not a compile target. Java 17 runtime was already covered; 21 was the untested step.

The compile target should stay at 11 while Java 11 Connect workers (Confluent 7.x, Apache 3.x) are supported, and when it moves it should move to **17**, the Connect 4.x floor. There is no reason to target 21.

## What this adds

One lane: Apache 4.1.1 on Java 21, `core` group only, to bound CI cost. The Java 17 lanes remain the full-coverage matrix. Plus the GHCR image that backs it.

## `run_tests.sh` could not express this

The 4.x branch hard-set `JAVA_VERSION="17"` *after* argument parsing, silently discarding `--java-version`. A lane declaring Java 21 would have run Java 17 and **reported success for a version it never exercised**. Confirmed against `master` before fixing.

The platform floor is now a default only. Two guards were added:

1. An explicit version below the Kafka 4.x floor fails fast rather than being quietly substituted. This matters because `end-to-end.yaml` defaults to `'11'`, so a future 4.x lane that forgets `java_test_version` now fails loudly instead of silently passing.
2. `--java-version` is validated as a bare major version. It feeds the image tag, so `11.0.2` or `17x` previously passed through and produced an unresolvable tag that failed later with a confusing error.

## Reviewer notes

- `test_group` is `core_java21`, not `core`, because the failure-log artifact name derives from it and `upload-artifact@v4` rejects duplicate names within a run. Verified no duplicate names across any job.
- Test resource collisions are not a concern: the java17 and java21 core lanes run identical tests concurrently against the same account, but `session_name_salt` generates a random 7-character salt per session and CI never pins `--name-salt`.
- Until `build-apache-kafka-images.yml` publishes `apache-kafka:4.1.1-java21`, `run_tests.sh` falls back to a local image build, so the lane degrades to slower rather than failing.

## Verification

Version resolution, all cases:

| Platform | `--java-version` | Result |
|---|---|---|
| 4.1.1 | unset / 17 / 21 | 17 / 17 / **21** |
| 4.1.1 | 11, 8 | rejected, below floor |
| 4.1.1, 3.9.2 | `17x`, `11.0.2`, `abc`, empty | rejected, malformed |
| 3.9.2 | unset / 11 / 21 | 11 / 11 / 21 |
| confluent 7.9.3 | n/a | unaffected |

Shell and YAML syntax valid.

The Java 21 runtime itself was validated locally under Podman, which does not need Snowflake credentials:

- `apache-kafka:4.1.1-java21` builds clean; Temurin 21.0.12 inside.
- Kafka 4.1.1 broker (KRaft) and Kafka Connect both start on Java 21.
- The **JDK 11-built** connector plugin loads and registers: `SnowflakeStreamingSinkConnector` v4.1.0.
- `PUT /config/validate` exercises the connector's own validation and RSA key parsing on Java 21. It fails only with `Cannot connect to Snowflake` against a deliberately bogus host, i.e. our code ran correctly.
- Logs contain **zero** `InaccessibleObjectException`, `UnsupportedClassVersionError`, `NoSuchMethodError`, `NoClassDefFoundError`, illegal-reflective-access warnings or `sun.misc.Unsafe` warnings.

Separately, compiling all 110 production sources at `release 21` produces exactly **one** JDK deprecation, `new URL(String)` in `Utils.java:116` (deprecated in Java 20, not marked for removal). `release 11` and `release 17` produce none. That is the entire Java 11 to 21 code delta.

## Not verified

This lane has never executed in GitHub Actions, and data flow into Snowflake on Java 21 is untested, since that needs credentials and cloud resources. That is precisely the gap this lane exists to close, and the first CI run is the test.
