### PR TITLE
SNOW-3956090: remediate bundled dependency findings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,11 +60,12 @@
         <!--Compatible protobuf version https://github.com/confluentinc/common/blob/v7.7.0/pom.xml#L91 -->
         <protobuf.version>3.25.5</protobuf.version>
         <guava.version>33.6.0-jre</guava.version>
+        <gson.version>2.13.2</gson.version>
 
-        <jackson.version>2.22.1</jackson.version>
+        <jackson.version>2.22.2</jackson.version>
         <commons-compress.version>1.28.0</commons-compress.version>
         <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
-        <snowflake-jdbc.version>4.3.2</snowflake-jdbc.version>
+        <snowflake-jdbc.version>4.3.3</snowflake-jdbc.version>
         <slf4j-api.version>2.0.18</slf4j-api.version>
         <commons-lang3.version>3.20.0</commons-lang3.version>
         <auto-value.version>1.11.1</auto-value.version>
@@ -77,7 +78,7 @@
             http://mitmproxy:8080 destination at the request-builder layer.
             Tracking ticket: SNOW-3683451.
         -->
-        <snowpipe-streaming.version>1.6.2</snowpipe-streaming.version>
+        <snowpipe-streaming.version>1.8.0</snowpipe-streaming.version>
 
     </properties>
 
@@ -261,7 +262,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-fips</artifactId>
-            <version>2.1.11</version>
+            <version>2.1.12</version>
             <scope>provided</scope>
         </dependency>
 
@@ -335,6 +336,11 @@
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java-util</artifactId>
             <version>${protobuf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>${gson.version}</version>
         </dependency>
 
         <dependency>

--- a/pom_confluent.xml
+++ b/pom_confluent.xml
@@ -70,13 +70,13 @@
         <!--Compatible protobuf version https://github.com/confluentinc/common/blob/v7.7.0/pom.xml#L91 -->
         <protobuf.version>3.25.5</protobuf.version>
         <guava.version>33.6.0-jre</guava.version>
+        <gson.version>2.13.2</gson.version>
 
-        <jackson.version>2.22.1</jackson.version>
+        <jackson.version>2.22.2</jackson.version>
         <commons-compress.version>1.28.0</commons-compress.version>
         <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
-        <snowflake-jdbc.version>4.3.2</snowflake-jdbc.version>
+        <snowflake-jdbc.version>4.3.3</snowflake-jdbc.version>
         <slf4j-api.version>2.0.18</slf4j-api.version>
-        <parquet.version>1.14.4</parquet.version>
         <commons-lang3.version>3.20.0</commons-lang3.version>
         <auto-value.version>1.11.1</auto-value.version>
 
@@ -88,7 +88,7 @@
             http://mitmproxy:8080 destination at the request-builder layer.
             Tracking ticket: SNOW-3683451.
         -->
-        <snowpipe-streaming.version>1.6.2</snowpipe-streaming.version>
+        <snowpipe-streaming.version>1.8.0</snowpipe-streaming.version>
 
     </properties>
 
@@ -409,7 +409,7 @@
             <!-- This dependency won't be present in the kafka connect runtime, hence we are packaging this in an uber jar -->
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-fips</artifactId>
-            <version>2.1.11</version>
+            <version>2.1.12</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.apache.kafka/connect-api -->
@@ -474,6 +474,11 @@
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java-util</artifactId>
             <version>${protobuf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>${gson.version}</version>
         </dependency>
 
         <dependency>
@@ -628,12 +633,6 @@
             <groupId>dev.failsafe</groupId>
             <artifactId>failsafe</artifactId>
             <version>3.3.2</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.parquet</groupId>
-            <artifactId>parquet-column</artifactId>
-            <version>${parquet.version}</version>
         </dependency>
 
         <!--junit for unit test-->


### PR DESCRIPTION
## Summary
- update Jackson to 2.22.2, Snowflake JDBC to 4.3.3, Bouncy Castle FIPS to 2.1.12, and Gson to 2.13.2 in both connector distributions
- update Snowpipe Streaming from 1.6.2 to 1.8.0, clearing the older Jackson findings while a fully patched SDK release is prepared
- remove the unused Confluent-only Parquet dependency and its legacy `javax.annotation-api` packaging

Tracks [SNOW-3956090](https://snowflakecomputing.atlassian.net/browse/SNOW-3956090).
Coordinated SDK fix: [snowflake-eng/snowflake-ingest-sdk#1062](https://github.com/snowflake-eng/snowflake-ingest-sdk/pull/1062).

## Test plan
- [x] dependency trees resolve the intended versions from both POMs
- [x] `mvn package -Dgpg.skip=true -DskipTests=true`
- [x] `mvn -f pom_confluent.xml clean package -Dgpg.skip=true -DskipTests=true`
- [x] clean Confluent package contains no Parquet or `javax.annotation-api` dependency JAR
- [ ] `mvn package -Dgpg.skip=true` — 828 tests passed; 40 credential-dependent tests could not run because `SNOWFLAKE_CREDENTIAL_FILE` is unavailable locally

## Before marking ready
- publish an SDK release containing [snowflake-eng/snowflake-ingest-sdk#1062](https://github.com/snowflake-eng/snowflake-ingest-sdk/pull/1062)
- replace SDK 1.8.0 with that release and rerun the connector validation matrix

Made with [Cursor](https://cursor.com)

[SNOW-3956090]: https://snowflakecomputing.atlassian.net/browse/SNOW-3956090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ