### PR TITLE
SNOW-3961901: use the documented term "workload-identity" in SPCS log messages

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/spcs/SpcsEnvironment.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/spcs/SpcsEnvironment.java
@@ -145,8 +145,8 @@ public final class SpcsEnvironment {
       throw new IllegalStateException(
           "Failed to read the SPCS session token at "
               + tokenPath
-              + ". This file is provided by the SPCS runtime; ambient authentication is only"
-              + " available to a connector running inside Snowpark Container Services.",
+              + ". This file is provided by the SPCS runtime; workload-identity authentication is"
+              + " only available to a connector running inside Snowpark Container Services.",
           e);
     }
     if (token.isEmpty()) {
@@ -198,15 +198,15 @@ public final class SpcsEnvironment {
         // their credential is being bypassed inside SPCS.
         LOGGER.warn(
             "Running inside Snowpark Container Services, but a credential is configured, so the"
-                + " existing authentication method is kept. Set '{}' to '{}' to use ambient SPCS"
-                + " authentication instead.",
+                + " existing authentication method is kept. Set '{}' to '{}' to use SPCS"
+                + " workload-identity authentication instead.",
             KafkaConnectorConfigParams.SNOWFLAKE_AUTHENTICATOR,
             AuthenticatorType.SPCS.toConfigValue());
         return raw;
       }
       LOGGER.info(
-          "Running inside Snowpark Container Services and '{}' was not configured; using ambient"
-              + " SPCS authentication.",
+          "Running inside Snowpark Container Services and '{}' was not configured; using SPCS"
+              + " workload-identity authentication.",
           KafkaConnectorConfigParams.SNOWFLAKE_AUTHENTICATOR);
     } else if (!AuthenticatorType.SPCS
         .toConfigValue()
@@ -246,8 +246,8 @@ public final class SpcsEnvironment {
         }) {
       if (!isBlank(resolved.get(credKey))) {
         LOGGER.warn(
-            "'{}' is set but will be ignored: ambient SPCS authentication uses the token supplied"
-                + " by the SPCS runtime.",
+            "'{}' is set but will be ignored: SPCS workload-identity authentication uses the"
+                + " token supplied by the SPCS runtime.",
             credKey);
       }
     }


### PR DESCRIPTION
## Summary

The docs call this **SPCS workload-identity authentication**. The connector's log and exception
messages said **"ambient"**, which appears nowhere in the documentation, so an operator who reads a
warning and searches the docs for the term finds nothing.

Four string literals in `SpcsEnvironment`, no behaviour change:

- the token-read failure message
- the warning when a credential is configured but no authenticator is named
- the info line when SPCS auth is adopted implicitly
- the warning that a superfluous credential is ignored

```
- 'snowflake.private.key' is set but will be ignored: ambient SPCS authentication uses the token supplied by the SPCS runtime.
+ 'snowflake.private.key' is set but will be ignored: SPCS workload-identity authentication uses the token supplied by the SPCS runtime.
```

Internal identifiers (`suppliesAmbientIdentity`, `AMBIENT_USER_PLACEHOLDER`) are unchanged.

## Test plan

- [x] `mvn test` -- 868 tests, 0 failures, 0 errors; same count as master
- [x] google-java-format check clean
- [x] No `ambient` left in any string literal under `src/main/java`
