### PR TITLE
SNOW-3961901: warn when snowflake.role.name is overridden under SPCS auth

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/internal/spcs/SpcsEnvironment.java
+++ b/src/main/java/com/snowflake/kafka/connector/internal/spcs/SpcsEnvironment.java
@@ -252,6 +252,15 @@ public final class SpcsEnvironment {
       }
     }
 
+    // The role is overridden rather than ignored: the session runs as the service user, whose
+    // default role is the service owner role.
+    if (!isBlank(resolved.get(KafkaConnectorConfigParams.SNOWFLAKE_ROLE_NAME))) {
+      LOGGER.warn(
+          "'{}' is set but will be overridden: SPCS workload-identity authentication uses the"
+              + " service owner's role. Assign the role when you run CREATE SERVICE.",
+          KafkaConnectorConfigParams.SNOWFLAKE_ROLE_NAME);
+    }
+
     return resolved;
   }
 

--- a/src/test/java/com/snowflake/kafka/connector/internal/spcs/SpcsEnvironmentTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/internal/spcs/SpcsEnvironmentTest.java
@@ -430,6 +430,55 @@ public class SpcsEnvironmentTest {
         .noneMatch(msg -> msg.contains(secret));
   }
 
+  /**
+   * The configured role is silently overridden by the service owner role, so it must warn. An
+   * ignored credential already warns; an ignored role changes which tables are visible.
+   */
+  @Test
+  void shouldWarnThatAConfiguredRoleIsOverriddenUnderSpcs() throws IOException {
+    simulateSpcs("token");
+
+    Logger rootLogger = Logger.getRootLogger();
+    CapturingAppender appender = new CapturingAppender();
+    rootLogger.addAppender(appender);
+    try {
+      Map<String, String> raw = new HashMap<>();
+      raw.put(KafkaConnectorConfigParams.NAME, "testConnector");
+      raw.put(KafkaConnectorConfigParams.SNOWFLAKE_ROLE_NAME, "MY_ROLE");
+      SpcsEnvironment.resolve(raw);
+    } finally {
+      rootLogger.removeAppender(appender);
+    }
+
+    assertThat(appender.getMessages())
+        .as("a configured role must be reported as overridden")
+        .anyMatch(
+            msg ->
+                msg.contains(KafkaConnectorConfigParams.SNOWFLAKE_ROLE_NAME)
+                    && msg.contains("overridden"));
+  }
+
+  /** No role configured, so there is nothing to warn about. */
+  @Test
+  void shouldNotWarnAboutTheRoleWhenNoneIsConfigured() throws IOException {
+    simulateSpcs("token");
+
+    Logger rootLogger = Logger.getRootLogger();
+    CapturingAppender appender = new CapturingAppender();
+    rootLogger.addAppender(appender);
+    try {
+      Map<String, String> raw = new HashMap<>();
+      raw.put(KafkaConnectorConfigParams.NAME, "testConnector");
+      SpcsEnvironment.resolve(raw);
+    } finally {
+      rootLogger.removeAppender(appender);
+    }
+
+    assertThat(appender.getMessages())
+        .as("no role configured, so no role warning")
+        .noneMatch(msg -> msg.contains(KafkaConnectorConfigParams.SNOWFLAKE_ROLE_NAME));
+  }
+
   private static class CapturingAppender extends AppenderSkeleton {
     private final List<String> messages = new ArrayList<>();
 


### PR DESCRIPTION
## Summary

Under SPCS workload-identity authentication the session runs as the service user, whose default role is the service owner role. A configured `snowflake.role.name` is therefore accepted and then overridden — but silently.

That asymmetry is the point: an ignored **credential** already warns, an ignored **role** did not. The role is the one that changes which tables are visible, so when it's wrong the only symptom is a misleading `ERR_TABLE_DOES_NOT_EXIST_NOT_AUTHORIZED` (404) for a table that exists and is queryable by the operator.

One warning, using the existing wording convention in this file and pointing at `CREATE SERVICE` to match the documentation:

```
WARN 'snowflake.role.name' is set but will be overridden: SPCS workload-identity
     authentication uses the service owner's role. Assign the role when you run CREATE SERVICE.
```

"overridden" rather than "ignored" is deliberate — it mirrors the documented behaviour ("accepted but overridden") and distinguishes this from the credential warnings, which really are ignored.

No behaviour change: log output only.

## Test plan

- [x] `SpcsEnvironmentTest` — 2 new tests: warns when a role is configured, stays quiet when none is. **28 pass.**
- [x] Full unit suite: **870 pass / 0 fail** (868 before this change).
- [x] Formatter clean: `fmt-maven-plugin:check`, 224 files, 0 non-complying.
- [x] Behaviour verified on live SPCS services across AWS, Azure and GCP: `snowflake.role.name` is accepted and the effective role is the service owner's.

## Note

Reusing the SNOW-3961901 ticket from #1554 as this is the same SPCS documentation-alignment follow-up. Retitle if a separate ticket is preferred.