### PR TITLE
docs: clarify KCv4 native SDK proxy configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,37 @@ The Snowflake Kafka Connector is a plugin for Apache Kafka Connect. It ingests d
 
 [Official documentation](https://docs.snowflake.com/en/user-guide/kafka-connector) for the Snowflake Kafka Connector
 
+## Proxy configuration for Kafka Connector v4
+
+Kafka Connector v4 uses two networking stacks:
+
+- Java and JDBC traffic uses JVM proxy settings configured by `jvm.proxy.*` connector
+  properties or equivalent Java system properties such as `https.proxyHost`.
+- Streaming data traffic uses the native Rust Snowpipe Streaming SDK. This includes
+  file-mode uploads to Snowflake-managed cloud storage. The native SDK does not read
+  Java system properties.
+
+Consequently, setting `KAFKA_OPTS=-Dhttps.proxyHost=...` configures the JVM but
+does not configure native SDK traffic.
+
+To route Snowpipe Streaming SDK traffic through a system proxy, configure standard
+proxy environment variables on every Kafka Connect worker before its JVM starts:
+
+```bash
+HTTP_PROXY=http://proxy.example.com:3128
+HTTPS_PROXY=http://proxy.example.com:3128
+NO_PROXY=localhost,127.0.0.1,.svc.cluster.local
+```
+
+`ALL_PROXY` is also supported as a fallback. Restart the Kafka Connect worker after
+changing these variables. Restarting only a connector or task might not recreate all
+native SDK clients in that worker.
+
+The worker must be able to reach both Snowflake service endpoints and the cloud-storage
+stage endpoints returned by Snowflake. Configure `NO_PROXY` according to which
+destinations should bypass the proxy. `NO_PROXY` entries are comma-separated; Java's
+`http.nonProxyHosts` uses a different, pipe-separated format.
+
 ## Contributing
 
 ### Guidelines

--- a/README.md
+++ b/README.md
@@ -6,37 +6,6 @@ The Snowflake Kafka Connector is a plugin for Apache Kafka Connect. It ingests d
 
 [Official documentation](https://docs.snowflake.com/en/user-guide/kafka-connector) for the Snowflake Kafka Connector
 
-## Proxy configuration for Kafka Connector v4
-
-Kafka Connector v4 uses two networking stacks:
-
-- Java and JDBC traffic uses JVM proxy settings configured by `jvm.proxy.*` connector
-  properties or equivalent Java system properties such as `https.proxyHost`.
-- Streaming data traffic uses the native Rust Snowpipe Streaming SDK. This includes
-  file-mode uploads to Snowflake-managed cloud storage. The native SDK does not read
-  Java system properties.
-
-Consequently, setting `KAFKA_OPTS=-Dhttps.proxyHost=...` configures the JVM but
-does not configure native SDK traffic.
-
-To route Snowpipe Streaming SDK traffic through a system proxy, configure standard
-proxy environment variables on every Kafka Connect worker before its JVM starts:
-
-```bash
-HTTP_PROXY=http://proxy.example.com:3128
-HTTPS_PROXY=http://proxy.example.com:3128
-NO_PROXY=localhost,127.0.0.1,.svc.cluster.local
-```
-
-`ALL_PROXY` is also supported as a fallback. Restart the Kafka Connect worker after
-changing these variables. Restarting only a connector or task might not recreate all
-native SDK clients in that worker.
-
-The worker must be able to reach both Snowflake service endpoints and the cloud-storage
-stage endpoints returned by Snowflake. Configure `NO_PROXY` according to which
-destinations should bypass the proxy. `NO_PROXY` entries are comma-separated; Java's
-`http.nonProxyHosts` uses a different, pipe-separated format.
-
 ## Contributing
 
 ### Guidelines

--- a/src/main/java/com/snowflake/kafka/connector/config/ConnectorConfigDefinition.java
+++ b/src/main/java/com/snowflake/kafka/connector/config/ConnectorConfigDefinition.java
@@ -195,7 +195,10 @@ public class ConnectorConfigDefinition {
             STRING,
             "",
             LOW,
-            "JVM option: https.proxyHost",
+            "Java/JDBC proxy host (JVM option: https.proxyHost). This does not configure the"
+                + " native Snowpipe Streaming SDK used by Kafka Connector v4 for streaming data"
+                + " and file-mode cloud-storage uploads. Configure HTTPS_PROXY in the Kafka"
+                + " Connect worker environment for native SDK traffic.",
             PROXY_INFO_DOC,
             0,
             Width.NONE,
@@ -205,7 +208,9 @@ public class ConnectorConfigDefinition {
             STRING,
             "",
             LOW,
-            "JVM option: https.proxyPort",
+            "Java/JDBC proxy port (JVM option: https.proxyPort). This does not configure the"
+                + " native Snowpipe Streaming SDK; include the port in the Kafka Connect worker's"
+                + " HTTP_PROXY or HTTPS_PROXY environment variable.",
             PROXY_INFO_DOC,
             1,
             Width.NONE,
@@ -215,7 +220,9 @@ public class ConnectorConfigDefinition {
             STRING,
             "",
             LOW,
-            "JVM option: http.nonProxyHosts",
+            "Java/JDBC proxy bypass list (JVM option: http.nonProxyHosts). This does not configure"
+                + " the native Snowpipe Streaming SDK; configure NO_PROXY in the Kafka Connect"
+                + " worker environment for native SDK traffic.",
             PROXY_INFO_DOC,
             2,
             Width.NONE,
@@ -225,7 +232,8 @@ public class ConnectorConfigDefinition {
             STRING,
             "",
             LOW,
-            "JVM proxy username",
+            "Java/JDBC proxy username. This does not configure proxy authentication for the native"
+                + " Snowpipe Streaming SDK.",
             PROXY_INFO_DOC,
             3,
             Width.NONE,
@@ -235,7 +243,8 @@ public class ConnectorConfigDefinition {
             PASSWORD,
             "",
             LOW,
-            "JVM proxy password",
+            "Java/JDBC proxy password. This does not configure proxy authentication for the native"
+                + " Snowpipe Streaming SDK.",
             PROXY_INFO_DOC,
             4,
             Width.NONE,


### PR DESCRIPTION
## Summary
- clarify that `jvm.proxy.*` configures Java/JDBC networking, not the native Snowpipe Streaming SDK
- direct KCv4 users to worker-level `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` configuration for streaming and file-mode traffic
- document the proxy distinction in generated connector-config descriptions

## Testing
- `./format.sh`
- `mvn -Dgpg.skip=true -DskipIntegrationTests=true -Dtest=ConnectorConfigValidatorTest test`