### PR TITLE
SNOW-4008937: close the connector's Snowflake connection on stop()

### DIFF
--- a/src/main/java/com/snowflake/kafka/connector/SnowflakeStreamingSinkConnector.java
+++ b/src/main/java/com/snowflake/kafka/connector/SnowflakeStreamingSinkConnector.java
@@ -78,6 +78,17 @@ public class SnowflakeStreamingSinkConnector extends SinkConnector {
   private SnowflakeTelemetryService telemetryClient;
   private long connectorStartTime;
 
+  /**
+   * Wires up the connection and its telemetry client exactly as {@code start()} does, so a test can
+   * exercise {@code stop()}. {@code start()} itself cannot be used for that: it builds a real
+   * Snowflake connection, which no unit test can satisfy.
+   */
+  @VisibleForTesting
+  void injectConnectionForTests(SnowflakeConnectionService connection) {
+    this.conn = connection;
+    this.telemetryClient = connection.getTelemetryClient();
+  }
+
   // Kafka Connect starts sink tasks without waiting for setup in
   // SnowflakeStreamingSinkConnector to finish.
   // This causes race conditions for: config validation, tables and stages
@@ -159,6 +170,20 @@ public class SnowflakeStreamingSinkConnector extends SinkConnector {
 
     if (telemetryClient != null) {
       telemetryClient.reportKafkaConnectStop(connectorStartTime);
+    }
+
+    // Closed after the stop telemetry is reported, never before: the report travels over this very
+    // connection. A telemetry client that buffers instead of sending per event also relies on the
+    // close itself to flush, so reversing the order would drop the kafka_stop event entirely.
+    if (conn != null) {
+      try {
+        conn.close();
+      } catch (Exception e) {
+        // Best-effort: the connector is shutting down and there is nothing left to salvage. Not
+        // narrowed to SnowflakeKafkaConnectorException because close() reports its own failure
+        // through the connection that just failed, so the surfacing type is not guaranteed.
+        LOGGER.warn("Failed to close the Snowflake connection on stop: {}", e.getMessage());
+      }
     }
   }
 

--- a/src/test/java/com/snowflake/kafka/connector/SnowflakeStreamingSinkConnectorTest.java
+++ b/src/test/java/com/snowflake/kafka/connector/SnowflakeStreamingSinkConnectorTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2019 Snowflake Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.snowflake.kafka.connector;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.snowflake.kafka.connector.internal.SnowflakeConnectionService;
+import com.snowflake.kafka.connector.internal.SnowflakeErrors;
+import com.snowflake.kafka.connector.internal.telemetry.SnowflakeTelemetryService;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+/**
+ * Guards the connection lifecycle of {@link SnowflakeStreamingSinkConnector}.
+ *
+ * <p>{@code start()} builds a long-lived, otherwise idle JDBC-backed connection — ingestion itself
+ * runs over separate Snowpipe Streaming channels — and for a long time {@code stop()} never closed
+ * it, leaking one connection per connector stop. These tests pin the close down, and pin down the
+ * order it happens in, which is the part that is easy to break by accident.
+ *
+ * <p>{@code start()} cannot be driven here, because it builds a real Snowflake connection that no
+ * unit test can satisfy; the connection is injected instead, wired the same way {@code start()}
+ * wires it.
+ */
+public class SnowflakeStreamingSinkConnectorTest {
+
+  @Test
+  public void stopClosesTheConnectionItHasHeldOpenSinceStart() {
+    // GIVEN a started connector holding a connection
+    SnowflakeConnectionService conn = connectionWithTelemetry();
+    SnowflakeStreamingSinkConnector connector = new SnowflakeStreamingSinkConnector();
+    connector.injectConnectionForTests(conn);
+
+    // WHEN the connector is stopped
+    connector.stop();
+
+    // THEN the connection is closed rather than left dangling for the worker's lifetime
+    verify(conn).close();
+  }
+
+  /**
+   * The stop telemetry travels over the connection being closed, so reporting has to happen first.
+   * A telemetry client that buffers rather than sending per event additionally depends on the close
+   * to flush — reverse these two calls and the {@code kafka_stop} event is lost, which is precisely
+   * the event Support needs when a connector goes down unexpectedly.
+   */
+  @Test
+  public void stopReportsTelemetryBeforeClosingTheConnectionItTravelsOver() {
+    SnowflakeConnectionService conn = connectionWithTelemetry();
+    SnowflakeTelemetryService telemetry = conn.getTelemetryClient();
+    SnowflakeStreamingSinkConnector connector = new SnowflakeStreamingSinkConnector();
+    connector.injectConnectionForTests(conn);
+
+    connector.stop();
+
+    InOrder order = inOrder(telemetry, conn);
+    order.verify(telemetry).reportKafkaConnectStop(0L);
+    order.verify(conn).close();
+  }
+
+  @Test
+  public void stopSwallowsAFailureToCloseBecauseTheConnectorIsAlreadyShuttingDown() {
+    // GIVEN a connection whose close() fails, as close() is permitted to do (ERROR_2005)
+    SnowflakeConnectionService conn = connectionWithTelemetry();
+    doThrow(SnowflakeErrors.ERROR_2005.getException()).when(conn).close();
+    SnowflakeStreamingSinkConnector connector = new SnowflakeStreamingSinkConnector();
+    connector.injectConnectionForTests(conn);
+
+    // WHEN / THEN stop() does not propagate it into the Kafka Connect worker's shutdown path
+    assertThatCode(connector::stop).doesNotThrowAnyException();
+    verify(conn).close();
+  }
+
+  @Test
+  public void stopIsSafeWhenStartNeverBuiltAConnection() {
+    // Kafka Connect calls stop() even when start() failed before assigning the connection.
+    assertThatCode(new SnowflakeStreamingSinkConnector()::stop).doesNotThrowAnyException();
+  }
+
+  private static SnowflakeConnectionService connectionWithTelemetry() {
+    SnowflakeConnectionService conn = mock(SnowflakeConnectionService.class);
+    when(conn.getTelemetryClient()).thenReturn(mock(SnowflakeTelemetryService.class));
+    return conn;
+  }
+}


### PR DESCRIPTION
## What leaked

`SnowflakeStreamingSinkConnector.start()` builds a real JDBC-backed connection:

```java
conn = SnowflakeConnectionServiceFactory.builder().setProperties(config).build();
telemetryClient = conn.getTelemetryClient();
```

It is used during `start()` for stage/table DDL and existence checks, then held for the connector's entire lifetime — otherwise idle, since ingestion itself goes through separate Snowpipe Streaming channels rather than this connection.

`stop()` never closed it. `conn.close()` appears nowhere in the connector's main sources; the only call sites are inside `StandardSnowflakeConnectionService.close()` itself and in tests. So **every connector stop leaked one connection.**

## The fix

`stop()` now closes the connection, after reporting the stop telemetry:

```java
if (telemetryClient != null) {
  telemetryClient.reportKafkaConnectStop(connectorStartTime);
}

if (conn != null) {
  try {
    conn.close();
  } catch (Exception e) {
    LOGGER.warn("Failed to close the Snowflake connection on stop: {}", e.getMessage());
  }
}
```

Two deliberate choices:

**Ordering.** The close comes *after* the telemetry report, because the report travels over the very connection being closed.

**Best-effort.** `SnowflakeConnectionService.close()` is declared `void close()` with no `throws` clause, but the implementation is not defensive — `StandardSnowflakeConnectionService.close()` raises `ERROR_2005` (an unchecked `SnowflakeKafkaConnectorException`) when the underlying JDBC close fails. `stop()` must not propagate that into the Kafka Connect worker's shutdown path. The catch is `Exception` rather than the narrower `SnowflakeKafkaConnectorException` because `close()`'s failure path builds its exception via `SnowflakeErrors.ERROR_2005.getException(e, this.telemetry)`, which reports through the connection that just failed to close — so the surfacing type is not guaranteed to be the declared one.

## Why it matters now

Beyond the leak, this is a prerequisite for migrating the connector's telemetry onto the **Universal Driver** core. That core's telemetry buffer flushes on only two triggers: a 100-entry threshold, or `connection.close()`. With no close on stop, the `kafka_stop` event — precisely the event Support needs to diagnose a connector that stopped unexpectedly — would silently never reach Snowflake once that migration lands.

Today this is masked: the legacy JDBC telemetry client sends synchronously per event (`sendBatchAsync()` in `SnowflakeTelemetryService.send()`), so a missing close costs only the connection. The leak is real regardless, and fixing it now removes a landmine for the pending migration.

Ticket: **SNOW-4008937** — *UD core telemetry: no way for a wrapper to force a flush, so per-event send semantics cannot be reproduced.* The connector's failure to close its connection on stop is the concrete blocker cited there.

## Tests

New `src/test/java/com/snowflake/kafka/connector/SnowflakeStreamingSinkConnectorTest.java` (JUnit 5 + AssertJ + Mockito, matching the existing unit-test style) covers four things:

| Test | Asserts |
|---|---|
| `stopClosesTheConnectionItHasHeldOpenSinceStart` | `close()` is invoked |
| `stopReportsTelemetryBeforeClosingTheConnectionItTravelsOver` | `InOrder`: telemetry report precedes close |
| `stopSwallowsAFailureToCloseBecauseTheConnectorIsAlreadyShuttingDown` | a throwing `close()` does not escape `stop()` |
| `stopIsSafeWhenStartNeverBuiltAConnection` | no NPE when `start()` never assigned `conn` |

`start()` cannot be driven from a unit test — it builds a real Snowflake connection — so the test injects the connection through a package-private `@VisibleForTesting` seam that wires `conn` and `telemetryClient` exactly as `start()` does. This mirrors the existing `effectiveConfigForTests()` seam already in this class; the Kafka Connect framework mandates a no-arg constructor, so constructor injection is not available.

These went into a new class rather than `SnowflakeStreamingSinkConnectorSpcsTest`, whose name and class javadoc scope it to SPCS ambient-credential resolution. `ConnectorIT` covers `stop()` only as part of a credential-gated integration path.

**Verification:**

- New tests: **4/4 pass.**
- Mutation-checked: with `conn.close()` disabled, **3 of the 4 fail** (the fourth guards the null path, so it correctly passes either way) — confirming the assertions actually bind to the fix.
- Full unit suite: `mvn test` → **874 tests, 0 failures, 40 errors.** All 40 errors are pre-existing and environmental: `IllegalState SNOWFLAKE_CREDENTIAL_FILE environment variable is not set`, raised from credential-gated config builders in `InternalUtilsTest`, `InternalUtilsNonSpcsRegressionTest`, `JdbcPropertiesTest`, `SnowflakeTelemetryServiceTest`, `StreamingClientPoolTest`, `StreamingClientPoolsTest`, `StreamingClientPropertiesTest`. None touch the connector class. Zero non-credential failures.
- Integration tests (`*IT`) were **not** run — they need live Snowflake credentials.
- `./format.sh` (google-java-format 1.24.0) run clean.

## Note for reviewers, out of scope here

`validate()` has the same shape of leak: it builds a `testConnection` (line ~265) for the database/schema existence checks and never closes it on any of its return paths. Left untouched to keep this PR to the one fix, but it likely deserves its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
